### PR TITLE
feat(cache-core): add action cache protocol and transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,2370 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08309dbcc659c5549a24ddb9b27027640641b282ef5768267c7e675558986a3"
+dependencies = [
+ "autocfg",
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mbx"
 version = "0.0.0"
+
+[[package]]
+name = "mbx-cache-core"
+version = "0.0.0"
+dependencies = [
+ "base64 0.23.1",
+ "blake3",
+ "eyre",
+ "fslock",
+ "futures-util",
+ "hex",
+ "log",
+ "mockito",
+ "rand 0.10.2",
+ "reflink-copy",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2",
+ "strum",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.5",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/mbx"]
+members = ["crates/mbx", "crates/mbx-cache-core"]
 
 [workspace.package]
 edition = "2024"

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "mbx-cache-core"
+version = "0.0.0"
+description = "Action cache protocol, CAS, authentication, and transport primitives for mbx"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+base64 = "0.23"
+blake3 = "1"
+eyre = "0.6"
+fslock = "0.2"
+futures-util = "0.3"
+hex = "0.4"
+log = "0.4"
+rand = "0.10"
+reflink-copy = "0.1"
+reqwest = { version = "0.13", default-features = false, features = [
+  "json",
+  "stream",
+] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_json_canonicalizer = "0.3"
+sha2 = "0.11"
+strum = { version = "0.28", features = ["derive"] }
+tempfile = "3"
+tokio = { version = "1", features = ["fs", "io-util", "rt", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["io"] }
+url = "2"
+
+[dev-dependencies]
+mockito = "1"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+
+[features]
+default = ["rustls"]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls"]
+rustls-native-roots = ["reqwest/rustls"]

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1,0 +1,3550 @@
+use crate::{
+    BlobSource, BlobUpload, CacheDigest, CacheDirectory, LocalActionCache, LocalCas,
+    ManifestPutOutcome, RemoteActionResult, RemoteCacheClient, RemoteCacheMode, RustcMetadata,
+    canonical_json,
+};
+use eyre::{Result, bail};
+use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
+use log::warn;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+
+const MAX_EXECUTABLE_IDENTITIES: usize = 64;
+const MAX_EXECUTABLE_IDENTITY_SIZE: usize = 64 * 1024;
+const MAX_EXECUTABLE_IDENTITY_BYTES: usize = 256 * 1024;
+const TASK_ACTION_MANIFEST_VERSION: u8 = 1;
+const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
+const MAX_ACTION_PREDICTION_PAYLOAD: usize = 256 * 1024;
+const MAX_REMOTE_TRANSFERS: usize = 64;
+const MAX_PREFETCH_TRANSFERS: usize = 48;
+const MAX_PREFETCH_ACTION_BATCH: usize = 256;
+const PREFETCH_ACTION_BATCH_DELAY: Duration = Duration::from_millis(5);
+const MAX_PREFETCH_DIRECTORY_OBJECTS: usize = 100_000;
+const MAX_PREFETCH_OBJECTS_PER_WAVE: usize = 100_000;
+
+/// Remote action-cache access owned by one task session.
+pub struct AgentRemoteCache {
+    pub client: RemoteCacheClient,
+    pub mode: RemoteCacheMode,
+    pub staging_dir: PathBuf,
+}
+
+/// Wire protocol version used between an in-process cache agent and its shims.
+pub const AGENT_PROTOCOL_VERSION: u8 = 1;
+
+/// A request accepted by the task-scoped cache agent.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentRequest {
+    Hello {
+        protocol: u8,
+        client_version: String,
+    },
+    /// Resolve a blob to a session-verified local CAS path.
+    FindBlob {
+        digest: CacheDigest,
+    },
+    /// Resolve blobs to session-verified local CAS paths.
+    FindBlobs {
+        digests: Vec<CacheDigest>,
+    },
+    StoreBlob {
+        digest: CacheDigest,
+        source: PathBuf,
+    },
+    FindActionResult {
+        action: CacheDigest,
+    },
+    RecordActionHit {
+        action: CacheDigest,
+        restore: RestoreStats,
+    },
+    RecordActionVerification {
+        matched: bool,
+        restore: RestoreStats,
+    },
+    StoreActionResult {
+        result: RemoteActionResult,
+    },
+    FindActionPrediction {
+        task: String,
+        invocation: CacheDigest,
+    },
+    RecordActionPrediction {
+        task: String,
+        prediction: ActionPrediction,
+    },
+    FindExecutableIdentity {
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+    },
+    StoreExecutableIdentity {
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+        stdout: Vec<u8>,
+    },
+}
+
+/// Local output restoration work performed by one action-cache adapter hit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestoreStats {
+    /// Cumulative time spent materializing and validating output files.
+    pub duration_ns: u64,
+    /// Number of compiler output files restored.
+    pub output_files: u64,
+    /// Declared size of compiler output files restored.
+    pub output_bytes: u64,
+}
+
+/// A response returned by the task-scoped cache agent.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentResponse {
+    Hello {
+        protocol: u8,
+        agent_version: String,
+    },
+    /// A local CAS path already verified against the requested digest.
+    Blob {
+        path: Option<PathBuf>,
+    },
+    /// Local CAS paths already verified against the requested digests.
+    Blobs {
+        paths: Vec<Option<PathBuf>>,
+    },
+    Stored {
+        path: PathBuf,
+    },
+    ActionResult {
+        result: Option<RemoteActionResult>,
+    },
+    ActionHitRecorded,
+    ActionVerificationRecorded,
+    ActionStored {
+        path: PathBuf,
+    },
+    ActionPrediction {
+        prediction: Option<ActionPrediction>,
+    },
+    ActionPredictionRecorded,
+    ExecutableIdentity {
+        stdout: Option<Vec<u8>>,
+    },
+    Error {
+        message: String,
+    },
+}
+
+/// Aggregate cache activity for one task session.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AgentStats {
+    /// End-to-end lifetime of the task-scoped cache session.
+    pub session_duration_ns: u64,
+    /// Number of action-result lookups.
+    pub lookups: u64,
+    /// Number of lookups that found a valid local action result.
+    pub hits: u64,
+    /// Number of newly stored content-addressed objects.
+    pub stores: u64,
+    /// Total size of newly stored objects.
+    pub stored_bytes: u64,
+    /// Number of cache hits compiled again for qualification.
+    pub verifications: u64,
+    /// Number of qualification builds that diverged from the cached result.
+    pub divergences: u64,
+    /// CAS payload bytes downloaded from the remote cache.
+    pub downloaded_bytes: u64,
+    /// CAS payload bytes uploaded to the remote cache.
+    pub uploaded_bytes: u64,
+    /// Complete actions staged before an adapter requested them.
+    pub prefetched_actions: u64,
+    /// Number of task manifest requests made to the remote cache.
+    pub remote_manifest_lookups: u64,
+    /// Cumulative time spent requesting remote task manifests.
+    pub remote_manifest_lookup_duration_ns: u64,
+    /// Number of action-result requests made to the remote cache.
+    pub remote_action_lookups: u64,
+    /// Cumulative time spent requesting remote action results.
+    pub remote_action_lookup_duration_ns: u64,
+    /// Number of blob requests made to the remote cache.
+    pub remote_blob_requests: u64,
+    /// Number of packed blob requests made to the remote cache.
+    pub remote_blob_pack_requests: u64,
+    /// Number of verified blobs received through packed responses.
+    pub remote_blob_pack_blobs: u64,
+    /// Cumulative time spent downloading and verifying remote blobs.
+    pub remote_blob_transfer_duration_ns: u64,
+    /// Cumulative time spent ingesting downloaded blobs into the local CAS.
+    pub local_cas_write_duration_ns: u64,
+    /// Number of speculative prefetch runs started for task manifests.
+    pub prefetch_runs: u64,
+    /// Cumulative wall time of speculative task-manifest prefetch runs.
+    pub prefetch_duration_ns: u64,
+    /// Cumulative time spent staging or materializing and validating cached outputs.
+    pub materialization_duration_ns: u64,
+    /// Number of compiler output files restored from action hits.
+    pub restored_output_files: u64,
+    /// Declared size of compiler output files restored from action hits.
+    pub restored_output_bytes: u64,
+}
+
+/// Adapter-owned data needed to reconstruct an action before fresh dependency
+/// discovery is available.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionPrediction {
+    pub invocation: CacheDigest,
+    pub action: CacheDigest,
+    pub adapter: String,
+    pub payload: String,
+}
+
+#[derive(Default)]
+struct AtomicAgentStats {
+    lookups: AtomicU64,
+    hits: AtomicU64,
+    stores: AtomicU64,
+    stored_bytes: AtomicU64,
+    verifications: AtomicU64,
+    divergences: AtomicU64,
+    downloaded_bytes: AtomicU64,
+    uploaded_bytes: AtomicU64,
+    prefetched_actions: AtomicU64,
+    remote_manifest_lookups: AtomicU64,
+    remote_manifest_lookup_duration_ns: AtomicU64,
+    remote_action_lookups: AtomicU64,
+    remote_action_lookup_duration_ns: AtomicU64,
+    remote_blob_requests: AtomicU64,
+    remote_blob_pack_requests: AtomicU64,
+    remote_blob_pack_blobs: AtomicU64,
+    remote_blob_transfer_duration_ns: AtomicU64,
+    local_cas_write_duration_ns: AtomicU64,
+    prefetch_runs: AtomicU64,
+    prefetch_duration_ns: AtomicU64,
+    materialization_duration_ns: AtomicU64,
+    restored_output_files: AtomicU64,
+    restored_output_bytes: AtomicU64,
+}
+
+struct AtomicDurationTimer<'a> {
+    started: Instant,
+    target: &'a AtomicU64,
+}
+
+impl<'a> AtomicDurationTimer<'a> {
+    fn start(target: &'a AtomicU64) -> Self {
+        Self {
+            started: Instant::now(),
+            target,
+        }
+    }
+}
+
+impl Drop for AtomicDurationTimer<'_> {
+    fn drop(&mut self) {
+        atomic_saturating_add(self.target, duration_ns(self.started));
+    }
+}
+
+fn duration_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().try_into().unwrap_or(u64::MAX)
+}
+
+fn atomic_saturating_add(target: &AtomicU64, value: u64) {
+    let _ = target.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(value))
+    });
+}
+
+fn queue_prefetch_digest(
+    verified: &BTreeMap<CacheDigest, PathBuf>,
+    pending: &mut BTreeMap<CacheDigest, ()>,
+    digest: CacheDigest,
+) {
+    if verified.contains_key(&digest) || pending.contains_key(&digest) {
+        return;
+    }
+    pending.insert(digest, ());
+}
+
+fn queue_prefetch_directory(
+    seen: &BTreeMap<CacheDigest, ()>,
+    pending: &mut BTreeMap<CacheDigest, ()>,
+    digest: CacheDigest,
+    limit: usize,
+) -> bool {
+    if seen.contains_key(&digest) || pending.contains_key(&digest) {
+        return true;
+    }
+    if seen.len().saturating_add(pending.len()) >= limit {
+        return false;
+    }
+    pending.insert(digest, ());
+    true
+}
+
+/// Shared state for an agent hosted by the process that owns a build session.
+///
+/// Transport listeners deliberately live in the embedder so the session
+/// lifecycle owns them. This type only contains ecosystem-independent CAS and
+/// protocol logic.
+#[derive(Clone)]
+pub struct CacheAgent {
+    cas: LocalCas,
+    actions: LocalActionCache,
+    verified_blobs: Arc<Mutex<BTreeMap<CacheDigest, PathBuf>>>,
+    version: Arc<str>,
+    write_locks: Arc<Mutex<BTreeMap<CacheDigest, Weak<tokio::sync::Mutex<()>>>>>,
+    action_locks: Arc<Mutex<BTreeMap<CacheDigest, Weak<tokio::sync::Mutex<()>>>>>,
+    stats: Arc<AtomicAgentStats>,
+    executable_identities: Arc<Mutex<BTreeMap<ExecutableIdentityKey, Vec<u8>>>>,
+    manifest_dir: Arc<PathBuf>,
+    task_actions: Arc<Mutex<BTreeMap<String, TaskActionState>>>,
+    next_task_run: Arc<AtomicU64>,
+    manifest_write_lock: Arc<Mutex<()>>,
+    remote: Option<Arc<RemoteCacheClient>>,
+    remote_mode: RemoteCacheMode,
+    remote_staging_dir: Arc<PathBuf>,
+    pending_remote_actions: Arc<Mutex<BTreeMap<CacheDigest, RemoteActionResult>>>,
+    remote_transfers: Arc<tokio::sync::Semaphore>,
+    prefetch_transfers: Arc<tokio::sync::Semaphore>,
+    prefetch_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskActionManifest {
+    version: u8,
+    task: String,
+    predictions: Vec<ActionPrediction>,
+}
+
+#[derive(Serialize)]
+struct TaskActionManifestSelector<'a> {
+    version: u8,
+    kind: &'static str,
+    task: &'a str,
+}
+
+#[derive(Debug, Clone, Default)]
+struct TaskActionState {
+    manifest: String,
+    baseline_loaded: bool,
+    predictions: BTreeMap<CacheDigest, ActionPrediction>,
+    remote_etag: Option<String>,
+}
+
+struct PrefetchedAction {
+    adapter: String,
+    result: RemoteActionResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ExecutableIdentityKey {
+    executable: PathBuf,
+    environment: BTreeMap<String, Option<String>>,
+}
+
+impl CacheAgent {
+    /// Create an agent backed by the cache rooted at `cache_dir`.
+    pub fn new(cache_dir: impl Into<PathBuf>, version: impl Into<Arc<str>>) -> Self {
+        Self::build(cache_dir.into(), version.into(), None)
+    }
+
+    /// Create an agent with local-first access to a remote action cache.
+    pub fn new_remote(
+        cache_dir: impl Into<PathBuf>,
+        version: impl Into<Arc<str>>,
+        remote: AgentRemoteCache,
+    ) -> Self {
+        Self::build(cache_dir.into(), version.into(), Some(remote))
+    }
+
+    fn build(cache_dir: PathBuf, version: Arc<str>, remote: Option<AgentRemoteCache>) -> Self {
+        let remote_mode = remote
+            .as_ref()
+            .map_or(RemoteCacheMode::ReadOnly, |remote| remote.mode);
+        let remote_staging_dir = remote.as_ref().map_or_else(
+            || cache_dir.join("remote"),
+            |remote| remote.staging_dir.clone(),
+        );
+        let remote = remote.map(|remote| Arc::new(remote.client));
+        Self {
+            cas: LocalCas::new(cache_dir.clone()),
+            actions: LocalActionCache::new(cache_dir.clone()),
+            verified_blobs: Arc::new(Mutex::new(BTreeMap::new())),
+            version,
+            write_locks: Arc::new(Mutex::new(BTreeMap::new())),
+            action_locks: Arc::new(Mutex::new(BTreeMap::new())),
+            stats: Arc::new(AtomicAgentStats::default()),
+            executable_identities: Arc::new(Mutex::new(BTreeMap::new())),
+            manifest_dir: Arc::new(cache_dir.join("task-manifests").join("v1")),
+            task_actions: Arc::new(Mutex::new(BTreeMap::new())),
+            next_task_run: Arc::new(AtomicU64::new(0)),
+            manifest_write_lock: Arc::new(Mutex::new(())),
+            remote,
+            remote_mode,
+            remote_staging_dir: Arc::new(remote_staging_dir),
+            pending_remote_actions: Arc::new(Mutex::new(BTreeMap::new())),
+            remote_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_REMOTE_TRANSFERS)),
+            prefetch_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_PREFETCH_TRANSFERS)),
+            prefetch_tasks: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Load the last successful action manifest for a task into this session.
+    pub async fn begin_task(&self, task: &str) -> Result<String> {
+        validate_task_identity(task)?;
+        let (remote_manifest, mut remote_etag) = if self.remote_mode.reads() {
+            match self.get_remote_task_manifest(task).await {
+                Ok(Some((manifest, etag))) => (Some(manifest), Some(etag)),
+                Ok(None) => (None, None),
+                Err(error) => {
+                    warn!("remote task action manifest lookup failed for {task}: {error}");
+                    (None, None)
+                }
+            }
+        } else {
+            (None, None)
+        };
+        let manifest = {
+            let _write_guard = self.manifest_write_lock.lock().unwrap();
+            let _file_guard = self.lock_task_manifest(task)?;
+            let local_manifest = self.load_task_manifest(task)?;
+            let manifest = match (remote_manifest, local_manifest) {
+                (Some(remote), Some(local)) => {
+                    let (manifest, merged) = merge_remote_task_manifest(task, remote, local);
+                    if !merged {
+                        remote_etag = None;
+                    }
+                    Some(manifest)
+                }
+                (Some(remote), None) => Some(remote),
+                (None, local) => local,
+            };
+            if let Some(manifest) = &manifest {
+                self.persist_task_manifest(manifest)?;
+            }
+            manifest
+        };
+        let state = if let Some(manifest) = manifest {
+            TaskActionState {
+                manifest: task.to_string(),
+                baseline_loaded: true,
+                predictions: manifest
+                    .predictions
+                    .into_iter()
+                    .map(|prediction| (prediction.invocation.clone(), prediction))
+                    .collect(),
+                remote_etag,
+            }
+        } else {
+            TaskActionState {
+                manifest: task.to_string(),
+                baseline_loaded: true,
+                remote_etag,
+                ..TaskActionState::default()
+            }
+        };
+        let sequence = self.next_task_run.fetch_add(1, Ordering::Relaxed);
+        let run =
+            CacheDigest::blake3(format!("{task}\0{}\0{sequence}", std::process::id()).as_bytes())
+                .hash;
+        let predictions = state.predictions.values().cloned().collect();
+        self.task_actions.lock().unwrap().insert(run.clone(), state);
+        self.spawn_prefetch_predictions(predictions);
+        Ok(run)
+    }
+
+    /// Cancel speculative downloads before the owning session exits.
+    pub async fn cancel_prefetches(&self) {
+        let tasks = std::mem::take(&mut *self.prefetch_tasks.lock().unwrap());
+        for task in &tasks {
+            task.abort();
+        }
+        for task in tasks {
+            if let Err(error) = task.await
+                && !error.is_cancelled()
+            {
+                warn!("remote action prefetch task failed: {error}");
+            }
+        }
+    }
+
+    #[cfg(test)]
+    async fn wait_for_prefetches(&self) {
+        let tasks = std::mem::take(&mut *self.prefetch_tasks.lock().unwrap());
+        for task in tasks {
+            if let Err(error) = task.await {
+                warn!("remote action prefetch task failed: {error}");
+            }
+        }
+    }
+
+    /// Atomically publish the candidate manifest collected by a successful task.
+    pub async fn commit_task(&self, run: &str) -> Result<()> {
+        validate_task_identity(run)?;
+        let state = self
+            .task_actions
+            .lock()
+            .unwrap()
+            .get(run)
+            .cloned()
+            .ok_or_else(|| eyre::eyre!("task action manifest baseline was not loaded"))?;
+        if !state.baseline_loaded {
+            bail!("task action manifest baseline was not loaded");
+        }
+        let task = state.manifest;
+        validate_task_identity(&task)?;
+        let manifest = {
+            let _write_guard = self.manifest_write_lock.lock().unwrap();
+            let _file_guard = self.lock_task_manifest(&task)?;
+            let mut predictions = self
+                .load_task_manifest(&task)?
+                .map(|manifest| {
+                    manifest
+                        .predictions
+                        .into_iter()
+                        .map(|prediction| (prediction.invocation.clone(), prediction))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default();
+            predictions.extend(state.predictions);
+            let manifest = TaskActionManifest {
+                version: TASK_ACTION_MANIFEST_VERSION,
+                task: task.clone(),
+                predictions: predictions.into_values().collect(),
+            };
+            validate_task_manifest(&manifest, &task)?;
+            self.persist_task_manifest(&manifest)?;
+            manifest
+        };
+        self.task_actions.lock().unwrap().remove(run);
+        if self.remote_mode.writes() {
+            match self
+                .put_remote_task_manifest(&task, manifest, state.remote_etag)
+                .await
+            {
+                Ok(remote_manifest) => {
+                    let _write_guard = self.manifest_write_lock.lock().unwrap();
+                    let reconciliation = (|| {
+                        let _file_guard = self.lock_task_manifest(&task)?;
+                        let manifest = match self.load_task_manifest(&task)? {
+                            Some(local) => {
+                                merge_remote_task_manifest(&task, remote_manifest, local).0
+                            }
+                            None => remote_manifest,
+                        };
+                        self.persist_task_manifest(&manifest)
+                    })();
+                    if let Err(error) = reconciliation {
+                        warn!(
+                            "remote task action manifest reconciliation failed for {task}: {error}"
+                        );
+                    }
+                }
+                Err(error) => {
+                    warn!("remote task action manifest upload failed for {task}: {error}");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn task_manifest_path(&self, task: &str) -> PathBuf {
+        self.manifest_dir.join(format!("{task}.json"))
+    }
+
+    fn task_manifest_lock_path(&self, task: &str) -> PathBuf {
+        self.manifest_dir.join("locks").join(format!("{task}.lock"))
+    }
+
+    fn lock_task_manifest(&self, task: &str) -> Result<fslock::LockFile> {
+        let path = self.task_manifest_lock_path(task);
+        fs::create_dir_all(path.parent().expect("task manifest lock has a parent"))?;
+        let mut lock = fslock::LockFile::open(&path)?;
+        lock.lock()?;
+        Ok(lock)
+    }
+
+    fn load_task_manifest(&self, task: &str) -> Result<Option<TaskActionManifest>> {
+        match fs::read(self.task_manifest_path(task)) {
+            Ok(contents) => Ok(Some(self.parse_task_manifest(task, &contents, false)?)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn parse_task_manifest(
+        &self,
+        task: &str,
+        contents: &[u8],
+        require_canonical: bool,
+    ) -> Result<TaskActionManifest> {
+        let manifest: TaskActionManifest = serde_json::from_slice(contents)?;
+        validate_task_manifest(&manifest, task)?;
+        if require_canonical && canonical_json(&manifest)? != contents {
+            bail!("task action manifest is not canonical JSON");
+        }
+        Ok(manifest)
+    }
+
+    fn task_manifest_selector(task: &str) -> Result<(Vec<u8>, CacheDigest)> {
+        let bytes = canonical_json(&TaskActionManifestSelector {
+            version: 1,
+            kind: "task_action_manifest",
+            task,
+        })?;
+        let digest = CacheDigest::blake3(&bytes);
+        Ok((bytes, digest))
+    }
+
+    fn persist_task_manifest(&self, manifest: &TaskActionManifest) -> Result<()> {
+        let bytes = canonical_json(manifest)?;
+        fs::create_dir_all(self.manifest_dir.as_path())?;
+        let mut temporary = tempfile::NamedTempFile::new_in(self.manifest_dir.as_path())?;
+        std::io::Write::write_all(temporary.as_file_mut(), &bytes)?;
+        temporary.as_file_mut().sync_all()?;
+        temporary
+            .persist(self.task_manifest_path(&manifest.task))
+            .map_err(|error| error.error)?;
+        Ok(())
+    }
+
+    async fn get_remote_task_manifest(
+        &self,
+        task: &str,
+    ) -> Result<Option<(TaskActionManifest, String)>> {
+        let Some(remote) = &self.remote else {
+            return Ok(None);
+        };
+        let (_, selector) = Self::task_manifest_selector(task)?;
+        let _permit = self.remote_transfers.acquire().await?;
+        self.stats
+            .remote_manifest_lookups
+            .fetch_add(1, Ordering::Relaxed);
+        let _timer = AtomicDurationTimer::start(&self.stats.remote_manifest_lookup_duration_ns);
+        let Some(remote_manifest) = remote.get_action_manifest(&selector).await? else {
+            return Ok(None);
+        };
+        let manifest = self.parse_task_manifest(task, &remote_manifest.bytes, true)?;
+        Ok(Some((manifest, remote_manifest.etag)))
+    }
+
+    async fn put_remote_task_manifest(
+        &self,
+        task: &str,
+        mut manifest: TaskActionManifest,
+        mut expected_etag: Option<String>,
+    ) -> Result<TaskActionManifest> {
+        let Some(remote) = &self.remote else {
+            return Ok(manifest);
+        };
+        let (_, selector) = Self::task_manifest_selector(task)?;
+        for _ in 0..4 {
+            let bytes = canonical_json(&manifest)?;
+            let outcome = {
+                let _permit = self.remote_transfers.acquire().await?;
+                remote
+                    .put_action_manifest(&selector, &bytes, expected_etag.as_deref())
+                    .await?
+            };
+            match outcome {
+                ManifestPutOutcome::Stored => return Ok(manifest),
+                ManifestPutOutcome::PreconditionFailed => {
+                    let Some((remote_manifest, etag)) = self.get_remote_task_manifest(task).await?
+                    else {
+                        expected_etag = None;
+                        continue;
+                    };
+                    manifest = merge_task_manifests(task, Some(remote_manifest), manifest)?;
+                    expected_etag = Some(etag);
+                }
+            }
+        }
+        bail!("remote task action manifest changed too frequently")
+    }
+
+    /// Return a snapshot of this session's cache activity.
+    pub fn stats(&self) -> AgentStats {
+        AgentStats {
+            session_duration_ns: 0,
+            lookups: self.stats.lookups.load(Ordering::Relaxed),
+            hits: self.stats.hits.load(Ordering::Relaxed),
+            stores: self.stats.stores.load(Ordering::Relaxed),
+            stored_bytes: self.stats.stored_bytes.load(Ordering::Relaxed),
+            verifications: self.stats.verifications.load(Ordering::Relaxed),
+            divergences: self.stats.divergences.load(Ordering::Relaxed),
+            downloaded_bytes: self.stats.downloaded_bytes.load(Ordering::Relaxed),
+            uploaded_bytes: self.stats.uploaded_bytes.load(Ordering::Relaxed),
+            prefetched_actions: self.stats.prefetched_actions.load(Ordering::Relaxed),
+            remote_manifest_lookups: self.stats.remote_manifest_lookups.load(Ordering::Relaxed),
+            remote_manifest_lookup_duration_ns: self
+                .stats
+                .remote_manifest_lookup_duration_ns
+                .load(Ordering::Relaxed),
+            remote_action_lookups: self.stats.remote_action_lookups.load(Ordering::Relaxed),
+            remote_action_lookup_duration_ns: self
+                .stats
+                .remote_action_lookup_duration_ns
+                .load(Ordering::Relaxed),
+            remote_blob_requests: self.stats.remote_blob_requests.load(Ordering::Relaxed),
+            remote_blob_pack_requests: self.stats.remote_blob_pack_requests.load(Ordering::Relaxed),
+            remote_blob_pack_blobs: self.stats.remote_blob_pack_blobs.load(Ordering::Relaxed),
+            remote_blob_transfer_duration_ns: self
+                .stats
+                .remote_blob_transfer_duration_ns
+                .load(Ordering::Relaxed),
+            local_cas_write_duration_ns: self
+                .stats
+                .local_cas_write_duration_ns
+                .load(Ordering::Relaxed),
+            prefetch_runs: self.stats.prefetch_runs.load(Ordering::Relaxed),
+            prefetch_duration_ns: self.stats.prefetch_duration_ns.load(Ordering::Relaxed),
+            materialization_duration_ns: self
+                .stats
+                .materialization_duration_ns
+                .load(Ordering::Relaxed),
+            restored_output_files: self.stats.restored_output_files.load(Ordering::Relaxed),
+            restored_output_bytes: self.stats.restored_output_bytes.load(Ordering::Relaxed),
+        }
+    }
+
+    fn write_lock(&self, digest: &CacheDigest) -> Arc<tokio::sync::Mutex<()>> {
+        Self::digest_lock(&self.write_locks, digest)
+    }
+
+    fn action_lock(&self, digest: &CacheDigest) -> Arc<tokio::sync::Mutex<()>> {
+        Self::digest_lock(&self.action_locks, digest)
+    }
+
+    fn digest_lock(
+        locks: &Mutex<BTreeMap<CacheDigest, Weak<tokio::sync::Mutex<()>>>>,
+        digest: &CacheDigest,
+    ) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = locks.lock().unwrap();
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(digest).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(digest.clone(), Arc::downgrade(&lock));
+        lock
+    }
+
+    fn spawn_prefetch_predictions(&self, predictions: Vec<ActionPrediction>) {
+        if predictions.is_empty() || !self.remote_mode.reads() || self.remote.is_none() {
+            return;
+        }
+        let agent = self.clone();
+        let task = tokio::spawn(async move {
+            agent.prefetch_predictions(predictions.iter()).await;
+        });
+        self.prefetch_tasks.lock().unwrap().push(task);
+    }
+
+    async fn prefetch_predictions<'a>(
+        &self,
+        predictions: impl Iterator<Item = &'a ActionPrediction>,
+    ) {
+        if !self.remote_mode.reads() || self.remote.is_none() {
+            return;
+        }
+        self.stats.prefetch_runs.fetch_add(1, Ordering::Relaxed);
+        let _timer = AtomicDurationTimer::start(&self.stats.prefetch_duration_ns);
+        let mut actions = BTreeMap::new();
+        for prediction in predictions {
+            actions
+                .entry(prediction.action.clone())
+                .or_insert_with(|| prediction.adapter.clone());
+        }
+        let mut actions = actions.into_iter();
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..MAX_PREFETCH_TRANSFERS {
+            let Some((action, adapter)) = actions.next() else {
+                break;
+            };
+            let agent = self.clone();
+            tasks.spawn(async move { agent.resolve_prefetch_action(action, adapter).await });
+        }
+        let mut resolved = Vec::new();
+        while !tasks.is_empty() {
+            let result = if resolved.is_empty() {
+                tasks.join_next().await
+            } else {
+                match tokio::time::timeout(PREFETCH_ACTION_BATCH_DELAY, tasks.join_next()).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        self.prefetch_resolved_actions(std::mem::take(&mut resolved))
+                            .await;
+                        continue;
+                    }
+                }
+            };
+            let Some(result) = result else {
+                break;
+            };
+            match result {
+                Ok(Ok(Some(action))) => resolved.push(action),
+                Ok(Ok(None)) => {}
+                Ok(Err(error)) => warn!("remote action prefetch failed: {error}"),
+                Err(error) => warn!("remote action prefetch task failed: {error}"),
+            }
+            if let Some((action, adapter)) = actions.next() {
+                let agent = self.clone();
+                tasks.spawn(async move { agent.resolve_prefetch_action(action, adapter).await });
+            }
+            if resolved.len() == MAX_PREFETCH_ACTION_BATCH {
+                self.prefetch_resolved_actions(std::mem::take(&mut resolved))
+                    .await;
+            }
+        }
+        if !resolved.is_empty() {
+            self.prefetch_resolved_actions(resolved).await;
+        }
+    }
+
+    #[cfg(test)]
+    async fn prefetch_action(&self, action: CacheDigest, adapter: String) -> Result<()> {
+        if let Some(action) = self.resolve_prefetch_action(action, adapter).await? {
+            self.prefetch_resolved_actions(vec![action]).await;
+        }
+        Ok(())
+    }
+
+    async fn resolve_prefetch_action(
+        &self,
+        action: CacheDigest,
+        adapter: String,
+    ) -> Result<Option<PrefetchedAction>> {
+        let remote = self
+            .remote
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("remote cache is not configured"))?;
+        let result = {
+            let lock = self.action_lock(&action);
+            let _guard = lock.lock().await;
+            if self.actions.find(&action)?.is_some() {
+                return Ok(None);
+            }
+            if let Some(result) = self
+                .pending_remote_actions
+                .lock()
+                .unwrap()
+                .get(&action)
+                .cloned()
+            {
+                result
+            } else {
+                let _prefetch_permit = self.prefetch_transfers.acquire().await?;
+                let result = {
+                    let _permit = self.remote_transfers.acquire().await?;
+                    self.get_remote_action_result(remote, &action).await?
+                };
+                let Some(result) = result else {
+                    return Ok(None);
+                };
+                self.pending_remote_actions
+                    .lock()
+                    .unwrap()
+                    .insert(action.clone(), result.clone());
+                result
+            }
+        };
+        Ok(Some(PrefetchedAction { adapter, result }))
+    }
+
+    fn prefetch_resolved_actions(&self, actions: Vec<PrefetchedAction>) -> BoxFuture<'_, ()> {
+        self.prefetch_resolved_actions_inner(actions).boxed()
+    }
+
+    async fn prefetch_resolved_actions_inner(&self, actions: Vec<PrefetchedAction>) {
+        let Some(remote) = self.remote.as_deref() else {
+            return;
+        };
+        if actions.is_empty() {
+            return;
+        }
+
+        let mut top_level = BTreeMap::new();
+        for action in &actions {
+            for digest in [
+                Some(&action.result.action),
+                action.result.metadata.as_ref(),
+                action.result.output_root.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                top_level.insert(digest.clone(), ());
+            }
+        }
+        let mut verified = self
+            .fetch_remote_blobs(
+                remote,
+                top_level.into_keys().collect(),
+                Some(&self.prefetch_transfers),
+            )
+            .await;
+
+        let mut next = BTreeMap::new();
+        let mut pending_directories = BTreeMap::new();
+        let mut parsed_directories = BTreeMap::new();
+        let mut rustc_metadata = BTreeMap::new();
+        for action in &actions {
+            if action.adapter == "rustc"
+                && let Some(metadata_digest) = &action.result.metadata
+            {
+                match verified
+                    .get(metadata_digest)
+                    .ok_or_else(|| eyre::eyre!("remote rustc action metadata is missing"))
+                    .and_then(|path| Self::parse_rustc_metadata(path))
+                {
+                    Ok(metadata) => {
+                        queue_prefetch_digest(&verified, &mut next, metadata.stdout.clone());
+                        queue_prefetch_digest(&verified, &mut next, metadata.stderr.clone());
+                        rustc_metadata.insert(metadata_digest.clone(), metadata);
+                    }
+                    Err(error) => warn!(
+                        "remote rustc action metadata prefetch failed for {}: {error}",
+                        action.result.action.hash
+                    ),
+                }
+            }
+            if let Some(output_root) = &action.result.output_root {
+                pending_directories.insert(output_root.clone(), ());
+            }
+        }
+
+        let mut seen_directories = BTreeMap::new();
+        loop {
+            let mut following = BTreeMap::new();
+            let mut directory_limit_exceeded = false;
+            for digest in pending_directories.into_keys() {
+                following.remove(&digest);
+                if seen_directories.insert(digest.clone(), ()).is_some() {
+                    continue;
+                }
+                if seen_directories.len() > MAX_PREFETCH_DIRECTORY_OBJECTS {
+                    warn!("remote action output tree is too large to prefetch");
+                    following.clear();
+                    break;
+                }
+                match verified
+                    .get(&digest)
+                    .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))
+                    .and_then(|path| Self::parse_cache_directory(path))
+                {
+                    Ok(directory) => {
+                        for file in &directory.files {
+                            queue_prefetch_digest(&verified, &mut next, file.digest.clone());
+                            if next.len() >= MAX_PREFETCH_OBJECTS_PER_WAVE {
+                                self.flush_prefetch_digest_batch(remote, &mut verified, &mut next)
+                                    .await;
+                            }
+                        }
+                        for child in &directory.directories {
+                            if !queue_prefetch_directory(
+                                &seen_directories,
+                                &mut following,
+                                child.digest.clone(),
+                                MAX_PREFETCH_DIRECTORY_OBJECTS,
+                            ) {
+                                warn!("remote action output tree is too large to prefetch");
+                                directory_limit_exceeded = true;
+                                break;
+                            }
+                            queue_prefetch_digest(&verified, &mut next, child.digest.clone());
+                            if next.len() >= MAX_PREFETCH_OBJECTS_PER_WAVE {
+                                self.flush_prefetch_digest_batch(remote, &mut verified, &mut next)
+                                    .await;
+                            }
+                        }
+                        parsed_directories.insert(digest, directory);
+                    }
+                    Err(error) => warn!(
+                        "remote action output directory prefetch failed for {}: {error}",
+                        digest.hash
+                    ),
+                }
+                if directory_limit_exceeded {
+                    following.clear();
+                    break;
+                }
+            }
+            self.flush_prefetch_digest_batch(remote, &mut verified, &mut next)
+                .await;
+            if following.is_empty() {
+                break;
+            }
+            pending_directories = following;
+        }
+
+        for action in actions {
+            match Self::validate_prefetched_action(
+                &action,
+                &verified,
+                &rustc_metadata,
+                &parsed_directories,
+            ) {
+                Ok(()) => {
+                    if let Err(error) = self.actions.store(&action.result) {
+                        warn!(
+                            "remote action prefetch could not publish {}: {error}",
+                            action.result.action.hash
+                        );
+                        continue;
+                    }
+                    self.pending_remote_actions
+                        .lock()
+                        .unwrap()
+                        .remove(&action.result.action);
+                    self.stats
+                        .prefetched_actions
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                Err(error) => warn!(
+                    "remote action prefetch was incomplete for {}: {error}",
+                    action.result.action.hash
+                ),
+            }
+        }
+    }
+
+    async fn flush_prefetch_digest_batch(
+        &self,
+        remote: &RemoteCacheClient,
+        verified: &mut BTreeMap<CacheDigest, PathBuf>,
+        pending: &mut BTreeMap<CacheDigest, ()>,
+    ) {
+        if pending.is_empty() {
+            return;
+        }
+        let digests = std::mem::take(pending).into_keys().collect();
+        verified.extend(
+            self.fetch_remote_blobs(remote, digests, Some(&self.prefetch_transfers))
+                .await,
+        );
+    }
+
+    async fn fetch_remote_blobs(
+        &self,
+        remote: &RemoteCacheClient,
+        digests: Vec<CacheDigest>,
+        prefetch_limit: Option<&tokio::sync::Semaphore>,
+    ) -> BTreeMap<CacheDigest, PathBuf> {
+        let mut verified = BTreeMap::new();
+        let mut missing = BTreeMap::new();
+        for digest in digests {
+            match self.find_verified_blob(&digest) {
+                Ok(Some(path)) => {
+                    verified.insert(digest, path);
+                }
+                Ok(None) => {
+                    missing.insert(digest, ());
+                }
+                Err(error) => warn!(
+                    "local cache blob lookup failed for {}: {error}",
+                    digest.hash
+                ),
+            }
+        }
+        if missing.is_empty() {
+            return verified;
+        }
+
+        let mut pack_candidates = missing.clone();
+        while !pack_candidates.is_empty() {
+            let requested = pack_candidates.keys().cloned().collect::<Vec<_>>();
+            let (pack, transfer_duration_ns) = {
+                let _prefetch_permit = match prefetch_limit {
+                    Some(limit) => match limit.acquire().await {
+                        Ok(permit) => Some(permit),
+                        Err(error) => {
+                            warn!(
+                                "remote cache blob pack could not acquire prefetch limit: {error}"
+                            );
+                            break;
+                        }
+                    },
+                    None => None,
+                };
+                let _transfer_permit = match self.remote_transfers.acquire().await {
+                    Ok(permit) => permit,
+                    Err(error) => {
+                        warn!("remote cache blob pack could not acquire transfer limit: {error}");
+                        break;
+                    }
+                };
+                let transfer_started = Instant::now();
+                let pack = remote
+                    .get_blob_pack(&requested, self.remote_staging_dir.as_path())
+                    .await;
+                (pack, duration_ns(transfer_started))
+            };
+            let pack = match pack {
+                Ok(Some(pack)) => pack,
+                Ok(None) => break,
+                Err(error) => {
+                    atomic_saturating_add(
+                        &self.stats.remote_blob_transfer_duration_ns,
+                        transfer_duration_ns,
+                    );
+                    warn!(
+                        "remote cache blob pack failed; falling back to individual blobs: {error}"
+                    );
+                    break;
+                }
+            };
+            atomic_saturating_add(
+                &self.stats.remote_blob_transfer_duration_ns,
+                transfer_duration_ns,
+            );
+            atomic_saturating_add(&self.stats.remote_blob_pack_requests, pack.requests);
+            atomic_saturating_add(&self.stats.remote_blob_pack_blobs, pack.blob_count);
+            atomic_saturating_add(&self.stats.downloaded_bytes, pack.payload_bytes);
+            if pack.requested.is_empty() {
+                break;
+            }
+            for digest in &pack.requested {
+                pack_candidates.remove(digest);
+            }
+            let mut ingests = stream::iter(pack.blobs.into_iter().map(|(digest, source)| {
+                let digest_for_result = digest.clone();
+                async move {
+                    (
+                        digest_for_result,
+                        self.ingest_packed_blob(digest, source).await,
+                    )
+                }
+            }))
+            .buffer_unordered(MAX_PREFETCH_TRANSFERS);
+            while let Some((digest, result)) = ingests.next().await {
+                match result {
+                    Ok(path) => {
+                        missing.remove(&digest);
+                        verified.insert(digest, path);
+                    }
+                    Err(error) => warn!(
+                        "remote cache packed blob ingest failed for {}: {error}",
+                        digest.hash
+                    ),
+                }
+            }
+        }
+
+        let mut transfers = stream::iter(missing.into_keys().map(|digest| {
+            let digest_for_result = digest.clone();
+            async move {
+                (
+                    digest_for_result,
+                    self.fetch_remote_blob_with_limit(remote, &digest, prefetch_limit)
+                        .await,
+                )
+            }
+        }))
+        .buffer_unordered(MAX_PREFETCH_TRANSFERS);
+        while let Some((digest, result)) = transfers.next().await {
+            match result {
+                Ok(path) => {
+                    verified.insert(digest, path);
+                }
+                Err(error) => warn!(
+                    "remote cache blob prefetch failed for {}: {error}",
+                    digest.hash
+                ),
+            }
+        }
+        verified
+    }
+
+    async fn ingest_packed_blob(&self, digest: CacheDigest, source: PathBuf) -> Result<PathBuf> {
+        let digest_size = digest.size;
+        let lock = self.write_lock(&digest);
+        let _guard = lock.lock().await;
+        let agent = self.clone();
+        let (path, stored, cas_duration_ns) = tokio::task::spawn_blocking(move || {
+            if let Some(path) = agent.find_verified_blob(&digest)? {
+                return Ok::<_, eyre::Report>((path, false, 0));
+            }
+            let cas_started = Instant::now();
+            let path = agent.cas.store_verified_file(&digest, &source)?;
+            let cas_duration_ns = duration_ns(cas_started);
+            agent.remember_verified_blob(&digest, &path);
+            Ok((path, true, cas_duration_ns))
+        })
+        .await??;
+        atomic_saturating_add(&self.stats.local_cas_write_duration_ns, cas_duration_ns);
+        if stored {
+            self.stats.stores.fetch_add(1, Ordering::Relaxed);
+            atomic_saturating_add(&self.stats.stored_bytes, digest_size);
+        }
+        Ok(path)
+    }
+
+    fn parse_rustc_metadata(path: &Path) -> Result<RustcMetadata> {
+        let bytes = fs::read(path)?;
+        let metadata: RustcMetadata = serde_json::from_slice(&bytes)?;
+        if metadata.version != 1 || metadata.kind != "rustc" || canonical_json(&metadata)? != bytes
+        {
+            bail!("remote rustc action metadata is invalid");
+        }
+        Ok(metadata)
+    }
+
+    fn parse_cache_directory(path: &Path) -> Result<CacheDirectory> {
+        let bytes = fs::read(path)?;
+        let directory: CacheDirectory = serde_json::from_slice(&bytes)?;
+        if directory.version != 1 || canonical_json(&directory)? != bytes {
+            bail!("remote action output directory is invalid");
+        }
+        Ok(directory)
+    }
+
+    #[cfg(test)]
+    fn load_cache_directory(&self, digest: &CacheDigest) -> Result<CacheDirectory> {
+        let path = self
+            .find_verified_blob(digest)?
+            .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))?;
+        Self::parse_cache_directory(&path)
+    }
+
+    fn validate_prefetched_action(
+        action: &PrefetchedAction,
+        verified: &BTreeMap<CacheDigest, PathBuf>,
+        rustc_metadata: &BTreeMap<CacheDigest, RustcMetadata>,
+        directories: &BTreeMap<CacheDigest, CacheDirectory>,
+    ) -> Result<()> {
+        if !verified.contains_key(&action.result.action) {
+            bail!("remote action descriptor is missing");
+        }
+        if let Some(metadata) = &action.result.metadata {
+            if action.adapter == "rustc" {
+                let metadata = rustc_metadata
+                    .get(metadata)
+                    .ok_or_else(|| eyre::eyre!("remote rustc action metadata is missing"))?;
+                for digest in [&metadata.stdout, &metadata.stderr] {
+                    if !verified.contains_key(digest) {
+                        bail!("remote rustc action diagnostic blob is missing");
+                    }
+                }
+            } else if !verified.contains_key(metadata) {
+                bail!("remote action metadata is missing");
+            }
+        }
+        let mut pending = action
+            .result
+            .output_root
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut seen = BTreeMap::new();
+        while let Some(digest) = pending.pop() {
+            if seen.insert(digest.clone(), ()).is_some() {
+                continue;
+            }
+            if seen.len() > MAX_PREFETCH_DIRECTORY_OBJECTS {
+                bail!("remote action output tree is too large");
+            }
+            let directory = directories
+                .get(&digest)
+                .ok_or_else(|| eyre::eyre!("remote action output directory is missing"))?;
+            for file in &directory.files {
+                if !verified.contains_key(&file.digest) {
+                    bail!("remote action output file is missing");
+                }
+            }
+            pending.extend(
+                directory
+                    .directories
+                    .iter()
+                    .map(|directory| directory.digest.clone()),
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    async fn prefetch_output_tree(
+        &self,
+        remote: &RemoteCacheClient,
+        output_root: &CacheDigest,
+    ) -> Result<()> {
+        let mut pending = vec![output_root.clone()];
+        let mut seen = BTreeMap::new();
+        while let Some(digest) = pending.pop() {
+            if seen.insert(digest.clone(), ()).is_some() {
+                continue;
+            }
+            if seen.len() > MAX_PREFETCH_DIRECTORY_OBJECTS {
+                bail!("remote action output tree is too large");
+            }
+            self.fetch_remote_blob_with_limit(remote, &digest, Some(&self.prefetch_transfers))
+                .await?;
+            let directory = self.load_cache_directory(&digest)?;
+            let mut transfers = stream::iter(directory.files.into_iter().map(|file| async move {
+                self.fetch_remote_blob_with_limit(
+                    remote,
+                    &file.digest,
+                    Some(&self.prefetch_transfers),
+                )
+                .await
+                .map(|_| ())
+            }))
+            .buffer_unordered(MAX_PREFETCH_TRANSFERS);
+            while let Some(result) = transfers.next().await {
+                result?;
+            }
+            pending.extend(
+                directory
+                    .directories
+                    .into_iter()
+                    .map(|directory| directory.digest),
+            );
+        }
+        Ok(())
+    }
+
+    async fn fetch_remote_blob(
+        &self,
+        remote: &RemoteCacheClient,
+        digest: &CacheDigest,
+    ) -> Result<PathBuf> {
+        self.fetch_remote_blob_with_limit(remote, digest, None)
+            .await
+    }
+
+    async fn fetch_remote_blob_with_limit(
+        &self,
+        remote: &RemoteCacheClient,
+        digest: &CacheDigest,
+        prefetch_limit: Option<&tokio::sync::Semaphore>,
+    ) -> Result<PathBuf> {
+        let lock = self.write_lock(digest);
+        let _guard = lock.lock().await;
+        if let Some(path) = self.find_verified_blob(digest)? {
+            return Ok(path);
+        }
+        let _prefetch_permit = match prefetch_limit {
+            Some(limit) => Some(limit.acquire().await?),
+            None => None,
+        };
+        let _permit = self.remote_transfers.acquire().await?;
+        self.stats
+            .remote_blob_requests
+            .fetch_add(1, Ordering::Relaxed);
+        let transfer_timer =
+            AtomicDurationTimer::start(&self.stats.remote_blob_transfer_duration_ns);
+        let temporary = remote
+            .get_blob_file(digest, self.remote_staging_dir.as_path())
+            .await?;
+        drop(transfer_timer);
+        let _cas_timer = AtomicDurationTimer::start(&self.stats.local_cas_write_duration_ns);
+        let path = self.cas.store_verified_file(digest, temporary.path())?;
+        self.remember_verified_blob(digest, &path);
+        self.stats.stores.fetch_add(1, Ordering::Relaxed);
+        self.stats
+            .stored_bytes
+            .fetch_add(digest.size, Ordering::Relaxed);
+        self.stats
+            .downloaded_bytes
+            .fetch_add(digest.size, Ordering::Relaxed);
+        Ok(path)
+    }
+
+    async fn respond(&self, request: AgentRequest) -> AgentResponse {
+        let result = match request {
+            AgentRequest::FindBlob { digest } => self.find_blob(&digest).await,
+            AgentRequest::FindBlobs { digests } => self.find_blobs(digests).await,
+            AgentRequest::StoreBlob { digest, source } => self.store_blob(&digest, &source).await,
+            AgentRequest::FindActionResult { action } => {
+                self.stats.lookups.fetch_add(1, Ordering::Relaxed);
+                self.find_action_result(&action).await
+            }
+            AgentRequest::RecordActionHit { action, restore } => {
+                self.record_action_hit(&action, restore)
+            }
+            AgentRequest::RecordActionVerification { matched, restore } => {
+                self.record_materialization(restore);
+                self.stats.verifications.fetch_add(1, Ordering::Relaxed);
+                if !matched {
+                    self.stats.divergences.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(AgentResponse::ActionVerificationRecorded)
+            }
+            AgentRequest::StoreActionResult { result } => self.store_action_result(&result).await,
+            AgentRequest::FindActionPrediction { task, invocation } => {
+                self.find_action_prediction(&task, &invocation)
+            }
+            AgentRequest::RecordActionPrediction { task, prediction } => {
+                self.record_action_prediction(&task, prediction)
+            }
+            AgentRequest::FindExecutableIdentity {
+                executable,
+                environment,
+            } => self.find_executable_identity(executable, environment),
+            AgentRequest::StoreExecutableIdentity {
+                executable,
+                environment,
+                stdout,
+            } => self.store_executable_identity(executable, environment, stdout),
+            AgentRequest::Hello { .. } => {
+                Err(eyre::eyre!("hello is only valid as the first request"))
+            }
+        };
+        result.unwrap_or_else(|error| AgentResponse::Error {
+            message: error.to_string(),
+        })
+    }
+
+    async fn find_blob(&self, digest: &CacheDigest) -> Result<AgentResponse> {
+        if let Some(path) = self.find_verified_blob(digest)? {
+            return Ok(AgentResponse::Blob { path: Some(path) });
+        }
+        if !self.remote_mode.reads() {
+            return Ok(AgentResponse::Blob { path: None });
+        }
+        let Some(remote) = &self.remote else {
+            return Ok(AgentResponse::Blob { path: None });
+        };
+        match self.fetch_remote_blob(remote, digest).await {
+            Ok(path) => Ok(AgentResponse::Blob { path: Some(path) }),
+            Err(error) => {
+                warn!(
+                    "remote cache blob lookup failed for {}: {error}",
+                    digest.hash
+                );
+                Ok(AgentResponse::Blob { path: None })
+            }
+        }
+    }
+
+    async fn find_blobs(&self, digests: Vec<CacheDigest>) -> Result<AgentResponse> {
+        let mut paths = BTreeMap::new();
+        let mut missing = Vec::new();
+        for digest in &digests {
+            match self.find_verified_blob(digest)? {
+                Some(path) => {
+                    paths.insert(digest.clone(), path);
+                }
+                None => {
+                    missing.push(digest.clone());
+                }
+            }
+        }
+
+        if !missing.is_empty()
+            && self.remote_mode.reads()
+            && let Some(remote) = &self.remote
+        {
+            paths.extend(self.fetch_remote_blobs(remote, missing, None).await);
+        }
+
+        Ok(AgentResponse::Blobs {
+            paths: digests
+                .into_iter()
+                .map(|digest| paths.get(&digest).cloned())
+                .collect(),
+        })
+    }
+
+    async fn store_blob(&self, digest: &CacheDigest, source: &Path) -> Result<AgentResponse> {
+        let remote = if self.remote_mode.writes() {
+            self.remote.as_deref()
+        } else {
+            None
+        };
+        let path = {
+            let lock = self.write_lock(digest);
+            let _guard = lock.lock().await;
+            if let Some(path) = self.find_verified_blob(digest)? {
+                path
+            } else {
+                let path = self.cas.store_file(digest, source)?;
+                self.remember_verified_blob(digest, &path);
+                self.stats.stores.fetch_add(1, Ordering::Relaxed);
+                self.stats
+                    .stored_bytes
+                    .fetch_add(digest.size, Ordering::Relaxed);
+                path
+            }
+        };
+        if let Some(remote) = remote {
+            let _permit = self.remote_transfers.acquire().await?;
+            if let Err(error) = remote
+                .put_blob(&BlobUpload {
+                    digest: digest.clone(),
+                    source: BlobSource::Path(path.clone()),
+                })
+                .await
+            {
+                warn!(
+                    "remote cache blob upload failed for {}: {error}",
+                    digest.hash
+                );
+            } else {
+                self.stats
+                    .uploaded_bytes
+                    .fetch_add(digest.size, Ordering::Relaxed);
+            }
+        }
+        Ok(AgentResponse::Stored { path })
+    }
+
+    fn find_verified_blob(&self, digest: &CacheDigest) -> Result<Option<PathBuf>> {
+        let remembered = self.verified_blobs.lock().unwrap().get(digest).cloned();
+        if let Some(path) = remembered {
+            if digest.matches_file(&path).unwrap_or(false) {
+                return Ok(Some(path));
+            }
+            self.verified_blobs.lock().unwrap().remove(digest);
+        }
+        let path = self.cas.find(digest)?;
+        if let Some(path) = &path {
+            self.remember_verified_blob(digest, path);
+        }
+        Ok(path)
+    }
+
+    fn remember_verified_blob(&self, digest: &CacheDigest, path: &Path) {
+        self.verified_blobs
+            .lock()
+            .unwrap()
+            .insert(digest.clone(), path.to_path_buf());
+    }
+
+    async fn find_action_result(&self, action: &CacheDigest) -> Result<AgentResponse> {
+        if let Some(result) = self.actions.find(action)? {
+            return Ok(AgentResponse::ActionResult {
+                result: Some(result),
+            });
+        }
+        if !self.remote_mode.reads() {
+            return Ok(AgentResponse::ActionResult { result: None });
+        }
+        let Some(remote) = &self.remote else {
+            return Ok(AgentResponse::ActionResult { result: None });
+        };
+        let lock = self.action_lock(action);
+        let _guard = lock.lock().await;
+        if let Some(result) = self.actions.find(action)? {
+            return Ok(AgentResponse::ActionResult {
+                result: Some(result),
+            });
+        }
+        if let Some(result) = self
+            .pending_remote_actions
+            .lock()
+            .unwrap()
+            .get(action)
+            .cloned()
+        {
+            return Ok(AgentResponse::ActionResult {
+                result: Some(result),
+            });
+        }
+        let _permit = self.remote_transfers.acquire().await?;
+        match self.get_remote_action_result(remote, action).await {
+            Ok(Some(result)) => {
+                self.pending_remote_actions
+                    .lock()
+                    .unwrap()
+                    .insert(action.clone(), result.clone());
+                Ok(AgentResponse::ActionResult {
+                    result: Some(result),
+                })
+            }
+            Ok(None) => Ok(AgentResponse::ActionResult { result: None }),
+            Err(error) => {
+                warn!(
+                    "remote cache action lookup failed for {}: {error}",
+                    action.hash
+                );
+                Ok(AgentResponse::ActionResult { result: None })
+            }
+        }
+    }
+
+    async fn store_action_result(&self, result: &RemoteActionResult) -> Result<AgentResponse> {
+        let path = self.actions.store(result)?;
+        if self.remote_mode.writes()
+            && let Some(remote) = &self.remote
+        {
+            let _permit = self.remote_transfers.acquire().await?;
+            if let Err(error) = remote.put_action_result(result).await {
+                warn!(
+                    "remote cache action upload failed for {}: {error}",
+                    result.action.hash
+                );
+            }
+        }
+        Ok(AgentResponse::ActionStored { path })
+    }
+
+    async fn get_remote_action_result(
+        &self,
+        remote: &RemoteCacheClient,
+        action: &CacheDigest,
+    ) -> Result<Option<RemoteActionResult>> {
+        self.stats
+            .remote_action_lookups
+            .fetch_add(1, Ordering::Relaxed);
+        let _timer = AtomicDurationTimer::start(&self.stats.remote_action_lookup_duration_ns);
+        remote.get_action_result(action).await
+    }
+
+    fn record_action_hit(
+        &self,
+        action: &CacheDigest,
+        restore: RestoreStats,
+    ) -> Result<AgentResponse> {
+        if self.actions.find(action)?.is_none() {
+            let pending = self.pending_remote_actions.lock().unwrap().remove(action);
+            if let Some(result) = pending {
+                self.actions.store(&result)?;
+            } else {
+                bail!("cannot record a hit for a missing action result");
+            }
+        }
+        self.record_restore(restore);
+        self.stats.hits.fetch_add(1, Ordering::Relaxed);
+        Ok(AgentResponse::ActionHitRecorded)
+    }
+
+    fn record_restore(&self, restore: RestoreStats) {
+        self.record_materialization(restore);
+        atomic_saturating_add(&self.stats.restored_output_files, restore.output_files);
+        atomic_saturating_add(&self.stats.restored_output_bytes, restore.output_bytes);
+    }
+
+    fn record_materialization(&self, restore: RestoreStats) {
+        atomic_saturating_add(&self.stats.materialization_duration_ns, restore.duration_ns);
+    }
+
+    fn find_action_prediction(
+        &self,
+        task: &str,
+        invocation: &CacheDigest,
+    ) -> Result<AgentResponse> {
+        validate_task_identity(task)?;
+        invocation.validate()?;
+        let prediction = self
+            .task_actions
+            .lock()
+            .unwrap()
+            .get(task)
+            .and_then(|state| state.predictions.get(invocation))
+            .cloned();
+        Ok(AgentResponse::ActionPrediction { prediction })
+    }
+
+    fn record_action_prediction(
+        &self,
+        task: &str,
+        prediction: ActionPrediction,
+    ) -> Result<AgentResponse> {
+        validate_task_identity(task)?;
+        validate_action_prediction(&prediction)?;
+        let mut tasks = self.task_actions.lock().unwrap();
+        let state = tasks.entry(task.to_string()).or_default();
+        if !state.predictions.contains_key(&prediction.invocation)
+            && state.predictions.len() >= MAX_TASK_ACTION_PREDICTIONS
+        {
+            bail!("task action manifest contains too many predictions");
+        }
+        state
+            .predictions
+            .insert(prediction.invocation.clone(), prediction);
+        Ok(AgentResponse::ActionPredictionRecorded)
+    }
+
+    fn executable_identity_key(
+        &self,
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+    ) -> Result<ExecutableIdentityKey> {
+        if !environment
+            .keys()
+            .all(|name| matches!(name.as_str(), "RUSTUP_HOME" | "RUSTUP_TOOLCHAIN"))
+        {
+            bail!("executable identity contains an unsupported environment variable");
+        }
+        Ok(ExecutableIdentityKey {
+            executable,
+            environment,
+        })
+    }
+
+    fn find_executable_identity(
+        &self,
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+    ) -> Result<AgentResponse> {
+        let key = self.executable_identity_key(executable, environment)?;
+        let stdout = self
+            .executable_identities
+            .lock()
+            .unwrap()
+            .get(&key)
+            .cloned();
+        Ok(AgentResponse::ExecutableIdentity { stdout })
+    }
+
+    fn store_executable_identity(
+        &self,
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+        stdout: Vec<u8>,
+    ) -> Result<AgentResponse> {
+        if stdout.len() > MAX_EXECUTABLE_IDENTITY_SIZE {
+            bail!("executable identity exceeds {MAX_EXECUTABLE_IDENTITY_SIZE} bytes");
+        }
+        let key = self.executable_identity_key(executable, environment)?;
+        let mut identities = self.executable_identities.lock().unwrap();
+        let is_new = !identities.contains_key(&key);
+        let previous_size = identities.get(&key).map_or(0, Vec::len);
+        if is_new && identities.len() >= MAX_EXECUTABLE_IDENTITIES {
+            bail!("executable identity cache contains too many entries");
+        }
+        let retained_bytes = identities.values().map(Vec::len).sum::<usize>();
+        if retained_bytes - previous_size + stdout.len() > MAX_EXECUTABLE_IDENTITY_BYTES {
+            bail!("executable identity cache contains too many bytes");
+        }
+        identities.insert(key, stdout.clone());
+        Ok(AgentResponse::ExecutableIdentity {
+            stdout: Some(stdout),
+        })
+    }
+
+    /// Serve newline-delimited protocol requests on an authenticated session stream.
+    pub async fn handle_connection<S>(&self, stream: S) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let (reader, mut writer) = tokio::io::split(stream);
+        let mut lines = BufReader::new(reader).lines();
+        let hello = lines
+            .next_line()
+            .await?
+            .ok_or_else(|| eyre::eyre!("connection closed before the agent handshake"))?;
+        let request: AgentRequest = serde_json::from_str(&hello)?;
+        match request {
+            AgentRequest::Hello {
+                protocol,
+                client_version,
+            } if protocol == AGENT_PROTOCOL_VERSION && client_version == self.version.as_ref() => {}
+            AgentRequest::Hello { protocol, .. } if protocol != AGENT_PROTOCOL_VERSION => {
+                send_response(
+                    &mut writer,
+                    &AgentResponse::Error {
+                        message: format!(
+                            "unsupported agent protocol {protocol}; expected {AGENT_PROTOCOL_VERSION}"
+                        ),
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
+            AgentRequest::Hello { client_version, .. } => {
+                send_response(
+                    &mut writer,
+                    &AgentResponse::Error {
+                        message: format!(
+                            "cache client {client_version} does not match agent {}",
+                            self.version
+                        ),
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
+            _ => bail!("the first agent request must be hello"),
+        }
+        send_response(
+            &mut writer,
+            &AgentResponse::Hello {
+                protocol: AGENT_PROTOCOL_VERSION,
+                agent_version: self.version.to_string(),
+            },
+        )
+        .await?;
+
+        while let Some(line) = lines.next_line().await? {
+            let response = match serde_json::from_str(&line) {
+                Ok(request) => self.respond(request).await,
+                Err(error) => AgentResponse::Error {
+                    message: format!("invalid agent request: {error}"),
+                },
+            };
+            send_response(&mut writer, &response).await?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_task_identity(task: &str) -> Result<()> {
+    if task.len() != 64
+        || !task
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("invalid task action identity");
+    }
+    Ok(())
+}
+
+fn validate_action_prediction(prediction: &ActionPrediction) -> Result<()> {
+    prediction.invocation.validate()?;
+    prediction.action.validate()?;
+    if prediction.adapter.is_empty()
+        || !prediction
+            .adapter
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        bail!("invalid action prediction adapter");
+    }
+    if prediction.payload.len() > MAX_ACTION_PREDICTION_PAYLOAD {
+        bail!("action prediction payload is too large");
+    }
+    serde_json::from_str::<serde_json::Value>(&prediction.payload)?;
+    Ok(())
+}
+
+fn validate_task_manifest(manifest: &TaskActionManifest, task: &str) -> Result<()> {
+    if manifest.version != TASK_ACTION_MANIFEST_VERSION || manifest.task != task {
+        bail!("task action manifest has an invalid identity");
+    }
+    if manifest.predictions.len() > MAX_TASK_ACTION_PREDICTIONS {
+        bail!("task action manifest contains too many predictions");
+    }
+    let mut invocations = BTreeMap::new();
+    for prediction in &manifest.predictions {
+        validate_action_prediction(prediction)?;
+        if invocations.insert(&prediction.invocation, ()).is_some() {
+            bail!("task action manifest contains duplicate predictions");
+        }
+    }
+    Ok(())
+}
+
+fn merge_task_manifests(
+    task: &str,
+    base: Option<TaskActionManifest>,
+    update: TaskActionManifest,
+) -> Result<TaskActionManifest> {
+    validate_task_manifest(&update, task)?;
+    let mut predictions = BTreeMap::new();
+    if let Some(base) = base {
+        validate_task_manifest(&base, task)?;
+        predictions.extend(
+            base.predictions
+                .into_iter()
+                .map(|prediction| (prediction.invocation.clone(), prediction)),
+        );
+    }
+    predictions.extend(
+        update
+            .predictions
+            .into_iter()
+            .map(|prediction| (prediction.invocation.clone(), prediction)),
+    );
+    let manifest = TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.to_owned(),
+        predictions: predictions.into_values().collect(),
+    };
+    validate_task_manifest(&manifest, task)?;
+    Ok(manifest)
+}
+
+fn merge_remote_task_manifest(
+    task: &str,
+    remote: TaskActionManifest,
+    local: TaskActionManifest,
+) -> (TaskActionManifest, bool) {
+    match merge_task_manifests(task, Some(remote), local.clone()) {
+        Ok(manifest) => (manifest, true),
+        Err(error) => {
+            warn!("remote task action manifest merge failed for {task}: {error}");
+            (local, false)
+        }
+    }
+}
+
+async fn send_response(
+    writer: &mut (impl AsyncWrite + Unpin),
+    response: &AgentResponse,
+) -> Result<()> {
+    let mut encoded = serde_json::to_vec(response)?;
+    encoded.push(b'\n');
+    writer.write_all(&encoded).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ACTION_RESULT_MEDIA_TYPE;
+    use std::time::Duration;
+
+    #[test]
+    fn directory_queue_counts_only_unique_unseen_nodes() {
+        let shared = CacheDigest::blake3(b"shared");
+        let first = CacheDigest::blake3(b"first");
+        let second = CacheDigest::blake3(b"second");
+        let overflow = CacheDigest::blake3(b"overflow");
+        let seen = BTreeMap::from([(shared.clone(), ())]);
+        let mut pending = BTreeMap::new();
+
+        assert!(queue_prefetch_directory(&seen, &mut pending, shared, 3));
+        assert!(pending.is_empty());
+        assert!(queue_prefetch_directory(
+            &seen,
+            &mut pending,
+            first.clone(),
+            3
+        ));
+        assert!(queue_prefetch_directory(&seen, &mut pending, first, 3));
+        assert!(queue_prefetch_directory(&seen, &mut pending, second, 3));
+        assert!(!queue_prefetch_directory(&seen, &mut pending, overflow, 3));
+        assert_eq!(pending.len(), 2);
+    }
+
+    async fn handshake(stream: &mut (impl AsyncRead + AsyncWrite + Unpin), version: &str) {
+        let request = AgentRequest::Hello {
+            protocol: AGENT_PROTOCOL_VERSION,
+            client_version: version.to_string(),
+        };
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        stream.write_all(&encoded).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut response = String::new();
+        BufReader::new(stream)
+            .read_line(&mut response)
+            .await
+            .unwrap();
+        assert!(matches!(
+            serde_json::from_str(&response).unwrap(),
+            AgentResponse::Hello { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn handshake_and_blob_round_trip() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source");
+        std::fs::write(&source, b"cached object").unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+        let (mut client, server) = tokio::io::duplex(16 * 1024);
+        let server_agent = agent.clone();
+        let task = tokio::spawn(async move { server_agent.handle_connection(server).await });
+
+        handshake(&mut client, "test-version").await;
+        let request = AgentRequest::StoreBlob {
+            digest: digest.clone(),
+            source,
+        };
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        client.write_all(&encoded).await.unwrap();
+        let mut response = String::new();
+        BufReader::new(&mut client)
+            .read_line(&mut response)
+            .await
+            .unwrap();
+        assert!(matches!(
+            serde_json::from_str(&response).unwrap(),
+            AgentResponse::Stored { .. }
+        ));
+        drop(client);
+        task.await.unwrap().unwrap();
+        assert_eq!(
+            agent.stats(),
+            AgentStats {
+                stores: 1,
+                stored_bytes: digest.size,
+                ..AgentStats::default()
+            }
+        );
+    }
+
+    #[test]
+    fn remembered_blobs_reject_same_size_corruption() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+        let digest = CacheDigest::blake3(b"cached object");
+        let path = agent.cas.store_bytes(&digest, b"cached object").unwrap();
+        assert_eq!(
+            agent.find_verified_blob(&digest).unwrap(),
+            Some(path.clone())
+        );
+
+        std::fs::write(&path, b"broken object").unwrap();
+
+        assert!(agent.find_verified_blob(&digest).is_err());
+        assert!(!agent.verified_blobs.lock().unwrap().contains_key(&digest));
+    }
+
+    #[tokio::test]
+    async fn publishes_a_complete_action_result() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+        let action = CacheDigest::blake3(b"action");
+        let metadata = CacheDigest::blake3(b"metadata");
+        let output_root = CacheDigest::blake3(b"directory");
+        for (digest, contents) in [
+            (&action, b"action".as_slice()),
+            (&metadata, b"metadata".as_slice()),
+            (&output_root, b"directory".as_slice()),
+        ] {
+            agent.cas.store_bytes(digest, contents).unwrap();
+        }
+        let response = agent
+            .respond(AgentRequest::StoreActionResult {
+                result: RemoteActionResult {
+                    action: action.clone(),
+                    metadata: Some(metadata),
+                    output_root: Some(output_root),
+                    version: 1,
+                },
+            })
+            .await;
+        assert!(matches!(response, AgentResponse::ActionStored { .. }));
+        let response = agent
+            .respond(AgentRequest::FindActionResult {
+                action: action.clone(),
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ActionResult {
+                result: Some(result)
+            } if result.action == action
+        ));
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionHit {
+                    action: action.clone(),
+                    restore: RestoreStats {
+                        duration_ns: 7,
+                        output_files: 2,
+                        output_bytes: 11,
+                    },
+                })
+                .await,
+            AgentResponse::ActionHitRecorded
+        ));
+        assert_eq!(
+            agent.stats(),
+            AgentStats {
+                lookups: 1,
+                hits: 1,
+                materialization_duration_ns: 7,
+                restored_output_files: 2,
+                restored_output_bytes: 11,
+                ..AgentStats::default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_action_result_is_a_cache_miss() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        let action = CacheDigest::blake3(b"missing action");
+        let response = agent
+            .respond(AgentRequest::FindActionResult {
+                action: action.clone(),
+            })
+            .await;
+
+        assert!(matches!(
+            response,
+            AgentResponse::ActionResult { result: None }
+        ));
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionHit {
+                    action,
+                    restore: RestoreStats::default(),
+                })
+                .await,
+            AgentResponse::Error { .. }
+        ));
+        assert_eq!(
+            agent.stats(),
+            AgentStats {
+                lookups: 1,
+                ..AgentStats::default()
+            }
+        );
+
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionVerification {
+                    matched: false,
+                    restore: RestoreStats {
+                        duration_ns: 7,
+                        output_files: 2,
+                        output_bytes: 11,
+                    },
+                })
+                .await,
+            AgentResponse::ActionVerificationRecorded
+        ));
+        assert_eq!(agent.stats().verifications, 1);
+        assert_eq!(agent.stats().divergences, 1);
+        assert_eq!(agent.stats().materialization_duration_ns, 7);
+        assert_eq!(agent.stats().restored_output_files, 0);
+        assert_eq!(agent.stats().restored_output_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn coalesces_repeated_remote_action_lookups() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let action = CacheDigest::blake3(b"remote action");
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: None,
+            output_root: None,
+            version: 1,
+        };
+        let remote = server
+            .mock("GET", action_path(&action).as_str())
+            .with_status(200)
+            .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+            .with_body(serde_json::to_vec(&result).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+
+        for _ in 0..2 {
+            assert!(matches!(
+                agent
+                    .respond(AgentRequest::FindActionResult {
+                        action: action.clone(),
+                    })
+                    .await,
+                AgentResponse::ActionResult {
+                    result: Some(found)
+                } if found == result
+            ));
+        }
+        remote.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn publishes_only_successfully_committed_task_action_manifests() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache");
+        let task = "a".repeat(64);
+        let first_invocation = CacheDigest::blake3(b"first invocation");
+        let first = ActionPrediction {
+            invocation: first_invocation.clone(),
+            action: CacheDigest::blake3(b"first action"),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+
+        let agent = CacheAgent::new(&cache, "test-version");
+        let first_run = agent.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: first_run.clone(),
+                    prediction: first.clone(),
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+        agent.commit_task(&first_run).await.unwrap();
+
+        let uncommitted = CacheAgent::new(&cache, "test-version");
+        let uncommitted_run = uncommitted.begin_task(&task).await.unwrap();
+        let second_invocation = CacheDigest::blake3(b"second invocation");
+        assert!(matches!(
+            uncommitted
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: uncommitted_run,
+                    prediction: ActionPrediction {
+                        invocation: second_invocation.clone(),
+                        action: CacheDigest::blake3(b"second action"),
+                        adapter: "rustc".into(),
+                        payload: "{}".into(),
+                    },
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+
+        let next_session = CacheAgent::new(&cache, "test-version");
+        let next_run = next_session.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            next_session
+                .respond(AgentRequest::FindActionPrediction {
+                    task: next_run.clone(),
+                    invocation: first_invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction {
+                prediction: Some(prediction)
+            } if prediction == first
+        ));
+        assert!(matches!(
+            next_session
+                .respond(AgentRequest::FindActionPrediction {
+                    task: next_run,
+                    invocation: second_invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction { prediction: None }
+        ));
+
+        let corrupt_task = "b".repeat(64);
+        fs::create_dir_all(next_session.manifest_dir.as_path()).unwrap();
+        fs::write(next_session.task_manifest_path(&corrupt_task), b"not json").unwrap();
+        assert!(next_session.begin_task(&corrupt_task).await.is_err());
+        let corrupt_run = "c".repeat(64);
+        next_session.task_actions.lock().unwrap().insert(
+            corrupt_run.clone(),
+            TaskActionState {
+                manifest: corrupt_task.clone(),
+                ..TaskActionState::default()
+            },
+        );
+        assert!(matches!(
+            next_session
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: corrupt_run.clone(),
+                    prediction: first,
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+        assert!(next_session.commit_task(&corrupt_run).await.is_err());
+        assert_eq!(
+            fs::read(next_session.task_manifest_path(&corrupt_task)).unwrap(),
+            b"not json"
+        );
+    }
+
+    #[tokio::test]
+    async fn round_trips_task_actions_between_fresh_local_caches() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let task = "e".repeat(64);
+        let invocation = CacheDigest::blake3(b"remote invocation");
+        let action_bytes = canonical_json(&serde_json::json!({"kind":"rustc"})).unwrap();
+        let stdout_bytes = b"cached stdout".to_vec();
+        let stderr_bytes = b"cached stderr".to_vec();
+        let artifact_bytes = b"cached artifact".to_vec();
+        let stdout = CacheDigest::blake3(&stdout_bytes);
+        let stderr = CacheDigest::blake3(&stderr_bytes);
+        let artifact = CacheDigest::blake3(&artifact_bytes);
+        let metadata_bytes = canonical_json(&RustcMetadata {
+            version: 1,
+            kind: "rustc".into(),
+            stdout: stdout.clone(),
+            stderr: stderr.clone(),
+        })
+        .unwrap();
+        let directory_bytes = canonical_json(&serde_json::json!({
+            "directories":[],
+            "files":[{"digest":artifact,"executable":false,"mode":420,"name":"artifact"}],
+            "symlinks":[],
+            "version":1
+        }))
+        .unwrap();
+        let action = CacheDigest::blake3(&action_bytes);
+        let metadata = CacheDigest::blake3(&metadata_bytes);
+        let output_root = CacheDigest::blake3(&directory_bytes);
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.clone()),
+            output_root: Some(output_root.clone()),
+            version: 1,
+        };
+        let prediction = ActionPrediction {
+            invocation: invocation.clone(),
+            action: action.clone(),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+        let manifest_bytes = canonical_json(&TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: vec![prediction.clone()],
+        })
+        .unwrap();
+        let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+        let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+
+        let mut mocks = Vec::new();
+        for (digest, bytes) in [
+            (&action, action_bytes.as_slice()),
+            (&metadata, metadata_bytes.as_slice()),
+            (&output_root, directory_bytes.as_slice()),
+            (&stdout, stdout_bytes.as_slice()),
+            (&stderr, stderr_bytes.as_slice()),
+            (&artifact, artifact_bytes.as_slice()),
+        ] {
+            mocks.push(
+                server
+                    .mock("PUT", blob_path(digest).as_str())
+                    .match_header("mbx-cache-namespace", "test")
+                    .match_body(bytes.to_vec())
+                    .with_status(200)
+                    .expect(1)
+                    .create_async()
+                    .await,
+            );
+        }
+        mocks.push(
+            server
+                .mock("PUT", action_path(&result.action).as_str())
+                .match_header("mbx-cache-namespace", "test")
+                .with_status(200)
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        mocks.push(
+            server
+                .mock("PUT", action_manifest_path(&selector).as_str())
+                .match_header("mbx-cache-namespace", "test")
+                .match_header("if-none-match", "*")
+                .match_body(manifest_bytes.clone())
+                .with_status(201)
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        mocks.push(
+            server
+                .mock("GET", action_manifest_path(&selector).as_str())
+                .with_status(200)
+                .with_header("etag", &format!("\"{manifest_etag}\""))
+                .with_body(manifest_bytes.clone())
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        mocks.push(
+            server
+                .mock("GET", action_path(&action).as_str())
+                .with_status(200)
+                .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+                .with_body(serde_json::to_vec(&result).unwrap())
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        for (digest, bytes) in [
+            (&action, action_bytes.as_slice()),
+            (&metadata, metadata_bytes.as_slice()),
+            (&output_root, directory_bytes.as_slice()),
+            (&stdout, stdout_bytes.as_slice()),
+            (&stderr, stderr_bytes.as_slice()),
+            (&artifact, artifact_bytes.as_slice()),
+        ] {
+            mocks.push(
+                server
+                    .mock("GET", blob_path(digest).as_str())
+                    .with_status(200)
+                    .with_body(bytes)
+                    .expect(1)
+                    .create_async()
+                    .await,
+            );
+        }
+
+        let writer = remote_agent(
+            &server,
+            directory.path().join("writer"),
+            RemoteCacheMode::WriteOnly,
+        );
+        for (index, (digest, bytes)) in [
+            (&action, action_bytes.as_slice()),
+            (&metadata, metadata_bytes.as_slice()),
+            (&output_root, directory_bytes.as_slice()),
+            (&stdout, stdout_bytes.as_slice()),
+            (&stderr, stderr_bytes.as_slice()),
+            (&artifact, artifact_bytes.as_slice()),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let source = directory.path().join(format!("source-{index}"));
+            fs::write(&source, bytes).unwrap();
+            assert!(matches!(
+                writer
+                    .respond(AgentRequest::StoreBlob {
+                        digest: digest.clone(),
+                        source,
+                    })
+                    .await,
+                AgentResponse::Stored { .. }
+            ));
+        }
+        assert!(matches!(
+            writer
+                .respond(AgentRequest::StoreActionResult {
+                    result: result.clone(),
+                })
+                .await,
+            AgentResponse::ActionStored { .. }
+        ));
+        let run = writer.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            writer
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: run.clone(),
+                    prediction: prediction.clone(),
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+        writer.commit_task(&run).await.unwrap();
+
+        let reader = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let run = reader.begin_task(&task).await.unwrap();
+        reader.wait_for_prefetches().await;
+        assert!(matches!(
+            reader
+                .respond(AgentRequest::FindActionPrediction {
+                    task: run,
+                    invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction {
+                prediction: Some(found)
+            } if found == prediction
+        ));
+        assert!(matches!(
+            reader
+                .respond(AgentRequest::FindActionResult {
+                    action: action.clone(),
+                })
+                .await,
+            AgentResponse::ActionResult {
+                result: Some(found)
+            } if found == result
+        ));
+        for digest in [&action, &metadata, &output_root] {
+            assert!(matches!(
+                reader
+                    .respond(AgentRequest::FindBlob {
+                        digest: digest.clone(),
+                    })
+                    .await,
+                AgentResponse::Blob { path: Some(_) }
+            ));
+        }
+        assert!(matches!(
+            reader
+                .respond(AgentRequest::RecordActionHit {
+                    action,
+                    restore: RestoreStats::default(),
+                })
+                .await,
+            AgentResponse::ActionHitRecorded
+        ));
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+        let stats = reader.stats();
+        assert_eq!(stats.prefetch_runs, 1);
+        assert_eq!(stats.prefetched_actions, 1);
+        assert!(stats.remote_manifest_lookups > 0);
+        assert!(stats.remote_action_lookups > 0);
+        assert!(stats.remote_blob_requests > 0);
+        assert!(stats.remote_manifest_lookup_duration_ns > 0);
+        assert!(stats.remote_action_lookup_duration_ns > 0);
+        assert!(stats.remote_blob_transfer_duration_ns > 0);
+        assert!(stats.local_cas_write_duration_ns > 0);
+        assert!(stats.prefetch_duration_ns > 0);
+    }
+
+    #[tokio::test]
+    async fn keeps_newer_local_predictions_when_remote_manifest_is_stale() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let task = "f".repeat(64);
+        let invocation = CacheDigest::blake3(b"shared invocation");
+        let local_prediction = ActionPrediction {
+            invocation: invocation.clone(),
+            action: CacheDigest::blake3(b"new local action"),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+        let remote_prediction = ActionPrediction {
+            invocation: invocation.clone(),
+            action: CacheDigest::blake3(b"stale remote action"),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+        let remote_manifest = TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: vec![remote_prediction],
+        };
+        let remote_bytes = canonical_json(&remote_manifest).unwrap();
+        let remote_etag = blake3::hash(&remote_bytes).to_hex().to_string();
+        let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+        let remote = server
+            .mock("GET", action_manifest_path(&selector).as_str())
+            .with_status(200)
+            .with_header("etag", &format!("\"{remote_etag}\""))
+            .with_body(remote_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        agent
+            .persist_task_manifest(&TaskActionManifest {
+                version: TASK_ACTION_MANIFEST_VERSION,
+                task: task.clone(),
+                predictions: vec![local_prediction.clone()],
+            })
+            .unwrap();
+
+        let run = agent.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::FindActionPrediction {
+                    task: run,
+                    invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction {
+                prediction: Some(found)
+            } if found == local_prediction
+        ));
+        let persisted = agent.load_task_manifest(&task).unwrap().unwrap();
+        assert_eq!(persisted.predictions, vec![local_prediction]);
+        remote.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn prefetch_does_not_block_task_initialization() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let task = "9".repeat(64);
+        let invocation = CacheDigest::blake3(b"prefetched invocation");
+        let action_bytes = b"prefetched action";
+        let action = CacheDigest::blake3(action_bytes);
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: None,
+            output_root: None,
+            version: 1,
+        };
+        let manifest_bytes = canonical_json(&TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: vec![ActionPrediction {
+                invocation,
+                action: action.clone(),
+                adapter: "rustc".into(),
+                payload: "{}".into(),
+            }],
+        })
+        .unwrap();
+        let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+        let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+        let manifest = server
+            .mock("GET", action_manifest_path(&selector).as_str())
+            .with_status(200)
+            .with_header("etag", &format!("\"{manifest_etag}\""))
+            .with_body(manifest_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+        let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+        let response_release = release.clone();
+        let result_bytes = serde_json::to_vec(&result).unwrap();
+        let action_result = server
+            .mock("GET", action_path(&action).as_str())
+            .with_status(200)
+            .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+            .with_chunked_body(move |writer| {
+                let (released, condition) = &*response_release;
+                let mut released = released.lock().unwrap();
+                while !*released {
+                    released = condition.wait(released).unwrap();
+                }
+                std::io::Write::write_all(writer, &result_bytes)
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        let action_blob = server
+            .mock("GET", blob_path(&action).as_str())
+            .with_status(200)
+            .with_body(action_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+
+        let begin = tokio::time::timeout(Duration::from_secs(2), agent.begin_task(&task)).await;
+        let (released, condition) = &*release;
+        *released.lock().unwrap() = true;
+        condition.notify_all();
+        let run = begin
+            .expect("task initialization waited for prefetch")
+            .unwrap();
+        assert_eq!(
+            agent
+                .task_actions
+                .lock()
+                .unwrap()
+                .get(&run)
+                .unwrap()
+                .predictions
+                .len(),
+            1
+        );
+        agent.wait_for_prefetches().await;
+        manifest.assert_async().await;
+        action_result.assert_async().await;
+        action_blob.assert_async().await;
+        assert!(agent.actions.find(&action).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn prefetches_complete_actions_in_directory_wave_blob_packs() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let action_bytes = b"packed action descriptor";
+        let stdout_bytes = b"packed stdout";
+        let stderr_bytes = b"packed stderr";
+        let artifact_bytes = b"packed artifact";
+        let action = CacheDigest::blake3(action_bytes);
+        let stdout = CacheDigest::blake3(stdout_bytes);
+        let stderr = CacheDigest::blake3(stderr_bytes);
+        let artifact = CacheDigest::blake3(artifact_bytes);
+        let metadata_bytes = canonical_json(&RustcMetadata {
+            version: 1,
+            kind: "rustc".into(),
+            stdout: stdout.clone(),
+            stderr: stderr.clone(),
+        })
+        .unwrap();
+        let metadata = CacheDigest::blake3(&metadata_bytes);
+        let directory_bytes = canonical_json(&serde_json::json!({
+            "directories": [],
+            "files": [{
+                "digest": artifact,
+                "executable": false,
+                "mode": 420,
+                "name": "artifact",
+            }],
+            "symlinks": [],
+            "version": 1,
+        }))
+        .unwrap();
+        let output_root = CacheDigest::blake3(&directory_bytes);
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.clone()),
+            output_root: Some(output_root.clone()),
+            version: 1,
+        };
+        let action_result = server
+            .mock("GET", action_path(&action).as_str())
+            .with_status(200)
+            .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+            .with_body(serde_json::to_vec(&result).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1048576}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let mut top = vec![
+            (action.clone(), action_bytes.as_slice()),
+            (metadata.clone(), metadata_bytes.as_slice()),
+            (output_root.clone(), directory_bytes.as_slice()),
+        ];
+        top.sort_by(|left, right| left.0.cmp(&right.0));
+        let first_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": top.iter().map(|(digest, _)| digest).collect::<Vec<_>>()
+            })))
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_body(blob_pack_body(&top))
+            .expect(1)
+            .create_async()
+            .await;
+        let mut leaves = vec![
+            (stdout.clone(), stdout_bytes.as_slice()),
+            (stderr.clone(), stderr_bytes.as_slice()),
+            (artifact.clone(), artifact_bytes.as_slice()),
+        ];
+        leaves.sort_by(|left, right| left.0.cmp(&right.0));
+        let second_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": leaves.iter().map(|(digest, _)| digest).collect::<Vec<_>>()
+            })))
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_body(blob_pack_body(&leaves))
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+
+        agent
+            .prefetch_action(action.clone(), "rustc".into())
+            .await
+            .unwrap();
+
+        assert_eq!(agent.actions.find(&action).unwrap(), Some(result));
+        let stats = agent.stats();
+        assert_eq!(stats.prefetched_actions, 1);
+        assert_eq!(stats.remote_blob_requests, 0);
+        assert_eq!(stats.remote_blob_pack_requests, 2);
+        assert_eq!(stats.remote_blob_pack_blobs, 6);
+        action_result.assert_async().await;
+        capabilities.assert_async().await;
+        first_pack.assert_async().await;
+        second_pack.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn foreground_blob_batches_use_blob_packs() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let mut entries = [
+            (CacheDigest::blake3(b"first"), b"first".as_slice()),
+            (CacheDigest::blake3(b"second"), b"second".as_slice()),
+        ];
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+        let requested = entries
+            .iter()
+            .map(|(digest, _)| digest.clone())
+            .collect::<Vec<_>>();
+        let response_requested = vec![
+            entries[0].0.clone(),
+            entries[1].0.clone(),
+            entries[0].0.clone(),
+        ];
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1048576}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": requested.clone()
+            })))
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_body(blob_pack_body(&entries))
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let response = agent
+            .respond(AgentRequest::FindBlobs {
+                digests: response_requested,
+            })
+            .await;
+
+        let AgentResponse::Blobs { paths } = response else {
+            panic!("unexpected blob lookup response");
+        };
+        assert_eq!(paths.len(), 3);
+        for (expected, path) in [entries[0].1, entries[1].1, entries[0].1]
+            .into_iter()
+            .zip(paths)
+        {
+            assert_eq!(fs::read(path.unwrap()).unwrap(), expected);
+        }
+        let stats = agent.stats();
+        assert_eq!(stats.remote_blob_requests, 0);
+        assert_eq!(stats.remote_blob_pack_requests, 1);
+        assert_eq!(stats.remote_blob_pack_blobs, 2);
+        capabilities.assert_async().await;
+        pack.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn preserves_successful_pack_metrics_when_a_later_chunk_falls_back() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let mut entries = [
+            (CacheDigest::blake3(b"first"), b"first".as_slice()),
+            (CacheDigest::blake3(b"second"), b"second".as_slice()),
+        ];
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+        let (first_digest, first_bytes) = entries[0].clone();
+        let (second_digest, second_bytes) = entries[1].clone();
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":1,"max_pack_bytes":1048576}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let first_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": [&first_digest]
+            })))
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_body(blob_pack_body(&[(first_digest.clone(), first_bytes)]))
+            .expect(1)
+            .create_async()
+            .await;
+        let failed_pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "digests": [&second_digest]
+            })))
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+        let fallback = server
+            .mock("GET", blob_path(&second_digest).as_str())
+            .with_status(200)
+            .with_body(second_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let remote = agent.remote.as_deref().unwrap();
+
+        let verified = agent
+            .fetch_remote_blobs(
+                remote,
+                vec![first_digest.clone(), second_digest.clone()],
+                Some(&agent.prefetch_transfers),
+            )
+            .await;
+
+        assert_eq!(verified.len(), 2);
+        assert_eq!(fs::read(&verified[&first_digest]).unwrap(), first_bytes);
+        assert_eq!(fs::read(&verified[&second_digest]).unwrap(), second_bytes);
+        let stats = agent.stats();
+        assert_eq!(stats.remote_blob_pack_requests, 1);
+        assert_eq!(stats.remote_blob_pack_blobs, 1);
+        assert_eq!(stats.remote_blob_requests, 1);
+        capabilities.assert_async().await;
+        first_pack.assert_async().await;
+        failed_pack.assert_async().await;
+        fallback.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn malformed_blob_pack_metadata_falls_back_to_individual_blobs() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let bytes = b"fallback blob";
+        let digest = CacheDigest::blake3(bytes);
+        server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1048576}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let pack = server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+            .with_header(crate::BLOB_PACK_BYTES_HEADER, "not-a-number")
+            .with_body(blob_pack_body(&[(digest.clone(), bytes.as_slice())]))
+            .expect(1)
+            .create_async()
+            .await;
+        let fallback = server
+            .mock("GET", blob_path(&digest).as_str())
+            .with_status(200)
+            .with_body(bytes)
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let remote = agent.remote.as_deref().unwrap();
+
+        let verified = agent
+            .fetch_remote_blobs(remote, vec![digest.clone()], None)
+            .await;
+
+        assert_eq!(fs::read(&verified[&digest]).unwrap(), bytes);
+        let stats = agent.stats();
+        assert_eq!(stats.remote_blob_pack_requests, 0);
+        assert_eq!(stats.remote_blob_pack_blobs, 0);
+        assert_eq!(stats.remote_blob_requests, 1);
+        pack.assert_async().await;
+        fallback.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn foreground_action_lookup_does_not_wait_for_prefetch_output() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let action_bytes = b"prefetched action";
+        let artifact_bytes = b"prefetched artifact";
+        let action = CacheDigest::blake3(action_bytes);
+        let artifact = CacheDigest::blake3(artifact_bytes);
+        let directory_bytes = canonical_json(&serde_json::json!({
+            "directories": [],
+            "files": [{
+                "digest": artifact,
+                "executable": false,
+                "mode": 420,
+                "name": "artifact",
+            }],
+            "symlinks": [],
+            "version": 1,
+        }))
+        .unwrap();
+        let output_root = CacheDigest::blake3(&directory_bytes);
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: None,
+            output_root: Some(output_root.clone()),
+            version: 1,
+        };
+        let action_result = server
+            .mock("GET", action_path(&action).as_str())
+            .with_status(200)
+            .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+            .with_body(serde_json::to_vec(&result).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let action_blob = server
+            .mock("GET", blob_path(&action).as_str())
+            .with_status(200)
+            .with_body(action_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+        let output_directory = server
+            .mock("GET", blob_path(&output_root).as_str())
+            .with_status(200)
+            .with_body(directory_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+        let started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let release = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let response_started = started.clone();
+        let response_release = release.clone();
+        let artifact_blob = server
+            .mock("GET", blob_path(&artifact).as_str())
+            .with_status(200)
+            .with_chunked_body(move |writer| {
+                response_started.store(true, Ordering::Release);
+                while !response_release.load(Ordering::Acquire) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                std::io::Write::write_all(writer, artifact_bytes)
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let prefetch_agent = agent.clone();
+        let prefetch_action = action.clone();
+        let prefetch = tokio::spawn(async move {
+            prefetch_agent
+                .prefetch_action(prefetch_action, "rustc".into())
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !started.load(Ordering::Acquire) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("prefetch did not request the output blob");
+
+        let foreground = tokio::time::timeout(
+            Duration::from_millis(250),
+            agent.find_action_result(&action),
+        )
+        .await;
+        release.store(true, Ordering::Release);
+        prefetch.await.unwrap().unwrap();
+        let foreground = foreground.expect("foreground action lookup waited for output prefetch");
+
+        assert!(matches!(
+            foreground.unwrap(),
+            AgentResponse::ActionResult {
+                result: Some(found)
+            } if found == result
+        ));
+        action_result.assert_async().await;
+        action_blob.assert_async().await;
+        output_directory.assert_async().await;
+        artifact_blob.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn session_completion_cancels_outstanding_prefetches() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        let task = tokio::spawn(std::future::pending::<()>());
+        agent.prefetch_tasks.lock().unwrap().push(task);
+
+        tokio::time::timeout(Duration::from_secs(1), agent.cancel_prefetches())
+            .await
+            .expect("prefetch cancellation blocked session completion");
+        assert!(agent.prefetch_tasks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn prefetch_reserves_capacity_for_foreground_transfers() {
+        let transfers = tokio::sync::Semaphore::new(MAX_REMOTE_TRANSFERS);
+        let _prefetch = transfers
+            .acquire_many(MAX_PREFETCH_TRANSFERS as u32)
+            .await
+            .unwrap();
+        assert!(transfers.available_permits() > 0);
+    }
+
+    #[tokio::test]
+    async fn prefetches_output_files_concurrently() {
+        let directory = tempfile::tempdir().unwrap();
+        let (responses, output_root) = output_tree_responses(8);
+        let (base_url, maximum_in_flight, server) =
+            delayed_blob_server(responses, Duration::from_millis(50)).await;
+        let agent = remote_agent_url(
+            base_url,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+
+        agent
+            .prefetch_output_tree(agent.remote.as_deref().unwrap(), &output_root)
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(maximum_in_flight.load(Ordering::Relaxed) > 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "local remote-cache throughput benchmark"]
+    async fn benchmark_prefetch_output_tree_latency() {
+        let files = std::env::var("MBX_BENCH_FILES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(96);
+        let latency = Duration::from_millis(
+            std::env::var("MBX_BENCH_LATENCY_MS")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(100),
+        );
+
+        let directory = tempfile::tempdir().unwrap();
+        let (responses, output_root) = output_tree_responses(files);
+        let (base_url, maximum_in_flight, server) = delayed_blob_server(responses, latency).await;
+        let agent = remote_agent_url(
+            base_url,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let remote = agent.remote.as_deref().unwrap();
+
+        let started = std::time::Instant::now();
+        agent
+            .prefetch_output_tree(remote, &output_root)
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+
+        eprintln!(
+            "prefetched {files} blobs with {} ms latency in {elapsed:?}",
+            latency.as_millis()
+        );
+        server.await.unwrap();
+        eprintln!(
+            "maximum concurrent requests: {}",
+            maximum_in_flight.load(Ordering::Relaxed)
+        );
+    }
+
+    fn output_tree_responses(files: usize) -> (BTreeMap<String, Vec<u8>>, CacheDigest) {
+        let mut entries = Vec::with_capacity(files);
+        let mut responses = BTreeMap::new();
+        for index in 0..files {
+            let body = format!("cached artifact {index}").into_bytes();
+            let digest = CacheDigest::blake3(&body);
+            entries.push(serde_json::json!({
+                "digest": digest,
+                "executable": false,
+                "mode": 420,
+                "name": format!("artifact-{index}"),
+            }));
+            responses.insert(blob_path(&digest), body);
+        }
+        let directory = canonical_json(&serde_json::json!({
+            "directories": [],
+            "files": entries,
+            "symlinks": [],
+            "version": 1,
+        }))
+        .unwrap();
+        let output_root = CacheDigest::blake3(&directory);
+        responses.insert(blob_path(&output_root), directory);
+        (responses, output_root)
+    }
+
+    fn blob_pack_body(entries: &[(CacheDigest, &[u8])]) -> Vec<u8> {
+        let mut pack = crate::BLOB_PACK_MAGIC.to_vec();
+        for (digest, bytes) in entries {
+            pack.push(match digest.algorithm.as_str() {
+                "blake3" => 1,
+                "sha256" => 2,
+                algorithm => panic!("unexpected test digest algorithm {algorithm}"),
+            });
+            pack.extend(hex::decode(&digest.hash).unwrap());
+            pack.extend(digest.size.to_be_bytes());
+            pack.extend_from_slice(bytes);
+        }
+        pack
+    }
+
+    async fn delayed_blob_server(
+        responses: BTreeMap<String, Vec<u8>>,
+        latency: Duration,
+    ) -> (
+        url::Url,
+        Arc<std::sync::atomic::AtomicUsize>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let responses = Arc::new(responses);
+        let request_count = responses.len();
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let maximum_in_flight = Arc::new(AtomicUsize::new(0));
+        let observed_maximum = maximum_in_flight.clone();
+        let server = tokio::spawn(async move {
+            let mut requests = tokio::task::JoinSet::new();
+            for _ in 0..request_count {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let responses = responses.clone();
+                let in_flight = in_flight.clone();
+                let maximum_in_flight = maximum_in_flight.clone();
+                requests.spawn(async move {
+                    let mut request = Vec::new();
+                    loop {
+                        let mut chunk = [0; 1024];
+                        let size = socket.read(&mut chunk).await.unwrap();
+                        assert!(size > 0, "client closed before sending request headers");
+                        request.extend_from_slice(&chunk[..size]);
+                        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let request = String::from_utf8_lossy(&request);
+                    let path = request
+                        .lines()
+                        .next()
+                        .and_then(|line| line.split_whitespace().nth(1))
+                        .unwrap();
+                    let body = responses.get(path).unwrap();
+                    let active = in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+                    maximum_in_flight.fetch_max(active, Ordering::Relaxed);
+                    tokio::time::sleep(latency).await;
+                    socket
+                        .write_all(
+                            format!(
+                                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                                body.len()
+                            )
+                            .as_bytes(),
+                        )
+                        .await
+                        .unwrap();
+                    socket.write_all(body).await.unwrap();
+                    in_flight.fetch_sub(1, Ordering::Relaxed);
+                });
+            }
+            while requests.join_next().await.is_some() {}
+        });
+        (
+            format!("http://{address}").parse().unwrap(),
+            observed_maximum,
+            server,
+        )
+    }
+
+    fn remote_agent(
+        server: &mockito::ServerGuard,
+        cache_dir: PathBuf,
+        mode: RemoteCacheMode,
+    ) -> CacheAgent {
+        remote_agent_url(server.url().parse().unwrap(), cache_dir, mode)
+    }
+
+    fn remote_agent_url(
+        base_url: url::Url,
+        cache_dir: PathBuf,
+        mode: RemoteCacheMode,
+    ) -> CacheAgent {
+        let client = RemoteCacheClient::new(crate::RemoteCacheConfig {
+            base_url,
+            namespace: "test".into(),
+            token: None,
+            token_file: None,
+            oidc_audience: None,
+            connect_timeout: Duration::from_secs(1),
+            read_timeout: Duration::from_secs(1),
+            download_timeout: Duration::from_secs(1),
+            retries: 0,
+        })
+        .unwrap();
+        CacheAgent::new_remote(
+            &cache_dir,
+            "test-version",
+            AgentRemoteCache {
+                client,
+                mode,
+                staging_dir: cache_dir.join("remote"),
+            },
+        )
+    }
+
+    fn blob_path(digest: &CacheDigest) -> String {
+        format!(
+            "/v1/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        )
+    }
+
+    fn action_path(digest: &CacheDigest) -> String {
+        format!(
+            "/v1/action-results/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        )
+    }
+
+    fn action_manifest_path(digest: &CacheDigest) -> String {
+        format!(
+            "/v1/action-manifests/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        )
+    }
+
+    #[tokio::test]
+    async fn merges_overlapping_runs_into_one_task_manifest() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache");
+        let task = "d".repeat(64);
+        let agent = CacheAgent::new(&cache, "test-version");
+        let first_run = agent.begin_task(&task).await.unwrap();
+        let second_run = agent.begin_task(&task).await.unwrap();
+        assert_ne!(first_run, second_run);
+        let first_invocation = CacheDigest::blake3(b"overlap one");
+        let second_invocation = CacheDigest::blake3(b"overlap two");
+        for (run, invocation) in [
+            (&first_run, &first_invocation),
+            (&second_run, &second_invocation),
+        ] {
+            assert!(matches!(
+                agent
+                    .respond(AgentRequest::RecordActionPrediction {
+                        task: run.clone(),
+                        prediction: ActionPrediction {
+                            invocation: invocation.clone(),
+                            action: CacheDigest::blake3(invocation.hash.as_bytes()),
+                            adapter: "rustc".into(),
+                            payload: "{}".into(),
+                        },
+                    })
+                    .await,
+                AgentResponse::ActionPredictionRecorded
+            ));
+        }
+        agent.commit_task(&first_run).await.unwrap();
+        agent.commit_task(&second_run).await.unwrap();
+
+        let next = CacheAgent::new(cache, "test-version");
+        let run = next.begin_task(&task).await.unwrap();
+        for invocation in [first_invocation, second_invocation] {
+            assert!(matches!(
+                next.respond(AgentRequest::FindActionPrediction {
+                    task: run.clone(),
+                    invocation,
+                })
+                .await,
+                AgentResponse::ActionPrediction {
+                    prediction: Some(_)
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn keeps_local_manifest_when_remote_merge_exceeds_prediction_limit() {
+        let task = "7".repeat(64);
+        let prediction = |index: usize| {
+            let digest = CacheDigest::blake3(&index.to_le_bytes());
+            ActionPrediction {
+                invocation: digest.clone(),
+                action: digest,
+                adapter: "rustc".into(),
+                payload: "{}".into(),
+            }
+        };
+        let local = TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: (0..MAX_TASK_ACTION_PREDICTIONS).map(prediction).collect(),
+        };
+        let expected_first = local.predictions[0].clone();
+        let remote = TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: vec![prediction(MAX_TASK_ACTION_PREDICTIONS)],
+        };
+
+        let (manifest, merged) = merge_remote_task_manifest(&task, remote, local);
+        assert!(!merged);
+        assert_eq!(manifest.predictions.len(), MAX_TASK_ACTION_PREDICTIONS);
+        assert_eq!(manifest.predictions[0], expected_first);
+    }
+
+    #[test]
+    fn task_manifest_lock_is_shared_across_agents() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache");
+        let first = CacheAgent::new(&cache, "test-version");
+        let second = CacheAgent::new(&cache, "test-version");
+        let task = "8".repeat(64);
+
+        let first_lock = first.lock_task_manifest(&task).unwrap();
+        let mut contender = fslock::LockFile::open(&second.task_manifest_lock_path(&task)).unwrap();
+        assert!(!contender.try_lock().unwrap());
+        drop(first_lock);
+        assert!(contender.try_lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn memoizes_client_observed_executable_identities() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        let executable = directory.path().join("rustc");
+        let environment = BTreeMap::from([("RUSTUP_TOOLCHAIN".into(), Some("stable".into()))]);
+
+        let response = agent
+            .respond(AgentRequest::FindExecutableIdentity {
+                executable: executable.clone(),
+                environment: environment.clone(),
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ExecutableIdentity { stdout: None }
+        ));
+
+        let response = agent
+            .respond(AgentRequest::StoreExecutableIdentity {
+                executable: executable.clone(),
+                environment: environment.clone(),
+                stdout: b"rustc identity".to_vec(),
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ExecutableIdentity {
+                stdout: Some(stdout)
+            } if stdout == b"rustc identity"
+        ));
+
+        let response = agent
+            .respond(AgentRequest::FindExecutableIdentity {
+                executable,
+                environment,
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ExecutableIdentity {
+                stdout: Some(stdout)
+            } if stdout == b"rustc identity"
+        ));
+    }
+
+    #[test]
+    fn bounds_executable_identity_entry_count() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        for index in 0..MAX_EXECUTABLE_IDENTITIES {
+            agent
+                .store_executable_identity(
+                    directory.path().join(format!("rustc-{index}")),
+                    BTreeMap::new(),
+                    vec![b'x'],
+                )
+                .unwrap();
+        }
+
+        assert!(
+            agent
+                .store_executable_identity(
+                    directory.path().join("one-too-many"),
+                    BTreeMap::new(),
+                    vec![b'x'],
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bounds_executable_identity_retained_bytes() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        for index in 0..MAX_EXECUTABLE_IDENTITY_BYTES / MAX_EXECUTABLE_IDENTITY_SIZE {
+            agent
+                .store_executable_identity(
+                    directory.path().join(format!("rustc-{index}")),
+                    BTreeMap::new(),
+                    vec![b'x'; MAX_EXECUTABLE_IDENTITY_SIZE],
+                )
+                .unwrap();
+        }
+
+        assert!(
+            agent
+                .store_executable_identity(
+                    directory.path().join("one-byte-too-many"),
+                    BTreeMap::new(),
+                    vec![b'x'],
+                )
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn version_skew_is_a_handshake_miss() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "agent-version");
+        let (mut client, server) = tokio::io::duplex(1024);
+        let task = tokio::spawn(async move { agent.handle_connection(server).await });
+        let request = AgentRequest::Hello {
+            protocol: AGENT_PROTOCOL_VERSION,
+            client_version: "other-version".into(),
+        };
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        client.write_all(&encoded).await.unwrap();
+        let mut response = String::new();
+        BufReader::new(&mut client)
+            .read_line(&mut response)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            serde_json::from_str(&response).unwrap(),
+            AgentResponse::Error { .. }
+        ));
+        task.await.unwrap().unwrap();
+    }
+}

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 
 const MAX_EXECUTABLE_IDENTITIES: usize = 64;
 const MAX_EXECUTABLE_IDENTITY_SIZE: usize = 64 * 1024;
@@ -37,6 +37,11 @@ pub struct AgentRemoteCache {
 
 /// Wire protocol version used between an in-process cache agent and its shims.
 pub const AGENT_PROTOCOL_VERSION: u8 = 1;
+/// Largest single protocol request the agent will read.
+///
+/// Requests are small JSON objects; the largest legitimate ones carry an output
+/// tree or a batch of digests, which stay far below this.
+const MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
 
 /// A request accepted by the task-scoped cache agent.
 #[derive(Debug, Serialize, Deserialize)]
@@ -1729,9 +1734,8 @@ impl CacheAgent {
         S: AsyncRead + AsyncWrite + Unpin,
     {
         let (reader, mut writer) = tokio::io::split(stream);
-        let mut lines = BufReader::new(reader).lines();
-        let hello = lines
-            .next_line()
+        let mut reader = BufReader::new(reader);
+        let hello = read_request(&mut reader)
             .await?
             .ok_or_else(|| eyre::eyre!("connection closed before the agent handshake"))?;
         let request: AgentRequest = serde_json::from_str(&hello)?;
@@ -1776,7 +1780,7 @@ impl CacheAgent {
         )
         .await?;
 
-        while let Some(line) = lines.next_line().await? {
+        while let Some(line) = read_request(&mut reader).await? {
             let response = match serde_json::from_str(&line) {
                 Ok(request) => self.respond(request).await,
                 Err(error) => AgentResponse::Error {
@@ -1786,6 +1790,42 @@ impl CacheAgent {
             send_response(&mut writer, &response).await?;
         }
         Ok(())
+    }
+}
+
+/// Read one newline-delimited request, refusing one that grows past the cap.
+///
+/// Any process running as this user can open the session socket, so a request
+/// that never terminates its line must not be able to grow the agent's memory
+/// without bound.
+async fn read_request<R>(reader: &mut R) -> Result<Option<String>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            break;
+        }
+        let (consumed, complete) = match available.iter().position(|byte| *byte == b'\n') {
+            Some(index) => (index, true),
+            None => (available.len(), false),
+        };
+        if line.len() + consumed > MAX_REQUEST_BYTES {
+            bail!("agent request exceeded {MAX_REQUEST_BYTES} bytes");
+        }
+        line.extend_from_slice(&available[..consumed]);
+        // The newline itself is consumed but never kept.
+        reader.consume(consumed + usize::from(complete));
+        if complete {
+            return Ok(Some(String::from_utf8(line)?));
+        }
+    }
+    if line.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(String::from_utf8(line)?))
     }
 }
 
@@ -1937,6 +1977,32 @@ mod tests {
             serde_json::from_str(&response).unwrap(),
             AgentResponse::Hello { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn rejects_a_request_that_never_ends_its_line() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+        let (mut client, server) = tokio::io::duplex(64 * 1024);
+        let task = tokio::spawn(async move { agent.handle_connection(server).await });
+
+        handshake(&mut client, "test-version").await;
+        // Never send a newline: the agent must give up rather than buffer
+        // whatever a peer is willing to write.
+        let filler = vec![b'x'; 64 * 1024];
+        let mut written = 0usize;
+        while written <= MAX_REQUEST_BYTES {
+            if client.write_all(&filler).await.is_err() {
+                break;
+            }
+            written += filler.len();
+        }
+
+        let error = task.await.unwrap().err().unwrap();
+        assert!(
+            error.to_string().contains("exceeded"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -532,8 +532,9 @@ impl RemoteCacheClient {
                 ) {
                     return Ok(None);
                 }
-                let capabilities: RemoteCacheCapabilities =
-                    response.error_for_status()?.json().await?;
+                let bytes =
+                    read_bounded_json(response.error_for_status()?, "capabilities").await?;
+                let capabilities: RemoteCacheCapabilities = serde_json::from_slice(&bytes)?;
                 if capabilities.protocol.major != PROTOCOL_VERSION {
                     bail!(
                         "remote cache capability protocol {} is incompatible with client protocol {PROTOCOL_VERSION}",
@@ -1851,6 +1852,30 @@ mod tests {
                 "unexpected error: {error}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_capabilities() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", format!("/v{PROTOCOL_VERSION}/capabilities").as_str())
+            .with_status(200)
+            .with_body(vec![b'x'; MAX_REMOTE_JSON_BYTES as usize + 1])
+            .create_async()
+            .await;
+
+        // Negotiation runs before any other request, so an unbounded body here
+        // would exhaust the process before the other limits ever apply.
+        let error = test_client(&server)
+            .blob_pack_limits()
+            .await
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(
+            error.contains("over the") || error.contains("exceeded the"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -1,0 +1,1913 @@
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use eyre::{Result, bail, eyre};
+use futures_util::TryStreamExt as _;
+use log::warn;
+use reqwest::StatusCode;
+use reqwest::header::{
+    ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, ETAG, HeaderMap, HeaderValue, IF_MATCH,
+    IF_NONE_MATCH,
+};
+use serde::{Deserialize, Serialize};
+use sha2::Digest as _;
+use std::collections::BTreeSet;
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use url::{Host, Url};
+
+mod agent;
+mod local;
+
+pub use agent::{
+    AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRemoteCache, AgentRequest, AgentResponse,
+    AgentStats, CacheAgent, RestoreStats,
+};
+pub use local::{LocalActionCache, LocalCas};
+
+pub const PROTOCOL_VERSION: u8 = 1;
+const PROTOCOL_HEADER: &str = "mbx-cache-protocol";
+const NAMESPACE_HEADER: &str = "mbx-cache-namespace";
+pub const ACTION_RESULT_MEDIA_TYPE: &str = "application/vnd.mbx.cache-action-result.v1+json";
+pub const DIRECTORY_MEDIA_TYPE: &str = "application/vnd.mbx.cache-directory.v1+json";
+pub const CLIENT_METADATA_MEDIA_TYPE: &str = "application/vnd.mbx.cache-client-metadata.v1+json";
+pub const TASK_ACTION_MANIFEST_MEDIA_TYPE: &str =
+    "application/vnd.mbx.cache-task-action-manifest.v1+json";
+pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
+pub const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mbx.cache-blob-pack.v1";
+const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mbx.cache-digests.v1+json";
+const BLOB_PACK_BLOBS_HEADER: &str = "mbx-cache-pack-blobs";
+const BLOB_PACK_BYTES_HEADER: &str = "mbx-cache-pack-bytes";
+const BLOB_PACK_MAGIC: &[u8; 8] = b"MBXPACK1";
+const BLOB_PACK_HEADER_BYTES: u64 = 1 + 32 + 8;
+const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
+const BLOB_PACK_TIMEOUT_BYTES_PER_UNIT: u64 = MAX_STAGED_BLOB_PACK_BYTES / 4;
+const BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT: usize = MAX_STAGED_BLOB_PACK_ITEMS / 4;
+
+/// Serialize a protocol object using the JSON Canonicalization Scheme.
+///
+/// Action digests are computed from these bytes, so callers must not use
+/// serde's struct field order as part of the wire contract.
+pub fn canonical_json(value: &impl Serialize) -> Result<Vec<u8>> {
+    Ok(serde_json_canonicalizer::to_vec(value)?)
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Default,
+    strum::EnumString,
+    strum::Display,
+    PartialEq,
+    Eq,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum RemoteCacheMode {
+    #[default]
+    ReadWrite,
+    ReadOnly,
+    WriteOnly,
+}
+
+impl RemoteCacheMode {
+    pub fn reads(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::ReadOnly)
+    }
+
+    pub fn writes(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::WriteOnly)
+    }
+}
+
+pub struct RemoteCacheConfig {
+    pub base_url: Url,
+    pub namespace: String,
+    pub token: Option<String>,
+    pub token_file: Option<PathBuf>,
+    pub oidc_audience: Option<String>,
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub download_timeout: Duration,
+    pub retries: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CacheDigest {
+    pub algorithm: String,
+    pub hash: String,
+    pub size: u64,
+}
+
+impl CacheDigest {
+    pub fn blake3(bytes: &[u8]) -> Self {
+        Self {
+            algorithm: "blake3".into(),
+            hash: blake3::hash(bytes).to_hex().to_string(),
+            size: bytes.len() as u64,
+        }
+    }
+
+    /// Hash a file while counting the bytes read in the same streaming pass.
+    pub fn blake3_file(path: &Path) -> Result<Self> {
+        let (hash, size) = hash_file_blake3(path)?;
+        Ok(Self {
+            algorithm: "blake3".into(),
+            hash,
+            size,
+        })
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.algorithm != "blake3" && self.algorithm != "sha256" {
+            bail!("unsupported remote cache digest algorithm");
+        }
+        if self.hash.len() != 64
+            || !self
+                .hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            bail!("invalid remote cache digest");
+        }
+        Ok(())
+    }
+
+    pub fn matches_bytes(&self, bytes: &[u8]) -> Result<bool> {
+        self.validate()?;
+        if self.size != bytes.len() as u64 {
+            return Ok(false);
+        }
+        let hash = match self.algorithm.as_str() {
+            "blake3" => blake3::hash(bytes).to_hex().to_string(),
+            "sha256" => hex::encode(sha2::Sha256::digest(bytes)),
+            _ => unreachable!("digest algorithm was validated"),
+        };
+        Ok(self.hash == hash)
+    }
+
+    pub fn matches_file(&self, path: &Path) -> Result<bool> {
+        self.validate()?;
+        let (hash, size) = match self.algorithm.as_str() {
+            "blake3" => hash_file_blake3(path)?,
+            "sha256" => hash_file_sha256(path)?,
+            _ => unreachable!("digest algorithm was validated"),
+        };
+        Ok(self.size == size && self.hash == hash)
+    }
+}
+
+fn hash_file_blake3(path: &Path) -> Result<(String, u64)> {
+    let mut file = File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0; 64 * 1024];
+    let mut size = 0;
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+        size += count as u64;
+    }
+    Ok((hasher.finalize().to_hex().to_string(), size))
+}
+
+fn hash_file_sha256(path: &Path) -> Result<(String, u64)> {
+    let mut file = File::open(path)?;
+    let mut hasher = sha2::Sha256::new();
+    let mut buffer = [0; 64 * 1024];
+    let mut size = 0;
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+        size += count as u64;
+    }
+    Ok((hex::encode(hasher.finalize()), size))
+}
+
+/// A canonical action-result record referencing objects in the CAS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteActionResult {
+    pub action: CacheDigest,
+    #[serde(default)]
+    pub metadata: Option<CacheDigest>,
+    #[serde(default)]
+    pub output_root: Option<CacheDigest>,
+    pub version: u8,
+}
+
+/// A canonical directory object stored in the CAS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheDirectory {
+    pub directories: Vec<CacheDirectoryNode>,
+    pub files: Vec<CacheFileNode>,
+    pub symlinks: Vec<CacheSymlinkNode>,
+    pub version: u8,
+}
+
+/// A child directory entry in a canonical cache directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheDirectoryNode {
+    pub digest: CacheDigest,
+    pub mode: u32,
+    pub name: String,
+}
+
+/// A file entry in a canonical cache directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheFileNode {
+    pub digest: CacheDigest,
+    pub executable: bool,
+    pub mode: u32,
+    pub name: String,
+}
+
+/// A symbolic-link entry in a canonical cache directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheSymlinkNode {
+    pub mode: u32,
+    pub name: String,
+    pub target: String,
+}
+
+/// Rust-specific action metadata stored alongside compiled outputs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcMetadata {
+    pub version: u8,
+    pub kind: String,
+    pub stdout: CacheDigest,
+    pub stderr: CacheDigest,
+}
+
+pub enum BlobSource {
+    Bytes(Vec<u8>),
+    File(tempfile::NamedTempFile),
+    Path(PathBuf),
+}
+
+pub struct BlobUpload {
+    pub digest: CacheDigest,
+    pub source: BlobSource,
+}
+
+pub struct RemoteActionManifest {
+    pub bytes: Vec<u8>,
+    pub etag: String,
+}
+
+/// A verified set of remote CAS objects downloaded through blob-pack streams.
+pub struct RemoteBlobPack {
+    _directory: tempfile::TempDir,
+    pub blobs: Vec<(CacheDigest, PathBuf)>,
+    pub requests: u64,
+    pub requested: Vec<CacheDigest>,
+    pub blob_count: u64,
+    pub payload_bytes: u64,
+    pub framed_bytes: u64,
+}
+
+struct DownloadedBlobPack {
+    directory: tempfile::TempDir,
+    blobs: Vec<(CacheDigest, PathBuf)>,
+    metadata: BlobPackResponseStats,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct BlobPackResponseMetadata {
+    content_length: Option<u64>,
+    blob_count: Option<u64>,
+    payload_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BlobPackResponseStats {
+    blob_count: u64,
+    payload_bytes: u64,
+    framed_bytes: u64,
+}
+
+impl BlobPackResponseMetadata {
+    fn from_headers(headers: &HeaderMap) -> Result<Self> {
+        Ok(Self {
+            content_length: optional_u64_header(headers, CONTENT_LENGTH.as_str())?,
+            blob_count: optional_u64_header(headers, BLOB_PACK_BLOBS_HEADER)?,
+            payload_bytes: optional_u64_header(headers, BLOB_PACK_BYTES_HEADER)?,
+        })
+    }
+
+    fn validate(self, decoded: BlobPackResponseStats) -> Result<BlobPackResponseStats> {
+        if let Some(content_length) = self.content_length
+            && content_length != decoded.framed_bytes
+        {
+            bail!(
+                "remote cache blob pack content length metadata mismatch: expected {}, decoded {}",
+                content_length,
+                decoded.framed_bytes
+            );
+        }
+        if let Some(blob_count) = self.blob_count
+            && blob_count != decoded.blob_count
+        {
+            bail!(
+                "remote cache blob pack blob count metadata mismatch: expected {}, decoded {}",
+                blob_count,
+                decoded.blob_count
+            );
+        }
+        if let Some(payload_bytes) = self.payload_bytes
+            && payload_bytes != decoded.payload_bytes
+        {
+            bail!(
+                "remote cache blob pack payload byte metadata mismatch: expected {}, decoded {}",
+                payload_bytes,
+                decoded.payload_bytes
+            );
+        }
+        Ok(BlobPackResponseStats {
+            blob_count: self.blob_count.unwrap_or(decoded.blob_count),
+            payload_bytes: self.payload_bytes.unwrap_or(decoded.payload_bytes),
+            framed_bytes: self.content_length.unwrap_or(decoded.framed_bytes),
+        })
+    }
+}
+
+fn optional_u64_header(headers: &HeaderMap, name: &str) -> Result<Option<u64>> {
+    let Some(value) = headers.get(name) else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .map_err(|_| eyre!("remote cache blob pack {name} header is not valid UTF-8"))?;
+    let value = value
+        .parse::<u64>()
+        .map_err(|_| eyre!("remote cache blob pack {name} header is not an unsigned integer"))?;
+    Ok(Some(value))
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteCacheCapabilities {
+    protocol: CapabilityProtocol,
+    #[serde(default)]
+    features: CapabilityFeatures,
+    #[serde(default)]
+    limits: CapabilityLimits,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilityProtocol {
+    major: u8,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CapabilityFeatures {
+    #[serde(default)]
+    blob_packs: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CapabilityLimits {
+    #[serde(default)]
+    max_batch_items: u64,
+    #[serde(default)]
+    max_pack_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BlobPackLimits {
+    max_items: usize,
+    max_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct DigestList<'a> {
+    digests: &'a [CacheDigest],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestPutOutcome {
+    Stored,
+    PreconditionFailed,
+}
+
+pub struct RemoteCacheClient {
+    base_url: Url,
+    namespace: String,
+    client: reqwest::Client,
+    credential: RemoteCacheCredential,
+    download_timeout: Duration,
+    retries: i64,
+    capabilities: tokio::sync::OnceCell<Option<BlobPackLimits>>,
+    blob_packs_disabled: AtomicBool,
+}
+
+impl RemoteCacheClient {
+    pub fn new(config: RemoteCacheConfig) -> Result<Self> {
+        let authenticated = config
+            .token
+            .as_deref()
+            .is_some_and(|token| !token.trim().is_empty())
+            || config.token_file.is_some()
+            || config
+                .oidc_audience
+                .as_deref()
+                .is_some_and(|audience| !audience.trim().is_empty());
+        validate_remote_url(&config.base_url, authenticated)?;
+        let client = reqwest::Client::builder()
+            .connect_timeout(config.connect_timeout)
+            .read_timeout(config.read_timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        let credential = remote_credential(&config, client.clone())?;
+        Ok(Self {
+            base_url: normalized_base_url(config.base_url),
+            namespace: config.namespace,
+            client,
+            credential,
+            download_timeout: config.download_timeout,
+            retries: config.retries,
+            capabilities: tokio::sync::OnceCell::new(),
+            blob_packs_disabled: AtomicBool::new(false),
+        })
+    }
+
+    fn action_result_endpoint(&self, action: &CacheDigest) -> Result<Url> {
+        action.validate()?;
+        if action.algorithm != "blake3" {
+            bail!("remote cache action keys must use blake3");
+        }
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        ))?)
+    }
+
+    fn blob_endpoint(&self, digest: &CacheDigest) -> Result<Url> {
+        digest.validate()?;
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        ))?)
+    }
+
+    fn action_manifest_endpoint(&self, key: &CacheDigest) -> Result<Url> {
+        key.validate()?;
+        if key.algorithm != "blake3" {
+            bail!("remote action manifest keys must use blake3");
+        }
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/action-manifests/{}/{}/{}",
+            key.algorithm, key.hash, key.size
+        ))?)
+    }
+
+    fn capabilities_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/capabilities"))?)
+    }
+
+    fn blob_pack_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/blobs:pack"))?)
+    }
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        url: Url,
+        media_type: &'static str,
+    ) -> Result<reqwest::RequestBuilder> {
+        let request = self
+            .client
+            .request(method, url)
+            .header(PROTOCOL_HEADER, u16::from(PROTOCOL_VERSION))
+            .header(NAMESPACE_HEADER, &self.namespace)
+            .header(ACCEPT, media_type);
+        if let Some(authorization) = self.credential.authorization().await? {
+            Ok(request.header(AUTHORIZATION, authorization))
+        } else {
+            Ok(request)
+        }
+    }
+
+    async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
+        self.capabilities
+            .get_or_try_init(|| async {
+                let url = self.capabilities_endpoint()?;
+                let response = self
+                    .request(reqwest::Method::GET, url, "application/json")
+                    .await?
+                    .send()
+                    .await?;
+                if matches!(
+                    response.status(),
+                    StatusCode::NOT_FOUND
+                        | StatusCode::METHOD_NOT_ALLOWED
+                        | StatusCode::NOT_IMPLEMENTED
+                ) {
+                    return Ok(None);
+                }
+                let capabilities: RemoteCacheCapabilities =
+                    response.error_for_status()?.json().await?;
+                if capabilities.protocol.major != PROTOCOL_VERSION {
+                    bail!(
+                        "remote cache capability protocol {} is incompatible with client protocol {PROTOCOL_VERSION}",
+                        capabilities.protocol.major
+                    );
+                }
+                if !capabilities.features.blob_packs {
+                    return Ok(None);
+                }
+                let max_items = usize::try_from(capabilities.limits.max_batch_items)
+                    .ok()
+                    .filter(|limit| *limit > 0)
+                    .ok_or_else(|| {
+                        eyre!("remote cache blob packs require a positive max_batch_items limit")
+                    })?;
+                if capabilities.limits.max_pack_bytes == 0 {
+                    bail!("remote cache blob packs require a positive max_pack_bytes limit");
+                }
+                Ok(Some(BlobPackLimits {
+                    max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
+                    max_bytes: capabilities
+                        .limits
+                        .max_pack_bytes
+                        .min(MAX_STAGED_BLOB_PACK_BYTES),
+                }))
+            })
+            .await
+            .copied()
+    }
+
+    /// Download verified CAS objects using the server's negotiated blob-pack extension.
+    ///
+    /// `None` means the server does not support blob packs. Objects omitted by a
+    /// supported server are absent from `blobs`, so callers can retry them through
+    /// the ordinary single-blob endpoint.
+    pub async fn get_blob_pack(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+    ) -> Result<Option<RemoteBlobPack>> {
+        if digests.is_empty() || self.blob_packs_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let Some(limits) = self.blob_pack_limits().await? else {
+            return Ok(None);
+        };
+        fs::create_dir_all(staging_dir)?;
+        let chunk = blob_pack_chunk(digests, limits)?;
+        if chunk.is_empty() {
+            return Ok(Some(RemoteBlobPack {
+                _directory: tempfile::tempdir_in(staging_dir)?,
+                blobs: Vec::new(),
+                requests: 0,
+                requested: Vec::new(),
+                blob_count: 0,
+                payload_bytes: 0,
+                framed_bytes: BLOB_PACK_MAGIC.len() as u64,
+            }));
+        }
+        match self.download_blob_pack_chunk(&chunk, staging_dir).await? {
+            Some(pack) => Ok(Some(RemoteBlobPack {
+                _directory: pack.directory,
+                blobs: pack.blobs,
+                requests: 1,
+                requested: chunk,
+                blob_count: pack.metadata.blob_count,
+                payload_bytes: pack.metadata.payload_bytes,
+                framed_bytes: pack.metadata.framed_bytes,
+            })),
+            None => {
+                self.blob_packs_disabled.store(true, Ordering::Relaxed);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn download_blob_pack_chunk(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+    ) -> Result<Option<DownloadedBlobPack>> {
+        let url = self.blob_pack_endpoint()?;
+        let body = serde_json::to_vec(&DigestList { digests })?;
+        let download_timeout = blob_pack_download_timeout(self.download_timeout, digests);
+        let download = retry_async("POST", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::POST, url.clone(), BLOB_PACK_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, DIGEST_LIST_MEDIA_TYPE)
+                .body(body.clone())
+                .send()
+                .await?;
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            ) {
+                return Ok(None);
+            }
+            let response = response.error_for_status()?;
+            let media_type = response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.split(';').next())
+                .map(str::trim);
+            if media_type != Some(BLOB_PACK_MEDIA_TYPE) {
+                bail!("remote cache blob pack has an invalid content type");
+            }
+            Ok(Some(
+                decode_blob_pack(response, digests, staging_dir).await?,
+            ))
+        });
+        tokio::time::timeout(download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
+    }
+
+    pub async fn get_action_result(
+        &self,
+        action: &CacheDigest,
+    ) -> Result<Option<RemoteActionResult>> {
+        let url = self.action_result_endpoint(action)?;
+        let result = retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::GET, url.clone(), ACTION_RESULT_MEDIA_TYPE)
+                .await?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            Ok(Some(
+                response
+                    .error_for_status()?
+                    .json::<RemoteActionResult>()
+                    .await?,
+            ))
+        })
+        .await?;
+        if let Some(result) = &result
+            && (result.version != 1 || result.action != *action)
+        {
+            bail!("remote action result does not match requested action");
+        }
+        Ok(result)
+    }
+
+    pub async fn put_action_result(&self, result: &RemoteActionResult) -> Result<()> {
+        let url = self.action_result_endpoint(&result.action)?;
+        let body = serde_json::to_vec(result)?;
+        retry_async("PUT", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::PUT, url.clone(), ACTION_RESULT_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, ACTION_RESULT_MEDIA_TYPE)
+                .header(IF_NONE_MATCH, "*")
+                .body(body.clone())
+                .send()
+                .await?;
+            if response.status() != StatusCode::PRECONDITION_FAILED {
+                response.error_for_status()?;
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn get_action_manifest(
+        &self,
+        key: &CacheDigest,
+    ) -> Result<Option<RemoteActionManifest>> {
+        let url = self.action_manifest_endpoint(key)?;
+        retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(
+                    reqwest::Method::GET,
+                    url.clone(),
+                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
+                )
+                .await?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            let response = response.error_for_status()?;
+            let etag = parse_strong_etag(response.headers().get(ETAG))?;
+            let bytes = response.bytes().await?.to_vec();
+            if blake3::hash(&bytes).to_hex().as_str() != etag {
+                bail!("remote action manifest ETag does not match its body");
+            }
+            Ok(Some(RemoteActionManifest { bytes, etag }))
+        })
+        .await
+    }
+
+    pub async fn put_action_manifest(
+        &self,
+        key: &CacheDigest,
+        bytes: &[u8],
+        expected_etag: Option<&str>,
+    ) -> Result<ManifestPutOutcome> {
+        let url = self.action_manifest_endpoint(key)?;
+        let body = bytes.to_vec();
+        let expected_etag = expected_etag.map(quoted_etag).transpose()?;
+        retry_async("PUT", &url, self.retries, || async {
+            let mut request = self
+                .request(
+                    reqwest::Method::PUT,
+                    url.clone(),
+                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
+                )
+                .await?
+                .header(CONTENT_TYPE, TASK_ACTION_MANIFEST_MEDIA_TYPE)
+                .body(body.clone());
+            request = if let Some(etag) = &expected_etag {
+                request.header(IF_MATCH, etag)
+            } else {
+                request.header(IF_NONE_MATCH, "*")
+            };
+            let response = request.send().await?;
+            if response.status() == StatusCode::PRECONDITION_FAILED {
+                return Ok(ManifestPutOutcome::PreconditionFailed);
+            }
+            response.error_for_status()?;
+            Ok(ManifestPutOutcome::Stored)
+        })
+        .await
+    }
+
+    pub async fn get_blob(
+        &self,
+        digest: &CacheDigest,
+        media_type: &'static str,
+    ) -> Result<Vec<u8>> {
+        digest.validate()?;
+        let url = self.blob_endpoint(digest)?;
+        retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::GET, url.clone(), media_type)
+                .await?
+                .send()
+                .await?
+                .error_for_status()?;
+            let bytes = response.bytes().await?.to_vec();
+            if !digest.matches_bytes(&bytes)? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(bytes)
+        })
+        .await
+    }
+
+    pub async fn get_blob_file(
+        &self,
+        digest: &CacheDigest,
+        staging_dir: &Path,
+    ) -> Result<tempfile::NamedTempFile> {
+        let url = self.blob_endpoint(digest)?;
+        let download = retry_async("GET", &url, self.retries, || async {
+            let mut response = self
+                .request(reqwest::Method::GET, url.clone(), BLOB_MEDIA_TYPE)
+                .await?
+                .send()
+                .await?;
+            response.error_for_status_ref()?;
+            fs::create_dir_all(staging_dir)?;
+            let temporary = tempfile::NamedTempFile::new_in(staging_dir)?;
+            let mut output = tokio::fs::File::from_std(temporary.reopen()?);
+            while let Some(chunk) = response.chunk().await? {
+                output.write_all(&chunk).await?;
+            }
+            output.flush().await?;
+            drop(output);
+            if !digest.matches_file(temporary.path())? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(temporary)
+        });
+        tokio::time::timeout(self.download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
+    }
+
+    pub async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
+        let url = self.blob_endpoint(&upload.digest)?;
+        retry_async("PUT", &url, self.retries, || async {
+            let (length, body) = match &upload.source {
+                BlobSource::Bytes(bytes) => {
+                    (bytes.len() as u64, reqwest::Body::from(bytes.clone()))
+                }
+                BlobSource::File(file) => {
+                    let file = tokio::fs::File::open(file.path()).await?;
+                    let length = file.metadata().await?.len();
+                    let stream = tokio_util::io::ReaderStream::new(file);
+                    (length, reqwest::Body::wrap_stream(stream))
+                }
+                BlobSource::Path(path) => {
+                    let file = tokio::fs::File::open(path).await?;
+                    let length = file.metadata().await?.len();
+                    let stream = tokio_util::io::ReaderStream::new(file);
+                    (length, reqwest::Body::wrap_stream(stream))
+                }
+            };
+            let response = self
+                .request(reqwest::Method::PUT, url.clone(), BLOB_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, BLOB_MEDIA_TYPE)
+                .header(CONTENT_LENGTH, length)
+                .header(IF_NONE_MATCH, "*")
+                .body(body)
+                .send()
+                .await?;
+            if response.status() != StatusCode::PRECONDITION_FAILED {
+                response.error_for_status()?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}
+
+fn blob_pack_chunk(digests: &[CacheDigest], limits: BlobPackLimits) -> Result<Vec<CacheDigest>> {
+    let mut seen = BTreeSet::new();
+    let mut chunk = Vec::new();
+    let mut chunk_bytes = 0_u64;
+    for digest in digests {
+        digest.validate()?;
+        if !seen.insert(digest.clone()) || digest.size > limits.max_bytes {
+            continue;
+        }
+        if chunk.len() == limits.max_items
+            || chunk_bytes.saturating_add(digest.size) > limits.max_bytes
+        {
+            break;
+        }
+        chunk_bytes = chunk_bytes.saturating_add(digest.size);
+        chunk.push(digest.clone());
+    }
+    Ok(chunk)
+}
+
+fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Duration {
+    let bytes = digests
+        .iter()
+        .fold(0_u64, |total, digest| total.saturating_add(digest.size));
+    let byte_units = bytes.div_ceil(BLOB_PACK_TIMEOUT_BYTES_PER_UNIT);
+    let item_units = digests.len().div_ceil(BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT);
+    let item_units = u64::try_from(item_units).unwrap_or(u64::MAX);
+    let multiplier = byte_units.max(item_units).max(1);
+    base.saturating_mul(u32::try_from(multiplier).unwrap_or(u32::MAX))
+}
+
+async fn decode_blob_pack(
+    response: reqwest::Response,
+    requested: &[CacheDigest],
+    staging_dir: &Path,
+) -> Result<DownloadedBlobPack> {
+    let metadata = BlobPackResponseMetadata::from_headers(response.headers())?;
+    let requested = requested.iter().cloned().collect::<BTreeSet<_>>();
+    let stream = response.bytes_stream().map_err(std::io::Error::other);
+    let mut reader = tokio_util::io::StreamReader::new(stream);
+    let mut magic = [0_u8; BLOB_PACK_MAGIC.len()];
+    reader.read_exact(&mut magic).await?;
+    if &magic != BLOB_PACK_MAGIC {
+        bail!("remote cache blob pack has invalid magic");
+    }
+
+    let directory = tempfile::tempdir_in(staging_dir)?;
+    let mut seen = BTreeSet::new();
+    let mut blobs = Vec::new();
+    let mut payload_bytes = 0_u64;
+    let mut framed_bytes = BLOB_PACK_MAGIC.len() as u64;
+    loop {
+        let mut algorithm = [0_u8; 1];
+        if reader.read(&mut algorithm).await? == 0 {
+            break;
+        }
+        let (algorithm, mut hasher) = match algorithm[0] {
+            1 => (
+                "blake3",
+                BlobPackHasher::Blake3(Box::new(blake3::Hasher::new())),
+            ),
+            2 => ("sha256", BlobPackHasher::Sha256(sha2::Sha256::new())),
+            _ => bail!("remote cache blob pack has an invalid digest algorithm"),
+        };
+        let mut hash = [0_u8; 32];
+        reader.read_exact(&mut hash).await?;
+        let mut size = [0_u8; 8];
+        reader.read_exact(&mut size).await?;
+        let digest = CacheDigest {
+            algorithm: algorithm.into(),
+            hash: hex::encode(hash),
+            size: u64::from_be_bytes(size),
+        };
+        if !requested.contains(&digest) {
+            bail!("remote cache blob pack returned an unrequested digest");
+        }
+        if !seen.insert(digest.clone()) {
+            bail!("remote cache blob pack returned a duplicate digest");
+        }
+        framed_bytes = framed_bytes
+            .checked_add(BLOB_PACK_HEADER_BYTES)
+            .and_then(|bytes| bytes.checked_add(digest.size))
+            .ok_or_else(|| eyre!("remote cache blob pack is too large"))?;
+        payload_bytes = payload_bytes
+            .checked_add(digest.size)
+            .ok_or_else(|| eyre!("remote cache blob pack payload is too large"))?;
+
+        let path = directory.path().join(blobs.len().to_string());
+        let mut output = tokio::fs::File::create(&path).await?;
+        let mut remaining = digest.size;
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let limit = usize::try_from(remaining.min(buffer.len() as u64)).unwrap();
+            let count = reader.read(&mut buffer[..limit]).await?;
+            if count == 0 {
+                bail!("remote cache blob pack ended before a blob was complete");
+            }
+            output.write_all(&buffer[..count]).await?;
+            hasher.update(&buffer[..count]);
+            remaining -= count as u64;
+        }
+        output.flush().await?;
+        drop(output);
+        if !hasher.matches(&digest.hash) {
+            bail!("remote cache blob pack failed digest verification");
+        }
+        blobs.push((digest, path));
+    }
+    let blob_count = blobs.len().try_into().unwrap_or(u64::MAX);
+    let metadata = metadata.validate(BlobPackResponseStats {
+        blob_count,
+        payload_bytes,
+        framed_bytes,
+    })?;
+    Ok(DownloadedBlobPack {
+        directory,
+        blobs,
+        metadata,
+    })
+}
+
+enum BlobPackHasher {
+    Blake3(Box<blake3::Hasher>),
+    Sha256(sha2::Sha256),
+}
+
+impl BlobPackHasher {
+    fn update(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Blake3(hasher) => {
+                hasher.update(bytes);
+            }
+            Self::Sha256(hasher) => {
+                hasher.update(bytes);
+            }
+        }
+    }
+
+    fn matches(self, expected: &str) -> bool {
+        match self {
+            Self::Blake3(hasher) => hasher.finalize().to_hex().as_str() == expected,
+            Self::Sha256(hasher) => hex::encode(hasher.finalize()) == expected,
+        }
+    }
+}
+
+fn parse_strong_etag(value: Option<&HeaderValue>) -> Result<String> {
+    let value = value
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| eyre!("remote action manifest response is missing an ETag"))?;
+    let etag = value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .filter(|value| is_lower_hex_digest(value))
+        .ok_or_else(|| eyre!("remote action manifest response has an invalid ETag"))?;
+    Ok(etag.to_owned())
+}
+
+fn quoted_etag(etag: &str) -> Result<HeaderValue> {
+    if !is_lower_hex_digest(etag) {
+        bail!("invalid remote action manifest ETag");
+    }
+    Ok(HeaderValue::from_str(&format!("\"{etag}\""))?)
+}
+
+fn is_lower_hex_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[derive(Clone)]
+enum RemoteCacheCredential {
+    None,
+    Static(HeaderValue),
+    File(PathBuf),
+    GithubActions(Arc<GithubActionsOidcCredential>),
+}
+
+struct GithubActionsOidcCredential {
+    audience: String,
+    request_url: Url,
+    request_token: HeaderValue,
+    client: reqwest::Client,
+    retries: i64,
+    cached: tokio::sync::Mutex<Option<CachedOidcToken>>,
+}
+
+struct CachedOidcToken {
+    authorization: HeaderValue,
+    expires_at: u64,
+}
+
+#[derive(Deserialize)]
+struct GithubActionsOidcResponse {
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct JwtExpiry {
+    exp: u64,
+}
+
+fn remote_credential(
+    config: &RemoteCacheConfig,
+    client: reqwest::Client,
+) -> Result<RemoteCacheCredential> {
+    if let Some(authorization) = authorization_header(config.token.as_deref())? {
+        return Ok(RemoteCacheCredential::Static(authorization));
+    }
+    if let Some(path) = &config.token_file {
+        return Ok(RemoteCacheCredential::File(path.clone()));
+    }
+    let Some(audience) = config
+        .oidc_audience
+        .as_deref()
+        .map(str::trim)
+        .filter(|audience| !audience.is_empty())
+    else {
+        return Ok(RemoteCacheCredential::None);
+    };
+    Ok(RemoteCacheCredential::GithubActions(Arc::new(
+        GithubActionsOidcCredential::from_env(audience, client, config.retries)?,
+    )))
+}
+
+fn authorization_header(token: Option<&str>) -> Result<Option<HeaderValue>> {
+    let Some(token) = token.map(str::trim).filter(|token| !token.is_empty()) else {
+        return Ok(None);
+    };
+    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))?;
+    value.set_sensitive(true);
+    Ok(Some(value))
+}
+
+impl RemoteCacheCredential {
+    async fn authorization(&self) -> Result<Option<HeaderValue>> {
+        match self {
+            Self::None => Ok(None),
+            Self::Static(value) => Ok(Some(value.clone())),
+            Self::File(path) => {
+                let token = tokio::fs::read_to_string(path).await.map_err(|err| {
+                    eyre!(
+                        "failed to read remote cache token file {}: {err}",
+                        path.display()
+                    )
+                })?;
+                authorization_header(Some(&token))?
+                    .ok_or_else(|| eyre!("remote cache token file {} is empty", path.display()))
+                    .map(Some)
+            }
+            Self::GithubActions(credential) => credential.authorization().await.map(Some),
+        }
+    }
+}
+
+impl GithubActionsOidcCredential {
+    fn from_env(audience: &str, client: reqwest::Client, retries: i64) -> Result<Self> {
+        let request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
+            eyre!(
+                "remote cache OIDC audience requires GitHub Actions OIDC; \
+                 grant `id-token: write` or set MBX_REMOTE_TOKEN"
+            )
+        })?;
+        let request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| {
+            eyre!(
+                "remote cache OIDC audience requires GitHub Actions OIDC; \
+                 ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing"
+            )
+        })?;
+        let request_url: Url = request_url
+            .parse()
+            .map_err(|err| eyre!("invalid GitHub Actions OIDC request URL: {err}"))?;
+        Self::new(audience, request_url, &request_token, client, retries)
+    }
+
+    fn new(
+        audience: &str,
+        mut request_url: Url,
+        request_token: &str,
+        client: reqwest::Client,
+        retries: i64,
+    ) -> Result<Self> {
+        validate_oidc_request_url(&request_url)?;
+        let query = request_url
+            .query_pairs()
+            .filter(|(key, _)| key != "audience")
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+        request_url.set_query(None);
+        request_url
+            .query_pairs_mut()
+            .extend_pairs(query)
+            .append_pair("audience", audience);
+        let request_token = authorization_header(Some(request_token))?
+            .ok_or_else(|| eyre!("GitHub Actions OIDC request token is empty"))?;
+        Ok(Self {
+            audience: audience.to_string(),
+            request_url,
+            request_token,
+            client,
+            retries,
+            cached: tokio::sync::Mutex::new(None),
+        })
+    }
+
+    async fn authorization(&self) -> Result<HeaderValue> {
+        const REFRESH_LEEWAY_SECONDS: u64 = 60;
+        let mut cached = self.cached.lock().await;
+        let now = unix_timestamp()?;
+        if let Some(token) = cached.as_ref()
+            && token.expires_at > now.saturating_add(REFRESH_LEEWAY_SECONDS)
+        {
+            return Ok(token.authorization.clone());
+        }
+        let response: GithubActionsOidcResponse =
+            retry_async("GET", &self.request_url, self.retries, || async {
+                Ok(self
+                    .client
+                    .get(self.request_url.clone())
+                    .header(AUTHORIZATION, self.request_token.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json()
+                    .await?)
+            })
+            .await
+            .map_err(|err| {
+                eyre!(
+                    "failed to acquire GitHub Actions OIDC token for audience {:?}: {err}",
+                    self.audience
+                )
+            })?;
+        let expires_at = jwt_expiry(&response.value)?;
+        if expires_at <= now.saturating_add(REFRESH_LEEWAY_SECONDS) {
+            bail!("GitHub Actions OIDC token expires too soon");
+        }
+        let authorization = authorization_header(Some(&response.value))?
+            .ok_or_else(|| eyre!("GitHub Actions returned an empty OIDC token"))?;
+        *cached = Some(CachedOidcToken {
+            authorization: authorization.clone(),
+            expires_at,
+        });
+        Ok(authorization)
+    }
+}
+
+fn jwt_expiry(token: &str) -> Result<u64> {
+    let payload = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| eyre!("GitHub Actions returned a malformed OIDC token"))?;
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| eyre!("GitHub Actions returned a malformed OIDC token"))?;
+    let claims: JwtExpiry = serde_json::from_slice(&payload)
+        .map_err(|_| eyre!("GitHub Actions OIDC token is missing a valid expiry"))?;
+    Ok(claims.exp)
+}
+
+fn unix_timestamp() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| eyre!("system clock is before the Unix epoch: {err}"))?
+        .as_secs())
+}
+
+fn validate_oidc_request_url(url: &Url) -> Result<()> {
+    if url.scheme() == "https"
+        || url.scheme() == "http"
+            && url.host().is_some_and(|host| match host {
+                Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+                Host::Ipv4(address) => address.is_loopback(),
+                Host::Ipv6(address) => address.is_loopback(),
+            })
+    {
+        Ok(())
+    } else {
+        bail!("GitHub Actions OIDC request URL must use HTTPS")
+    }
+}
+
+fn validate_remote_url(base_url: &Url, authenticated: bool) -> Result<()> {
+    if base_url.scheme() == "https" {
+        return Ok(());
+    }
+    if base_url.scheme() != "http" {
+        bail!("remote cache URL must use HTTPS");
+    }
+    let is_loopback = base_url.host().is_some_and(|host| match host {
+        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+        Host::Ipv4(address) => address.is_loopback(),
+        Host::Ipv6(address) => address.is_loopback(),
+    });
+    if !is_loopback && authenticated {
+        bail!("remote cache URL must use HTTPS except for loopback development servers");
+    }
+    if !is_loopback {
+        warn!(
+            "using an unauthenticated remote build cache over plain HTTP; cache traffic can be read \
+             or modified in transit"
+        );
+    }
+    Ok(())
+}
+
+fn normalized_base_url(mut url: Url) -> Url {
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+    url
+}
+
+fn retry_delays(retries: i64) -> impl Iterator<Item = Duration> {
+    [200u64, 1_000, 4_000, 15_000]
+        .into_iter()
+        .chain(std::iter::repeat(15_000))
+        .map(Duration::from_millis)
+        .map(|duration| {
+            let factor = 0.5 + rand::random::<f64>() * 0.5;
+            Duration::from_secs_f64(duration.as_secs_f64() * factor)
+        })
+        .take(retries.max(0) as usize)
+}
+
+/// hyper-util exposes DNS failures in the error chain as a `dns error` source,
+/// but reqwest intentionally erases the concrete connector type. Match that
+/// stable connector error label rather than platform-specific resolver text.
+fn is_dns_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if source.to_string() == "dns error" {
+            return true;
+        }
+        current = source.source();
+    }
+    false
+}
+
+fn is_transient(error: &eyre::Report) -> bool {
+    // An unavailable hostname is a deterministic configuration error. reqwest
+    // categorizes it as a connect error, but retrying only delays the diagnosis.
+    if is_dns_error(error.as_ref()) {
+        return false;
+    }
+    error.chain().any(|source| {
+        let Some(error) = source.downcast_ref::<reqwest::Error>() else {
+            return false;
+        };
+        if error.is_timeout() || error.is_connect() || error.is_body() {
+            return true;
+        }
+        error.status().is_some_and(|status| {
+            let status = status.as_u16();
+            status == 408 || status == 429 || (500..600).contains(&status)
+        })
+    })
+}
+
+async fn retry_async<F, Fut, T>(verb: &str, url: &Url, retries: i64, mut operation: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut delays = retry_delays(retries);
+    let mut attempt = 1;
+    loop {
+        let started_at = Instant::now();
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) if is_transient(&error) => {
+                let Some(delay) = delays.next() else {
+                    return Err(error);
+                };
+                warn!(
+                    "HTTP {verb} {url} attempt {attempt} failed after {:?} (transient): {error}; retrying in {delay:?}",
+                    started_at.elapsed()
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_json_uses_jcs_key_and_number_encoding() {
+        let value = serde_json::json!({"z": 1.0e30, "a": {"d": true, "c": null}});
+        assert_eq!(
+            canonical_json(&value).unwrap(),
+            br#"{"a":{"c":null,"d":true},"z":1e+30}"#
+        );
+    }
+
+    #[test]
+    fn dns_errors_are_not_transient() {
+        #[derive(Debug)]
+        struct DnsError;
+
+        impl std::fmt::Display for DnsError {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("dns error")
+            }
+        }
+
+        impl std::error::Error for DnsError {}
+
+        let error = eyre::Report::new(DnsError);
+        assert!(is_dns_error(error.as_ref()));
+        assert!(!is_transient(&error));
+    }
+
+    #[test]
+    fn cache_digest_verifies_its_declared_algorithm() {
+        let bytes = b"remote cache blob";
+        let sha256 = CacheDigest {
+            algorithm: "sha256".into(),
+            hash: hex::encode(sha2::Sha256::digest(bytes)),
+            size: bytes.len() as u64,
+        };
+        assert!(sha256.matches_bytes(bytes).unwrap());
+        assert!(!sha256.matches_bytes(b"different").unwrap());
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        fs::write(file.path(), bytes).unwrap();
+        assert!(sha256.matches_file(file.path()).unwrap());
+        assert_eq!(
+            CacheDigest::blake3_file(file.path()).unwrap().size,
+            bytes.len() as u64
+        );
+        assert!(
+            CacheDigest::blake3_file(file.path())
+                .unwrap()
+                .matches_bytes(bytes)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn action_result_keys_require_blake3() {
+        let client = RemoteCacheClient::new(RemoteCacheConfig {
+            base_url: "http://127.0.0.1:1".parse().unwrap(),
+            namespace: "test".into(),
+            token: None,
+            token_file: None,
+            oidc_audience: None,
+            connect_timeout: Duration::from_secs(1),
+            read_timeout: Duration::from_secs(1),
+            download_timeout: Duration::from_secs(1),
+            retries: 0,
+        })
+        .unwrap();
+        let action = CacheDigest {
+            algorithm: "sha256".into(),
+            hash: "0".repeat(64),
+            size: 0,
+        };
+
+        assert!(
+            client
+                .action_result_endpoint(&action)
+                .unwrap_err()
+                .to_string()
+                .contains("must use blake3")
+        );
+    }
+
+    #[tokio::test]
+    async fn downloads_negotiated_blob_packs_and_omits_missing_objects() {
+        let mut server = mockito::Server::new_async().await;
+        let first_bytes = b"first packed blob";
+        let second_bytes = b"second packed blob";
+        let first = CacheDigest::blake3(first_bytes);
+        let second = CacheDigest::blake3(second_bytes);
+        let missing = CacheDigest::blake3(b"missing packed blob");
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .match_header(PROTOCOL_HEADER, "1")
+            .match_header(AUTHORIZATION.as_str(), "Bearer test-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let packed = encode_blob_pack(&[
+            (&first, first_bytes.as_slice()),
+            (&second, second_bytes.as_slice()),
+        ]);
+        let packed_len = packed.len().to_string();
+        let packed_blobs = 2.to_string();
+        let packed_payload_bytes = (first.size + second.size).to_string();
+        let request = server
+            .mock("POST", "/v1/blobs:pack")
+            .match_header(PROTOCOL_HEADER, "1")
+            .match_header(NAMESPACE_HEADER, "test")
+            .match_header("content-type", DIGEST_LIST_MEDIA_TYPE)
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_header("content-length", &packed_len)
+            .with_header(BLOB_PACK_BLOBS_HEADER, &packed_blobs)
+            .with_header(BLOB_PACK_BYTES_HEADER, &packed_payload_bytes)
+            .with_body(packed)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let pack = client
+            .get_blob_pack(
+                &[first.clone(), missing, second.clone(), first.clone()],
+                staging.path(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(pack.requests, 1);
+        assert_eq!(pack.blob_count, 2);
+        assert_eq!(pack.payload_bytes, first.size + second.size);
+        assert_eq!(
+            pack.framed_bytes,
+            BLOB_PACK_MAGIC.len() as u64 + 2 * BLOB_PACK_HEADER_BYTES + first.size + second.size
+        );
+        assert_eq!(pack.blobs.len(), 2);
+        assert_eq!(fs::read(&pack.blobs[0].1).unwrap(), first_bytes);
+        assert_eq!(fs::read(&pack.blobs[1].1).unwrap(), second_bytes);
+        capabilities.assert_async().await;
+        request.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_mismatched_blob_pack_metadata() {
+        let mut server = mockito::Server::new_async().await;
+        let contents = b"packed blob";
+        let digest = CacheDigest::blake3(contents);
+        mock_blob_pack_capabilities(&mut server).await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_header(BLOB_PACK_BLOBS_HEADER, "2")
+            .with_body(encode_blob_pack(&[(&digest, contents.as_slice())]))
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = client
+            .get_blob_pack(&[digest], staging.path())
+            .await
+            .err()
+            .unwrap();
+
+        assert!(error.to_string().contains("blob count metadata mismatch"));
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_blob_pack_metadata() {
+        let mut server = mockito::Server::new_async().await;
+        let contents = b"packed blob";
+        let digest = CacheDigest::blake3(contents);
+        mock_blob_pack_capabilities(&mut server).await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_header(BLOB_PACK_BYTES_HEADER, "not-a-number")
+            .with_body(encode_blob_pack(&[(&digest, contents.as_slice())]))
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = client
+            .get_blob_pack(&[digest], staging.path())
+            .await
+            .err()
+            .unwrap();
+
+        assert!(error.to_string().contains("not an unsigned integer"));
+    }
+
+    #[tokio::test]
+    async fn rejects_unrequested_blob_pack_frames() {
+        let mut server = mockito::Server::new_async().await;
+        let requested = CacheDigest::blake3(b"requested");
+        let injected_bytes = b"not requested";
+        let injected = CacheDigest::blake3(injected_bytes);
+        server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_body(encode_blob_pack(&[(&injected, injected_bytes.as_slice())]))
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = client
+            .get_blob_pack(&[requested], staging.path())
+            .await
+            .err()
+            .unwrap();
+
+        assert!(error.to_string().contains("unrequested digest"));
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_blob_packs_are_not_advertised() {
+        let mut server = mockito::Server::new_async().await;
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        assert!(
+            client
+                .get_blob_pack(&[CacheDigest::blake3(b"blob")], staging.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        capabilities.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn disables_blob_packs_when_the_advertised_endpoint_is_unavailable() {
+        let mut server = mockito::Server::new_async().await;
+        let capabilities = server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let request = server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+        let digest = CacheDigest::blake3(b"blob");
+
+        assert!(
+            client
+                .get_blob_pack(std::slice::from_ref(&digest), staging.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            client
+                .get_blob_pack(&[digest], staging.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        capabilities.assert_async().await;
+        request.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_truncated_blob_pack_frames() {
+        let mut server = mockito::Server::new_async().await;
+        let contents = b"complete blob";
+        let digest = CacheDigest::blake3(contents);
+        let mut pack = encode_blob_pack(&[(&digest, contents.as_slice())]);
+        pack.truncate(pack.len() - 3);
+        mock_blob_pack_capabilities(&mut server).await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_body(pack)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = match client.get_blob_pack(&[digest], staging.path()).await {
+            Err(error) => error,
+            Ok(_) => panic!("truncated pack should be rejected"),
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("ended before a blob was complete")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_blob_pack_frames_with_corrupt_content() {
+        let mut server = mockito::Server::new_async().await;
+        let digest = CacheDigest::blake3(b"expected");
+        let corrupt = b"corrupt!";
+        let pack = encode_blob_pack(&[(&digest, corrupt.as_slice())]);
+        mock_blob_pack_capabilities(&mut server).await;
+        server
+            .mock("POST", "/v1/blobs:pack")
+            .with_status(200)
+            .with_header("content-type", BLOB_PACK_MEDIA_TYPE)
+            .with_body(pack)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let error = match client.get_blob_pack(&[digest], staging.path()).await {
+            Err(error) => error,
+            Ok(_) => panic!("corrupt pack should be rejected"),
+        };
+
+        assert!(error.to_string().contains("failed digest verification"));
+    }
+
+    #[test]
+    fn blob_pack_chunk_honors_item_and_byte_limits() {
+        let first = CacheDigest::blake3(b"1234");
+        let second = CacheDigest::blake3(b"5678");
+        let oversized = CacheDigest::blake3(b"123456789");
+        let chunk = blob_pack_chunk(
+            &[first.clone(), second.clone(), first.clone(), oversized],
+            BlobPackLimits {
+                max_items: 10,
+                max_bytes: 7,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(chunk, vec![first]);
+
+        let chunk = blob_pack_chunk(
+            &[CacheDigest::blake3(b"a"), CacheDigest::blake3(b"b")],
+            BlobPackLimits {
+                max_items: 1,
+                max_bytes: 100,
+            },
+        )
+        .unwrap();
+        assert_eq!(chunk.len(), 1);
+    }
+
+    #[test]
+    fn blob_pack_timeout_scales_with_declared_work() {
+        let base = Duration::from_secs(10);
+        let small = CacheDigest::blake3(b"small");
+        assert_eq!(blob_pack_download_timeout(base, &[small]), base);
+
+        let large = CacheDigest {
+            algorithm: "blake3".into(),
+            hash: "0".repeat(64),
+            size: MAX_STAGED_BLOB_PACK_BYTES,
+        };
+        assert_eq!(
+            blob_pack_download_timeout(base, &[large]),
+            base.saturating_mul(4)
+        );
+
+        let many = (0..=BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT)
+            .map(|index| CacheDigest::blake3(index.to_string().as_bytes()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            blob_pack_download_timeout(base, &many),
+            base.saturating_mul(2)
+        );
+    }
+
+    #[test]
+    fn bearer_authorization_headers_are_sensitive() {
+        let header = authorization_header(Some(" test-token ")).unwrap().unwrap();
+        assert_eq!(header, "Bearer test-token");
+        assert!(header.is_sensitive());
+        assert!(authorization_header(Some(" ")).unwrap().is_none());
+    }
+
+    fn test_client(server: &mockito::ServerGuard) -> RemoteCacheClient {
+        RemoteCacheClient::new(RemoteCacheConfig {
+            base_url: server.url().parse().unwrap(),
+            namespace: "test".into(),
+            token: Some("test-token".into()),
+            token_file: None,
+            oidc_audience: None,
+            connect_timeout: Duration::from_secs(1),
+            read_timeout: Duration::from_secs(1),
+            download_timeout: Duration::from_secs(1),
+            retries: 0,
+        })
+        .unwrap()
+    }
+
+    async fn mock_blob_pack_capabilities(server: &mut mockito::ServerGuard) {
+        server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "features":{"blob_packs":true},
+                    "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+    }
+
+    fn encode_blob_pack(entries: &[(&CacheDigest, &[u8])]) -> Vec<u8> {
+        let mut pack = BLOB_PACK_MAGIC.to_vec();
+        for (digest, contents) in entries {
+            assert_eq!(digest.size, contents.len() as u64);
+            pack.push(match digest.algorithm.as_str() {
+                "blake3" => 1,
+                "sha256" => 2,
+                algorithm => panic!("unexpected test digest algorithm {algorithm}"),
+            });
+            pack.extend(hex::decode(&digest.hash).unwrap());
+            pack.extend(digest.size.to_be_bytes());
+            pack.extend_from_slice(contents);
+        }
+        pack
+    }
+
+    #[tokio::test]
+    async fn token_file_credentials_are_reloaded() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cache-token");
+        fs::write(&path, "first-token\n").unwrap();
+        let credential = RemoteCacheCredential::File(path.clone());
+
+        let first = credential.authorization().await.unwrap().unwrap();
+        assert_eq!(first, "Bearer first-token");
+        assert!(first.is_sensitive());
+
+        fs::write(path, "rotated-token\n").unwrap();
+        let rotated = credential.authorization().await.unwrap().unwrap();
+        assert_eq!(rotated, "Bearer rotated-token");
+    }
+
+    #[tokio::test]
+    async fn github_actions_oidc_tokens_are_acquired_and_cached() {
+        let mut server = mockito::Server::new_async().await;
+        let expires_at = unix_timestamp().unwrap() + 3600;
+        let token = test_jwt(expires_at);
+        let token_response = serde_json::json!({"value":token}).to_string();
+        let request = server
+            .mock("GET", "/oidc")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "audience".into(),
+                "https://cache.example.com".into(),
+            ))
+            .match_header("authorization", "Bearer request-secret")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(token_response)
+            .expect(1)
+            .create_async()
+            .await;
+        let credential = GithubActionsOidcCredential::new(
+            "https://cache.example.com",
+            format!("{}/oidc?api-version=1&audience=old", server.url())
+                .parse()
+                .unwrap(),
+            "request-secret",
+            reqwest::Client::new(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            credential.request_url.query_pairs().collect::<Vec<_>>(),
+            vec![
+                ("api-version".into(), "1".into()),
+                ("audience".into(), "https://cache.example.com".into()),
+            ]
+        );
+
+        let first = credential.authorization().await.unwrap();
+        let second = credential.authorization().await.unwrap();
+
+        assert_eq!(first, format!("Bearer {token}"));
+        assert_eq!(first, second);
+        assert!(first.is_sensitive());
+        request.assert_async().await;
+    }
+
+    #[test]
+    fn oidc_request_urls_require_https_except_for_loopback() {
+        validate_oidc_request_url(&"https://example.com/oidc".parse().unwrap()).unwrap();
+        validate_oidc_request_url(&"http://127.0.0.1:3000/oidc".parse().unwrap()).unwrap();
+        assert!(validate_oidc_request_url(&"http://example.com/oidc".parse().unwrap()).is_err());
+    }
+
+    fn test_jwt(expires_at: u64) -> String {
+        let header = URL_SAFE_NO_PAD.encode(b"{}");
+        let claims = URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&serde_json::json!({"exp":expires_at})).unwrap());
+        format!("{header}.{claims}.signature")
+    }
+
+    #[test]
+    fn remote_urls_require_https_for_authenticated_requests() {
+        for url in [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://[::1]:3000",
+            "https://cache.example.com",
+        ] {
+            validate_remote_url(&url.parse().unwrap(), true).unwrap();
+        }
+        let insecure: Url = "http://cache.example.com".parse().unwrap();
+        assert!(validate_remote_url(&insecure, true).is_err());
+        validate_remote_url(&insecure, false).unwrap();
+        assert!(validate_remote_url(&"ftp://localhost/cache".parse().unwrap(), false).is_err());
+    }
+}

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -43,6 +43,13 @@ const BLOB_PACK_BLOBS_HEADER: &str = "mbx-cache-pack-blobs";
 const BLOB_PACK_BYTES_HEADER: &str = "mbx-cache-pack-bytes";
 const BLOB_PACK_MAGIC: &[u8; 8] = b"MBXPACK1";
 const BLOB_PACK_HEADER_BYTES: u64 = 1 + 32 + 8;
+/// Cap the JSON bodies a remote cache can hand back. Blob downloads are bounded
+/// by the size their digest promises, but action results and manifests carry no
+/// such claim, so without an explicit ceiling a hostile or broken server can
+/// stream until this process runs out of memory -- for manifests, long before
+/// `validate_task_manifest` ever sees the payload. The bound matches the agent's
+/// own request ceiling so both ends of the protocol refuse the same magnitude.
+const MAX_REMOTE_JSON_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
 const BLOB_PACK_TIMEOUT_BYTES_PER_UNIT: u64 = MAX_STAGED_BLOB_PACK_BYTES / 4;
@@ -660,12 +667,8 @@ impl RemoteCacheClient {
             if response.status() == StatusCode::NOT_FOUND {
                 return Ok(None);
             }
-            Ok(Some(
-                response
-                    .error_for_status()?
-                    .json::<RemoteActionResult>()
-                    .await?,
-            ))
+            let bytes = read_bounded_json(response.error_for_status()?, "action result").await?;
+            Ok(Some(serde_json::from_slice::<RemoteActionResult>(&bytes)?))
         })
         .await?;
         if let Some(result) = &result
@@ -716,7 +719,7 @@ impl RemoteCacheClient {
             }
             let response = response.error_for_status()?;
             let etag = parse_strong_etag(response.headers().get(ETAG))?;
-            let bytes = response.bytes().await?.to_vec();
+            let bytes = read_bounded_json(response, "action manifest").await?;
             if blake3::hash(&bytes).to_hex().as_str() != etag {
                 bail!("remote action manifest ETag does not match its body");
             }
@@ -896,6 +899,29 @@ fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Durati
     let item_units = u64::try_from(item_units).unwrap_or(u64::MAX);
     let multiplier = byte_units.max(item_units).max(1);
     base.saturating_mul(u32::try_from(multiplier).unwrap_or(u32::MAX))
+}
+
+/// Buffer a JSON response body, refusing to grow past [`MAX_REMOTE_JSON_BYTES`].
+/// A declared `Content-Length` is rejected up front so an oversized body costs
+/// nothing to refuse; the streaming check then covers servers that understate or
+/// omit it.
+async fn read_bounded_json(response: reqwest::Response, what: &str) -> Result<Vec<u8>> {
+    if let Some(length) = response.content_length()
+        && length > MAX_REMOTE_JSON_BYTES
+    {
+        bail!(
+            "remote cache {what} declared {length} bytes, over the {MAX_REMOTE_JSON_BYTES} byte limit"
+        );
+    }
+    let mut response = response;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        if bytes.len() as u64 + chunk.len() as u64 > MAX_REMOTE_JSON_BYTES {
+            bail!("remote cache {what} exceeded the {MAX_REMOTE_JSON_BYTES} byte limit");
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
 }
 
 async fn decode_blob_pack(
@@ -1822,6 +1848,45 @@ mod tests {
                 error
                     .to_string()
                     .contains("exceeded the size of its digest"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_action_json_larger_than_the_limit() {
+        let mut server = mockito::Server::new_async().await;
+        let key = CacheDigest::blake3(b"action");
+        let oversized = vec![b'x'; MAX_REMOTE_JSON_BYTES as usize + 1];
+        for kind in ["action-results", "action-manifests"] {
+            server
+                .mock(
+                    "GET",
+                    format!(
+                        "/v{PROTOCOL_VERSION}/{kind}/{}/{}/{}",
+                        key.algorithm, key.hash, key.size
+                    )
+                    .as_str(),
+                )
+                .with_status(200)
+                // The manifest path parses the ETag before the body, so the
+                // limit only gets its say once a well-formed one is present.
+                .with_header("etag", &format!("\"{}\"", blake3::hash(b"any").to_hex()))
+                .with_body(oversized.clone())
+                .create_async()
+                .await;
+        }
+        let client = test_client(&server);
+
+        // Neither endpoint's body is bounded by a digest, so the limit is the
+        // only thing standing between a hostile server and this process's memory.
+        for error in [
+            client.get_action_result(&key).await.err().unwrap(),
+            client.get_action_manifest(&key).await.err().unwrap(),
+        ] {
+            assert!(
+                error.to_string().contains("over the")
+                    || error.to_string().contains("exceeded the"),
                 "unexpected error: {error}"
             );
         }

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -767,13 +767,22 @@ impl RemoteCacheClient {
         digest.validate()?;
         let url = self.blob_endpoint(digest)?;
         retry_async("GET", &url, self.retries, || async {
-            let response = self
+            let mut response = self
                 .request(reqwest::Method::GET, url.clone(), media_type)
                 .await?
                 .send()
                 .await?
                 .error_for_status()?;
-            let bytes = response.bytes().await?.to_vec();
+            // Stop reading as soon as the response outgrows the digest it claims
+            // to satisfy. A server that streams more than it promised must not be
+            // able to exhaust this process before verification rejects it.
+            let mut bytes = Vec::new();
+            while let Some(chunk) = response.chunk().await? {
+                if bytes.len() as u64 + chunk.len() as u64 > digest.size {
+                    bail!("remote cache blob exceeded the size of its digest");
+                }
+                bytes.extend_from_slice(&chunk);
+            }
             if !digest.matches_bytes(&bytes)? {
                 bail!("remote cache blob failed digest verification");
             }
@@ -798,7 +807,14 @@ impl RemoteCacheClient {
             fs::create_dir_all(staging_dir)?;
             let temporary = tempfile::NamedTempFile::new_in(staging_dir)?;
             let mut output = tokio::fs::File::from_std(temporary.reopen()?);
+            // Bound the download by the digest's own size so an oversized
+            // response cannot fill the disk before verification rejects it.
+            let mut written = 0u64;
             while let Some(chunk) = response.chunk().await? {
+                written += chunk.len() as u64;
+                if written > digest.size {
+                    bail!("remote cache blob exceeded the size of its digest");
+                }
                 output.write_all(&chunk).await?;
             }
             output.flush().await?;
@@ -1769,6 +1785,46 @@ mod tests {
         assert_eq!(header, "Bearer test-token");
         assert!(header.is_sensitive());
         assert!(authorization_header(Some(" ")).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn rejects_blob_larger_than_its_digest() {
+        let mut server = mockito::Server::new_async().await;
+        let digest = CacheDigest::blake3(b"small");
+        let endpoint = format!(
+            "/v{PROTOCOL_VERSION}/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        );
+        server
+            .mock("GET", endpoint.as_str())
+            .with_status(200)
+            .with_header("content-type", BLOB_MEDIA_TYPE)
+            .with_body(vec![b'x'; 4096])
+            .expect(2)
+            .create_async()
+            .await;
+        let client = test_client(&server);
+        let staging = tempfile::tempdir().unwrap();
+
+        let buffered = client
+            .get_blob(&digest, BLOB_MEDIA_TYPE)
+            .await
+            .err()
+            .unwrap();
+        let streamed = client
+            .get_blob_file(&digest, staging.path())
+            .await
+            .err()
+            .unwrap();
+
+        for error in [buffered, streamed] {
+            assert!(
+                error
+                    .to_string()
+                    .contains("exceeded the size of its digest"),
+                "unexpected error: {error}"
+            );
+        }
     }
 
     fn test_client(server: &mockito::ServerGuard) -> RemoteCacheClient {

--- a/crates/mbx-cache-core/src/local.rs
+++ b/crates/mbx-cache-core/src/local.rs
@@ -1,0 +1,372 @@
+use crate::{CacheDigest, RemoteActionResult, canonical_json};
+use eyre::{Result, bail};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// A validated, content-addressed store on the local filesystem.
+#[derive(Debug, Clone)]
+pub struct LocalCas {
+    root: PathBuf,
+}
+
+/// A local index from action digests to their referenced cache objects.
+#[derive(Debug, Clone)]
+pub struct LocalActionCache {
+    root: PathBuf,
+    cas: LocalCas,
+}
+
+impl LocalCas {
+    /// Create a local content-addressed store beneath `root`.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Return the root shared by this store and its action-result index.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Resolve the storage path for a validated digest.
+    pub fn path_for(&self, digest: &CacheDigest) -> Result<PathBuf> {
+        digest.validate()?;
+        Ok(self
+            .root
+            .join("cas/v1")
+            .join(&digest.algorithm)
+            .join(&digest.hash[..2])
+            .join(format!("{}-{}", digest.hash, digest.size)))
+    }
+
+    /// Find and verify a stored object.
+    pub fn find(&self, digest: &CacheDigest) -> Result<Option<PathBuf>> {
+        let path = self.path_for(digest)?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        if !digest.matches_file(&path)? {
+            bail!(
+                "local CAS blob failed digest verification: {}",
+                path.display()
+            );
+        }
+        Ok(Some(path))
+    }
+
+    /// Atomically store bytes after verifying their declared digest.
+    pub fn store_bytes(&self, digest: &CacheDigest, bytes: &[u8]) -> Result<PathBuf> {
+        if !digest.matches_bytes(bytes)? {
+            bail!("bytes do not match the declared CAS digest");
+        }
+        self.store_with(digest, |temporary| {
+            temporary.write_all(bytes)?;
+            Ok(())
+        })
+    }
+
+    /// Atomically store a file after verifying its declared digest.
+    pub fn store_file(&self, digest: &CacheDigest, source: &Path) -> Result<PathBuf> {
+        self.store_file_inner(digest, source, true)
+    }
+
+    /// Store a file whose digest was already verified by this crate.
+    pub(crate) fn store_verified_file(
+        &self,
+        digest: &CacheDigest,
+        source: &Path,
+    ) -> Result<PathBuf> {
+        self.store_file_inner(digest, source, false)
+    }
+
+    fn store_file_inner(
+        &self,
+        digest: &CacheDigest,
+        source: &Path,
+        verify: bool,
+    ) -> Result<PathBuf> {
+        let destination = self.path_for(digest)?;
+        if let Some(existing) = self.find(digest)? {
+            return Ok(existing);
+        }
+        let parent = destination.parent().expect("CAS path has a parent");
+        fs::create_dir_all(parent)?;
+        let staging = tempfile::tempdir_in(parent)?;
+        let temporary = staging.path().join("blob");
+        reflink_copy::reflink_or_copy(source, &temporary)?;
+        let temporary = tempfile::TempPath::try_from_path(temporary)?;
+        make_owner_writable(&temporary)?;
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&temporary)?
+            .sync_all()?;
+        if verify && !digest.matches_file(&temporary)? {
+            bail!("staged blob does not match the declared CAS digest");
+        }
+        if fs::metadata(&temporary)?.len() != digest.size {
+            bail!("staged blob size does not match the declared CAS digest");
+        }
+        match temporary.persist_noclobber(&destination) {
+            Ok(()) => Ok(destination),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => self
+                .find(digest)?
+                .ok_or_else(|| eyre::eyre!("concurrent CAS write did not publish a valid blob")),
+            Err(error) => Err(error.error.into()),
+        }
+    }
+
+    fn store_with(
+        &self,
+        digest: &CacheDigest,
+        write: impl FnOnce(&mut tempfile::NamedTempFile) -> Result<()>,
+    ) -> Result<PathBuf> {
+        let destination = self.path_for(digest)?;
+        if let Some(existing) = self.find(digest)? {
+            return Ok(existing);
+        }
+        let parent = destination.parent().expect("CAS path has a parent");
+        fs::create_dir_all(parent)?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        write(&mut temporary)?;
+        temporary.flush()?;
+        temporary.as_file().sync_all()?;
+        if !digest.matches_file(temporary.path())? {
+            bail!("staged blob does not match the declared CAS digest");
+        }
+        match temporary.persist_noclobber(&destination) {
+            Ok(_) => Ok(destination),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => self
+                .find(digest)?
+                .ok_or_else(|| eyre::eyre!("concurrent CAS write did not publish a valid blob")),
+            Err(error) => Err(error.error.into()),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn make_owner_writable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(permissions.mode() | 0o200);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn make_owner_writable(path: &Path) -> Result<()> {
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_readonly(false);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+impl LocalActionCache {
+    /// Create an action-result index beneath `root`.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        Self {
+            cas: LocalCas::new(root.clone()),
+            root,
+        }
+    }
+
+    /// Resolve the storage path for an action digest.
+    pub fn path_for(&self, action: &CacheDigest) -> Result<PathBuf> {
+        action.validate()?;
+        if action.algorithm != "blake3" {
+            bail!("local action keys must use blake3");
+        }
+        Ok(self
+            .root
+            .join("action-results/v1")
+            .join(&action.algorithm)
+            .join(&action.hash[..2])
+            .join(format!("{}-{}.json", action.hash, action.size)))
+    }
+
+    /// Find and strictly validate a canonical action result.
+    pub fn find(&self, action: &CacheDigest) -> Result<Option<RemoteActionResult>> {
+        let path = self.path_for(action)?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        let bytes = fs::read(&path)?;
+        let result: RemoteActionResult = serde_json::from_slice(&bytes)?;
+        if result.version != 1 || result.action != *action || canonical_json(&result)? != bytes {
+            bail!("local action result is invalid: {}", path.display());
+        }
+        Ok(Some(result))
+    }
+
+    /// Atomically publish an action result after validating all referenced objects.
+    pub fn store(&self, result: &RemoteActionResult) -> Result<PathBuf> {
+        if result.version != 1 {
+            bail!("unsupported local action result version");
+        }
+        for digest in [
+            Some(&result.action),
+            result.metadata.as_ref(),
+            result.output_root.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if self.cas.find(digest)?.is_none() {
+                bail!("cannot publish an action result with a missing blob");
+            }
+        }
+        let destination = self.path_for(&result.action)?;
+        let replace_invalid = match self.find(&result.action) {
+            Ok(Some(existing)) => {
+                if existing == *result {
+                    return Ok(destination);
+                }
+                bail!("local action key already has a different result");
+            }
+            Ok(None) => false,
+            Err(_) => true,
+        };
+        let parent = destination
+            .parent()
+            .expect("action-result path has a parent");
+        fs::create_dir_all(parent)?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        temporary.write_all(&canonical_json(result)?)?;
+        temporary.flush()?;
+        temporary.as_file().sync_all()?;
+        if replace_invalid {
+            temporary
+                .persist(&destination)
+                .map_err(|error| error.error)?;
+            return Ok(destination);
+        }
+        match temporary.persist_noclobber(&destination) {
+            Ok(_) => Ok(destination),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => self
+                .find(&result.action)?
+                .filter(|existing| existing == result)
+                .map(|_| destination)
+                .ok_or_else(|| eyre::eyre!("concurrent action write was invalid or conflicting")),
+            Err(error) => Err(error.error.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stores_and_validates_blobs_atomically() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let digest = CacheDigest::blake3(b"cached object");
+
+        let path = cas.store_bytes(&digest, b"cached object").unwrap();
+        assert_eq!(cas.find(&digest).unwrap(), Some(path.clone()));
+        assert_eq!(fs::read(&path).unwrap(), b"cached object");
+        assert_eq!(cas.store_bytes(&digest, b"cached object").unwrap(), path);
+        assert!(cas.store_bytes(&digest, b"other object").is_err());
+    }
+
+    #[test]
+    fn stored_files_are_independent_from_the_source() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path().join("cache"));
+        let source = directory.path().join("source");
+        fs::write(&source, b"cached object").unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+
+        let stored = cas.store_file(&digest, &source).unwrap();
+        fs::write(source, b"other object!").unwrap();
+
+        assert_eq!(fs::read(stored).unwrap(), b"cached object");
+        assert!(cas.find(&digest).unwrap().is_some());
+    }
+
+    #[test]
+    fn rejects_files_with_the_wrong_digest() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path().join("cache"));
+        let source = directory.path().join("source");
+        fs::write(&source, b"other object").unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+
+        assert!(cas.store_file(&digest, &source).is_err());
+        assert!(!cas.path_for(&digest).unwrap().exists());
+    }
+
+    #[test]
+    fn stores_read_only_source_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path().join("cache"));
+        let source = directory.path().join("source");
+        fs::write(&source, b"cached object").unwrap();
+        let mut permissions = fs::metadata(&source).unwrap().permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&source, permissions).unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+
+        let stored = cas.store_file(&digest, &source).unwrap();
+
+        assert_eq!(fs::read(stored).unwrap(), b"cached object");
+        assert!(fs::metadata(&source).unwrap().permissions().readonly());
+        make_owner_writable(&source).unwrap();
+    }
+
+    #[test]
+    fn rejects_corrupt_existing_blobs() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let digest = CacheDigest::blake3(b"cached object");
+        let path = cas.store_bytes(&digest, b"cached object").unwrap();
+        fs::write(path, b"corrupt").unwrap();
+
+        assert!(cas.find(&digest).is_err());
+    }
+
+    #[test]
+    fn publishes_action_results_after_referenced_blobs() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let actions = LocalActionCache::new(directory.path());
+        let action = CacheDigest::blake3(b"action");
+        let metadata = CacheDigest::blake3(b"metadata");
+        let output_root = CacheDigest::blake3(b"directory");
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.clone()),
+            output_root: Some(output_root.clone()),
+            version: 1,
+        };
+
+        assert!(actions.store(&result).is_err());
+        cas.store_bytes(&action, b"action").unwrap();
+        cas.store_bytes(&metadata, b"metadata").unwrap();
+        cas.store_bytes(&output_root, b"directory").unwrap();
+        actions.store(&result).unwrap();
+        assert_eq!(actions.find(&action).unwrap(), Some(result));
+    }
+
+    #[test]
+    fn atomically_replaces_a_corrupt_action_result() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let actions = LocalActionCache::new(directory.path());
+        let action = CacheDigest::blake3(b"action");
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: None,
+            output_root: None,
+            version: 1,
+        };
+        cas.store_bytes(&action, b"action").unwrap();
+        let path = actions.path_for(&action).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"truncated").unwrap();
+
+        assert!(actions.find(&action).is_err());
+        assert_eq!(actions.store(&result).unwrap(), path);
+        assert_eq!(actions.find(&action).unwrap(), Some(result));
+    }
+}


### PR DESCRIPTION
Ports `mise-cache-core` into this repo as `mbx-cache-core`: the action-cache protocol, canonical-JSON action digests, local CAS and action cache, the remote HTTP client (blob packs, retries, static-token and GitHub Actions OIDC auth), and the cache agent.

The port is verbatim apart from the wire rename, which is the point of doing it now — before anything in the wild speaks these names:

| mise | mbx |
| --- | --- |
| `application/vnd.mise.cache-*` | `application/vnd.mbx.cache-*` |
| `mise-cache-protocol`, `mise-cache-namespace` | `mbx-cache-protocol`, `mbx-cache-namespace` |
| `mise-cache-pack-blobs`, `mise-cache-pack-bytes` | `mbx-cache-pack-blobs`, `mbx-cache-pack-bytes` |
| `MISEPK01` blob-pack magic | `MBXPACK1` |
| `MISE_TASK_CACHE_REMOTE_TOKEN` (in an OIDC error hint) | `MBX_REMOTE_TOKEN` |
| `MISE_CACHE_BENCH_*` (ignored benchmark knobs) | `MBX_BENCH_*` |

The magic is a fixed 8 bytes, so it is `MBXPACK1` rather than the `MBXPK01` the plan first listed; PR #1 is updated to match.

Protocol version stays 1. The `CacheAgent` doc comment no longer refers to `mise run` — transport listeners still live in the embedder, which will be the `mbx` CLI.

All 51 upstream tests come along and pass, including the mockito-backed remote-client and blob-pack coverage.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cache protocol, CAS integrity, and remote auth (tokens/OIDC) are security-sensitive, but the crate is additive and not yet used by `mbx`.
> 
> **Overview**
> Adds **`mbx-cache-core`**: action-cache protocol, canonical-JSON digests, local CAS/action cache, remote HTTP client, and a task-scoped `CacheAgent`. This is a port of `mise-cache-core` with **mbx wire names** (`application/vnd.mbx.cache-*`, `mbx-cache-*` headers, `MBXPACK1` blob-pack magic) before anything speaks the old names.
> 
> The agent serves a newline-delimited JSON protocol for blob/action lookup and store, task-manifest predictions, prefetch of remote actions (including blob packs), and bounded executable-identity memoization. The remote client covers blob packs, retries, static tokens, and GitHub Actions OIDC.
> 
> Workspace membership is updated; `mbx` does not depend on the crate yet. Upstream tests (including mockito remote/blob-pack coverage) are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd3374adf63724291e4493f57ffdfa90de725a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->