### PR TITLE
feat(session): add the cache session and rustc shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "bytesize"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
+
+[[package]]
 name = "cc"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +238,27 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -811,6 +838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +882,23 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "mbx"
 version = "0.0.0"
+dependencies = [
+ "bytesize",
+ "dirs",
+ "eyre",
+ "log",
+ "mbx-cache-core",
+ "mbx-cache-rustc",
+ "rand 0.10.2",
+ "reflink-copy",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "toml",
+ "which",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "mbx-cache-core"
@@ -990,6 +1043,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1199,6 +1258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1528,6 +1598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1874,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2386,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -8,3 +8,33 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+bytesize = "2"
+dirs = "6"
+eyre = "0.6"
+log = "0.4"
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.0.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.0.0", default-features = false }
+reflink-copy = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync"] }
+toml = "0.9"
+which = "8"
+
+[target.'cfg(windows)'.dependencies]
+rand = "0.10"
+windows-sys = { version = "0.61", features = [
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_System_Threading",
+] }
+
+[features]
+default = ["rustls"]
+native-tls = ["mbx-cache-core/native-tls", "mbx-cache-rustc/native-tls"]
+rustls = ["mbx-cache-core/rustls", "mbx-cache-rustc/rustls"]
+rustls-native-roots = [
+  "mbx-cache-core/rustls-native-roots",
+  "mbx-cache-rustc/rustls-native-roots",
+]

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -14,6 +14,7 @@ eyre = "0.6"
 log = "0.4"
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.0.0", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.0.0", default-features = false }
+rand = "0.10"
 reflink-copy = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -23,8 +24,8 @@ toml = "0.9"
 which = "8"
 
 [target.'cfg(windows)'.dependencies]
-rand = "0.10"
 windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
   "Win32_Security",
   "Win32_Security_Authorization",
   "Win32_System_Threading",

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -19,7 +19,7 @@ reflink-copy = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 toml = "0.9"
 which = "8"
 

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -1,0 +1,267 @@
+//! Configuration, resolved from environment variables over an optional file.
+//!
+//! Precedence is environment, then `~/.config/mbx/config.toml`, then defaults.
+
+use crate::util::parse_duration;
+use eyre::{Context, Result};
+use mbx_cache_core::RemoteCacheMode;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_HTTP_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+const DEFAULT_HTTP_RETRIES: i64 = 3;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+struct ConfigFile {
+    cache_dir: Option<PathBuf>,
+    stats_report: Option<PathBuf>,
+    remote: RemoteFile,
+    http: HttpFile,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+struct RemoteFile {
+    url: Option<String>,
+    namespace: Option<String>,
+    token: Option<String>,
+    token_file: Option<PathBuf>,
+    oidc_audience: Option<String>,
+    mode: Option<RemoteCacheMode>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+struct HttpFile {
+    timeout: Option<String>,
+    download_timeout: Option<String>,
+    retries: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub cache_dir: PathBuf,
+    pub stats_report: Option<PathBuf>,
+    pub verify: bool,
+    pub remote: RemoteSettings,
+    pub http: HttpSettings,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RemoteSettings {
+    pub url: Option<String>,
+    pub namespace: Option<String>,
+    pub token: Option<String>,
+    pub token_file: Option<PathBuf>,
+    pub oidc_audience: Option<String>,
+    pub mode: RemoteCacheMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpSettings {
+    pub timeout: Duration,
+    pub download_timeout: Duration,
+    pub retries: i64,
+}
+
+impl Default for HttpSettings {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_HTTP_TIMEOUT,
+            download_timeout: DEFAULT_HTTP_DOWNLOAD_TIMEOUT,
+            retries: DEFAULT_HTTP_RETRIES,
+        }
+    }
+}
+
+impl Config {
+    /// Load configuration for this machine.
+    pub fn load() -> Result<Self> {
+        let file = match config_file_path() {
+            Some(path) => read_config_file(&path)?,
+            None => ConfigFile::default(),
+        };
+        Self::from_parts(file, |name| std::env::var(name).ok())
+    }
+
+    fn from_parts(file: ConfigFile, get_env: impl Fn(&str) -> Option<String>) -> Result<Self> {
+        let cache_dir = get_env("MBX_CACHE_DIR")
+            .map(PathBuf::from)
+            .or(file.cache_dir)
+            .or_else(default_cache_dir)
+            .ok_or_else(|| {
+                eyre::eyre!("could not determine a cache directory; set MBX_CACHE_DIR")
+            })?;
+        let mode = match get_env("MBX_REMOTE_MODE") {
+            Some(value) => value
+                .parse()
+                .wrap_err_with(|| format!("invalid MBX_REMOTE_MODE: {value}"))?,
+            None => file.remote.mode.unwrap_or_default(),
+        };
+        let http = HttpSettings {
+            timeout: optional_duration("MBX_HTTP_TIMEOUT", &get_env, file.http.timeout.as_deref())?
+                .unwrap_or(DEFAULT_HTTP_TIMEOUT),
+            download_timeout: optional_duration(
+                "MBX_HTTP_DOWNLOAD_TIMEOUT",
+                &get_env,
+                file.http.download_timeout.as_deref(),
+            )?
+            .unwrap_or(DEFAULT_HTTP_DOWNLOAD_TIMEOUT),
+            retries: match get_env("MBX_HTTP_RETRIES") {
+                Some(value) => value
+                    .parse()
+                    .wrap_err_with(|| format!("invalid MBX_HTTP_RETRIES: {value}"))?,
+                None => file.http.retries.unwrap_or(DEFAULT_HTTP_RETRIES),
+            },
+        };
+        Ok(Self {
+            cache_dir,
+            stats_report: get_env("MBX_STATS_REPORT")
+                .map(PathBuf::from)
+                .or(file.stats_report),
+            verify: get_env("MBX_VERIFY").is_some_and(|value| !value.is_empty() && value != "0"),
+            remote: RemoteSettings {
+                url: get_env("MBX_REMOTE_URL").or(file.remote.url),
+                namespace: get_env("MBX_REMOTE_NAMESPACE").or(file.remote.namespace),
+                token: get_env("MBX_REMOTE_TOKEN").or(file.remote.token),
+                token_file: get_env("MBX_REMOTE_TOKEN_FILE")
+                    .map(PathBuf::from)
+                    .or(file.remote.token_file),
+                oidc_audience: get_env("MBX_REMOTE_OIDC_AUDIENCE").or(file.remote.oidc_audience),
+                mode,
+            },
+            http,
+        })
+    }
+
+    /// Where cached actions and blobs live.
+    pub fn store_dir(&self) -> PathBuf {
+        self.cache_dir.join("actions")
+    }
+}
+
+fn optional_duration(
+    name: &str,
+    get_env: &impl Fn(&str) -> Option<String>,
+    from_file: Option<&str>,
+) -> Result<Option<Duration>> {
+    match get_env(name) {
+        Some(value) => parse_duration(&value)
+            .map(Some)
+            .wrap_err_with(|| format!("invalid {name}")),
+        None => from_file.map(parse_duration).transpose(),
+    }
+}
+
+fn read_config_file(path: &Path) -> Result<ConfigFile> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            toml::from_str(&contents).wrap_err_with(|| format!("invalid {}", path.display()))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(ConfigFile::default()),
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn config_file_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join("mbx").join("config.toml"))
+}
+
+fn default_cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir().map(|dir| dir.join("mbx"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn env(values: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let values: HashMap<String, String> = values
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        move |name: &str| values.get(name).cloned()
+    }
+
+    #[test]
+    fn environment_overrides_the_file() {
+        let file: ConfigFile = toml::from_str(
+            r#"
+            cache_dir = "/from/file"
+            [remote]
+            url = "https://file.example"
+            namespace = "file"
+            mode = "read-only"
+            [http]
+            timeout = "5s"
+            retries = 9
+            "#,
+        )
+        .unwrap();
+        let config = Config::from_parts(
+            file,
+            env(&[
+                ("MBX_CACHE_DIR", "/from/env"),
+                ("MBX_REMOTE_URL", "https://env.example"),
+                ("MBX_REMOTE_MODE", "write-only"),
+                ("MBX_HTTP_TIMEOUT", "250ms"),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(config.cache_dir, PathBuf::from("/from/env"));
+        assert_eq!(config.remote.url.unwrap(), "https://env.example");
+        assert_eq!(config.remote.mode, RemoteCacheMode::WriteOnly);
+        assert_eq!(config.http.timeout, Duration::from_millis(250));
+        // Values absent from the environment still come from the file.
+        assert_eq!(config.remote.namespace.unwrap(), "file");
+        assert_eq!(config.http.retries, 9);
+    }
+
+    #[test]
+    fn defaults_apply_without_configuration() {
+        let config = Config::from_parts(ConfigFile::default(), env(&[])).unwrap();
+        assert_eq!(config.http.timeout, DEFAULT_HTTP_TIMEOUT);
+        assert_eq!(config.http.download_timeout, DEFAULT_HTTP_DOWNLOAD_TIMEOUT);
+        assert_eq!(config.http.retries, DEFAULT_HTTP_RETRIES);
+        assert_eq!(config.remote.mode, RemoteCacheMode::ReadWrite);
+        assert!(config.remote.url.is_none());
+        assert!(!config.verify);
+        assert!(config.store_dir().ends_with("actions"));
+    }
+
+    #[test]
+    fn rejects_unparseable_values() {
+        assert!(
+            Config::from_parts(
+                ConfigFile::default(),
+                env(&[("MBX_REMOTE_MODE", "sideways")])
+            )
+            .is_err()
+        );
+        assert!(
+            Config::from_parts(ConfigFile::default(), env(&[("MBX_HTTP_TIMEOUT", "later")]))
+                .is_err()
+        );
+        assert!(
+            Config::from_parts(ConfigFile::default(), env(&[("MBX_HTTP_RETRIES", "many")]))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn verify_is_off_for_empty_and_zero() {
+        for value in ["", "0"] {
+            let config =
+                Config::from_parts(ConfigFile::default(), env(&[("MBX_VERIFY", value)])).unwrap();
+            assert!(!config.verify, "MBX_VERIFY={value:?} should not enable");
+        }
+        let config =
+            Config::from_parts(ConfigFile::default(), env(&[("MBX_VERIFY", "1")])).unwrap();
+        assert!(config.verify);
+    }
+}

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -1,0 +1,12 @@
+//! mbx: a build cache for Rust projects.
+//!
+//! Compilations are cached as individual rustc actions in a content-addressed
+//! store shared by every project and worktree on a machine, and optionally
+//! shared further through a remote cache.
+
+pub mod config;
+pub mod policy;
+pub mod session;
+pub mod util;
+
+mod rustc;

--- a/crates/mbx/src/main.rs
+++ b/crates/mbx/src/main.rs
@@ -1,4 +1,12 @@
-fn main() {
-    eprintln!("mbx is not implemented yet; see PLAN.md");
-    std::process::exit(1);
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    // Cargo invokes the rustc shim thousands of times per build. Dispatch on
+    // argv0 before any runtime, logging, or configuration setup.
+    if mbx::session::is_rustc_shim() {
+        return mbx::session::run_rustc_shim();
+    }
+
+    eprintln!("mbx: the command line is not implemented yet; see PLAN.md");
+    ExitCode::from(1)
 }

--- a/crates/mbx/src/policy.rs
+++ b/crates/mbx/src/policy.rs
@@ -1,0 +1,143 @@
+//! Remote-cache write policy.
+//!
+//! Cache writes are only trusted from a CI context that a pull request cannot
+//! influence, so untrusted contexts read the remote cache but never publish to
+//! it. Release builds do not participate at all.
+
+use mbx_cache_core::RemoteCacheMode;
+
+/// Resolve the remote-cache mode that is actually permitted here.
+///
+/// Returns `None` when the configured mode leaves nothing to do.
+pub fn effective_remote_cache_mode(configured: RemoteCacheMode) -> Option<RemoteCacheMode> {
+    effective_remote_cache_mode_with(configured, |name| std::env::var(name).ok())
+}
+
+fn effective_remote_cache_mode_with(
+    configured: RemoteCacheMode,
+    get_env: impl Fn(&str) -> Option<String>,
+) -> Option<RemoteCacheMode> {
+    if trusted_cache_writer(&get_env) {
+        return Some(configured);
+    }
+    match configured {
+        RemoteCacheMode::ReadWrite | RemoteCacheMode::ReadOnly => Some(RemoteCacheMode::ReadOnly),
+        RemoteCacheMode::WriteOnly => None,
+    }
+}
+
+/// Whether this is a release build, which never uses the cache.
+pub fn release_context() -> bool {
+    release_context_with(|name| std::env::var(name).ok())
+}
+
+fn trusted_cache_writer(get_env: &impl Fn(&str) -> Option<String>) -> bool {
+    if env_truthy(get_env("GITHUB_ACTIONS")) {
+        return get_env("GITHUB_EVENT_NAME").as_deref() == Some("push")
+            && get_env("GITHUB_REF_TYPE").as_deref() == Some("branch")
+            && env_truthy(get_env("GITHUB_REF_PROTECTED"));
+    }
+    if env_truthy(get_env("GITLAB_CI")) {
+        return get_env("CI_PIPELINE_SOURCE").as_deref() == Some("push")
+            && get_env("CI_COMMIT_TAG").is_none()
+            && get_env("CI_MERGE_REQUEST_IID").is_none()
+            && env_truthy(get_env("CI_COMMIT_REF_PROTECTED"));
+    }
+    false
+}
+
+fn release_context_with(get_env: impl Fn(&str) -> Option<String>) -> bool {
+    (env_truthy(get_env("GITHUB_ACTIONS"))
+        && (get_env("GITHUB_REF_TYPE").as_deref() == Some("tag")
+            || get_env("GITHUB_EVENT_NAME").as_deref() == Some("release")))
+        || (env_truthy(get_env("GITLAB_CI")) && get_env("CI_COMMIT_TAG").is_some())
+}
+
+fn env_truthy(value: Option<String>) -> bool {
+    value.is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn env(values: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let values: HashMap<String, String> = values
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        move |name: &str| values.get(name).cloned()
+    }
+
+    #[test]
+    fn untrusted_contexts_only_read() {
+        let local = env(&[]);
+        assert_eq!(
+            effective_remote_cache_mode_with(RemoteCacheMode::ReadWrite, &local),
+            Some(RemoteCacheMode::ReadOnly)
+        );
+        assert_eq!(
+            effective_remote_cache_mode_with(RemoteCacheMode::WriteOnly, &local),
+            None
+        );
+    }
+
+    #[test]
+    fn protected_branch_pushes_may_write() {
+        let ci = env(&[
+            ("GITHUB_ACTIONS", "true"),
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "branch"),
+            ("GITHUB_REF_PROTECTED", "true"),
+        ]);
+        assert_eq!(
+            effective_remote_cache_mode_with(RemoteCacheMode::ReadWrite, &ci),
+            Some(RemoteCacheMode::ReadWrite)
+        );
+    }
+
+    #[test]
+    fn pull_requests_may_not_write() {
+        let pull_request = env(&[
+            ("GITHUB_ACTIONS", "true"),
+            ("GITHUB_EVENT_NAME", "pull_request"),
+            ("GITHUB_REF_TYPE", "branch"),
+            ("GITHUB_REF_PROTECTED", "true"),
+        ]);
+        assert_eq!(
+            effective_remote_cache_mode_with(RemoteCacheMode::ReadWrite, &pull_request),
+            Some(RemoteCacheMode::ReadOnly)
+        );
+    }
+
+    #[test]
+    fn merge_requests_may_not_write() {
+        let merge_request = env(&[
+            ("GITLAB_CI", "true"),
+            ("CI_PIPELINE_SOURCE", "push"),
+            ("CI_MERGE_REQUEST_IID", "7"),
+            ("CI_COMMIT_REF_PROTECTED", "true"),
+        ]);
+        assert_eq!(
+            effective_remote_cache_mode_with(RemoteCacheMode::ReadWrite, &merge_request),
+            Some(RemoteCacheMode::ReadOnly)
+        );
+    }
+
+    #[test]
+    fn tags_and_releases_are_release_contexts() {
+        assert!(release_context_with(env(&[
+            ("GITHUB_ACTIONS", "1"),
+            ("GITHUB_REF_TYPE", "tag"),
+        ])));
+        assert!(release_context_with(env(&[
+            ("GITLAB_CI", "1"),
+            ("CI_COMMIT_TAG", "v1.0.0"),
+        ])));
+        assert!(!release_context_with(env(&[
+            ("GITHUB_ACTIONS", "1"),
+            ("GITHUB_REF_TYPE", "branch"),
+        ])));
+    }
+}

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1,0 +1,1154 @@
+use crate::session;
+use eyre::{Context, Result, bail};
+use mbx_cache_core::{
+    ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode,
+    RemoteActionResult, RestoreStats, RustcMetadata, canonical_json,
+};
+use mbx_cache_rustc::{
+    ActionContext, CompilerIdentity, DiscoveredInputs, PathMapping, RustcAction, RustcDepInfo,
+    RustcInputPrediction, RustcInvocation, RustcOutputs,
+};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::{OsStr, OsString};
+use std::io::{Read as _, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, ExitStatus, Output};
+use std::time::{Instant, SystemTime};
+
+struct CachedCompilation {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    outputs: Vec<CachedOutput>,
+    restore: RestoreStats,
+}
+
+struct CachedOutput {
+    path: PathBuf,
+    digest: CacheDigest,
+    mode: u32,
+}
+
+struct StagedOutputs {
+    directory: tempfile::TempDir,
+    files: Vec<(tempfile::TempPath, PathBuf)>,
+}
+
+pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
+    let invocation = RustcInvocation::parse(arguments)?;
+    let working_dir = std::env::current_dir()?;
+    let outputs = invocation.outputs(&working_dir)?;
+
+    let verify = std::env::var_os(session::VERIFY_ENV).is_some();
+    let mut verification = None;
+    let mut action_lookup_attempted = false;
+    if outputs.dep_info.is_file()
+        && let Ok((action, discovered)) =
+            action_from_current_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)
+    {
+        action_lookup_attempted = true;
+        match restore_result(&action, &outputs, &discovered, !verify) {
+            Ok(Some(cached)) => {
+                record_prediction(rustc, &invocation, &action, &discovered, &working_dir);
+                if verify {
+                    verification = Some(cached);
+                } else {
+                    let _ = replay_bytes(&cached.stdout, &cached.stderr);
+                    return Ok(ExitCode::SUCCESS);
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("mbx warning: result was not restored: {error:#}");
+            }
+        }
+    }
+    if !action_lookup_attempted {
+        match restore_predicted_result(rustc, &invocation, &outputs, &working_dir, !verify) {
+            Ok(Some(cached)) => {
+                if verify {
+                    verification = Some(cached);
+                } else {
+                    let _ = replay_bytes(&cached.stdout, &cached.stderr);
+                    return Ok(ExitCode::SUCCESS);
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("mbx warning: prediction was not restored: {error:#}");
+            }
+        }
+    }
+
+    let compilation_started = SystemTime::now();
+    let output = Command::new(rustc)
+        .args(arguments)
+        .current_dir(&working_dir)
+        .output()
+        .wrap_err("failed to execute rustc")?;
+    let _ = replay_output(&output);
+    if let Some(cached) = verification {
+        let matched = cached_matches(&cached, &output);
+        record_verification(matched, cached.restore);
+        if !matched {
+            eprintln!("mbx warning: shadow verification diverged from cached output");
+        }
+        return Ok(exit_code(output.status));
+    }
+    if output.status.success() {
+        let publication: Result<()> = (|| {
+            let (action, discovered) =
+                action_from_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)?;
+            discovered.verify_not_modified_since(compilation_started)?;
+            discovered.verify()?;
+            let mut cacheable_outputs = outputs.files.clone();
+            cacheable_outputs.push(outputs.dep_info.clone());
+            publish_result(&action.digest, &action.bytes, &cacheable_outputs, &output)?;
+            record_prediction(rustc, &invocation, &action, &discovered, &working_dir);
+            Ok(())
+        })();
+        if let Err(error) = publication {
+            eprintln!("mbx warning: result was not stored: {error:#}");
+        }
+    }
+    Ok(exit_code(output.status))
+}
+
+fn restore_predicted_result(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    outputs: &RustcOutputs,
+    working_dir: &Path,
+    restore_outputs: bool,
+) -> Result<Option<CachedCompilation>> {
+    let task = std::env::var(session::BUILD_ENV)
+        .wrap_err_with(|| format!("{} is not set", session::BUILD_ENV))?;
+    let mut context = base_action_context(rustc, working_dir)?;
+    let invocation_digest = invocation.invocation_digest(&context)?;
+    let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
+        task,
+        invocation: invocation_digest.clone(),
+    }])?;
+    let Some(response) = responses.into_iter().next() else {
+        bail!("cache agent did not return an action prediction response");
+    };
+    let prediction = match response {
+        AgentResponse::ActionPrediction {
+            prediction: Some(prediction),
+        } => prediction,
+        AgentResponse::ActionPrediction { prediction: None } => return Ok(None),
+        AgentResponse::Error { message } => bail!(message),
+        _ => bail!("cache agent returned an unexpected action prediction response"),
+    };
+    if prediction.adapter != "rustc" || prediction.invocation != invocation_digest {
+        bail!("cache agent returned an incompatible rustc action prediction");
+    }
+    let input_prediction: RustcInputPrediction = serde_json::from_str(&prediction.payload)?;
+    if String::from_utf8(canonical_json(&input_prediction)?)? != prediction.payload {
+        bail!("cache agent returned a non-canonical rustc action prediction");
+    }
+    let discovered = input_prediction.discover(working_dir, &context.path_mappings)?;
+    discovered.clone().apply_to(&mut context)?;
+    let action = invocation.action(context)?;
+    let restored = restore_result(&action, outputs, &discovered, restore_outputs)?;
+    if restored.is_some() {
+        record_prediction_value(invocation_digest, action.digest.clone(), prediction.payload);
+    }
+    Ok(restored)
+}
+
+fn action_from_dep_info(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    dep_info: &Path,
+    working_dir: &Path,
+) -> Result<(RustcAction, DiscoveredInputs)> {
+    let dep_info = RustcDepInfo::read(dep_info)?;
+    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir)
+}
+
+fn action_from_current_dep_info(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    dep_info: &Path,
+    working_dir: &Path,
+) -> Result<(RustcAction, DiscoveredInputs)> {
+    let dep_info = RustcDepInfo::read(dep_info)?;
+    verify_environment(&dep_info.environment)?;
+    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir)
+}
+
+fn action_from_parsed_dep_info(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    dep_info: &RustcDepInfo,
+    working_dir: &Path,
+) -> Result<(RustcAction, DiscoveredInputs)> {
+    let discovered = invocation.discover_inputs(dep_info, working_dir)?;
+    let mut context = base_action_context(rustc, working_dir)?;
+    discovered.clone().apply_to(&mut context)?;
+    let action = invocation.action(context)?;
+    Ok((action, discovered))
+}
+
+fn base_action_context(rustc: &OsStr, working_dir: &Path) -> Result<ActionContext> {
+    Ok(ActionContext {
+        compiler: compiler_identity(rustc)?,
+        working_dir: working_dir.to_path_buf(),
+        path_mappings: path_mappings(working_dir),
+        environment: BTreeMap::new(),
+        inputs: Vec::new(),
+    })
+}
+
+fn record_prediction(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    action: &RustcAction,
+    discovered: &DiscoveredInputs,
+    working_dir: &Path,
+) {
+    let result = (|| {
+        let context = base_action_context(rustc, working_dir)?;
+        let invocation_digest = invocation.invocation_digest(&context)?;
+        let prediction = invocation.prediction(&context, discovered)?;
+        let payload = String::from_utf8(canonical_json(&prediction)?)?;
+        record_prediction_value(invocation_digest, action.digest.clone(), payload);
+        Result::<()>::Ok(())
+    })();
+    if let Err(error) = result {
+        eprintln!("mbx warning: action prediction was not recorded: {error:#}");
+    }
+}
+
+fn record_prediction_value(invocation: CacheDigest, action: CacheDigest, payload: String) {
+    let result = (|| {
+        let task = std::env::var(session::BUILD_ENV)
+            .wrap_err_with(|| format!("{} is not set", session::BUILD_ENV))?;
+        let responses = session::request_agent(&[AgentRequest::RecordActionPrediction {
+            task,
+            prediction: ActionPrediction {
+                invocation,
+                action,
+                adapter: "rustc".into(),
+                payload,
+            },
+        }])?;
+        match responses.into_iter().next() {
+            Some(AgentResponse::ActionPredictionRecorded) => Ok(()),
+            Some(AgentResponse::Error { message }) => bail!(message),
+            _ => bail!("cache agent returned an unexpected prediction response"),
+        }
+    })();
+    if let Err(error) = result {
+        eprintln!("mbx warning: action prediction was not recorded: {error:#}");
+    }
+}
+
+fn verify_environment(environment: &BTreeMap<String, Option<String>>) -> Result<()> {
+    for (name, expected) in environment {
+        let actual = std::env::var_os(name)
+            .map(|value| {
+                value.into_string().map_err(|_| {
+                    eyre::eyre!("compiler environment input is not valid UTF-8: {name}")
+                })
+            })
+            .transpose()?;
+        if &actual != expected {
+            bail!("compiler environment input changed: {name}");
+        }
+    }
+    Ok(())
+}
+
+fn restore_result(
+    action: &RustcAction,
+    outputs: &RustcOutputs,
+    discovered: &DiscoveredInputs,
+    restore_outputs: bool,
+) -> Result<Option<CachedCompilation>> {
+    let responses = session::request_agent(&[AgentRequest::FindActionResult {
+        action: action.digest.clone(),
+    }])?;
+    let Some(response) = responses.into_iter().next() else {
+        bail!("cache agent did not return an action lookup response");
+    };
+    let result = match response {
+        AgentResponse::ActionResult { result } => match result {
+            Some(result) => result,
+            None => return Ok(None),
+        },
+        AgentResponse::Error { message } => bail!(message),
+        _ => bail!("cache agent returned an unexpected action lookup response"),
+    };
+    if result.version != 1 || result.action != action.digest {
+        bail!("cached rustc action result has an invalid identity");
+    }
+    let metadata_digest = result
+        .metadata
+        .ok_or_else(|| eyre::eyre!("cached rustc action result has no metadata"))?;
+    let output_root_digest = result
+        .output_root
+        .ok_or_else(|| eyre::eyre!("cached rustc action result has no output root"))?;
+    let roots = find_blobs(&[
+        action.digest.clone(),
+        metadata_digest.clone(),
+        output_root_digest.clone(),
+    ])?;
+    let cached_action = read_verified_blob(&roots[0], &action.digest, "action descriptor")?;
+    if cached_action != action.bytes {
+        bail!("cached rustc action descriptor does not match the invocation");
+    }
+    let metadata: RustcMetadata =
+        read_canonical_blob(&roots[1], &metadata_digest, "rustc metadata")?;
+    if metadata.version != 1 || metadata.kind != "rustc" {
+        bail!("cached rustc metadata is unsupported");
+    }
+    let directory: CacheDirectory =
+        read_canonical_blob(&roots[2], &output_root_digest, "output directory")?;
+    let files = validated_outputs(directory, outputs)?;
+    let cached_outputs = files
+        .iter()
+        .map(|(node, destination)| CachedOutput {
+            path: destination.clone(),
+            digest: node.digest.clone(),
+            mode: node.mode,
+        })
+        .collect();
+    let restored_output_files = files.len().try_into().unwrap_or(u64::MAX);
+    let restored_output_bytes = files.iter().fold(0_u64, |total, (node, _)| {
+        total.saturating_add(node.digest.size)
+    });
+
+    let mut digests = vec![metadata.stdout.clone(), metadata.stderr.clone()];
+    digests.extend(files.iter().map(|(node, _)| node.digest.clone()));
+    let blobs = find_blobs(&digests)?;
+    let stdout = read_verified_blob(&blobs[0], &metadata.stdout, "stdout")?;
+    let stderr = read_verified_blob(&blobs[1], &metadata.stderr, "stderr")?;
+
+    let materialization_started = Instant::now();
+    std::fs::create_dir_all(&outputs.directory)?;
+    let staging = tempfile::tempdir_in(&outputs.directory)?;
+    let mut staged = Vec::with_capacity(files.len());
+    for (index, ((node, destination), source)) in files.into_iter().zip(&blobs[2..]).enumerate() {
+        let temporary = stage_cached_output(staging.path(), index, source, &node)?;
+        staged.push((temporary, destination));
+    }
+    let staged = StagedOutputs {
+        directory: staging,
+        files: staged,
+    };
+
+    discovered.verify()?;
+    verify_environment(&discovered.environment)?;
+    finalize_restored_outputs(staged, restore_outputs)?;
+    let restore = RestoreStats {
+        duration_ns: materialization_started
+            .elapsed()
+            .as_nanos()
+            .try_into()
+            .unwrap_or(u64::MAX),
+        output_files: restored_output_files,
+        output_bytes: restored_output_bytes,
+    };
+    if restore_outputs {
+        record_action_hit(&action.digest, restore);
+    }
+    Ok(Some(CachedCompilation {
+        stdout,
+        stderr,
+        outputs: cached_outputs,
+        restore,
+    }))
+}
+
+fn finalize_restored_outputs(staged: StagedOutputs, restore_outputs: bool) -> Result<()> {
+    if restore_outputs {
+        persist_outputs(staged)?;
+    }
+    Ok(())
+}
+
+fn stage_cached_output(
+    directory: &Path,
+    index: usize,
+    source: &Path,
+    node: &CacheFileNode,
+) -> Result<tempfile::TempPath> {
+    let temporary = directory.join(format!("output-{index}"));
+    reflink_copy::reflink_or_copy(source, &temporary)
+        .wrap_err_with(|| format!("failed to materialize cached rustc output {}", node.name))?;
+    let temporary = tempfile::TempPath::try_from_path(temporary)?;
+    make_owner_writable(&temporary)?;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&temporary)?
+        .sync_all()?;
+    if !node.digest.matches_file(&temporary)? {
+        bail!(
+            "cached rustc output failed digest verification: {}",
+            node.name
+        );
+    }
+    apply_file_mode(&temporary, node.mode)?;
+    Ok(temporary)
+}
+
+fn cached_matches(cached: &CachedCompilation, output: &Output) -> bool {
+    output.status.success()
+        && cached.stdout == output.stdout
+        && cached.stderr == output.stderr
+        && cached.outputs.iter().all(|expected| {
+            std::fs::metadata(&expected.path).is_ok_and(|metadata| {
+                file_mode(&metadata) == expected.mode
+                    && expected
+                        .digest
+                        .matches_file(&expected.path)
+                        .unwrap_or(false)
+            })
+        })
+}
+
+fn record_verification(matched: bool, restore: RestoreStats) {
+    let responses =
+        session::request_agent(&[AgentRequest::RecordActionVerification { matched, restore }]);
+    match responses.map(|responses| responses.into_iter().next()) {
+        Ok(Some(AgentResponse::ActionVerificationRecorded)) => {}
+        Ok(Some(AgentResponse::Error { message })) => {
+            eprintln!("mbx warning: verification was not recorded: {message}");
+        }
+        Ok(_) => eprintln!("mbx warning: verification was not recorded"),
+        Err(error) => {
+            eprintln!("mbx warning: verification was not recorded: {error:#}");
+        }
+    }
+}
+
+fn persist_outputs(staged: StagedOutputs) -> Result<()> {
+    let StagedOutputs {
+        directory: _directory,
+        files,
+    } = staged;
+    let destinations = files
+        .iter()
+        .map(|(_, destination)| destination.clone())
+        .collect::<Vec<_>>();
+    for (temporary, destination) in files {
+        let persisted = temporary
+            .persist(&destination)
+            .map_err(|error| error.error)
+            .wrap_err_with(|| format!("failed to atomically restore {}", destination.display()));
+        if let Err(error) = persisted {
+            for destination in &destinations {
+                match std::fs::remove_file(destination) {
+                    Ok(()) => {}
+                    Err(remove_error) if remove_error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(remove_error) => eprintln!(
+                        "mbx warning: failed to roll back {}: {remove_error}",
+                        destination.display()
+                    ),
+                }
+            }
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+fn record_action_hit(action: &CacheDigest, restore: RestoreStats) {
+    let responses = session::request_agent(&[AgentRequest::RecordActionHit {
+        action: action.clone(),
+        restore,
+    }]);
+    match responses.map(|responses| responses.into_iter().next()) {
+        Ok(Some(AgentResponse::ActionHitRecorded)) => {}
+        Ok(Some(AgentResponse::Error { message })) => {
+            eprintln!("mbx warning: hit was not recorded: {message}");
+        }
+        Ok(_) => eprintln!("mbx warning: hit was not recorded"),
+        Err(error) => {
+            eprintln!("mbx warning: hit was not recorded: {error:#}");
+        }
+    }
+}
+
+fn find_blobs(digests: &[CacheDigest]) -> Result<Vec<PathBuf>> {
+    let responses = session::request_agent(&[AgentRequest::FindBlobs {
+        digests: digests.to_vec(),
+    }])?;
+    let Some(response) = responses.into_iter().next() else {
+        bail!("cache agent did not return a blob lookup response");
+    };
+    match response {
+        AgentResponse::Blobs { paths } if paths.len() == digests.len() => paths
+            .into_iter()
+            .zip(digests)
+            .map(|(path, digest)| match path {
+                Some(path) => Ok(path),
+                None => bail!("cached rustc action is missing blob {}", digest.hash),
+            })
+            .collect(),
+        AgentResponse::Blobs { .. } => {
+            bail!("cache agent returned an incomplete blob lookup response")
+        }
+        AgentResponse::Blob { path: Some(path) } if digests.len() == 1 => Ok(vec![path]),
+        AgentResponse::Blob { path: None } if digests.len() == 1 => {
+            let digest = &digests[0];
+            bail!("cached rustc action is missing blob {}", digest.hash)
+        }
+        AgentResponse::Error { message } => bail!(message),
+        _ => bail!("cache agent returned an unexpected blob lookup response"),
+    }
+}
+
+fn read_canonical_blob<T>(path: &Path, digest: &CacheDigest, description: &str) -> Result<T>
+where
+    T: DeserializeOwned + Serialize,
+{
+    let bytes = read_verified_blob(path, digest, description)?;
+    let value = serde_json::from_slice(&bytes)
+        .wrap_err_with(|| format!("cached {description} is not valid JSON"))?;
+    if canonical_json(&value)? != bytes {
+        bail!("cached {description} is not canonical JSON");
+    }
+    Ok(value)
+}
+
+fn read_verified_blob(path: &Path, digest: &CacheDigest, description: &str) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?.read_to_end(&mut bytes)?;
+    if !digest.matches_bytes(&bytes)? {
+        bail!("cached {description} failed digest verification");
+    }
+    Ok(bytes)
+}
+
+fn validated_outputs(
+    directory: CacheDirectory,
+    outputs: &RustcOutputs,
+) -> Result<Vec<(CacheFileNode, PathBuf)>> {
+    if directory.version != 1 || !directory.directories.is_empty() || !directory.symlinks.is_empty()
+    {
+        bail!("cached rustc output directory has unsupported entries");
+    }
+    let mut expected = outputs
+        .files
+        .iter()
+        .chain(std::iter::once(&outputs.dep_info))
+        .map(|path| {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| eyre::eyre!("expected rustc output name is not UTF-8"))?;
+            if path.parent() != Some(outputs.directory.as_path()) {
+                bail!("expected rustc output escapes its output directory");
+            }
+            Ok((name.to_string(), path.clone()))
+        })
+        .collect::<Result<BTreeMap<_, _>>>()?;
+    if directory.files.len() != expected.len() {
+        bail!("cached rustc output set does not match the invocation");
+    }
+    let mut files = Vec::with_capacity(directory.files.len());
+    for node in directory.files {
+        validate_file_mode(&node)?;
+        let destination = expected
+            .remove(&node.name)
+            .ok_or_else(|| eyre::eyre!("cached rustc output is unexpected: {}", node.name))?;
+        files.push((node, destination));
+    }
+    if !expected.is_empty() {
+        bail!("cached rustc output set is incomplete");
+    }
+    Ok(files)
+}
+
+fn compiler_identity(rustc: &OsStr) -> Result<CompilerIdentity> {
+    let executable = resolve_executable(rustc)?;
+    let environment = ["RUSTUP_HOME", "RUSTUP_TOOLCHAIN"]
+        .into_iter()
+        .map(|name| (name.into(), std::env::var(name).ok()))
+        .collect::<BTreeMap<_, _>>();
+    let responses = session::request_agent(&[AgentRequest::FindExecutableIdentity {
+        executable: executable.clone(),
+        environment: environment.clone(),
+    }])?;
+    let Some(AgentResponse::ExecutableIdentity { stdout }) = responses.into_iter().next() else {
+        bail!("cache agent did not return the rustc identity");
+    };
+    let stdout = if let Some(stdout) = stdout {
+        stdout
+    } else {
+        let mut command = Command::new(&executable);
+        command.arg("-vV");
+        for (name, value) in &environment {
+            if let Some(value) = value {
+                command.env(name, value);
+            } else {
+                command.env_remove(name);
+            }
+        }
+        let output = command
+            .output()
+            .wrap_err("failed to query the rustc identity")?;
+        if !output.status.success() {
+            bail!(
+                "rustc identity command failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let responses = session::request_agent(&[AgentRequest::StoreExecutableIdentity {
+            executable,
+            environment,
+            stdout: output.stdout,
+        }])?;
+        let Some(AgentResponse::ExecutableIdentity {
+            stdout: Some(stdout),
+        }) = responses.into_iter().next()
+        else {
+            bail!("cache agent did not store the rustc identity");
+        };
+        stdout
+    };
+    let verbose = std::str::from_utf8(&stdout).wrap_err("rustc identity is not UTF-8")?;
+    let release = identity_field(verbose, "release")?;
+    let host = identity_field(verbose, "host")?;
+    let rustc_version = verbose
+        .lines()
+        .filter(|line| {
+            line.starts_with("rustc ")
+                || line.starts_with("commit-hash:")
+                || line.starts_with("commit-date:")
+                || line.starts_with("LLVM version:")
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    if rustc_version.is_empty() {
+        bail!("rustc identity is missing its version");
+    }
+    let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| release.to_string());
+    Ok(CompilerIdentity {
+        toolchain,
+        rustc_version,
+        host: host.to_string(),
+    })
+}
+
+fn identity_field<'a>(verbose: &'a str, field: &str) -> Result<&'a str> {
+    verbose
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{field}: ")))
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| eyre::eyre!("rustc identity is missing {field}"))
+}
+
+fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
+    let mut mappings = Vec::new();
+    let mut roots = BTreeSet::new();
+    add_mapping(
+        &mut mappings,
+        &mut roots,
+        working_dir.to_path_buf(),
+        "workspace",
+    );
+    for (name, placeholder) in [
+        ("CARGO_HOME", "cargo_home"),
+        ("RUSTUP_HOME", "rustup_home"),
+        ("HOME", "home"),
+        ("USERPROFILE", "home"),
+    ] {
+        if let Some(root) = std::env::var_os(name).map(PathBuf::from)
+            && root.is_absolute()
+        {
+            add_mapping(&mut mappings, &mut roots, root, placeholder);
+        }
+    }
+    mappings
+}
+
+fn add_mapping(
+    mappings: &mut Vec<PathMapping>,
+    roots: &mut BTreeSet<PathBuf>,
+    root: PathBuf,
+    placeholder: &str,
+) {
+    if roots.insert(root.clone())
+        && !mappings
+            .iter()
+            .any(|mapping| mapping.placeholder == placeholder)
+    {
+        mappings.push(PathMapping::new(root, placeholder));
+    }
+}
+
+fn replay_output(output: &Output) -> Result<()> {
+    replay_bytes(&output.stdout, &output.stderr)
+}
+
+fn replay_bytes(stdout_bytes: &[u8], stderr_bytes: &[u8]) -> Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(stdout_bytes)?;
+    stdout.flush()?;
+    let mut stderr = std::io::stderr().lock();
+    stderr.write_all(stderr_bytes)?;
+    stderr.flush()?;
+    Ok(())
+}
+
+fn staging_directory() -> Result<tempfile::TempDir> {
+    let root = std::env::var_os(session::STAGING_ENV)
+        .map(PathBuf::from)
+        .ok_or_else(|| eyre::eyre!("{} is not set", session::STAGING_ENV))?;
+    Ok(tempfile::tempdir_in(root)?)
+}
+
+fn resolve_executable(executable: &OsStr) -> Result<PathBuf> {
+    let executable = PathBuf::from(executable);
+    if executable.is_absolute() {
+        return Ok(executable);
+    }
+    which::which(&executable).wrap_err_with(|| {
+        format!(
+            "failed to resolve compiler executable {}",
+            executable.display()
+        )
+    })
+}
+
+fn publish_result(
+    action: &CacheDigest,
+    action_bytes: &[u8],
+    outputs: &[PathBuf],
+    output: &Output,
+) -> Result<()> {
+    if outputs.is_empty() {
+        bail!("rustc produced no cacheable outputs");
+    }
+    let staging = staging_directory()?;
+    let mut blobs = vec![staged_bytes(staging.path(), "action.json", action_bytes)?];
+    let stdout = staged_bytes(staging.path(), "stdout", &output.stdout)?;
+    let stderr = staged_bytes(staging.path(), "stderr", &output.stderr)?;
+    blobs.extend([stdout.clone(), stderr.clone()]);
+
+    let mut files = Vec::with_capacity(outputs.len());
+    for path in outputs {
+        let metadata = std::fs::metadata(path)
+            .wrap_err_with(|| format!("failed to inspect rustc output {}", path.display()))?;
+        if !metadata.is_file() {
+            bail!("rustc output is not a regular file: {}", path.display());
+        }
+        let digest = CacheDigest::blake3_file(path)?;
+        blobs.push((digest.clone(), path.clone()));
+        files.push(CacheFileNode {
+            digest,
+            executable: false,
+            mode: file_mode(&metadata),
+            name: path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| eyre::eyre!("rustc output name is not UTF-8"))?
+                .to_string(),
+        });
+    }
+    files.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let metadata = canonical_json(&RustcMetadata {
+        version: 1,
+        kind: "rustc".into(),
+        stdout: stdout.0,
+        stderr: stderr.0,
+    })?;
+    let metadata = staged_bytes(staging.path(), "metadata.json", &metadata)?;
+    blobs.push(metadata.clone());
+    let directory = canonical_json(&CacheDirectory {
+        directories: Vec::new(),
+        files,
+        symlinks: Vec::new(),
+        version: 1,
+    })?;
+    let directory = staged_bytes(staging.path(), "directory.json", &directory)?;
+    blobs.push(directory.clone());
+
+    let mut requests = Vec::new();
+    let mut published = BTreeSet::new();
+    for (digest, source) in blobs {
+        if published.insert(digest.clone()) {
+            requests.push(AgentRequest::StoreBlob { digest, source });
+        }
+    }
+    requests.push(AgentRequest::StoreActionResult {
+        result: RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.0),
+            output_root: Some(directory.0),
+            version: 1,
+        },
+    });
+    for response in session::request_agent(&requests)? {
+        match response {
+            AgentResponse::Stored { .. } | AgentResponse::ActionStored { .. } => {}
+            AgentResponse::Error { message } => bail!(message),
+            _ => bail!("cache agent returned an unexpected publish response"),
+        }
+    }
+    Ok(())
+}
+
+fn staged_bytes(directory: &Path, name: &str, bytes: &[u8]) -> Result<(CacheDigest, PathBuf)> {
+    let path = directory.join(name);
+    std::fs::write(&path, bytes)?;
+    Ok((CacheDigest::blake3(bytes), path))
+}
+
+#[cfg(unix)]
+fn file_mode(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt as _;
+    metadata.permissions().mode() & 0o644
+}
+
+#[cfg(windows)]
+fn file_mode(_metadata: &std::fs::Metadata) -> u32 {
+    0
+}
+
+#[cfg(unix)]
+fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
+    if node.executable
+        || node.mode & !0o777 != 0
+        || node.mode & 0o111 != 0
+        || node.mode & 0o022 != 0
+    {
+        bail!("cached rustc output has an unsafe file mode: {}", node.name);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
+    if node.executable || node.mode != 0 {
+        bail!("cached rustc output has an unsafe file mode: {}", node.name);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_file_mode(temporary: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(temporary, std::fs::Permissions::from_mode(mode))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn apply_file_mode(_temporary: &Path, _mode: u32) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_owner_writable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_mode(permissions.mode() | 0o200);
+    std::fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn make_owner_writable(path: &Path) -> Result<()> {
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_readonly(false);
+    std::fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn exit_code(status: ExitStatus) -> ExitCode {
+    use std::os::unix::process::ExitStatusExt as _;
+    ExitCode::from(
+        status
+            .code()
+            .unwrap_or_else(|| 128 + status.signal().unwrap_or(1)) as u8,
+    )
+}
+
+#[cfg(windows)]
+fn exit_code(status: ExitStatus) -> ExitCode {
+    // SAFETY: this process is only a compiler wrapper and must preserve the
+    // compiler's full Windows status code, which stable ExitCode cannot hold.
+    unsafe { windows_sys::Win32::System::Threading::ExitProcess(status.code().unwrap_or(1) as u32) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn staged_outputs(root: &Path, entries: Vec<(&[u8], PathBuf)>) -> StagedOutputs {
+        let directory = tempfile::tempdir_in(root).unwrap();
+        let files = entries
+            .into_iter()
+            .enumerate()
+            .map(|(index, (contents, destination))| {
+                let path = directory.path().join(format!("output-{index}"));
+                std::fs::write(&path, contents).unwrap();
+                (
+                    tempfile::TempPath::try_from_path(path).unwrap(),
+                    destination,
+                )
+            })
+            .collect();
+        StagedOutputs { directory, files }
+    }
+
+    fn test_outputs(root: &Path) -> RustcOutputs {
+        let directory = root.join("out");
+        RustcOutputs {
+            files: vec![directory.join("libdemo.rlib")],
+            dep_info: directory.join("demo.d"),
+            directory,
+        }
+    }
+
+    fn test_file(name: &str) -> CacheFileNode {
+        CacheFileNode {
+            digest: CacheDigest::blake3(b"artifact"),
+            executable: false,
+            mode: if cfg!(unix) { 0o644 } else { 0 },
+            name: name.into(),
+        }
+    }
+
+    fn test_directory(files: Vec<CacheFileNode>) -> CacheDirectory {
+        CacheDirectory {
+            directories: Vec::new(),
+            files,
+            symlinks: Vec::new(),
+            version: 1,
+        }
+    }
+
+    fn test_output_directory(file: CacheFileNode) -> CacheDirectory {
+        test_directory(vec![file, test_file("demo.d")])
+    }
+
+    #[test]
+    fn parses_verbose_rustc_identity() {
+        let verbose = "rustc 1.97.0 (abc 2026-08-01)\n\
+                       binary: rustc\n\
+                       commit-hash: abc\n\
+                       commit-date: 2026-08-01\n\
+                       host: x86_64-unknown-linux-gnu\n\
+                       release: 1.97.0\n\
+                       LLVM version: 22.0.0\n";
+        assert_eq!(identity_field(verbose, "release").unwrap(), "1.97.0");
+        assert_eq!(
+            identity_field(verbose, "host").unwrap(),
+            "x86_64-unknown-linux-gnu"
+        );
+    }
+
+    #[test]
+    fn mappings_do_not_duplicate_home_placeholders() {
+        let directory = tempfile::tempdir().unwrap();
+        let mappings = path_mappings(directory.path());
+        let placeholders = mappings
+            .iter()
+            .map(|mapping| &mapping.placeholder)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(placeholders.len(), mappings.len());
+    }
+
+    #[test]
+    fn validates_exact_rustc_output_set() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        let files =
+            validated_outputs(test_output_directory(test_file("libdemo.rlib")), &outputs).unwrap();
+
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().any(|(_, path)| path == &outputs.files[0]));
+        assert!(files.iter().any(|(_, path)| path == &outputs.dep_info));
+    }
+
+    #[test]
+    fn rejects_cached_output_path_traversal() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        assert!(
+            validated_outputs(
+                test_output_directory(test_file("../libdemo.rlib")),
+                &outputs,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_executable_rustc_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        let mut file = test_file("libdemo.rlib");
+        file.executable = true;
+        assert!(validated_outputs(test_output_directory(file), &outputs).is_err());
+    }
+
+    #[test]
+    fn rejects_group_or_world_writable_rustc_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        let mut file = test_file("libdemo.rlib");
+        file.mode = 0o666;
+        assert!(validated_outputs(test_output_directory(file), &outputs).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publication_masks_unsafe_rustc_output_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o666))
+            .unwrap();
+        assert_eq!(file_mode(&file.as_file().metadata().unwrap()), 0o644);
+    }
+
+    #[test]
+    fn rolls_back_outputs_after_a_partial_persist() {
+        let root = tempfile::tempdir().unwrap();
+        let first_destination = root.path().join("first.rlib");
+        let blocked_destination = root.path().join("blocked.rmeta");
+        std::fs::create_dir(&blocked_destination).unwrap();
+        let staged = staged_outputs(
+            root.path(),
+            vec![
+                (b"first", first_destination.clone()),
+                (b"second", blocked_destination.clone()),
+            ],
+        );
+
+        assert!(persist_outputs(staged).is_err());
+        assert!(!first_destination.exists());
+        assert!(blocked_destination.is_dir());
+    }
+
+    #[test]
+    fn qualification_does_not_publish_cached_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("cached.rlib");
+        let staged = staged_outputs(root.path(), vec![(b"cached", destination.clone())]);
+
+        finalize_restored_outputs(staged, false).unwrap();
+
+        assert!(!destination.exists());
+    }
+
+    #[test]
+    fn materialized_outputs_are_independent_from_the_cas() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("cas-blob");
+        std::fs::write(&source, b"artifact").unwrap();
+        let staging = tempfile::tempdir_in(root.path()).unwrap();
+        let node = test_file("artifact.rlib");
+
+        let output = stage_cached_output(staging.path(), 0, &source, &node).unwrap();
+        std::fs::write(&output, b"modified").unwrap();
+
+        assert_eq!(std::fs::read(source).unwrap(), b"artifact");
+        assert_eq!(std::fs::read(output).unwrap(), b"modified");
+    }
+
+    #[test]
+    fn rejects_same_size_corrupt_cached_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("cas-blob");
+        std::fs::write(&source, b"corrupt!").unwrap();
+        let staging = tempfile::tempdir_in(root.path()).unwrap();
+        let node = test_file("artifact.rlib");
+
+        assert!(stage_cached_output(staging.path(), 0, &source, &node).is_err());
+    }
+
+    #[test]
+    fn materializes_read_only_cached_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("cas-blob");
+        std::fs::write(&source, b"artifact").unwrap();
+        let mut permissions = std::fs::metadata(&source).unwrap().permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&source, permissions).unwrap();
+        let staging = tempfile::tempdir_in(root.path()).unwrap();
+        let node = test_file("artifact.rlib");
+
+        let output = stage_cached_output(staging.path(), 0, &source, &node).unwrap();
+
+        assert_eq!(std::fs::read(output).unwrap(), b"artifact");
+        assert!(std::fs::metadata(&source).unwrap().permissions().readonly());
+        make_owner_writable(&source).unwrap();
+    }
+
+    #[test]
+    fn rejects_same_size_corrupt_cached_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("cas-blob");
+        std::fs::write(&source, b"corrupt!").unwrap();
+        let digest = CacheDigest::blake3(b"artifact");
+
+        assert!(read_verified_blob(&source, &digest, "test blob").is_err());
+    }
+
+    #[test]
+    #[ignore = "local materialization benchmark"]
+    fn benchmark_cached_output_materialization() {
+        let size_mib = std::env::var("MBX_BENCH_MIB")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(128);
+        let iterations = std::env::var("MBX_BENCH_ITERATIONS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(4);
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("cas-blob");
+        let mut source_file = std::fs::File::create(&source).unwrap();
+        let chunk = vec![0x5a; 1024 * 1024];
+        for _ in 0..size_mib {
+            source_file.write_all(&chunk).unwrap();
+        }
+        source_file.sync_all().unwrap();
+        drop(source_file);
+        let digest = CacheDigest::blake3_file(&source).unwrap();
+        let node = CacheFileNode {
+            digest: digest.clone(),
+            executable: false,
+            mode: if cfg!(unix) { 0o644 } else { 0 },
+            name: "artifact.rlib".into(),
+        };
+
+        let started = std::time::Instant::now();
+        for _ in 0..iterations {
+            let mut temporary = tempfile::NamedTempFile::new_in(root.path()).unwrap();
+            let mut input = std::fs::File::open(&source).unwrap();
+            std::io::copy(&mut input, temporary.as_file_mut()).unwrap();
+            temporary.flush().unwrap();
+            temporary.as_file().sync_all().unwrap();
+            assert!(digest.matches_file(temporary.path()).unwrap());
+            apply_file_mode(temporary.path(), node.mode).unwrap();
+        }
+        let copied = started.elapsed();
+
+        let staging = tempfile::tempdir_in(root.path()).unwrap();
+        let started = std::time::Instant::now();
+        for _ in 0..iterations {
+            stage_cached_output(staging.path(), 0, &source, &node).unwrap();
+        }
+        let materialized = started.elapsed();
+
+        println!(
+            "materialized {iterations} x {size_mib} MiB: copied={copied:.2?}, reflink_or_copy={materialized:.2?}, speedup={:.2}x",
+            copied.as_secs_f64() / materialized.as_secs_f64()
+        );
+    }
+}

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -114,6 +114,12 @@ impl CacheSession {
         if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), shim.clone())
             && previous != shim
         {
+            // The shim defers to a wrapper that was already configured rather
+            // than compiling around it, since that wrapper may do more than
+            // cache. Say so, because the alternative is a silent no-op.
+            warn!(
+                "RUSTC_WRAPPER is already set to {previous}; deferring to it, so this build is not cached"
+            );
             environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
         }
         // Incremental compilation is never cacheable, so it is disabled rather
@@ -220,6 +226,12 @@ fn action_remote_cache(config: &Config, store: &Path) -> Result<Option<AgentRemo
         download_timeout: config.http.download_timeout,
         retries: config.http.retries,
     })?;
+    // Release builds publish artifacts that must not depend on a cache, so they
+    // do not read one either. The CLI already skips the whole session; this
+    // keeps a library caller from reaching the remote behind its back.
+    if crate::policy::release_context() {
+        return Ok(None);
+    }
     let Some(mode) = crate::policy::effective_remote_cache_mode(config.remote.mode) else {
         return Ok(None);
     };

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -852,12 +852,9 @@ mod tests {
         assert!(values.contains_key(SOCKET_ENV));
         assert!(values.contains_key(STAGING_ENV));
         assert_eq!(values.get(BUILD_ENV).unwrap().len(), 64);
-        assert!(
-            values
-                .get("RUSTC_WRAPPER")
-                .unwrap()
-                .ends_with(RUSTC_SHIM_STEM)
-        );
+        // The shim carries an .exe suffix on Windows, so compare stems.
+        let wrapper = Path::new(values.get("RUSTC_WRAPPER").unwrap());
+        assert_eq!(wrapper.file_stem().unwrap(), RUSTC_SHIM_STEM);
         assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
         assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");
         assert!(!values.contains_key(VERIFY_ENV));

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -746,13 +746,11 @@ fn request_agent_at(socket: &OsString, requests: &[AgentRequest]) -> Result<Vec<
 fn request_agent_at(socket: &OsString, requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
     let endpoint = socket.to_string_lossy().into_owned();
     tokio::runtime::Builder::new_current_thread()
-        .enable_io()
+        .enable_all()
         .build()?
         .block_on(async move {
             use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
-            let mut stream = tokio::net::windows::named_pipe::ClientOptions::new()
-                .open(&endpoint)
-                .wrap_err("failed to connect to the cache session")?;
+            let mut stream = connect_pipe(&endpoint).await?;
             let request = AgentRequest::Hello {
                 protocol: AGENT_PROTOCOL_VERSION,
                 client_version: VERSION.into(),
@@ -780,6 +778,34 @@ fn request_agent_at(socket: &OsString, requests: &[AgentRequest]) -> Result<Vec<
             }
             Ok(responses)
         })
+}
+
+/// Open the agent's pipe, waiting out the instances that are already busy.
+///
+/// The agent keeps one spare instance and creates the next only after accepting,
+/// so the rustc processes cargo runs in parallel routinely arrive to a busy
+/// pipe. Without this they would fall back to uncached compiles.
+#[cfg(windows)]
+async fn connect_pipe(endpoint: &str) -> Result<tokio::net::windows::named_pipe::NamedPipeClient> {
+    use std::time::Instant;
+    use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
+
+    const RETRY_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
+
+    let deadline = Instant::now() + RETRY_DEADLINE;
+    loop {
+        match tokio::net::windows::named_pipe::ClientOptions::new().open(endpoint) {
+            Ok(client) => return Ok(client),
+            Err(error)
+                if error.raw_os_error() == Some(ERROR_PIPE_BUSY as i32)
+                    && Instant::now() < deadline => {}
+            Err(error) => {
+                return Err(error).wrap_err("failed to connect to the cache session");
+            }
+        }
+        tokio::time::sleep(RETRY_DELAY).await;
+    }
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1,0 +1,984 @@
+//! Build-session lifecycle: the cache agent, its transport, and the rustc shim
+//! that cargo invokes through `RUSTC_WRAPPER`.
+
+use crate::config::Config;
+use crate::util::{duration_ns, format_duration, write_atomic};
+use bytesize::ByteSize;
+use eyre::{Context, Result, bail};
+use log::{debug, warn};
+use mbx_cache_core::{
+    AGENT_PROTOCOL_VERSION, AgentRemoteCache, AgentRequest, AgentResponse, AgentStats, CacheAgent,
+    CacheDigest, RemoteCacheClient, RemoteCacheConfig, canonical_json,
+};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+#[cfg(unix)]
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::sync::Mutex;
+use std::time::Instant;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+pub const RUSTC_SHIM_STEM: &str = "mbx-rustc";
+const SOCKET_ENV: &str = "MBX_SOCKET";
+pub(crate) const STAGING_ENV: &str = "MBX_STAGING_DIR";
+pub(crate) const BUILD_ENV: &str = "MBX_BUILD";
+pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
+const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const IDENTITY_VERSION: u8 = 1;
+
+/// A cache session: the agent, its listener, and the shim cargo will invoke.
+pub struct CacheSession {
+    socket: String,
+    rustc_shim: PathBuf,
+    staging: PathBuf,
+    verify: bool,
+    agent: CacheAgent,
+    started: Instant,
+    shutdown: Mutex<Option<oneshot::Sender<()>>>,
+    server: Mutex<Option<JoinHandle<Result<()>>>>,
+}
+
+impl CacheSession {
+    /// Install the shim, start the agent, and begin serving the shim's requests.
+    ///
+    /// `session_dir` holds the shim, socket, and staging directory, and is
+    /// expected to be a temporary directory owned by the caller.
+    pub async fn start(session_dir: &Path, config: &Config) -> Result<Self> {
+        let shim = install_session_shim(session_dir)?;
+        let staging = session_dir.join("staging");
+        std::fs::create_dir(&staging)?;
+        let store = config.store_dir();
+        let agent = if let Some(remote) = action_remote_cache(config, &store)? {
+            CacheAgent::new_remote(store, VERSION, remote)
+        } else {
+            CacheAgent::new(store, VERSION)
+        };
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (socket, server) = spawn_server(session_dir, agent.clone(), shutdown_rx).await?;
+        Ok(Self {
+            socket,
+            rustc_shim: shim,
+            staging,
+            verify: config.verify,
+            agent,
+            started: Instant::now(),
+            shutdown: Mutex::new(Some(shutdown_tx)),
+            server: Mutex::new(Some(server)),
+        })
+    }
+
+    /// Begin the build's action run and return the environment cargo needs.
+    ///
+    /// `environment` is amended in place so a caller can pass the environment it
+    /// already intends to hand to cargo. Any `RUSTC_WRAPPER` already present is
+    /// preserved for the shim to chain to. The manifest identity is derived from
+    /// `workspace_root` and `command` here so that callers cannot supply one the
+    /// protocol would reject.
+    pub async fn begin(
+        &self,
+        workspace_root: &Path,
+        command: &[String],
+        environment: &mut BTreeMap<String, String>,
+    ) -> Option<ActionRun> {
+        let identity = build_identity(workspace_root, command);
+        let (protocol_build, action_run) = match self.agent.begin_task(&identity).await {
+            Ok(run) => (
+                run.clone(),
+                Some(ActionRun {
+                    run,
+                    agent: self.agent.clone(),
+                }),
+            ),
+            Err(error) => {
+                warn!("build action manifest was not loaded: {error}");
+                (identity, None)
+            }
+        };
+        let shim = self.rustc_shim.to_string_lossy().into_owned();
+        environment.insert(SOCKET_ENV.into(), self.socket.clone());
+        environment.insert(
+            STAGING_ENV.into(),
+            self.staging.to_string_lossy().into_owned(),
+        );
+        environment.insert(BUILD_ENV.into(), protocol_build);
+        if self.verify {
+            environment.insert(VERIFY_ENV.into(), "1".into());
+        } else {
+            environment.remove(VERIFY_ENV);
+        }
+        if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), shim.clone())
+            && previous != shim
+        {
+            environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
+        }
+        // Incremental compilation is never cacheable, so it is disabled rather
+        // than left to bypass every action.
+        environment.insert("CARGO_INCREMENTAL".into(), "0".into());
+        action_run
+    }
+
+    /// Stop the agent and collect this session's statistics.
+    pub async fn finish(&self) -> Result<AgentStats> {
+        if let Some(shutdown) = self.shutdown.lock().unwrap().take() {
+            let _ = shutdown.send(());
+        }
+        let server = self.server.lock().unwrap().take();
+        if let Some(server) = server {
+            server.await??;
+        }
+        self.agent.cancel_prefetches().await;
+        let mut stats = self.agent.stats();
+        stats.session_duration_ns = duration_ns(self.started.elapsed());
+        Ok(stats)
+    }
+}
+
+impl Drop for CacheSession {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.get_mut().unwrap().take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(server) = self.server.get_mut().unwrap().take() {
+            server.abort();
+        }
+    }
+}
+
+/// An in-flight build's action manifest, committed when the build succeeds.
+pub struct ActionRun {
+    run: String,
+    agent: CacheAgent,
+}
+
+impl ActionRun {
+    pub async fn commit(self) -> Result<()> {
+        self.agent.commit_task(&self.run).await
+    }
+}
+
+#[derive(Serialize)]
+struct ActionIdentity<'a> {
+    version: u8,
+    workspace: &'a str,
+    command: &'a [String],
+}
+
+/// Identity for this build's prefetch manifest.
+///
+/// Manifests are namespaced by identity, so this only affects how well one
+/// build can predict another's actions; action keys themselves are independent
+/// of it.
+pub fn build_identity(workspace_root: &Path, command: &[String]) -> String {
+    let workspace = workspace_marker(workspace_root);
+    let material = ActionIdentity {
+        version: IDENTITY_VERSION,
+        workspace: &workspace,
+        command,
+    };
+    let bytes = canonical_json(&material).expect("build identity must serialize");
+    CacheDigest::blake3(&bytes).hash
+}
+
+/// Identify a workspace by its dependency graph rather than its location, so
+/// that separate worktrees of one project share a manifest.
+fn workspace_marker(workspace_root: &Path) -> String {
+    match std::fs::read(workspace_root.join("Cargo.lock")) {
+        Ok(lock) => CacheDigest::blake3(&lock).hash,
+        Err(_) => workspace_root
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    }
+}
+
+fn action_remote_cache(config: &Config, store: &Path) -> Result<Option<AgentRemoteCache>> {
+    let Some(base_url) = config.remote.url.clone() else {
+        return Ok(None);
+    };
+    let namespace = config
+        .remote
+        .namespace
+        .as_deref()
+        .map(str::trim)
+        .filter(|namespace| !namespace.is_empty())
+        .ok_or_else(|| eyre::eyre!("a remote cache namespace is required when a URL is set"))?
+        .to_string();
+    let client = RemoteCacheClient::new(RemoteCacheConfig {
+        base_url: base_url.parse().wrap_err("invalid remote cache URL")?,
+        namespace,
+        token: config.remote.token.clone(),
+        token_file: config.remote.token_file.clone(),
+        oidc_audience: config.remote.oidc_audience.clone(),
+        connect_timeout: config.http.timeout,
+        read_timeout: config.http.timeout,
+        download_timeout: config.http.download_timeout,
+        retries: config.http.retries,
+    })?;
+    let Some(mode) = crate::policy::effective_remote_cache_mode(config.remote.mode) else {
+        return Ok(None);
+    };
+    Ok(Some(AgentRemoteCache {
+        client,
+        mode,
+        staging_dir: store.join("remote"),
+    }))
+}
+
+#[derive(Serialize)]
+struct StatsReport {
+    version: u8,
+    session_duration_ns: u64,
+    lookups: u64,
+    hits: u64,
+    misses: u64,
+    compiler_invocations_avoided: u64,
+    verifications: u64,
+    divergences: u64,
+    prefetched_actions: u64,
+    prefetch_runs: u64,
+    downloaded_bytes: u64,
+    uploaded_bytes: u64,
+    stored_bytes: u64,
+    restored_output_files: u64,
+    restored_output_bytes: u64,
+    remote_manifest_lookups: u64,
+    remote_action_lookups: u64,
+    remote_blob_requests: u64,
+    remote_blob_pack_requests: u64,
+    remote_blob_pack_blobs: u64,
+    remote_manifest_lookup_duration_ns: u64,
+    remote_action_lookup_duration_ns: u64,
+    remote_blob_transfer_duration_ns: u64,
+    local_cas_write_duration_ns: u64,
+    prefetch_duration_ns: u64,
+    materialization_duration_ns: u64,
+}
+
+impl From<&AgentStats> for StatsReport {
+    fn from(stats: &AgentStats) -> Self {
+        Self {
+            version: 1,
+            session_duration_ns: stats.session_duration_ns,
+            lookups: stats.lookups,
+            hits: stats.hits,
+            misses: cache_misses(stats),
+            compiler_invocations_avoided: stats.hits,
+            verifications: stats.verifications,
+            divergences: stats.divergences,
+            prefetched_actions: stats.prefetched_actions,
+            prefetch_runs: stats.prefetch_runs,
+            downloaded_bytes: stats.downloaded_bytes,
+            uploaded_bytes: stats.uploaded_bytes,
+            stored_bytes: stats.stored_bytes,
+            restored_output_files: stats.restored_output_files,
+            restored_output_bytes: stats.restored_output_bytes,
+            remote_manifest_lookups: stats.remote_manifest_lookups,
+            remote_action_lookups: stats.remote_action_lookups,
+            remote_blob_requests: stats.remote_blob_requests,
+            remote_blob_pack_requests: stats.remote_blob_pack_requests,
+            remote_blob_pack_blobs: stats.remote_blob_pack_blobs,
+            remote_manifest_lookup_duration_ns: stats.remote_manifest_lookup_duration_ns,
+            remote_action_lookup_duration_ns: stats.remote_action_lookup_duration_ns,
+            remote_blob_transfer_duration_ns: stats.remote_blob_transfer_duration_ns,
+            local_cas_write_duration_ns: stats.local_cas_write_duration_ns,
+            prefetch_duration_ns: stats.prefetch_duration_ns,
+            materialization_duration_ns: stats.materialization_duration_ns,
+        }
+    }
+}
+
+/// Report a finished session to stderr, and to a JSON file when configured.
+pub fn display_stats(stats: &AgentStats, config: &Config) {
+    if let Some(path) = &config.stats_report
+        && let Err(error) = write_stats_report(path, stats)
+    {
+        warn!(
+            "the statistics report could not be written to {}: {error}",
+            path.display()
+        );
+    }
+    if stats.lookups == 0
+        && stats.stores == 0
+        && stats.verifications == 0
+        && stats.downloaded_bytes == 0
+        && stats.uploaded_bytes == 0
+    {
+        return;
+    }
+    note(&format!(
+        "cache: {} hits, {} misses, {} prefetched; {} downloaded, {} uploaded, {} stored locally",
+        stats.hits,
+        cache_misses(stats),
+        stats.prefetched_actions,
+        ByteSize::b(stats.downloaded_bytes).display().iec(),
+        ByteSize::b(stats.uploaded_bytes).display().iec(),
+        ByteSize::b(stats.stored_bytes).display().iec(),
+    ));
+    let remote_lookup_duration_ns = stats
+        .remote_manifest_lookup_duration_ns
+        .saturating_add(stats.remote_action_lookup_duration_ns);
+    note(&format!(
+        "cache timing: {} session, {} prefetch; cumulative {} remote lookup, {} blob transfer, {} CAS write, {} materialization",
+        format_nanos(stats.session_duration_ns),
+        format_nanos(stats.prefetch_duration_ns),
+        format_nanos(remote_lookup_duration_ns),
+        format_nanos(stats.remote_blob_transfer_duration_ns),
+        format_nanos(stats.local_cas_write_duration_ns),
+        format_nanos(stats.materialization_duration_ns),
+    ));
+    if stats.verifications > 0 {
+        note(&format!(
+            "cache qualification: {} verified, {} diverged",
+            stats.verifications, stats.divergences,
+        ));
+    }
+}
+
+/// Write to stderr without failing the build when the pipe is closed.
+fn note(message: &str) {
+    use std::io::Write as _;
+    let _ = writeln!(std::io::stderr(), "{message}");
+}
+
+fn write_stats_report(path: &Path, stats: &AgentStats) -> Result<()> {
+    let mut report = serde_json::to_vec_pretty(&StatsReport::from(stats))?;
+    report.push(b'\n');
+    write_atomic(path, &report)
+}
+
+fn format_nanos(nanoseconds: u64) -> String {
+    format_duration(std::time::Duration::from_nanos(nanoseconds))
+}
+
+fn cache_misses(stats: &AgentStats) -> u64 {
+    stats
+        .lookups
+        .saturating_sub(stats.hits)
+        .saturating_sub(stats.verifications)
+}
+
+fn install_session_shim(session_dir: &Path) -> Result<PathBuf> {
+    let executable = std::env::current_exe().wrap_err("failed to locate the running mbx binary")?;
+    install_shim(&executable, session_dir)
+}
+
+/// Install a rustc shim into `directory` as a link to `executable`.
+///
+/// The shim must be the same binary as the agent: the handshake requires an
+/// exact version match, which a hard link guarantees for free.
+pub fn install_shim(executable: &Path, directory: &Path) -> Result<PathBuf> {
+    let filename = if cfg!(windows) {
+        format!("{RUSTC_SHIM_STEM}.exe")
+    } else {
+        RUSTC_SHIM_STEM.into()
+    };
+    let shim = directory.join(filename);
+    let _ = std::fs::remove_file(&shim);
+    if let Err(link_error) = std::fs::hard_link(executable, &shim) {
+        std::fs::copy(executable, &shim).wrap_err_with(|| {
+            format!("failed to install the rustc shim by hard link ({link_error}) or copy")
+        })?;
+    }
+    Ok(shim)
+}
+
+#[cfg(unix)]
+async fn spawn_server(
+    session_dir: &Path,
+    agent: CacheAgent,
+    mut shutdown: oneshot::Receiver<()>,
+) -> Result<(String, JoinHandle<Result<()>>)> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let socket = session_dir.join("cache-agent.sock");
+    let listener = tokio::net::UnixListener::bind(&socket)?;
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))?;
+    let endpoint = socket.to_string_lossy().into_owned();
+    let server = tokio::spawn(async move {
+        let _cleanup = SocketCleanup(socket);
+        loop {
+            tokio::select! {
+                accepted = listener.accept() => {
+                    let (stream, _) = accepted?;
+                    let agent = agent.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = agent.handle_connection(stream).await {
+                            debug!("cache agent connection failed: {error}");
+                        }
+                    });
+                }
+                _ = &mut shutdown => return Ok(()),
+            }
+        }
+    });
+    Ok((endpoint, server))
+}
+
+#[cfg(unix)]
+struct SocketCleanup(PathBuf);
+
+#[cfg(unix)]
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[cfg(windows)]
+async fn spawn_server(
+    _session_dir: &Path,
+    agent: CacheAgent,
+    mut shutdown: oneshot::Receiver<()>,
+) -> Result<(String, JoinHandle<Result<()>>)> {
+    let endpoint = format!(
+        r"\\.\pipe\mbx-cache-{}-{}",
+        std::process::id(),
+        crate::util::random_string(12)
+    );
+    let first_server = create_named_pipe(&endpoint, true)?;
+    let server_endpoint = endpoint.clone();
+    let server = tokio::spawn(async move {
+        let mut next_server = Some(first_server);
+        loop {
+            let pipe = next_server
+                .take()
+                .expect("the next named-pipe server is always prepared");
+            tokio::select! {
+                connected = pipe.connect() => {
+                    connected?;
+                    next_server = Some(create_named_pipe(&server_endpoint, false)?);
+                    let agent = agent.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = agent.handle_connection(pipe).await {
+                            debug!("cache agent connection failed: {error}");
+                        }
+                    });
+                }
+                _ = &mut shutdown => return Ok(()),
+            }
+        }
+    });
+    Ok((endpoint, server))
+}
+
+#[cfg(windows)]
+fn create_named_pipe(
+    endpoint: &str,
+    first_pipe_instance: bool,
+) -> Result<tokio::net::windows::named_pipe::NamedPipeServer> {
+    use std::mem::size_of;
+    use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+
+    let security = CurrentUserSecurityDescriptor::new()?;
+    let mut attributes = SECURITY_ATTRIBUTES {
+        nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: security.0,
+        bInheritHandle: 0,
+    };
+    let mut options = tokio::net::windows::named_pipe::ServerOptions::new();
+    options.first_pipe_instance(first_pipe_instance);
+    // SAFETY: `attributes` and its owned security descriptor remain valid for
+    // the duration of CreateNamedPipeW, and the handle is not inheritable.
+    unsafe {
+        options
+            .create_with_security_attributes_raw(endpoint, (&raw mut attributes).cast())
+            .wrap_err("failed to create the current-user-only cache pipe")
+    }
+}
+
+#[cfg(windows)]
+struct CurrentUserSecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
+
+#[cfg(windows)]
+impl CurrentUserSecurityDescriptor {
+    fn new() -> Result<Self> {
+        use std::mem::size_of;
+        use std::ptr::null_mut;
+        use windows_sys::Win32::Foundation::HANDLE;
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+            SDDL_REVISION_1,
+        };
+        use windows_sys::Win32::Security::{
+            GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
+        };
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        let mut token: HANDLE = null_mut();
+        // SAFETY: `token` is a valid out pointer and the process pseudo-handle
+        // is always valid in the calling process.
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) } == 0 {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to open the current process token");
+        }
+        let token = OwnedWindowsHandle(token);
+
+        let mut required = 0;
+        // The first call intentionally obtains the required buffer size.
+        // SAFETY: a null information pointer is required for this size query.
+        unsafe {
+            GetTokenInformation(token.0, TokenUser, null_mut(), 0, &raw mut required);
+        }
+        if required == 0 {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to size the current process user token");
+        }
+        let word_count = (required as usize).div_ceil(size_of::<usize>());
+        let mut token_information = vec![0usize; word_count];
+        // SAFETY: the aligned buffer is at least `required` bytes long and the
+        // API initializes it as TOKEN_USER on success.
+        if unsafe {
+            GetTokenInformation(
+                token.0,
+                TokenUser,
+                token_information.as_mut_ptr().cast(),
+                required,
+                &raw mut required,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to read the current process user token");
+        }
+        // SAFETY: GetTokenInformation successfully initialized the aligned
+        // buffer as TOKEN_USER and its SID remains owned by that buffer.
+        let user_sid = unsafe {
+            (*(token_information.as_ptr().cast::<TOKEN_USER>()))
+                .User
+                .Sid
+        };
+        let mut sid_string = null_mut();
+        // SAFETY: `user_sid` points into the live token-information buffer and
+        // `sid_string` is a valid out pointer.
+        if unsafe { ConvertSidToStringSidW(user_sid, &raw mut sid_string) } == 0 {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to format the current process user SID");
+        }
+        let sid_string = LocalWindowsAllocation(sid_string.cast());
+        // SAFETY: ConvertSidToStringSidW returned a valid NUL-terminated string
+        // whose allocation remains live through `sid_string`.
+        let sid = unsafe { nul_terminated_wide(sid_string.0.cast()) };
+
+        let mut sddl: Vec<u16> = "D:P(A;;GA;;;".encode_utf16().collect();
+        sddl.extend_from_slice(sid);
+        sddl.extend([')' as u16, 0]);
+        let mut descriptor = null_mut();
+        // SAFETY: the SDDL is NUL-terminated, `descriptor` is a valid out
+        // pointer, and the returned allocation is owned by LocalFree.
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl.as_ptr(),
+                SDDL_REVISION_1,
+                &raw mut descriptor,
+                null_mut(),
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to restrict the cache pipe to the current user");
+        }
+        drop(token);
+        drop(sid_string);
+        debug_assert!(!descriptor.is_null());
+        Ok(Self(descriptor))
+    }
+}
+
+#[cfg(windows)]
+impl Drop for CurrentUserSecurityDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: this allocation came from
+        // ConvertStringSecurityDescriptorToSecurityDescriptorW.
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
+        }
+    }
+}
+
+#[cfg(windows)]
+struct OwnedWindowsHandle(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for OwnedWindowsHandle {
+    fn drop(&mut self) {
+        // SAFETY: this handle came from OpenProcessToken and is owned here.
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct LocalWindowsAllocation(windows_sys::Win32::Foundation::HLOCAL);
+
+#[cfg(windows)]
+impl Drop for LocalWindowsAllocation {
+    fn drop(&mut self) {
+        // SAFETY: this allocation came from a Win32 API documented to use
+        // LocalAlloc and has not previously been freed.
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+unsafe fn nul_terminated_wide<'a>(value: *const u16) -> &'a [u16] {
+    let mut length = 0;
+    // SAFETY: the caller guarantees that `value` points to a valid
+    // NUL-terminated UTF-16 string.
+    while unsafe { *value.add(length) } != 0 {
+        length += 1;
+    }
+    // SAFETY: the scan above established the initialized string length.
+    unsafe { std::slice::from_raw_parts(value, length) }
+}
+
+/// Whether this process was invoked as the rustc shim.
+pub fn is_rustc_shim() -> bool {
+    std::env::args_os()
+        .next()
+        .as_deref()
+        .map(Path::new)
+        .and_then(Path::file_stem)
+        .is_some_and(|stem| stem == OsStr::new(RUSTC_SHIM_STEM))
+}
+
+/// Ultra-early argv0 path used by cargo's `RUSTC_WRAPPER` integration.
+///
+/// Cargo invokes this thousands of times per build, so it runs before any
+/// runtime, logging, or configuration is set up. Cacheable invocations restore
+/// from or publish through the cache; anything else is a transparent compiler
+/// call.
+pub fn run_rustc_shim() -> ExitCode {
+    let mut arguments = std::env::args_os().skip(1);
+    let Some(rustc) = arguments.next() else {
+        eprintln!("mbx: the rustc shim expected the rustc executable as its first argument");
+        return ExitCode::from(1);
+    };
+    let arguments = arguments.collect::<Vec<_>>();
+    if std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV).is_none() {
+        match crate::rustc::compile(&rustc, &arguments) {
+            Ok(exit_code) => return exit_code,
+            Err(_error) => {
+                #[cfg(debug_assertions)]
+                eprintln!("mbx: rustc cache bypassed: {_error:#}");
+            }
+        }
+    }
+
+    run_transparent_rustc(rustc, arguments)
+}
+
+fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode {
+    let mut command = if let Some(wrapper) = std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV) {
+        let mut command = Command::new(wrapper);
+        command.arg(&rustc);
+        command
+    } else {
+        Command::new(&rustc)
+    };
+    command.args(arguments);
+    command.env_remove(PREVIOUS_RUSTC_WRAPPER_ENV);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        let error = command.exec();
+        eprintln!("mbx: the rustc shim failed to execute rustc: {error}");
+        ExitCode::from(1)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle as _;
+        use windows_sys::Win32::System::Threading::GetExitCodeProcess;
+
+        match command.spawn().and_then(|mut child| {
+            child.wait()?;
+            let mut exit_code = 1;
+            // SAFETY: the child owns a valid process handle until it is
+            // dropped, and `exit_code` is a valid out pointer.
+            if unsafe { GetExitCodeProcess(child.as_raw_handle().cast(), &raw mut exit_code) } == 0
+            {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(exit_code)
+            }
+        }) {
+            Ok(exit_code) => {
+                // SAFETY: This process is only a transparent compiler wrapper.
+                // ExitProcess is required to preserve Windows exception codes,
+                // which cannot be represented by stable Rust's ExitCode API.
+                unsafe { windows_sys::Win32::System::Threading::ExitProcess(exit_code) }
+            }
+            Err(error) => {
+                eprintln!("mbx: the rustc shim failed to execute rustc: {error}");
+                ExitCode::from(1)
+            }
+        }
+    }
+}
+
+pub(crate) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
+    let socket =
+        std::env::var_os(SOCKET_ENV).ok_or_else(|| eyre::eyre!("{SOCKET_ENV} is not set"))?;
+    request_agent_at(&socket, requests)
+}
+
+#[cfg(unix)]
+fn request_agent_at(socket: &OsString, requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
+    let mut stream = std::os::unix::net::UnixStream::connect(Path::new(socket))
+        .wrap_err("failed to connect to the cache session")?;
+    sync_handshake(&mut stream)?;
+    requests
+        .iter()
+        .map(|request| sync_request(&mut stream, request))
+        .collect()
+}
+
+#[cfg(windows)]
+fn request_agent_at(socket: &OsString, requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
+    let endpoint = socket.to_string_lossy().into_owned();
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()?
+        .block_on(async move {
+            use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+            let mut stream = tokio::net::windows::named_pipe::ClientOptions::new()
+                .open(&endpoint)
+                .wrap_err("failed to connect to the cache session")?;
+            let request = AgentRequest::Hello {
+                protocol: AGENT_PROTOCOL_VERSION,
+                client_version: VERSION.into(),
+            };
+            let mut encoded = serde_json::to_vec(&request)?;
+            encoded.push(b'\n');
+            stream.write_all(&encoded).await?;
+            stream.flush().await?;
+            let mut response = String::new();
+            tokio::io::BufReader::new(&mut stream)
+                .read_line(&mut response)
+                .await?;
+            validate_handshake_response(&response)?;
+            let mut responses = Vec::with_capacity(requests.len());
+            for request in requests {
+                let mut encoded = serde_json::to_vec(request)?;
+                encoded.push(b'\n');
+                stream.write_all(&encoded).await?;
+                stream.flush().await?;
+                let mut response = String::new();
+                tokio::io::BufReader::new(&mut stream)
+                    .read_line(&mut response)
+                    .await?;
+                responses.push(serde_json::from_str(&response)?);
+            }
+            Ok(responses)
+        })
+}
+
+#[cfg(unix)]
+fn sync_handshake(stream: &mut (impl std::io::Read + Write)) -> Result<()> {
+    let request = AgentRequest::Hello {
+        protocol: AGENT_PROTOCOL_VERSION,
+        client_version: VERSION.into(),
+    };
+    serde_json::to_writer(&mut *stream, &request)?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    let mut response = String::new();
+    BufReader::new(&mut *stream).read_line(&mut response)?;
+    validate_handshake_response(&response)
+}
+
+#[cfg(unix)]
+fn sync_request(
+    stream: &mut (impl std::io::Read + Write),
+    request: &AgentRequest,
+) -> Result<AgentResponse> {
+    serde_json::to_writer(&mut *stream, request)?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    let mut response = String::new();
+    BufReader::new(&mut *stream).read_line(&mut response)?;
+    Ok(serde_json::from_str(&response)?)
+}
+
+fn validate_handshake_response(response: &str) -> Result<()> {
+    match serde_json::from_str(response)? {
+        AgentResponse::Hello {
+            protocol,
+            agent_version,
+        } if protocol == AGENT_PROTOCOL_VERSION && agent_version == VERSION => Ok(()),
+        AgentResponse::Error { message } => bail!(message),
+        _ => bail!("the cache agent returned an incompatible handshake"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(cache_dir: &Path) -> Config {
+        Config {
+            cache_dir: cache_dir.to_path_buf(),
+            stats_report: None,
+            verify: false,
+            remote: Default::default(),
+            http: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_environment_directs_cargo_at_the_shim() {
+        let cache = tempfile::tempdir().unwrap();
+        let session_dir = tempfile::tempdir().unwrap();
+        let session = CacheSession::start(session_dir.path(), &test_config(cache.path()))
+            .await
+            .unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
+        let run = session
+            .begin(workspace.path(), &["build".to_string()], &mut values)
+            .await;
+
+        assert!(run.is_some());
+        assert!(values.contains_key(SOCKET_ENV));
+        assert!(values.contains_key(STAGING_ENV));
+        assert_eq!(values.get(BUILD_ENV).unwrap().len(), 64);
+        assert!(
+            values
+                .get("RUSTC_WRAPPER")
+                .unwrap()
+                .ends_with(RUSTC_SHIM_STEM)
+        );
+        assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
+        assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");
+        assert!(!values.contains_key(VERIFY_ENV));
+
+        session.finish().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn verify_mode_is_passed_to_the_shim() {
+        let cache = tempfile::tempdir().unwrap();
+        let session_dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(cache.path());
+        config.verify = true;
+        let session = CacheSession::start(session_dir.path(), &config)
+            .await
+            .unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        let mut values = BTreeMap::new();
+        session
+            .begin(workspace.path(), &["build".to_string()], &mut values)
+            .await;
+
+        assert_eq!(values.get(VERIFY_ENV).unwrap(), "1");
+
+        session.finish().await.unwrap();
+    }
+
+    #[test]
+    fn identity_follows_the_dependency_graph_not_the_path() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        std::fs::write(first.path().join("Cargo.lock"), "version = 4\n").unwrap();
+        std::fs::write(second.path().join("Cargo.lock"), "version = 4\n").unwrap();
+        let command = ["build".to_string()];
+
+        assert_eq!(
+            build_identity(first.path(), &command),
+            build_identity(second.path(), &command),
+            "separate worktrees of one project must share a manifest"
+        );
+
+        std::fs::write(second.path().join("Cargo.lock"), "version = 3\n").unwrap();
+        assert_ne!(
+            build_identity(first.path(), &command),
+            build_identity(second.path(), &command),
+        );
+        assert_ne!(
+            build_identity(first.path(), &command),
+            build_identity(first.path(), &["test".to_string()]),
+        );
+    }
+
+    #[test]
+    fn identity_falls_back_to_the_directory_name() {
+        let directory = tempfile::tempdir().unwrap();
+        let command = ["build".to_string()];
+        assert_eq!(
+            build_identity(directory.path(), &command).len(),
+            64,
+            "a project without a lockfile still gets an identity"
+        );
+    }
+
+    #[test]
+    fn handshake_rejects_version_skew() {
+        let response = serde_json::to_string(&AgentResponse::Hello {
+            protocol: AGENT_PROTOCOL_VERSION,
+            agent_version: "another-version".into(),
+        })
+        .unwrap();
+        assert!(validate_handshake_response(&response).is_err());
+    }
+
+    #[test]
+    fn qualification_results_are_not_reported_as_misses() {
+        let stats = AgentStats {
+            lookups: 5,
+            hits: 2,
+            verifications: 2,
+            ..AgentStats::default()
+        };
+        assert_eq!(cache_misses(&stats), 1);
+    }
+
+    #[test]
+    fn writes_versioned_stats_report() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("nested").join("stats.json");
+        let stats = AgentStats {
+            session_duration_ns: 42,
+            lookups: 5,
+            hits: 2,
+            verifications: 1,
+            prefetched_actions: 3,
+            downloaded_bytes: 1024,
+            restored_output_files: 7,
+            restored_output_bytes: 2048,
+            remote_blob_requests: 4,
+            remote_blob_pack_requests: 2,
+            remote_blob_pack_blobs: 100,
+            materialization_duration_ns: 9,
+            ..AgentStats::default()
+        };
+
+        write_stats_report(&path, &stats).unwrap();
+        let report: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+
+        assert_eq!(report["version"], 1);
+        assert_eq!(report["session_duration_ns"], 42);
+        assert_eq!(report["hits"], 2);
+        assert_eq!(report["misses"], 2);
+        assert_eq!(report["compiler_invocations_avoided"], 2);
+        assert_eq!(report["prefetched_actions"], 3);
+        assert_eq!(report["downloaded_bytes"], 1024);
+        assert_eq!(report["restored_output_files"], 7);
+        assert_eq!(report["restored_output_bytes"], 2048);
+        assert_eq!(report["remote_blob_requests"], 4);
+        assert_eq!(report["remote_blob_pack_requests"], 2);
+        assert_eq!(report["remote_blob_pack_blobs"], 100);
+        assert_eq!(report["materialization_duration_ns"], 9);
+    }
+}

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -59,9 +59,12 @@ pub fn duration_ns(duration: Duration) -> u64 {
     duration.as_nanos().try_into().unwrap_or(u64::MAX)
 }
 
-#[cfg(windows)]
+/// Generate an unpredictable alphanumeric string.
+///
+/// Only the Windows named-pipe endpoint needs this, but it is compiled
+/// everywhere so that every platform's CI type-checks it.
 pub fn random_string(length: usize) -> String {
-    use rand::Rng as _;
+    use rand::RngExt as _;
     use rand::distr::Alphanumeric;
 
     rand::rng()
@@ -84,6 +87,15 @@ mod tests {
 
         write_atomic(&path, b"[]\n").unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"[]\n");
+    }
+
+    #[test]
+    fn random_strings_have_the_requested_length_and_differ() {
+        let first = random_string(12);
+        assert_eq!(first.chars().count(), 12);
+        assert!(first.chars().all(|character| character.is_alphanumeric()));
+        assert_ne!(first, random_string(12));
+        assert!(random_string(0).is_empty());
     }
 
     #[test]

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -1,0 +1,98 @@
+use eyre::{Context, Result};
+use std::io::Write as _;
+use std::path::Path;
+use std::time::Duration;
+
+/// Write `contents` to `path` so readers never observe a partial file.
+pub fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| eyre::eyre!("path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".mbx-")
+        .tempfile_in(parent)?;
+    temporary.write_all(contents)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .wrap_err_with(|| format!("failed atomic write: {}", path.display()))?;
+    Ok(())
+}
+
+/// Format a duration for humans, widening precision as the duration grows.
+pub fn format_duration(duration: Duration) -> String {
+    if duration < Duration::from_millis(1) {
+        format!("{duration:.0?}")
+    } else if duration < Duration::from_secs(1) {
+        format!("{duration:.1?}")
+    } else {
+        format!("{duration:.2?}")
+    }
+}
+
+/// Parse a duration written as a bare number of seconds or with a unit suffix.
+pub fn parse_duration(value: &str) -> Result<Duration> {
+    let value = value.trim();
+    let (digits, multiplier) = if let Some(digits) = value.strip_suffix("ms") {
+        (digits, 1)
+    } else if let Some(digits) = value.strip_suffix('s') {
+        (digits, 1_000)
+    } else if let Some(digits) = value.strip_suffix('m') {
+        (digits, 60 * 1_000)
+    } else if let Some(digits) = value.strip_suffix('h') {
+        (digits, 60 * 60 * 1_000)
+    } else {
+        (value, 1_000)
+    };
+    let amount: u64 = digits
+        .trim()
+        .parse()
+        .wrap_err_with(|| format!("invalid duration: {value}"))?;
+    Ok(Duration::from_millis(amount.saturating_mul(multiplier)))
+}
+
+pub fn duration_ns(duration: Duration) -> u64 {
+    duration.as_nanos().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(windows)]
+pub fn random_string(length: usize) -> String {
+    use rand::Rng as _;
+    use rand::distr::Alphanumeric;
+
+    rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_files_atomically() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("nested").join("report.json");
+        write_atomic(&path, b"{}\n").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"{}\n");
+
+        write_atomic(&path, b"[]\n").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"[]\n");
+    }
+
+    #[test]
+    fn parses_durations_with_and_without_units() {
+        assert_eq!(parse_duration("30").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("250ms").unwrap(), Duration::from_millis(250));
+        assert_eq!(parse_duration("10m").unwrap(), Duration::from_secs(600));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7_200));
+        assert!(parse_duration("soon").is_err());
+    }
+}


### PR DESCRIPTION
Ports the session and wrapper glue that lived in mise's `src/cache/session.rs` and `src/cache/rustc.rs`, with its three ties to mise cut.

**Configuration** (`config.rs`) replaces mise's `Settings`. Environment variables win over `~/.config/mbx/config.toml`, which wins over defaults; the nine remote-cache fields, the stats-report path, and the HTTP timeouts/retries all come from there instead of mise's settings tree.

**Manifest identity** (`session.rs`) replaces mise's task-shaped identity, which serialized `TaskRunPhase` and `RunEntry`. mbx keys manifests on `{version, workspace, command}`, where `workspace` is the `Cargo.lock` digest rather than the checkout path — so two worktrees of the same dependency graph share one manifest, which is the whole point of the exercise. A project with no lockfile falls back to the directory name. `begin()` derives the identity itself from the workspace root and command, so a caller cannot hand the protocol an identity it would reject.

**Utilities**: `write_atomic`, `format_duration`, `duration_ns`, and the Windows `random_string` are inlined in `util.rs`; `warn!`/`debug!` go through `log`, and the stats lines go to stderr through a helper that ignores a closed pipe instead of panicking.

**Policy** (`policy.rs`) is copied, not moved — mise still needs its own copy for the task-result cache. Untrusted contexts read but never write; pull requests and merge requests never write; tags and releases do not participate.

The shim keeps every mechanic that made it fast and safe in mise: argv0 dispatch as the first statement of `main` before any runtime, logging, or config setup; installation as a hard link of the running binary (so the agent handshake can demand an exact version match); transparent `exec` of the real rustc on any bypass; chaining to a pre-existing `RUSTC_WRAPPER`; and `CARGO_INCREMENTAL=0` in the session environment.

Renamed for the new brand: `MISE_CACHE_SOCKET` → `MBX_SOCKET`, `MISE_CACHE_STAGING_DIR` → `MBX_STAGING_DIR`, `MISE_CACHE_TASK` → `MBX_BUILD`, `MISE_CACHE_RUST_VERIFY` → `MBX_VERIFY`, `MISE_CACHE_PREVIOUS_RUSTC_WRAPPER` → `MBX_PREVIOUS_RUSTC_WRAPPER`, shim stem `mise-cache-rustc` → `mbx-rustc`.

Everything is `pub` on the library so the CLI in the next PR consumes it; `main` currently does the shim dispatch and nothing else. Verified by hand that a binary copied to `mbx-rustc` dispatches on argv0, classifies `--version` as a non-cacheable compiler query, and passes through to the real rustc.

Workspace tests: 105 passing.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is the compiler wrapper and IPC path that restores artifacts, talks to a remote cache, and decides who may write. Bugs here can poison builds, leak cache writes from untrusted CI, or mishandle local sockets/pipes.
> 
> **Overview**
> Implements the **cache session and rustc shim** that cargo will invoke via `RUSTC_WRAPPER`. `main` now dispatches on argv0 (`mbx-rustc`) before any runtime setup; the rest of the CLI is still a stub.
> 
> **`CacheSession`** starts a local agent (Unix socket `0600`, or a current-user-only Windows named pipe), installs a hard-linked shim, and injects env for cargo (`MBX_SOCKET`, staging, build identity, `CARGO_INCREMENTAL=0`). Manifest identity is `{version, Cargo.lock digest, command}` so worktrees of the same graph share predictions. Existing wrappers are chained, not wrapped.
> 
> The **rustc path** looks up cached actions (dep-info or prediction), verifies blobs, reflink-or-copies outputs atomically, then publishes successful compiles. Shadow verification can run without restoring. Untrusted CI is forced **read-only**; PRs/MRs never write; tags/releases skip the remote cache.
> 
> Config is env over `~/.config/mbx/config.toml` over defaults (cache dir, remote URL/token/mode, HTTP timeouts). Library APIs are public for the upcoming CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961501f4cf280794ecc451d4ff98cba39a0832db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->