### PR TITLE
feat(session): count compilations the cache declined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ version = "0.0.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
+ "strum",
  "tempfile",
  "thiserror",
 ]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ activity prints nothing:
 
 ```
 cache: 12 hits, 3 misses, 12 prefetched; 4.1 MiB downloaded, 0 B uploaded, 1.2 MiB stored locally
+cache bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
 ```
+
+The second line accounts for compilations mbx declined to cache, grouped by
+reason. It is the honest counterpart to the hit rate: a build can hit every
+action it looked up and still spend most of its time on work that never entered
+the cache.
 
 Store management:
 

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -70,6 +70,10 @@ pub enum AgentRequest {
         action: CacheDigest,
         restore: RestoreStats,
     },
+    /// A compilation the adapter declined to cache, grouped by reason.
+    RecordBypass {
+        kind: String,
+    },
     RecordActionVerification {
         matched: bool,
         restore: RestoreStats,
@@ -132,6 +136,7 @@ pub enum AgentResponse {
     },
     ActionHitRecorded,
     ActionVerificationRecorded,
+    BypassRecorded,
     ActionStored {
         path: PathBuf,
     },
@@ -148,7 +153,7 @@ pub enum AgentResponse {
 }
 
 /// Aggregate cache activity for one task session.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AgentStats {
     /// End-to-end lifetime of the task-scoped cache session.
     pub session_duration_ns: u64,
@@ -170,6 +175,8 @@ pub struct AgentStats {
     pub uploaded_bytes: u64,
     /// Complete actions staged before an adapter requested them.
     pub prefetched_actions: u64,
+    /// Compilations that were not cacheable, counted by reason.
+    pub bypasses: BTreeMap<String, u64>,
     /// Number of task manifest requests made to the remote cache.
     pub remote_manifest_lookups: u64,
     /// Cumulative time spent requesting remote task manifests.
@@ -234,6 +241,7 @@ struct AtomicAgentStats {
     prefetch_runs: AtomicU64,
     prefetch_duration_ns: AtomicU64,
     materialization_duration_ns: AtomicU64,
+    bypasses: Mutex<BTreeMap<String, u64>>,
     restored_output_files: AtomicU64,
     restored_output_bytes: AtomicU64,
 }
@@ -690,6 +698,7 @@ impl CacheAgent {
             downloaded_bytes: self.stats.downloaded_bytes.load(Ordering::Relaxed),
             uploaded_bytes: self.stats.uploaded_bytes.load(Ordering::Relaxed),
             prefetched_actions: self.stats.prefetched_actions.load(Ordering::Relaxed),
+            bypasses: self.stats.bypasses.lock().unwrap().clone(),
             remote_manifest_lookups: self.stats.remote_manifest_lookups.load(Ordering::Relaxed),
             remote_manifest_lookup_duration_ns: self
                 .stats
@@ -1376,6 +1385,10 @@ impl CacheAgent {
             AgentRequest::RecordActionHit { action, restore } => {
                 self.record_action_hit(&action, restore)
             }
+            AgentRequest::RecordBypass { kind } => {
+                *self.stats.bypasses.lock().unwrap().entry(kind).or_insert(0) += 1;
+                Ok(AgentResponse::BypassRecorded)
+            }
             AgentRequest::RecordActionVerification { matched, restore } => {
                 self.record_materialization(restore);
                 self.stats.verifications.fetch_add(1, Ordering::Relaxed);
@@ -2003,6 +2016,26 @@ mod tests {
             error.to_string().contains("exceeded"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn counts_bypasses_by_reason() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+
+        for kind in [
+            "unsupported-crate-type",
+            "unsupported-crate-type",
+            "incremental",
+        ] {
+            agent
+                .respond(AgentRequest::RecordBypass { kind: kind.into() })
+                .await;
+        }
+
+        let stats = agent.stats();
+        assert_eq!(stats.bypasses.get("unsupported-crate-type"), Some(&2));
+        assert_eq!(stats.bypasses.get("incremental"), Some(&1));
     }
 
     #[tokio::test]

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.0.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -12,6 +12,16 @@ pub use dep_info::{DepInfoCommand, DiscoveredInputs, RustcDepInfo};
 pub const ACTION_SCHEMA_VERSION: u8 = 1;
 pub const ADAPTER_VERSION: u8 = 1;
 
+impl BypassReason {
+    /// A stable, low-cardinality name for this reason.
+    ///
+    /// Many variants carry a path or a flag, so `Display` text cannot be
+    /// aggregated; statistics group by this instead.
+    pub fn kind(&self) -> &'static str {
+        self.into()
+    }
+}
+
 const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
     "codegen-units",
     "control-flow-guard",
@@ -45,7 +55,8 @@ const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
     "tls-model",
 ];
 
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
 pub enum BypassReason {
     #[error("rustc argument {index} is not valid UTF-8")]
     NonUtf8Argument { index: usize },
@@ -1026,6 +1037,21 @@ fn slash_path(path: &Path) -> Result<String, BypassReason> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn bypass_kinds_are_stable_and_field_independent() {
+        assert_eq!(BypassReason::CompilerQuery.kind(), "compiler-query");
+        assert_eq!(BypassReason::Incremental.kind(), "incremental");
+        assert_eq!(
+            BypassReason::UnsupportedCrateType("bin".into()).kind(),
+            "unsupported-crate-type"
+        );
+        // Two reasons of one kind group together despite differing fields.
+        assert_eq!(
+            BypassReason::UnmappedAbsolutePath(PathBuf::from("/a")).kind(),
+            BypassReason::UnmappedAbsolutePath(PathBuf::from("/b")).kind()
+        );
+    }
+
     use super::*;
 
     fn args(values: &[&str]) -> Vec<OsString> {

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -268,6 +268,7 @@ struct StatsReport {
     divergences: u64,
     prefetched_actions: u64,
     prefetch_runs: u64,
+    bypasses: BTreeMap<String, u64>,
     downloaded_bytes: u64,
     uploaded_bytes: u64,
     stored_bytes: u64,
@@ -299,6 +300,7 @@ impl From<&AgentStats> for StatsReport {
             divergences: stats.divergences,
             prefetched_actions: stats.prefetched_actions,
             prefetch_runs: stats.prefetch_runs,
+            bypasses: stats.bypasses.clone(),
             downloaded_bytes: stats.downloaded_bytes,
             uploaded_bytes: stats.uploaded_bytes,
             stored_bytes: stats.stored_bytes,
@@ -334,6 +336,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         && stats.verifications == 0
         && stats.downloaded_bytes == 0
         && stats.uploaded_bytes == 0
+        && stats.bypasses.is_empty()
     {
         return;
     }
@@ -346,6 +349,18 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         ByteSize::b(stats.uploaded_bytes).display().iec(),
         ByteSize::b(stats.stored_bytes).display().iec(),
     ));
+    if !stats.bypasses.is_empty() {
+        let total: u64 = stats.bypasses.values().sum();
+        // Most frequent first: the head of this list is where the next win is.
+        let mut reasons: Vec<_> = stats.bypasses.iter().collect();
+        reasons.sort_by(|left, right| right.1.cmp(left.1).then(left.0.cmp(right.0)));
+        let detail = reasons
+            .iter()
+            .map(|(kind, count)| format!("{count} {kind}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        note(&format!("cache bypassed {total} compilations: {detail}"));
+    }
     let remote_lookup_duration_ns = stats
         .remote_manifest_lookup_duration_ns
         .saturating_add(stats.remote_action_lookup_duration_ns);
@@ -692,9 +707,10 @@ pub fn run_rustc_shim() -> ExitCode {
     if std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV).is_none() {
         match crate::rustc::compile(&rustc, &arguments) {
             Ok(exit_code) => return exit_code,
-            Err(_error) => {
+            Err(error) => {
+                record_bypass(&error);
                 #[cfg(debug_assertions)]
-                eprintln!("mbx: rustc cache bypassed: {_error:#}");
+                eprintln!("mbx: rustc cache bypassed: {error:#}");
             }
         }
     }
@@ -757,6 +773,19 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
 /// that an explicit disable cannot be mistaken for an enable.
 pub(crate) fn verify_requested() -> bool {
     std::env::var_os(VERIFY_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
+/// Tell the session that this compilation was not cacheable.
+///
+/// Bypasses never reach the agent otherwise, so without this they are invisible
+/// outside a debug build. Reported by reason kind rather than message, since
+/// several reasons carry a path or a flag.
+fn record_bypass(error: &eyre::Report) {
+    let kind = error
+        .downcast_ref::<mbx_cache_rustc::BypassReason>()
+        .map_or("other", mbx_cache_rustc::BypassReason::kind);
+    // A shim running outside a session has nowhere to report, which is fine.
+    let _ = request_agent(&[AgentRequest::RecordBypass { kind: kind.into() }]);
 }
 
 pub(crate) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {


### PR DESCRIPTION
A bypassed compilation never talks to the agent, so it never appeared in any statistic. The only way to see one was a debug build printing to stderr — which is how I measured mise earlier, and it turns out that undercounts: cargo swallows the stderr of its own probe invocations, so the debug log showed 248 bypasses where the agent counts **283**.

The shim now reports each bypass by reason, and the session prints a breakdown and puts it in the JSON report. On mise:

```
cache bypassed 283 compilations: 156 unsupported-crate-type, 91 unsupported-search-path,
18 standard-input, 9 compiler-query, 6 unknown-flag, 1 native-library,
1 no-cacheable-output, 1 no-dep-info
```

That line is the honest counterpart to the hit rate. mise hits **every** action it looks up — 824 of 824 — and still compiles 156 crates whose type is not cacheable, which is why the wall-clock win is far smaller than the hit rate suggests. Without this you can only see the good half.

## Notes on the implementation

- Kinds come from a `strum`-derived kebab-case name on `BypassReason`, not its `Display` text: variants like `UnknownFlag(String)` and `UnmappedAbsolutePath(PathBuf)` carry a flag or a path, so their messages have unbounded cardinality and cannot be grouped. Deriving the name also means a new variant cannot silently fall into an "other" bucket.
- The shim recovers the kind by downcasting the report, falling back to `other`, and a shim running outside a session has nowhere to report, which is fine.
- `AgentStats` loses `Copy` to carry the map. Every consumer only ever cloned it.
- One extra socket round trip per bypassed compilation — 283 of them on mise, against a build that already takes 84 seconds.

## What it already tells us

Two findings worth acting on later, both invisible before this:

- **6 `unknown-flag` bypasses.** Something in mise's build passes a flag the allowlist does not model. I could not identify which from this run, because that message is exactly the stderr cargo swallows — an argument for a future bypass log written to a file rather than stderr.
- **18 `standard-input` and 9 `compiler-query`** are cargo probing the compiler. Those are correctly uncacheable and are noise in the total; worth separating from genuine misses if the number ever drives a decision.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: extra agent RPCs and a stats map. Cache keys, restore, and bypass decisions are unchanged.
> 
> **Overview**
> Bypassed rustc invocations now show up in session stats instead of vanishing unless you had a debug build.
> 
> The shim reports each decline to the agent by a stable kebab-case `BypassReason` kind (not the unbounded Display text). The session JSON report includes the map, and stderr prints a second line like `cache bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path`, sorted by frequency. `AgentStats` is no longer `Copy` because it carries that map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c630c9dd28caf2341f0b12dc8b20ef9cb8463f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->