### PR TITLE
feat(cli): add build, gc, and cache commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +123,12 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -156,6 +212,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +259,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -230,6 +332,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +412,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +466,16 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -756,10 +922,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jni"
@@ -884,8 +1092,11 @@ name = "mbx"
 version = "0.0.0"
 dependencies = [
  "bytesize",
+ "clap",
  "dirs",
+ "env_logger",
  "eyre",
+ "filetime",
  "log",
  "mbx-cache-core",
  "mbx-cache-rustc",
@@ -1002,12 +1213,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1090,6 +1307,21 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1257,7 +1489,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1390,7 +1622,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1520,7 +1752,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1684,6 +1916,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -1933,7 +2171,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -2017,6 +2255,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/PLAN.md
+++ b/PLAN.md
@@ -47,8 +47,8 @@ mbx build [-- <cargo args>]
      │    ├─ local CAS + action cache (~/.cache/mbx)
      │    └─ optional remote cache client (blob packs, OIDC/token auth)
      ├─ env injection: RUSTC_WRAPPER=<session>/mbx-rustc, MBX_SOCKET,
-     │    MBX_STAGING_DIR,
-     │    MBX_TASK, CARGO_INCREMENTAL=0, MBX_PREVIOUS_RUSTC_WRAPPER chaining
+     │    MBX_STAGING_DIR, MBX_BUILD, MBX_WORKSPACE_ROOT, MBX_TARGET_DIR,
+     │    CARGO_INCREMENTAL=0, MBX_PREVIOUS_RUSTC_WRAPPER chaining
      ├─ run cargo
      └─ finish: flush staged uploads, print stats, optional JSON report
 ```
@@ -89,15 +89,35 @@ Two modes:
 On any unsupported invocation, error, or bypass condition the shim execs the
 real rustc transparently. Correctness beats hit rate everywhere.
 
+### Path mapping
+
+Cache keys hold no absolute paths. The session passes the workspace root and the
+target directory to the shim, which maps them to `${workspace}` and `${target}`
+placeholders along with `${cargo_home}`, `${rustup_home}`, and `${home}`.
+
+Both roots have to be passed in rather than inferred: cargo compiles a
+dependency with its working directory inside the registry, so the shim sees no
+sign of the workspace whose target directory it is writing to. Mapping the
+target directory first, ahead of the workspace that usually contains it, also
+keeps keys stable when the target directory moves elsewhere.
+
+A path that matches no root bypasses the cache rather than entering a key. The
+roots come from `cargo metadata`, since a target directory can be set by flag,
+environment, or cargo configuration, and `--manifest-path` can move the build
+elsewhere entirely.
+
 ### Cache identity
 
 mise keyed its session manifests by task definition. mbx defines its own
-identity (v1): a canonical JSON of `{version, workspace_root_marker, command}`
-where `workspace_root_marker` is path-mapped so identical projects in
-different worktrees share manifests. The identity only namespaces
-prefetch manifests — action keys themselves come from `mbx-cache-rustc` and
-are identity-independent. Bumping the identity version invalidates manifests,
-not cached actions.
+identity (v1): a canonical JSON of `{version, workspace, command}`, where
+`workspace` is the digest of `Cargo.lock` rather than the checkout path, so
+separate worktrees of one dependency graph share a manifest. A project with no
+lockfile falls back to its directory name.
+
+The identity only namespaces prefetch manifests — action keys come from
+`mbx-cache-rustc` and are independent of it. A wrong identity costs a cold
+prefetch, never a wrong result, so bumping the version invalidates manifests
+and not cached actions.
 
 ## Protocol
 
@@ -109,6 +129,7 @@ Same protocol as mise action-cache v1, renamed. The wire rename table:
 | `mise-cache-protocol` header | `mbx-cache-protocol` |
 | `mise-cache-namespace` header | `mbx-cache-namespace` |
 | `MISEPK01` blob-pack magic | `MBXPACK1` |
+| `MISE_CACHE_TASK` env var | `MBX_BUILD` |
 | `MISE_CACHE_*` env vars | `MBX_*` (client), `MBX_CACHE_*` (server) |
 | `mise-cache-rustc` shim stem | `mbx-rustc` |
 
@@ -123,6 +144,7 @@ Protocol version stays 1; nothing in the wild speaks the old names.
   `build.rustc-wrapper` in `~/.cargo/config.toml`. If that key already names
   another wrapper, such as sccache, setup reports it and changes nothing:
   silently displacing a wrapper the user chose is worse than doing nothing.
+  Depends on standalone shim mode, so it lands with it.
 - `mbx-rustc` (argv0) — the shim; not invoked by humans.
 
 ## Configuration
@@ -185,10 +207,12 @@ The failure mode is a recompile, never a wrong result.
 3. `feat: mbx-cache-core` — port from mise with wire renames; tests included.
 4. `feat: mbx-cache-rustc` — port; depends on core.
 5. `feat: session + shim library` — port mise's session/shim glue, severed
-   from mise: own config, own identity, inlined utils, standalone shim mode.
-6. `feat: mbx CLI` — `build`, `gc`, `cache`, `setup` commands.
-7. `docs: usage + integration tests` — real README (experimental banner),
-   cold/warm/second-checkout integration tests.
+   from mise: own config, own identity, inlined utils.
+6. `feat: mbx CLI` — `build`, `gc`, and `cache` commands, plus the cold/warm and
+   second-checkout integration tests.
+7. `feat: standalone shim mode` — cache reads and writes without a session, so
+   plain `cargo build` benefits through `build.rustc-wrapper`, plus `mbx setup`.
+8. `docs: usage` — real README behind an experimental banner.
 
 Server repo follow-up (separate stack in `jdx/mbx-cache`): rebrand crate,
 env vars, and wire constants to match `mbx-cache-core` exactly.

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 
 [dependencies]
 bytesize = "2"
+clap = { version = "4", features = ["derive"] }
+env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"
 log = "0.4"
@@ -22,6 +24,11 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 toml = "0.9"
 which = "8"
+
+[dev-dependencies]
+filetime = "0.2"
+serde_json = "1"
+tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -235,6 +235,9 @@ fn inherited_environment(get_env: impl Fn(&str) -> Option<String>) -> BTreeMap<S
 /// move the whole build elsewhere. Inference is kept as a fallback, and costs
 /// only cache hits when it is wrong, since an unmapped path bypasses.
 fn resolve_roots(cargo: &std::ffi::OsStr, arguments: &[String], working_dir: &Path) -> Roots {
+    // Everything below inspects cargo's own flags only; the real build still
+    // receives the full argument list untouched.
+    let arguments = cargo_arguments(arguments);
     let reported = cargo_roots(cargo, arguments);
     // `-C` moves the directory cargo resolves relative paths against, so the
     // fallbacks below have to follow it rather than this process's cwd.
@@ -279,6 +282,20 @@ const PROBE_GLOBAL_FLAGS: [&str; 3] = ["-C", "--config", "-Z"];
 /// because a probe left to itself may reach the registry the build was told to
 /// stay away from.
 const PROBE_MANIFEST_TOGGLES: [&str; 3] = ["--offline", "--frozen", "--locked"];
+
+/// Cargo's own arguments, stopping at the `--` that hands the rest to rustc.
+///
+/// The separator matters more than it looks: past it, `-C` is a codegen option,
+/// not a directory for cargo to run in, and `-C opt-level=3` is ordinary. Reading
+/// one as the other would point the probe and the path mapping at a directory
+/// that does not exist, so every action would bypass.
+fn cargo_arguments(arguments: &[String]) -> &[String] {
+    let end = arguments
+        .iter()
+        .position(|argument| argument == "--")
+        .unwrap_or(arguments.len());
+    &arguments[..end]
+}
 
 /// Collect the occurrences of `flags` from `arguments`, preserving order and
 /// repeats. Cargo allows `--flag value`, `--flag=value`, and, for the short
@@ -499,6 +516,44 @@ mod tests {
             forwarded_flags(&arguments, &PROBE_GLOBAL_FLAGS)
                 .iter()
                 .all(|argument| argument != "--release")
+        );
+    }
+
+    #[test]
+    fn rustc_flags_after_the_separator_are_not_cargo_globals() {
+        let arguments = [
+            "build",
+            "--config",
+            "build.jobs=2",
+            "--",
+            "-C",
+            "opt-level=3",
+            "-Zunstable-thing",
+            "--config",
+            "not.cargos=1",
+        ]
+        .map(String::from);
+
+        // Only the flag before `--` belongs to cargo. Forwarding rustc's `-C`
+        // would send the probe looking for a directory called "opt-level=3".
+        assert_eq!(
+            forwarded_flags(cargo_arguments(&arguments), &PROBE_GLOBAL_FLAGS),
+            ["--config", "build.jobs=2"]
+        );
+        let working_dir = Path::new("/workspace");
+        assert_eq!(
+            invocation_dir(cargo_arguments(&arguments), working_dir),
+            working_dir
+        );
+        // Without the separator the same tokens are cargo's, and -C wins.
+        let no_separator: Vec<String> = arguments
+            .iter()
+            .filter(|argument| *argument != "--")
+            .cloned()
+            .collect();
+        assert_eq!(
+            invocation_dir(cargo_arguments(&no_separator), working_dir),
+            Path::new("/workspace/opt-level=3")
         );
     }
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -1,0 +1,273 @@
+//! The mbx command line.
+
+use crate::config::Config;
+use crate::session::CacheSession;
+use crate::{policy, store};
+use bytesize::ByteSize;
+use clap::{Args, Parser, Subcommand};
+use eyre::{Context, Result, bail};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+#[derive(Parser)]
+#[command(name = "mbx", version, about = "A build cache for Rust projects")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run cargo with the build cache enabled.
+    Build(BuildArgs),
+    /// Evict cached objects until the store fits a size budget.
+    Gc(GcArgs),
+    /// Inspect the local store.
+    Cache(CacheArgs),
+}
+
+#[derive(Args)]
+struct BuildArgs {
+    /// Arguments passed to cargo, starting with the subcommand.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    arguments: Vec<String>,
+}
+
+#[derive(Args)]
+struct GcArgs {
+    /// Size the store may occupy afterwards, for example 20GB.
+    #[arg(long, value_name = "SIZE")]
+    max_size: ByteSize,
+}
+
+#[derive(Args)]
+struct CacheArgs {
+    #[command(subcommand)]
+    command: CacheCommands,
+}
+
+#[derive(Subcommand)]
+enum CacheCommands {
+    /// Print the store directory.
+    Dir,
+    /// Summarize what the store holds.
+    Stats,
+}
+
+/// Parse the command line and run it.
+pub fn run() -> Result<ExitCode> {
+    let cli = Cli::parse();
+    let config = Config::load()?;
+    match cli.command {
+        Commands::Build(args) => build(&config, &args.arguments),
+        Commands::Gc(args) => gc(&config, args.max_size.as_u64()).map(|()| ExitCode::SUCCESS),
+        Commands::Cache(args) => match args.command {
+            CacheCommands::Dir => {
+                println!("{}", config.store_dir().display());
+                Ok(ExitCode::SUCCESS)
+            }
+            CacheCommands::Stats => cache_stats(&config).map(|()| ExitCode::SUCCESS),
+        },
+    }
+}
+
+fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
+    validate_build_arguments(arguments)?;
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    // Release builds publish artifacts that must not depend on a cache, and a
+    // tag build has no later build to share with anyway.
+    if policy::release_context() {
+        log::warn!("the build cache is disabled for release builds");
+        return run_cargo(&cargo, arguments, BTreeMap::new());
+    }
+
+    let workspace_root = workspace_root(&std::env::current_dir()?);
+    let target_dir = target_dir(&workspace_root);
+    let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    runtime.block_on(async {
+        let session = CacheSession::start(session_dir.path(), config).await?;
+        let mut environment = BTreeMap::new();
+        let run = session
+            .begin(&workspace_root, &target_dir, arguments, &mut environment)
+            .await;
+
+        let status = run_cargo(&cargo, arguments, environment);
+
+        // A failed build has nothing to publish, and its manifest would record
+        // actions that never completed.
+        match (&status, run) {
+            (Ok(code), Some(run)) if *code == ExitCode::SUCCESS => {
+                if let Err(error) = run.commit().await {
+                    log::warn!("the build manifest was not committed: {error}");
+                }
+            }
+            _ => {}
+        }
+
+        match session.finish().await {
+            Ok(stats) => crate::session::display_stats(&stats, config),
+            Err(error) => log::warn!("the cache session did not shut down cleanly: {error}"),
+        }
+        status
+    })
+}
+
+fn run_cargo(
+    cargo: &std::ffi::OsStr,
+    arguments: &[String],
+    environment: BTreeMap<String, String>,
+) -> Result<ExitCode> {
+    let mut command = Command::new(cargo);
+    command.args(arguments);
+    command.envs(environment);
+    let status = command
+        .status()
+        .wrap_err_with(|| format!("failed to run {}", cargo.to_string_lossy()))?;
+    Ok(exit_code(status))
+}
+
+#[cfg(unix)]
+fn exit_code(status: std::process::ExitStatus) -> ExitCode {
+    use std::os::unix::process::ExitStatusExt as _;
+    // A signalled cargo has no exit code of its own; report the conventional
+    // 128 + signal so callers can tell it apart from a clean failure.
+    match (status.code(), status.signal()) {
+        (Some(code), _) => ExitCode::from(code as u8),
+        (None, Some(signal)) => ExitCode::from(128u8.saturating_add(signal as u8)),
+        (None, None) => ExitCode::FAILURE,
+    }
+}
+
+#[cfg(not(unix))]
+fn exit_code(status: std::process::ExitStatus) -> ExitCode {
+    match status.code() {
+        Some(code) => ExitCode::from(code as u8),
+        None => ExitCode::FAILURE,
+    }
+}
+
+fn gc(config: &Config, max_bytes: u64) -> Result<()> {
+    let store = config.store_dir();
+    let outcome = store::gc(&store, max_bytes)?;
+    println!(
+        "evicted {} objects and {} action results ({}); {} remain",
+        outcome.removed_objects,
+        outcome.removed_action_results,
+        ByteSize::b(outcome.removed_bytes).display().iec(),
+        ByteSize::b(outcome.remaining_bytes).display().iec(),
+    );
+    Ok(())
+}
+
+fn cache_stats(config: &Config) -> Result<()> {
+    let store = config.store_dir();
+    let stats = store::stats(&store)?;
+    println!("store: {}", store.display());
+    println!(
+        "objects: {} ({})",
+        stats.objects,
+        ByteSize::b(stats.object_bytes).display().iec()
+    );
+    println!(
+        "action results: {} ({})",
+        stats.action_results,
+        ByteSize::b(stats.action_result_bytes).display().iec()
+    );
+    println!(
+        "total: {}",
+        ByteSize::b(stats.total_bytes()).display().iec()
+    );
+    Ok(())
+}
+
+/// Find the workspace root above `start`.
+///
+/// The outermost directory holding a `Cargo.lock` is preferred, since that is
+/// the one cargo resolves against; a directory holding only a `Cargo.toml`
+/// stands in when there is no lockfile yet.
+fn workspace_root(start: &Path) -> PathBuf {
+    let mut lockfile = None;
+    let mut manifest = None;
+    for directory in start.ancestors() {
+        if directory.join("Cargo.lock").is_file() {
+            lockfile = Some(directory.to_path_buf());
+        }
+        if directory.join("Cargo.toml").is_file() {
+            manifest = Some(directory.to_path_buf());
+        }
+    }
+    lockfile.or(manifest).unwrap_or_else(|| start.to_path_buf())
+}
+
+/// Resolve the directory cargo will write build outputs to.
+///
+/// Only the environment and the default location are consulted. A target
+/// directory set through cargo configuration is not found here, which costs
+/// cache hits for those output paths but never correctness: an unmapped path
+/// bypasses the cache.
+fn target_dir(workspace_root: &Path) -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .filter(|dir| dir.is_absolute())
+        .unwrap_or_else(|| workspace_root.join("target"))
+}
+
+/// Reject a build invocation that cargo would not accept anyway.
+pub fn validate_build_arguments(arguments: &[String]) -> Result<()> {
+    if arguments.is_empty() {
+        bail!("mbx build expects a cargo subcommand, for example: mbx build build --release");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_the_outermost_lockfile_as_the_workspace_root() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let member = root.join("crates").join("member");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(root.join("Cargo.lock"), "version = 4\n").unwrap();
+        std::fs::write(root.join("Cargo.toml"), "[workspace]\n").unwrap();
+        std::fs::write(member.join("Cargo.toml"), "[package]\n").unwrap();
+
+        assert_eq!(workspace_root(&member), root);
+    }
+
+    #[test]
+    fn falls_back_to_a_manifest_without_a_lockfile() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let nested = root.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(root.join("Cargo.toml"), "[package]\n").unwrap();
+
+        assert_eq!(workspace_root(&nested), root);
+    }
+
+    #[test]
+    fn falls_back_to_the_starting_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        assert_eq!(workspace_root(directory.path()), directory.path());
+    }
+
+    #[test]
+    fn target_dir_defaults_under_the_workspace() {
+        let root = Path::new("/workspace");
+        assert_eq!(target_dir(root), Path::new("/workspace/target"));
+    }
+
+    #[test]
+    fn build_requires_a_cargo_subcommand() {
+        assert!(validate_build_arguments(&[]).is_err());
+        assert!(validate_build_arguments(&["build".to_string()]).is_ok());
+    }
+}

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -82,8 +82,9 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
         return run_cargo(&cargo, arguments, BTreeMap::new());
     }
 
-    let workspace_root = workspace_root(&std::env::current_dir()?);
-    let target_dir = target_dir(&workspace_root);
+    let working_dir = std::env::current_dir()?;
+    let workspace_root = workspace_root(&working_dir);
+    let target_dir = target_dir(&workspace_root, &working_dir, arguments);
     let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -206,15 +207,36 @@ fn workspace_root(start: &Path) -> PathBuf {
 
 /// Resolve the directory cargo will write build outputs to.
 ///
-/// Only the environment and the default location are consulted. A target
-/// directory set through cargo configuration is not found here, which costs
-/// cache hits for those output paths but never correctness: an unmapped path
-/// bypasses the cache.
-fn target_dir(workspace_root: &Path) -> PathBuf {
-    std::env::var_os("CARGO_TARGET_DIR")
+/// `--target-dir` beats `CARGO_TARGET_DIR`, which beats the default beneath the
+/// workspace, matching cargo. A target directory set through cargo
+/// configuration is still not found here, which costs cache hits for those
+/// output paths but never correctness: an unmapped path bypasses the cache.
+fn target_dir(workspace_root: &Path, working_dir: &Path, arguments: &[String]) -> PathBuf {
+    let requested = target_dir_argument(arguments)
         .map(PathBuf::from)
-        .filter(|dir| dir.is_absolute())
-        .unwrap_or_else(|| workspace_root.join("target"))
+        .or_else(|| std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from))
+        .filter(|dir| !dir.as_os_str().is_empty());
+    match requested {
+        // Cargo resolves a relative target directory against the invocation
+        // directory, not the workspace root.
+        Some(dir) if dir.is_relative() => working_dir.join(dir),
+        Some(dir) => dir,
+        None => workspace_root.join("target"),
+    }
+}
+
+/// Read `--target-dir <path>` or `--target-dir=<path>` out of cargo's arguments.
+fn target_dir_argument(arguments: &[String]) -> Option<&str> {
+    let mut arguments = arguments.iter();
+    while let Some(argument) = arguments.next() {
+        if let Some(value) = argument.strip_prefix("--target-dir=") {
+            return Some(value);
+        }
+        if argument == "--target-dir" {
+            return arguments.next().map(String::as_str);
+        }
+    }
+    None
 }
 
 /// Reject a build invocation that cargo would not accept anyway.
@@ -262,7 +284,51 @@ mod tests {
     #[test]
     fn target_dir_defaults_under_the_workspace() {
         let root = Path::new("/workspace");
-        assert_eq!(target_dir(root), Path::new("/workspace/target"));
+        let cwd = Path::new("/workspace/crates/member");
+        assert_eq!(target_dir(root, cwd, &[]), Path::new("/workspace/target"));
+    }
+
+    #[test]
+    fn target_dir_follows_the_cargo_argument() {
+        let root = Path::new("/workspace");
+        let cwd = Path::new("/elsewhere");
+        let joined = ["build".to_string(), "--target-dir=/tmp/out".to_string()];
+        let split = [
+            "build".to_string(),
+            "--target-dir".to_string(),
+            "/tmp/out".to_string(),
+        ];
+
+        assert_eq!(target_dir(root, cwd, &joined), Path::new("/tmp/out"));
+        assert_eq!(target_dir(root, cwd, &split), Path::new("/tmp/out"));
+    }
+
+    #[test]
+    fn target_dir_resolves_a_relative_argument_against_the_working_directory() {
+        let root = Path::new("/workspace");
+        let cwd = Path::new("/workspace/crates/member");
+        let arguments = [
+            "build".to_string(),
+            "--target-dir".to_string(),
+            "out".to_string(),
+        ];
+
+        assert_eq!(
+            target_dir(root, cwd, &arguments),
+            Path::new("/workspace/crates/member/out")
+        );
+    }
+
+    #[test]
+    fn target_dir_ignores_a_trailing_flag_without_a_value() {
+        let root = Path::new("/workspace");
+        let cwd = Path::new("/workspace");
+        let arguments = ["build".to_string(), "--target-dir".to_string()];
+
+        assert_eq!(
+            target_dir(root, cwd, &arguments),
+            Path::new("/workspace/target")
+        );
     }
 
     #[test]

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -236,19 +236,22 @@ fn inherited_environment(get_env: impl Fn(&str) -> Option<String>) -> BTreeMap<S
 /// only cache hits when it is wrong, since an unmapped path bypasses.
 fn resolve_roots(cargo: &std::ffi::OsStr, arguments: &[String], working_dir: &Path) -> Roots {
     let reported = cargo_roots(cargo, arguments);
+    // `-C` moves the directory cargo resolves relative paths against, so the
+    // fallbacks below have to follow it rather than this process's cwd.
+    let invocation_dir = invocation_dir(arguments, working_dir);
     let workspace_root = reported
         .as_ref()
         .map(|roots| roots.workspace_root.clone())
-        .unwrap_or_else(|| workspace_root(working_dir));
+        .unwrap_or_else(|| workspace_root(&invocation_dir));
     // An explicit flag outranks anything cargo reports from configuration.
     let target_dir = target_dir_argument(arguments)
-        .map(|value| absolute(working_dir, value))
+        .map(|value| absolute(&invocation_dir, value))
         .or_else(|| reported.map(|roots| roots.target_dir))
         .or_else(|| {
             std::env::var_os("CARGO_TARGET_DIR")
                 .map(PathBuf::from)
                 .filter(|dir| !dir.as_os_str().is_empty())
-                .map(|dir| absolute(working_dir, &dir.to_string_lossy()))
+                .map(|dir| absolute(&invocation_dir, &dir.to_string_lossy()))
         })
         .unwrap_or_else(|| workspace_root.join("target"));
     Roots {
@@ -267,12 +270,65 @@ fn absolute(working_dir: &Path, value: &str) -> PathBuf {
     }
 }
 
+/// Cargo options that belong before the subcommand and change what `cargo
+/// metadata` would report. `-C` moves the whole invocation, and `--config` can
+/// set `build.target-dir` outright, so a probe that drops them describes a
+/// different tree than the one being built.
+const PROBE_GLOBAL_FLAGS: [&str; 3] = ["-C", "--config", "-Z"];
+/// Options cargo accepts only after the subcommand. The network flags matter
+/// because a probe left to itself may reach the registry the build was told to
+/// stay away from.
+const PROBE_MANIFEST_TOGGLES: [&str; 3] = ["--offline", "--frozen", "--locked"];
+
+/// Collect the occurrences of `flags` from `arguments`, preserving order and
+/// repeats. Cargo allows `--flag value`, `--flag=value`, and, for the short
+/// forms, `-Zvalue`.
+fn forwarded_flags(arguments: &[String], flags: &[&str]) -> Vec<String> {
+    let mut forwarded = Vec::new();
+    let mut remaining = arguments.iter();
+    while let Some(argument) = remaining.next() {
+        if let Some((flag, value)) = argument
+            .split_once('=')
+            .filter(|(flag, _)| flags.contains(flag))
+        {
+            forwarded.push(flag.to_string());
+            forwarded.push(value.to_string());
+        } else if flags.contains(&argument.as_str()) {
+            if let Some(value) = remaining.next() {
+                forwarded.push(argument.clone());
+                forwarded.push(value.clone());
+            }
+        } else if flags
+            .iter()
+            .any(|flag| flag.len() == 2 && argument.len() > 2 && argument.starts_with(flag))
+        {
+            forwarded.push(argument.clone());
+        }
+    }
+    forwarded
+}
+
+/// The directory cargo resolves relative paths against, which `-C` can move.
+fn invocation_dir(arguments: &[String], working_dir: &Path) -> PathBuf {
+    flag_value(arguments, "-C")
+        .map(|value| absolute(working_dir, value))
+        .unwrap_or_else(|| working_dir.to_path_buf())
+}
+
 fn cargo_roots(cargo: &std::ffi::OsStr, arguments: &[String]) -> Option<Roots> {
     let mut command = Command::new(cargo);
+    // Globals come first; cargo rejects them after the subcommand.
+    command.args(forwarded_flags(arguments, &PROBE_GLOBAL_FLAGS));
     command.args(["metadata", "--no-deps", "--format-version", "1"]);
     // Describe the project the build will actually operate on.
     if let Some(manifest) = flag_value(arguments, "--manifest-path") {
         command.args(["--manifest-path", manifest]);
+    }
+    for toggle in arguments
+        .iter()
+        .filter(|argument| PROBE_MANIFEST_TOGGLES.contains(&argument.as_str()))
+    {
+        command.arg(toggle);
     }
     let output = command.output().ok()?;
     if !output.status.success() {
@@ -410,6 +466,81 @@ mod tests {
         let empty = inherited_environment(|name| (name == "RUSTC_WRAPPER").then(String::new));
         assert!(empty.is_empty());
         assert!(inherited_environment(|_| None).is_empty());
+    }
+
+    #[test]
+    fn forwards_repeated_and_attached_global_flags() {
+        let arguments = [
+            "build",
+            "--config",
+            "build.target-dir=\"/one\"",
+            "--config=net.offline=true",
+            "-Zunstable-options",
+            "-C",
+            "/tree",
+            "--release",
+        ]
+        .map(String::from);
+
+        assert_eq!(
+            forwarded_flags(&arguments, &PROBE_GLOBAL_FLAGS),
+            [
+                "--config",
+                "build.target-dir=\"/one\"",
+                "--config",
+                "net.offline=true",
+                "-Zunstable-options",
+                "-C",
+                "/tree",
+            ]
+        );
+        // A flag the probe does not understand must not leak into it.
+        assert!(
+            forwarded_flags(&arguments, &PROBE_GLOBAL_FLAGS)
+                .iter()
+                .all(|argument| argument != "--release")
+        );
+    }
+
+    #[test]
+    fn a_config_set_target_dir_reaches_the_probe() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "").unwrap();
+        let manifest = root.join("Cargo.toml");
+        let configured = root.join("configured-target");
+
+        // Without the override cargo reports the default; with it the probe has
+        // to report the same directory the build will write to, or the outputs
+        // go unmapped and every action bypasses the cache.
+        let arguments = [
+            "build".to_string(),
+            "--offline".to_string(),
+            "--manifest-path".to_string(),
+            manifest.display().to_string(),
+        ];
+        let default = resolve_roots(std::ffi::OsStr::new("cargo"), &arguments, root);
+        assert_eq!(default.target_dir, root.join("target"));
+
+        let overridden = [
+            arguments.to_vec(),
+            vec![
+                "--config".to_string(),
+                // A TOML literal string: a Windows path's backslashes are
+                // escape sequences inside a basic string, which silently
+                // mangled the value and left the probe reporting the default.
+                format!("build.target-dir='{}'", configured.display()),
+            ],
+        ]
+        .concat();
+        let roots = resolve_roots(std::ffi::OsStr::new("cargo"), &overridden, root);
+        assert_eq!(roots.target_dir, configured);
     }
 
     #[test]

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -83,8 +83,7 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     }
 
     let working_dir = std::env::current_dir()?;
-    let workspace_root = workspace_root(&working_dir);
-    let target_dir = target_dir(&workspace_root, &working_dir, arguments);
+    let roots = resolve_roots(&cargo, arguments, &working_dir);
     let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -92,9 +91,14 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
 
     runtime.block_on(async {
         let session = CacheSession::start(session_dir.path(), config).await?;
-        let mut environment = BTreeMap::new();
+        let mut environment = inherited_environment(|name| std::env::var(name).ok());
         let run = session
-            .begin(&workspace_root, &target_dir, arguments, &mut environment)
+            .begin(
+                &roots.workspace_root,
+                &roots.target_dir,
+                arguments,
+                &mut environment,
+            )
             .await;
 
         let status = run_cargo(&cargo, arguments, environment);
@@ -205,34 +209,99 @@ fn workspace_root(start: &Path) -> PathBuf {
     lockfile.or(manifest).unwrap_or_else(|| start.to_path_buf())
 }
 
-/// Resolve the directory cargo will write build outputs to.
+/// Settings the shim maps out of its cache keys.
+#[derive(Debug, PartialEq, Eq)]
+struct Roots {
+    workspace_root: PathBuf,
+    target_dir: PathBuf,
+}
+
+/// Carry a `RUSTC_WRAPPER` the caller already configured into the session.
 ///
-/// `--target-dir` beats `CARGO_TARGET_DIR`, which beats the default beneath the
-/// workspace, matching cargo. A target directory set through cargo
-/// configuration is still not found here, which costs cache hits for those
-/// output paths but never correctness: an unmapped path bypasses the cache.
-fn target_dir(workspace_root: &Path, working_dir: &Path, arguments: &[String]) -> PathBuf {
-    let requested = target_dir_argument(arguments)
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from))
-        .filter(|dir| !dir.as_os_str().is_empty());
-    match requested {
-        // Cargo resolves a relative target directory against the invocation
-        // directory, not the workspace root.
-        Some(dir) if dir.is_relative() => working_dir.join(dir),
-        Some(dir) => dir,
-        None => workspace_root.join("target"),
+/// The session records it so the shim can defer to it; without this it would be
+/// dropped silently and whatever it does would stop happening.
+fn inherited_environment(get_env: impl Fn(&str) -> Option<String>) -> BTreeMap<String, String> {
+    let mut environment = BTreeMap::new();
+    if let Some(wrapper) = get_env("RUSTC_WRAPPER").filter(|value| !value.is_empty()) {
+        environment.insert("RUSTC_WRAPPER".into(), wrapper);
+    }
+    environment
+}
+
+/// Resolve the workspace root and target directory cargo will actually use.
+///
+/// Cargo is the only authority: the target directory can come from the
+/// environment, a flag, or cargo's own configuration, and `--manifest-path` can
+/// move the whole build elsewhere. Inference is kept as a fallback, and costs
+/// only cache hits when it is wrong, since an unmapped path bypasses.
+fn resolve_roots(cargo: &std::ffi::OsStr, arguments: &[String], working_dir: &Path) -> Roots {
+    let reported = cargo_roots(cargo, arguments);
+    let workspace_root = reported
+        .as_ref()
+        .map(|roots| roots.workspace_root.clone())
+        .unwrap_or_else(|| workspace_root(working_dir));
+    // An explicit flag outranks anything cargo reports from configuration.
+    let target_dir = target_dir_argument(arguments)
+        .map(|value| absolute(working_dir, value))
+        .or_else(|| reported.map(|roots| roots.target_dir))
+        .or_else(|| {
+            std::env::var_os("CARGO_TARGET_DIR")
+                .map(PathBuf::from)
+                .filter(|dir| !dir.as_os_str().is_empty())
+                .map(|dir| absolute(working_dir, &dir.to_string_lossy()))
+        })
+        .unwrap_or_else(|| workspace_root.join("target"));
+    Roots {
+        workspace_root,
+        target_dir,
     }
 }
 
-/// Read `--target-dir <path>` or `--target-dir=<path>` out of cargo's arguments.
+/// Cargo resolves a relative directory against the invocation directory.
+fn absolute(working_dir: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else {
+        working_dir.join(path)
+    }
+}
+
+fn cargo_roots(cargo: &std::ffi::OsStr, arguments: &[String]) -> Option<Roots> {
+    let mut command = Command::new(cargo);
+    command.args(["metadata", "--no-deps", "--format-version", "1"]);
+    // Describe the project the build will actually operate on.
+    if let Some(manifest) = flag_value(arguments, "--manifest-path") {
+        command.args(["--manifest-path", manifest]);
+    }
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_cargo_roots(&output.stdout)
+}
+
+fn parse_cargo_roots(metadata: &[u8]) -> Option<Roots> {
+    let metadata: serde_json::Value = serde_json::from_slice(metadata).ok()?;
+    Some(Roots {
+        workspace_root: PathBuf::from(metadata.get("workspace_root")?.as_str()?),
+        target_dir: PathBuf::from(metadata.get("target_directory")?.as_str()?),
+    })
+}
+
 fn target_dir_argument(arguments: &[String]) -> Option<&str> {
+    flag_value(arguments, "--target-dir")
+}
+
+/// Read `--flag <value>` or `--flag=<value>` out of cargo's arguments.
+fn flag_value<'a>(arguments: &'a [String], flag: &str) -> Option<&'a str> {
+    let joined = format!("{flag}=");
     let mut arguments = arguments.iter();
     while let Some(argument) = arguments.next() {
-        if let Some(value) = argument.strip_prefix("--target-dir=") {
+        if let Some(value) = argument.strip_prefix(&joined) {
             return Some(value);
         }
-        if argument == "--target-dir" {
+        if argument == flag {
             return arguments.next().map(String::as_str);
         }
     }
@@ -282,53 +351,65 @@ mod tests {
     }
 
     #[test]
-    fn target_dir_defaults_under_the_workspace() {
-        let root = Path::new("/workspace");
-        let cwd = Path::new("/workspace/crates/member");
-        assert_eq!(target_dir(root, cwd, &[]), Path::new("/workspace/target"));
-    }
-
-    #[test]
-    fn target_dir_follows_the_cargo_argument() {
-        let root = Path::new("/workspace");
-        let cwd = Path::new("/elsewhere");
+    fn reads_both_flag_spellings() {
         let joined = ["build".to_string(), "--target-dir=/tmp/out".to_string()];
         let split = [
             "build".to_string(),
             "--target-dir".to_string(),
             "/tmp/out".to_string(),
         ];
+        let dangling = ["build".to_string(), "--target-dir".to_string()];
 
-        assert_eq!(target_dir(root, cwd, &joined), Path::new("/tmp/out"));
-        assert_eq!(target_dir(root, cwd, &split), Path::new("/tmp/out"));
+        assert_eq!(target_dir_argument(&joined), Some("/tmp/out"));
+        assert_eq!(target_dir_argument(&split), Some("/tmp/out"));
+        assert_eq!(target_dir_argument(&dangling), None);
+        assert_eq!(target_dir_argument(&["build".to_string()]), None);
     }
 
     #[test]
-    fn target_dir_resolves_a_relative_argument_against_the_working_directory() {
-        let root = Path::new("/workspace");
-        let cwd = Path::new("/workspace/crates/member");
-        let arguments = [
-            "build".to_string(),
-            "--target-dir".to_string(),
-            "out".to_string(),
-        ];
+    fn reads_the_roots_cargo_reports() {
+        let metadata = br#"{
+            "workspace_root": "/elsewhere/project",
+            "target_directory": "/var/cache/shared-target",
+            "packages": []
+        }"#;
 
         assert_eq!(
-            target_dir(root, cwd, &arguments),
+            parse_cargo_roots(metadata).unwrap(),
+            Roots {
+                workspace_root: PathBuf::from("/elsewhere/project"),
+                target_dir: PathBuf::from("/var/cache/shared-target"),
+            }
+        );
+    }
+
+    #[test]
+    fn ignores_unusable_cargo_metadata() {
+        assert!(parse_cargo_roots(b"not json").is_none());
+        assert!(parse_cargo_roots(br#"{"packages": []}"#).is_none());
+    }
+
+    #[test]
+    fn resolves_a_relative_directory_against_the_working_directory() {
+        let cwd = Path::new("/workspace/crates/member");
+        assert_eq!(
+            absolute(cwd, "out"),
             Path::new("/workspace/crates/member/out")
         );
+        assert_eq!(absolute(cwd, "/tmp/out"), Path::new("/tmp/out"));
     }
 
     #[test]
-    fn target_dir_ignores_a_trailing_flag_without_a_value() {
-        let root = Path::new("/workspace");
-        let cwd = Path::new("/workspace");
-        let arguments = ["build".to_string(), "--target-dir".to_string()];
+    fn carries_an_inherited_wrapper_into_the_session() {
+        let with = inherited_environment(|name| {
+            (name == "RUSTC_WRAPPER").then(|| "/usr/bin/sccache".to_string())
+        });
+        assert_eq!(with.get("RUSTC_WRAPPER").unwrap(), "/usr/bin/sccache");
 
-        assert_eq!(
-            target_dir(root, cwd, &arguments),
-            Path::new("/workspace/target")
-        );
+        // An empty value is how a shell unsets it in practice.
+        let empty = inherited_environment(|name| (name == "RUSTC_WRAPPER").then(String::new));
+        assert!(empty.is_empty());
+        assert!(inherited_environment(|_| None).is_empty());
     }
 
     #[test]

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -4,9 +4,11 @@
 //! store shared by every project and worktree on a machine, and optionally
 //! shared further through a remote cache.
 
+pub mod cli;
 pub mod config;
 pub mod policy;
 pub mod session;
+pub mod store;
 pub mod util;
 
 mod rustc;

--- a/crates/mbx/src/main.rs
+++ b/crates/mbx/src/main.rs
@@ -7,6 +7,16 @@ fn main() -> ExitCode {
         return mbx::session::run_rustc_shim();
     }
 
-    eprintln!("mbx: the command line is not implemented yet; see PLAN.md");
-    ExitCode::from(1)
+    env_logger::Builder::from_env(env_logger::Env::default().filter_or("MBX_LOG", "info"))
+        .format_target(false)
+        .format_timestamp(None)
+        .init();
+
+    match mbx::cli::run() {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("mbx: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -649,13 +649,17 @@ fn identity_field<'a>(verbose: &'a str, field: &str) -> Result<&'a str> {
 fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     let mut roots = BTreeSet::new();
-    add_mapping(
-        &mut mappings,
-        &mut roots,
-        working_dir.to_path_buf(),
-        "workspace",
-    );
+    // The target directory comes first, and before the workspace that usually
+    // contains it: output paths are the ones that differ between checkouts, and
+    // mapping them explicitly also keeps keys stable when the target directory
+    // is moved out of the workspace.
+    //
+    // Cargo compiles a dependency with its working directory inside the
+    // registry, not in the workspace, so neither root can be inferred from the
+    // working directory -- the session passes both in.
     for (name, placeholder) in [
+        (session::TARGET_DIR_ENV, "target"),
+        (session::WORKSPACE_ROOT_ENV, "workspace"),
         ("CARGO_HOME", "cargo_home"),
         ("RUSTUP_HOME", "rustup_home"),
         ("HOME", "home"),
@@ -666,6 +670,16 @@ fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
         {
             add_mapping(&mut mappings, &mut roots, root, placeholder);
         }
+    }
+    // Without a session there is no workspace root to trust, so fall back to
+    // the working directory rather than bypassing every action.
+    if !roots.iter().any(|root| working_dir.starts_with(root)) {
+        add_mapping(
+            &mut mappings,
+            &mut roots,
+            working_dir.to_path_buf(),
+            "workspace",
+        );
     }
     mappings
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -40,7 +40,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     let working_dir = std::env::current_dir()?;
     let outputs = invocation.outputs(&working_dir)?;
 
-    let verify = std::env::var_os(session::VERIFY_ENV).is_some();
+    let verify = session::verify_requested();
     let mut verification = None;
     let mut action_lookup_attempted = false;
     if outputs.dep_info.is_file()

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -119,11 +119,12 @@ impl CacheSession {
             self.staging.to_string_lossy().into_owned(),
         );
         environment.insert(BUILD_ENV.into(), protocol_build);
-        if self.verify {
-            environment.insert(VERIFY_ENV.into(), "1".into());
-        } else {
-            environment.remove(VERIFY_ENV);
-        }
+        // Always state this explicitly: removing the key would leave the shim
+        // inheriting whatever the parent environment had.
+        environment.insert(
+            VERIFY_ENV.into(),
+            if self.verify { "1" } else { "0" }.into(),
+        );
         if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), shim.clone())
             && previous != shim
         {
@@ -750,6 +751,14 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
     }
 }
 
+/// Whether the shim should verify cached results against a real compilation.
+///
+/// An empty value or `0` is off, matching how the configuration reads it, so
+/// that an explicit disable cannot be mistaken for an enable.
+pub(crate) fn verify_requested() -> bool {
+    std::env::var_os(VERIFY_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
 pub(crate) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
     let socket =
         std::env::var_os(SOCKET_ENV).ok_or_else(|| eyre::eyre!("{SOCKET_ENV} is not set"))?;
@@ -913,7 +922,7 @@ mod tests {
         assert_eq!(wrapper.file_stem().unwrap(), RUSTC_SHIM_STEM);
         assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
         assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");
-        assert!(!values.contains_key(VERIFY_ENV));
+        assert_eq!(values.get(VERIFY_ENV).unwrap(), "0");
 
         session.finish().await.unwrap();
     }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -27,6 +27,8 @@ const SOCKET_ENV: &str = "MBX_SOCKET";
 pub(crate) const STAGING_ENV: &str = "MBX_STAGING_DIR";
 pub(crate) const BUILD_ENV: &str = "MBX_BUILD";
 pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
+pub(crate) const WORKSPACE_ROOT_ENV: &str = "MBX_WORKSPACE_ROOT";
+pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const IDENTITY_VERSION: u8 = 1;
@@ -82,6 +84,7 @@ impl CacheSession {
     pub async fn begin(
         &self,
         workspace_root: &Path,
+        target_dir: &Path,
         command: &[String],
         environment: &mut BTreeMap<String, String>,
     ) -> Option<ActionRun> {
@@ -100,6 +103,16 @@ impl CacheSession {
             }
         };
         let shim = self.rustc_shim.to_string_lossy().into_owned();
+        // The shim maps these roots out of its cache keys; a dependency compiles
+        // with its working directory in the registry, so it cannot find them.
+        environment.insert(
+            WORKSPACE_ROOT_ENV.into(),
+            workspace_root.to_string_lossy().into_owned(),
+        );
+        environment.insert(
+            TARGET_DIR_ENV.into(),
+            target_dir.to_string_lossy().into_owned(),
+        );
         environment.insert(SOCKET_ENV.into(), self.socket.clone());
         environment.insert(
             STAGING_ENV.into(),
@@ -883,7 +896,12 @@ mod tests {
         let workspace = tempfile::tempdir().unwrap();
         let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
         let run = session
-            .begin(workspace.path(), &["build".to_string()], &mut values)
+            .begin(
+                workspace.path(),
+                &workspace.path().join("target"),
+                &["build".to_string()],
+                &mut values,
+            )
             .await;
 
         assert!(run.is_some());
@@ -913,7 +931,12 @@ mod tests {
         let workspace = tempfile::tempdir().unwrap();
         let mut values = BTreeMap::new();
         session
-            .begin(workspace.path(), &["build".to_string()], &mut values)
+            .begin(
+                workspace.path(),
+                &workspace.path().join("target"),
+                &["build".to_string()],
+                &mut values,
+            )
             .await;
 
         assert_eq!(values.get(VERIFY_ENV).unwrap(), "1");

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -105,6 +105,11 @@ fn remove(path: &Path) -> Result<bool> {
 
 /// Whether an action result references an object the store no longer has.
 ///
+/// The digests checked here are exactly the ones `LocalActionCache::store`
+/// requires. If the sweep checked fewer, eviction could leave an entry that
+/// cannot be republished -- `store` would reject the identical result for a
+/// missing blob while the index still claimed to hold it.
+///
 /// Only the top-level objects are checked; a result whose output tree lost a
 /// nested object still restores as a miss, which is safe.
 fn action_result_is_dangling(cas: &LocalCas, path: &Path) -> Result<bool> {
@@ -119,9 +124,13 @@ fn action_result_is_dangling(cas: &LocalCas, path: &Path) -> Result<bool> {
     let Ok(result) = serde_json::from_slice::<RemoteActionResult>(&bytes) else {
         return Ok(false);
     };
-    for digest in [result.metadata.as_ref(), result.output_root.as_ref()]
-        .into_iter()
-        .flatten()
+    for digest in [
+        Some(&result.action),
+        result.metadata.as_ref(),
+        result.output_root.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
     {
         // A verification failure leaves the object unusable, same as missing.
         if cas.find(digest).unwrap_or(None).is_none() {
@@ -250,6 +259,32 @@ mod tests {
             }
         );
         assert_eq!(stats(store).unwrap().objects, 1);
+    }
+
+    #[test]
+    fn drops_an_action_result_whose_descriptor_blob_is_gone() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        let action = store_object(store, b"action key");
+        let output_root = store_object(store, b"output root blob");
+        let result = RemoteActionResult {
+            version: 1,
+            action: action.clone(),
+            metadata: None,
+            output_root: Some(output_root.clone()),
+        };
+        let cache = LocalActionCache::new(store);
+        cache.store(&result).unwrap();
+
+        // Evict only the descriptor blob, leaving the output root in place.
+        std::fs::remove_file(LocalCas::new(store).find(&action).unwrap().unwrap()).unwrap();
+
+        let outcome = gc(store, u64::MAX).unwrap();
+
+        // Left behind, this entry would report a hit that `store` could never
+        // republish, since publication requires the descriptor blob.
+        assert_eq!(outcome.removed_action_results, 1);
+        assert!(cache.find(&action).unwrap().is_none());
     }
 
     #[test]

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -78,15 +78,15 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
     }
 
     // An action result whose objects are gone can only produce a miss, so drop
-    // it rather than leave the index pointing at nothing.
-    if outcome.removed_objects > 0 {
-        let cas = LocalCas::new(store);
-        for entry in &results {
-            if action_result_is_dangling(&cas, &entry.path)? && remove(&entry.path)? {
-                live_bytes = live_bytes.saturating_sub(entry.size);
-                outcome.removed_action_results += 1;
-                outcome.removed_bytes += entry.size;
-            }
+    // it rather than leave the index pointing at nothing. This runs whether or
+    // not this call evicted anything, since another process may have, and a
+    // store that is over budget on results alone still needs the sweep.
+    let cas = LocalCas::new(store);
+    for entry in &results {
+        if action_result_is_dangling(&cas, &entry.path)? && remove(&entry.path)? {
+            live_bytes = live_bytes.saturating_sub(entry.size);
+            outcome.removed_action_results += 1;
+            outcome.removed_bytes += entry.size;
         }
     }
 

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -1,0 +1,281 @@
+//! Store inspection and garbage collection.
+//!
+//! The store holds three trees: `cas/v1` for content-addressed objects,
+//! `action-results/v1` for the results that reference them, and
+//! `task-manifests/v1` for the prediction index. Only the first two are
+//! collected; manifests are small and are what makes a cold build fast.
+
+use eyre::{Context, Result};
+use mbx_cache_core::{LocalCas, RemoteActionResult};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+const CAS_DIR: &str = "cas/v1";
+const ACTION_RESULTS_DIR: &str = "action-results/v1";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct StoreStats {
+    pub objects: u64,
+    pub object_bytes: u64,
+    pub action_results: u64,
+    pub action_result_bytes: u64,
+}
+
+impl StoreStats {
+    pub fn total_bytes(&self) -> u64 {
+        self.object_bytes.saturating_add(self.action_result_bytes)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct GcOutcome {
+    pub removed_objects: u64,
+    pub removed_action_results: u64,
+    pub removed_bytes: u64,
+    pub remaining_bytes: u64,
+}
+
+/// Summarize what the store currently holds.
+pub fn stats(store: &Path) -> Result<StoreStats> {
+    let objects = walk_files(&store.join(CAS_DIR))?;
+    let results = walk_files(&store.join(ACTION_RESULTS_DIR))?;
+    Ok(StoreStats {
+        objects: objects.len() as u64,
+        object_bytes: objects.iter().map(|entry| entry.size).sum(),
+        action_results: results.len() as u64,
+        action_result_bytes: results.iter().map(|entry| entry.size).sum(),
+    })
+}
+
+/// Evict objects until the store fits within `max_bytes`.
+///
+/// Eviction is least-recently-used by access time where the filesystem records
+/// it, falling back to modification time. Restores hard-link or reflink out of
+/// the store rather than reading through it, so this ordering is only an
+/// approximation -- evicting a live object costs a recompile, never correctness.
+pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
+    let mut objects = walk_files(&store.join(CAS_DIR))?;
+    let results = walk_files(&store.join(ACTION_RESULTS_DIR))?;
+    let mut live_bytes = objects
+        .iter()
+        .chain(results.iter())
+        .map(|entry| entry.size)
+        .sum::<u64>();
+
+    let mut outcome = GcOutcome::default();
+    if live_bytes > max_bytes {
+        objects.sort_by_key(|entry| entry.used);
+        for entry in &objects {
+            if live_bytes <= max_bytes {
+                break;
+            }
+            if remove(&entry.path)? {
+                live_bytes = live_bytes.saturating_sub(entry.size);
+                outcome.removed_objects += 1;
+                outcome.removed_bytes += entry.size;
+            }
+        }
+    }
+
+    // An action result whose objects are gone can only produce a miss, so drop
+    // it rather than leave the index pointing at nothing.
+    if outcome.removed_objects > 0 {
+        let cas = LocalCas::new(store);
+        for entry in &results {
+            if action_result_is_dangling(&cas, &entry.path)? && remove(&entry.path)? {
+                live_bytes = live_bytes.saturating_sub(entry.size);
+                outcome.removed_action_results += 1;
+                outcome.removed_bytes += entry.size;
+            }
+        }
+    }
+
+    outcome.remaining_bytes = live_bytes;
+    Ok(outcome)
+}
+
+fn remove(path: &Path) -> Result<bool> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        // A concurrent build may have evicted or replaced it already.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to evict {}", path.display())),
+    }
+}
+
+/// Whether an action result references an object the store no longer has.
+///
+/// Only the top-level objects are checked; a result whose output tree lost a
+/// nested object still restores as a miss, which is safe.
+fn action_result_is_dangling(cas: &LocalCas, path: &Path) -> Result<bool> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error).wrap_err_with(|| format!("failed to read {}", path.display()));
+        }
+    };
+    // An unparseable result is already useless; the cache rejects it on read.
+    let Ok(result) = serde_json::from_slice::<RemoteActionResult>(&bytes) else {
+        return Ok(false);
+    };
+    for digest in [result.metadata.as_ref(), result.output_root.as_ref()]
+        .into_iter()
+        .flatten()
+    {
+        // A verification failure leaves the object unusable, same as missing.
+        if cas.find(digest).unwrap_or(None).is_none() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+struct Entry {
+    path: PathBuf,
+    size: u64,
+    used: SystemTime,
+}
+
+fn walk_files(root: &Path) -> Result<Vec<Entry>> {
+    let mut entries = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let listing = match std::fs::read_dir(&directory) {
+            Ok(listing) => listing,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error)
+                    .wrap_err_with(|| format!("failed to read {}", directory.display()));
+            }
+        };
+        for entry in listing {
+            let entry = entry?;
+            let metadata = match entry.metadata() {
+                Ok(metadata) => metadata,
+                // A concurrent build may be publishing into the store.
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            if metadata.is_dir() {
+                pending.push(entry.path());
+            } else if metadata.is_file() {
+                let used = metadata
+                    .accessed()
+                    .or_else(|_| metadata.modified())
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                entries.push(Entry {
+                    path: entry.path(),
+                    size: metadata.len(),
+                    used,
+                });
+            }
+        }
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mbx_cache_core::{CacheDigest, LocalActionCache};
+    use std::time::Duration;
+
+    fn store_object(store: &Path, contents: &[u8]) -> CacheDigest {
+        let digest = CacheDigest::blake3(contents);
+        LocalCas::new(store).store_bytes(&digest, contents).unwrap();
+        digest
+    }
+
+    /// Backdate an object so eviction order is deterministic.
+    fn age(store: &Path, digest: &CacheDigest, age: Duration) {
+        let path = LocalCas::new(store).path_for(digest).unwrap();
+        let when = SystemTime::now() - age;
+        let time = filetime::FileTime::from_system_time(when);
+        filetime::set_file_times(path, time, time).unwrap();
+    }
+
+    #[test]
+    fn reports_an_empty_store() {
+        let directory = tempfile::tempdir().unwrap();
+        assert_eq!(stats(directory.path()).unwrap(), StoreStats::default());
+    }
+
+    #[test]
+    fn counts_objects_and_results() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        store_object(store, b"first");
+        store_object(store, b"second object");
+
+        let stats = stats(store).unwrap();
+
+        assert_eq!(stats.objects, 2);
+        assert_eq!(stats.object_bytes, 5 + 13);
+        assert_eq!(stats.total_bytes(), 18);
+    }
+
+    #[test]
+    fn keeps_the_store_under_its_budget_evicting_oldest_first() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        let old = store_object(store, b"0123456789");
+        let recent = store_object(store, b"abcdefghij");
+        age(store, &old, Duration::from_secs(60 * 60));
+        age(store, &recent, Duration::from_secs(1));
+
+        let outcome = gc(store, 10).unwrap();
+
+        assert_eq!(outcome.removed_objects, 1);
+        assert_eq!(outcome.removed_bytes, 10);
+        assert_eq!(outcome.remaining_bytes, 10);
+        let cas = LocalCas::new(store);
+        assert!(cas.find(&old).unwrap().is_none());
+        assert!(cas.find(&recent).unwrap().is_some());
+    }
+
+    #[test]
+    fn leaves_a_store_within_budget_alone() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        store_object(store, b"kept");
+
+        let outcome = gc(store, 1024).unwrap();
+
+        assert_eq!(
+            outcome,
+            GcOutcome {
+                remaining_bytes: 4,
+                ..GcOutcome::default()
+            }
+        );
+        assert_eq!(stats(store).unwrap().objects, 1);
+    }
+
+    #[test]
+    fn drops_action_results_left_without_their_objects() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        let action = store_object(store, b"action key");
+        let metadata = store_object(store, b"metadata blob");
+        let result = RemoteActionResult {
+            version: 1,
+            action: action.clone(),
+            metadata: Some(metadata),
+            output_root: None,
+        };
+        LocalActionCache::new(store).store(&result).unwrap();
+
+        // A budget of zero evicts every object, orphaning the result.
+        let outcome = gc(store, 0).unwrap();
+
+        assert!(outcome.removed_objects >= 1);
+        assert_eq!(outcome.removed_action_results, 1);
+        assert!(
+            LocalActionCache::new(store)
+                .find(&action)
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1,0 +1,136 @@
+//! End-to-end coverage for `mbx build`.
+//!
+//! Each test drives the real binary over a throwaway project with no
+//! dependencies, so nothing here needs the network.
+
+use std::path::Path;
+use std::process::Command;
+
+fn write_project(directory: &Path) {
+    std::fs::create_dir_all(directory.join("src")).unwrap();
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("src/lib.rs"),
+        "pub fn double(value: u32) -> u32 {\n    value * 2\n}\n",
+    )
+    .unwrap();
+    // Manifest identity follows the lockfile, and cargo would otherwise write
+    // it during the first build -- changing the identity between two runs that
+    // are supposed to share a manifest.
+    let status = Command::new(cargo())
+        .current_dir(directory)
+        .args(["generate-lockfile", "--offline"])
+        .status()
+        .expect("cargo should run");
+    assert!(status.success(), "the fixture should resolve offline");
+}
+
+fn cargo() -> std::ffi::OsString {
+    std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into())
+}
+
+/// Build `project` against `store`, returning the run's statistics.
+fn build(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project)
+        .args(["build", "build", "--offline"])
+        .env("MBX_CACHE_DIR", store)
+        .env("MBX_STATS_REPORT", report)
+        // Cargo's own environment for this test would otherwise redirect the
+        // fixture's output into this crate's target directory.
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("mbx should run");
+    assert!(
+        output.status.success(),
+        "build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = std::fs::read(report).expect("a statistics report should be written");
+    serde_json::from_slice(&report).expect("the report should be JSON")
+}
+
+fn count(stats: &serde_json::Value, field: &str) -> u64 {
+    stats[field]
+        .as_u64()
+        .unwrap_or_else(|| panic!("{field} should be a number"))
+}
+
+#[test]
+fn restores_a_wiped_target_directory_from_the_store() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    let cold = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("cold.json"),
+    );
+    assert_eq!(count(&cold, "hits"), 0, "a cold build cannot hit");
+    assert!(
+        count(&cold, "stored_bytes") > 0,
+        "a cold build should publish its outputs: {cold}"
+    );
+
+    std::fs::remove_dir_all(project.path().join("target")).unwrap();
+
+    let warm = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("warm.json"),
+    );
+    assert!(
+        count(&warm, "hits") > 0,
+        "the rebuilt target directory should be restored: {warm}"
+    );
+    assert_eq!(
+        count(&warm, "compiler_invocations_avoided"),
+        count(&warm, "hits")
+    );
+}
+
+#[test]
+fn a_second_checkout_starts_warm() {
+    let store = tempfile::tempdir().unwrap();
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(first.path());
+    write_project(second.path());
+
+    build(
+        first.path(),
+        store.path(),
+        &reports.path().join("first.json"),
+    );
+    let warm = build(
+        second.path(),
+        store.path(),
+        &reports.path().join("second.json"),
+    );
+
+    assert!(
+        count(&warm, "hits") > 0,
+        "a checkout at another path should reuse the first build: {warm}"
+    );
+}
+
+#[test]
+fn an_empty_store_reports_nothing() {
+    let store = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .args(["cache", "stats"])
+        .env("MBX_CACHE_DIR", store.path())
+        .output()
+        .expect("mbx should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("objects: 0"), "unexpected output: {stdout}");
+}


### PR DESCRIPTION
Adds the command line, and with it the first end-to-end proof that the cache works.

- `mbx build [cargo args…]` starts a session, points cargo at the shim, commits the manifest on success, prints the stats lines, and propagates cargo's exit status (a signalled cargo becomes `128 + signal` so callers can tell it apart from a clean failure). Release and tag builds skip the cache entirely and just run cargo.
- `mbx gc --max-size <SIZE>` evicts objects until the store fits, oldest first, then drops action results whose objects are gone so the index does not point at nothing.
- `mbx cache dir` and `mbx cache stats` report where the store is and what it holds.

## Fixes a bypass inherited from mise

While testing this I found that **every dependency compilation was bypassing the cache**, in mbx and in mise alike. Cargo compiles a dependency with its working directory inside the registry rather than in your project, so the shim's "workspace" root was the registry source directory, and the `--out-dir` it was actually writing to — your project's `target/debug/deps` — matched no mapping at all:

```
mbx warning: result was not stored: absolute path has no stable cache mapping:
  /…/demo/target/debug/deps
```

The session now passes the workspace root and the target directory to the shim explicitly, since neither can be inferred from the working directory of a dependency build. The target directory is mapped ahead of the workspace that usually contains it, which also keeps keys stable when someone moves their target directory elsewhere. On the same fixture, stored bytes went from 62 KiB to 325 KiB — the dependency graph is now actually cached.

## Verified end to end

On a two-crate fixture:

| run | result |
| --- | --- |
| cold | `0 hits, 0 misses; 324.9 KiB stored locally` |
| `rm -rf target`, rebuild | `2 hits, 0 misses; 0 B stored` |
| copy to another path, build | `2 hits, 0 misses` |
| after `gc --max-size 100KB` | `0 hits, 2 misses` — recompiles and republishes |

The last row is the important one for GC: evicting a live object costs a recompile and nothing else.

Three integration tests encode this (`crates/mbx/tests/build.rs`), driving the real binary over a dependency-free fixture so CI needs no network. They pre-resolve the fixture's lockfile, because manifest identity follows the lockfile digest and cargo would otherwise write it during the first build — changing the identity between two runs that are meant to share a manifest.

`PLAN.md` is updated to match what landed: the new path-mapping section, the corrected identity description, and a revised delivery sequence — standalone shim mode and `mbx setup` are their own PR rather than part of the session PR, since `setup` is not useful without it.

Workspace tests: 120 passing.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache-key path mapping and store GC, which can change hit rates or evict live objects (recompile, not wrong results). Not auth or remote protocol.
> 
> **Overview**
> Adds the `mbx` CLI so cargo can run under a cache session, and so the local store can be inspected and trimmed.
> 
> **`mbx build`** starts a session, injects the rustc shim, commits the prefetch manifest only on success, prints stats, and returns cargo’s exit status (signalled cargo becomes `128 + signal`). Release/tag builds skip the cache.
> 
> **Path mapping fix:** the session now passes `MBX_WORKSPACE_ROOT` and `MBX_TARGET_DIR` (from `cargo metadata`, with flag/env fallbacks). The shim maps `${target}` before `${workspace}` so dependency compiles in the registry still cache `target/` outputs, and keys stay stable if the target dir moves. `MBX_VERIFY` is always set explicitly (`0`/`1`).
> 
> **`mbx gc --max-size`** LRU-evicts CAS objects then drops dangling action results. **`mbx cache dir` / `stats`** report store location and size.
> 
> Integration tests cover cold/warm rebuild after wiping `target/` and a second checkout at another path. `PLAN.md` splits standalone shim/`setup` into a later PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9e496450d8c820228be76e21715d3baf6bc09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->