### PR TITLE
feat(session): log why each compilation was not cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ defaults.
 | `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
 | `MBX_HTTP_RETRIES` | `http.retries` | `3` | request retries |
 | `MBX_VERIFY` | — | unset | compile anyway and compare against the cache |
+| `MBX_BYPASS_LOG` | — | unset | append the full reason for every uncached compilation to this file |
 
 ```toml
 # ~/.config/mbx/config.toml

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -660,7 +660,9 @@ impl<'a> Parser<'a> {
 
     fn parse_short(&mut self, value: &str) -> Result<(), BypassReason> {
         match value {
-            "-h" | "-V" => return Err(BypassReason::CompilerQuery),
+            // `-vV` is how cargo and build scripts ask for the verbose
+            // version, so it is a query rather than a flag left unmodeled.
+            "-h" | "-V" | "-vV" => return Err(BypassReason::CompilerQuery),
             "-g" | "-O" | "-v" => {
                 self.parsed.push(Argument::Plain(value.into()));
                 return Ok(());
@@ -1037,6 +1039,16 @@ fn slash_path(path: &Path) -> Result<String, BypassReason> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn verbose_version_is_a_query_not_an_unmodeled_flag() {
+        // cargo runs `rustc -vV` to identify the compiler; reporting it as an
+        // unmodeled flag sends people hunting for a gap that is not there.
+        assert_eq!(
+            RustcInvocation::parse(&args(&["-vV"])).unwrap_err(),
+            BypassReason::CompilerQuery
+        );
+    }
+
     #[test]
     fn bypass_kinds_are_stable_and_field_independent() {
         assert_eq!(BypassReason::CompilerQuery.kind(), "compiler-query");

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -91,7 +91,7 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
 
     runtime.block_on(async {
         let session = CacheSession::start(session_dir.path(), config).await?;
-        let mut environment = inherited_environment(|name| std::env::var(name).ok());
+        let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
         let run = session
             .begin(
                 &roots.workspace_root,
@@ -220,10 +220,23 @@ struct Roots {
 ///
 /// The session records it so the shim can defer to it; without this it would be
 /// dropped silently and whatever it does would stop happening.
-fn inherited_environment(get_env: impl Fn(&str) -> Option<String>) -> BTreeMap<String, String> {
+fn inherited_environment(
+    get_env: impl Fn(&str) -> Option<String>,
+    working_dir: &Path,
+) -> BTreeMap<String, String> {
     let mut environment = BTreeMap::new();
     if let Some(wrapper) = get_env("RUSTC_WRAPPER").filter(|value| !value.is_empty()) {
         environment.insert("RUSTC_WRAPPER".into(), wrapper);
+    }
+    // Cargo gives every shim its own working directory, so a relative
+    // destination would scatter records across crate directories -- or fail
+    // outright in a read-only registry checkout. Resolve it here, against the
+    // directory the user typed it in, like every other path the shim receives.
+    if let Some(log) = get_env(crate::session::BYPASS_LOG_ENV).filter(|value| !value.is_empty()) {
+        environment.insert(
+            crate::session::BYPASS_LOG_ENV.into(),
+            absolute(working_dir, &log).display().to_string(),
+        );
     }
     environment
 }
@@ -474,15 +487,59 @@ mod tests {
 
     #[test]
     fn carries_an_inherited_wrapper_into_the_session() {
-        let with = inherited_environment(|name| {
-            (name == "RUSTC_WRAPPER").then(|| "/usr/bin/sccache".to_string())
-        });
+        let cwd = Path::new("/workspace");
+        let with = inherited_environment(
+            |name| (name == "RUSTC_WRAPPER").then(|| "/usr/bin/sccache".to_string()),
+            cwd,
+        );
         assert_eq!(with.get("RUSTC_WRAPPER").unwrap(), "/usr/bin/sccache");
 
         // An empty value is how a shell unsets it in practice.
-        let empty = inherited_environment(|name| (name == "RUSTC_WRAPPER").then(String::new));
+        let empty = inherited_environment(|name| (name == "RUSTC_WRAPPER").then(String::new), cwd);
         assert!(empty.is_empty());
-        assert!(inherited_environment(|_| None).is_empty());
+        assert!(inherited_environment(|_| None, cwd).is_empty());
+    }
+
+    #[test]
+    fn absolutizes_the_bypass_log_before_the_shims_inherit_it() {
+        let cwd = Path::new("/workspace");
+        let relative = inherited_environment(
+            |name| (name == crate::session::BYPASS_LOG_ENV).then(|| "bypass.log".to_string()),
+            cwd,
+        );
+        // Left relative, each shim would resolve this against whichever crate
+        // directory cargo happened to give it. Compare as paths: the separator
+        // is not the same on every platform.
+        assert_eq!(
+            Path::new(relative.get(crate::session::BYPASS_LOG_ENV).unwrap()),
+            cwd.join("bypass.log")
+        );
+
+        // An absolute destination is passed through untouched. Ask the platform
+        // for one -- a leading slash is not absolute on Windows.
+        let already = std::env::temp_dir().join("bypass.log");
+        assert!(
+            already.is_absolute(),
+            "{} should be absolute",
+            already.display()
+        );
+        let given = already.display().to_string();
+        let absolute_path = inherited_environment(
+            |name| (name == crate::session::BYPASS_LOG_ENV).then(|| given.clone()),
+            cwd,
+        );
+        assert_eq!(
+            Path::new(absolute_path.get(crate::session::BYPASS_LOG_ENV).unwrap()),
+            already
+        );
+
+        assert!(
+            !inherited_environment(
+                |name| (name == crate::session::BYPASS_LOG_ENV).then(String::new),
+                cwd
+            )
+            .contains_key(crate::session::BYPASS_LOG_ENV)
+        );
     }
 
     #[test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -30,6 +30,7 @@ pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
 pub(crate) const WORKSPACE_ROOT_ENV: &str = "MBX_WORKSPACE_ROOT";
 pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
+const BYPASS_LOG_ENV: &str = "MBX_BYPASS_LOG";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const IDENTITY_VERSION: u8 = 1;
 
@@ -784,8 +785,31 @@ fn record_bypass(error: &eyre::Report) {
     let kind = error
         .downcast_ref::<mbx_cache_rustc::BypassReason>()
         .map_or("other", mbx_cache_rustc::BypassReason::kind);
+    append_bypass_log(kind, error);
     // A shim running outside a session has nowhere to report, which is fine.
     let _ = request_agent(&[AgentRequest::RecordBypass { kind: kind.into() }]);
+}
+
+/// Append the full reason to `MBX_BYPASS_LOG`, when one is configured.
+///
+/// The aggregate counts say which kinds dominate; this says exactly which flag
+/// or path caused each one. It exists because stderr cannot be relied on:
+/// cargo swallows the output of its own probe invocations, so some bypasses are
+/// invisible there.
+fn append_bypass_log(kind: &str, error: &eyre::Report) {
+    let Some(path) = std::env::var_os(BYPASS_LOG_ENV).filter(|path| !path.is_empty()) else {
+        return;
+    };
+    // One write per line so parallel shims interleave whole records.
+    let line = format!("{kind}\t{error:#}\n");
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        use std::io::Write as _;
+        let _ = file.write_all(line.as_bytes());
+    }
 }
 
 pub(crate) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -30,7 +30,7 @@ pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
 pub(crate) const WORKSPACE_ROOT_ENV: &str = "MBX_WORKSPACE_ROOT";
 pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
-const BYPASS_LOG_ENV: &str = "MBX_BYPASS_LOG";
+pub(crate) const BYPASS_LOG_ENV: &str = "MBX_BYPASS_LOG";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const IDENTITY_VERSION: u8 = 1;
 
@@ -800,16 +800,33 @@ fn append_bypass_log(kind: &str, error: &eyre::Report) {
     let Some(path) = std::env::var_os(BYPASS_LOG_ENV).filter(|path| !path.is_empty()) else {
         return;
     };
-    // One write per line so parallel shims interleave whole records.
+    // O_APPEND places each write at the end of the file, so one write per
+    // record is what keeps parallel shims from splicing their lines together.
+    // Records are a single short line for that reason: a write the kernel had
+    // to break up could still interleave, and nothing here can prevent it.
     let line = format!("{kind}\t{error:#}\n");
-    if let Ok(mut file) = std::fs::OpenOptions::new()
+    if let Err(problem) = append_line(&path, &line) {
+        // Say so once. This runs per compilation and a destination that cannot
+        // be written now will fail for every later record too, so warning each
+        // time would bury the build in identical lines. Without this the
+        // requested log is simply absent, with nothing explaining why.
+        static WARNED: std::sync::Once = std::sync::Once::new();
+        WARNED.call_once(|| {
+            eprintln!(
+                "mbx warning: {BYPASS_LOG_ENV} was not written ({}): {problem}",
+                Path::new(&path).display()
+            );
+        });
+    }
+}
+
+fn append_line(path: &OsString, line: &str) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(path)
-    {
-        use std::io::Write as _;
-        let _ = file.write_all(line.as_bytes());
-    }
+        .open(path)?;
+    file.write_all(line.as_bytes())
 }
 
 pub(crate) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {


### PR DESCRIPTION
The counts from #10 say which kinds of bypass dominate. This says exactly which flag or path caused each one:

```sh
MBX_BYPASS_LOG=/tmp/bypass.tsv mbx build build
```

It writes to a file rather than stderr on purpose. stderr is not trustworthy for this — cargo swallows the output of its own probe invocations, which is precisely why a debug build undercounted mise's bypasses (248 printed, 283 actually happened). One `write_all` per record, appended, so parallel shims interleave whole lines.

## What it found on the first run

All six `unknown-flag` bypasses on mise were the same thing:

```
unknown-flag	rustc flag is not modeled by the cache adapter: -vV
```

`rustc -vV` is the verbose version query cargo and build scripts use to identify the compiler. It is a *query*, not a compilation, and the parser already has a reason for exactly that — it just did not recognise the short spelling alongside `-h` and `-V`. So it is classified as `compiler-query` now.

This changes no hit rate: `-vV` was never cacheable and still is not. What it changes is that the diagnostic stops pointing at a modeling gap that does not exist. That matters more than it sounds, because the whole value of the bypass breakdown is that a number in it should mean "there is real work to do here".

The fix is one line plus a test, and it ships with the tool that found it, which seemed more useful than splitting them.

## mise's breakdown afterwards

```
156 unsupported-crate-type   (85 bin, 68 proc-macro, 3 cdylib)
 91 unsupported-search-path  (native)
 18 standard-input           (cargo probing the compiler)
 15 compiler-query           (was 9, plus the 6 above)
  1 native-library
  1 no-cacheable-output
  1 no-dep-info
```

No unexplained entries left. Every remaining bypass is a documented limitation, and the two big ones — crate types and native search paths — are now measured rather than guessed at, which makes them a much easier call to prioritise.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only: optional append-only logging and a parser reclassification that does not change cacheability or hit rate.
> 
> **Overview**
> Adds `MBX_BYPASS_LOG` so each uncached rustc invocation can append a TSV line (`kind` + full reason) to a file. Cargo swallows probe stderr, so this is the way to see every bypass, including ones that never print.
> 
> The path is resolved against the user’s working directory before shims inherit it, so a relative destination does not scatter across crate dirs or fail in a read-only registry checkout. Parallel shims use one `O_APPEND` write per short line; a failed destination warns once.
> 
> Also classifies `rustc -vV` as `compiler-query` instead of `unknown-flag`. That is cargo’s verbose version probe, not a modeling gap, and it was never cacheable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7db6bbb283a9997ab86429162ff62cf81e7a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->