### PR TITLE
perf(session): stop fsyncing restored outputs

### DIFF
--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -381,10 +381,10 @@ fn stage_cached_output(
         .wrap_err_with(|| format!("failed to materialize cached rustc output {}", node.name))?;
     let temporary = tempfile::TempPath::try_from_path(temporary)?;
     make_owner_writable(&temporary)?;
-    std::fs::OpenOptions::new()
-        .write(true)
-        .open(&temporary)?
-        .sync_all()?;
+    // Deliberately not fsynced. These are build artifacts in a target
+    // directory, and cargo does not sync its own outputs either, so syncing
+    // here buys no durability the build relies on -- it only costs one fsync
+    // per restored file, which on a large workspace is most of the restore.
     if !node.digest.matches_file(&temporary)? {
         bail!(
             "cached rustc output failed digest verification: {}",


### PR DESCRIPTION
Restoring a cached action fsynced every output file before verifying its digest. On mise that is 2470 files, and at roughly 13 ms each it dominated the restore: **materialization was 31.7s of a 106s warm build**, nine tenths of it waiting on the disk rather than moving data.

The data movement itself is already cheap and I confirmed it rather than assuming — a restored `libaho_corasick.rlib` and its CAS blob have byte-identical physical extents marked `shared` on btrfs, so `reflink_or_copy` is genuinely reflinking and N worktrees really do cost about 1x disk.

## Why removing it is safe

These are build artifacts in a target directory. Cargo does not fsync its own outputs, and it does not fsync the fingerprint files it uses to decide whether those outputs are current. So the durability we were buying protected one half of a pair whose other half was never protected: after a crash, cargo's fingerprint and mbx's artifact are equally likely to be stale, and either way the answer is a rebuild. Removing the sync leaves mbx at parity with cargo instead of paying for a guarantee the surrounding build never had.

Verification still happens — the digest check is unchanged, and it reads through the page cache, so it never needed the file on disk to be correct.

## Measured

mise, 1069 packages, 32 cores, btrfs, restoring the same 824 actions each time:

| | materialization | warm build |
| --- | --- | --- |
| before | 31.7s | 106s |
| after | 3.3s | 84s |
| repeat | 3.4s | 87s |

Same 824 hits, same 2470 files restored, build succeeds. Against the 129s cold build, that moves the warm speedup from 18% to about 35%.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change to cache restore durability. Digest verification is unchanged; crash recovery stays at cargo’s existing rebuild-on-stale-fingerprint model.
> 
> **Overview**
> Removes the per-file `fsync` after materializing cached rustc outputs in `stage_cached_output`. Restore still reflinks/copies, makes the file writable, and verifies the digest; it just no longer forces durability to disk.
> 
> That fsync dominated warm restore on large workspaces (one sync per restored artifact) without matching cargo, which also does not fsync target outputs or fingerprints. After a crash, either side can be stale and the result is a rebuild. Digest checks still read through the page cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af14e0097ab348fa8b368f078a7c14b16e24045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->