### PR TITLE
docs: qualify cross-checkout sharing, and test the boundary

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -20,8 +20,9 @@ a standalone home. mise will eventually consume mbx and drop its embedded copy.
    reflink/hardlink, and evicts with a byte-budget LRU (`mbx gc`).
 3. **Git worktrees build cold.** Fingerprints embed absolute paths, so a fresh
    worktree rebuilds everything. mbx's action keys use path mapping, so a new
-   worktree is warm from its first build while keeping its own target dir (no
-   cargo lock contention, no incremental-artifact thrashing).
+   worktree starts mostly warm while keeping its own target dir (no cargo lock
+   contention, no incremental-artifact thrashing). Mostly, not entirely: see
+   the note on `OUT_DIR` under path mapping.
 4. **CI caching is coarse.** Tarball-the-target-dir caching is slow,
    size-capped, and all-or-nothing. mbx restores exactly the actions a build
    needs, in batched blob packs, from an ephemeral runner's empty store.
@@ -105,6 +106,16 @@ A path that matches no root bypasses the cache rather than entering a key. The
 roots come from `cargo metadata`, since a target directory can be set by flag,
 environment, or cargo configuration, and `--manifest-path` can move the build
 elsewhere entirely.
+
+Environment *values* are a deliberate exception: they enter the key verbatim,
+unmapped. The one that matters is `OUT_DIR`, which every crate that includes
+build-script output consumes, and which differs per checkout. Mapping it would
+lift cross-checkout sharing — measured at 65% of actions on mise — but a crate
+may bake that path into its artifact, and no input distinguishes one that does
+from one that does not. Both fixtures behave identically from the cache's point
+of view, so mapping the value could restore an artifact carrying another
+checkout's path. The conservative choice costs hits; the alternative can be
+wrong.
 
 ### Cache identity
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ See [PLAN.md](PLAN.md) for the design and the road to v1.
 - **Caches each rustc action once.** A compilation you have done before is
   restored instead of repeated, whatever directory you are in.
 - **Deduplicates across checkouts.** Cache keys hold no absolute paths, so a
-  second worktree of the same dependency graph builds warm. Each keeps its own
-  `target/` directory, so there is no cargo lock contention between them.
+  second worktree of the same dependency graph builds largely warm — measured at
+  65% of actions on mise, with the shortfall explained under limits below. Each
+  keeps its own `target/` directory, so there is no cargo lock contention
+  between them.
 - **Collects garbage.** `mbx gc` evicts to a size budget, which cargo has never
   done for `target/`.
 - **Shares through a remote.** CI and teammates can restore from a
@@ -137,6 +139,15 @@ Not yet:
   session to talk to, and per-process prefetch manifests cannot be shared
   across the many rustc processes cargo spawns, so `build.rustc-wrapper` and an
   `mbx setup` command are waiting on that. Use `mbx build`.
+- **A crate whose compilation consumes `OUT_DIR` does not share across
+  checkouts.** That covers any crate with a build script that generates code
+  included via `include!(concat!(env!("OUT_DIR"), …))`. `OUT_DIR` is an absolute
+  path and an input to the compilation, so two checkouts produce different keys.
+  This is deliberate rather than an oversight: a crate is free to bake that path
+  into its artifact, and nothing in the inputs distinguishes one that does from
+  one that does not, so treating the value as interchangeable could hand you an
+  artifact containing another checkout's path. Crates whose build scripts only
+  emit cfgs or link directives share normally.
 - **Linking is not cached**, so binaries and dylibs always link.
 - **Incremental compilation is disabled** inside `mbx build`. Cargo builds
   dependencies non-incrementally anyway, which is where the cache earns its

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -78,6 +78,9 @@ fn restores_a_wiped_target_directory_from_the_store() {
         "a cold build should publish its outputs: {cold}"
     );
 
+    // Load-bearing, not cleanup: the wipe is what forces the warm build to
+    // restore from the store. Left in place, cargo would find the cold build's
+    // outputs and the test would pass without exercising the cache at all.
     std::fs::remove_dir_all(project.path().join("target")).unwrap();
 
     let warm = build(
@@ -88,6 +91,12 @@ fn restores_a_wiped_target_directory_from_the_store() {
     assert!(
         count(&warm, "hits") > 0,
         "the rebuilt target directory should be restored: {warm}"
+    );
+    // A hit that never lands on disk is still a broken restore, so check the
+    // artifact itself rather than trusting the counter.
+    assert!(
+        project.path().join("target/debug/libfixture.rlib").exists(),
+        "the restored artifact should be materialized: {warm}"
     );
     assert_eq!(
         count(&warm, "compiler_invocations_avoided"),
@@ -119,6 +128,66 @@ fn a_second_checkout_starts_warm() {
         count(&warm, "hits") > 0,
         "a checkout at another path should reuse the first build: {warm}"
     );
+}
+
+/// Write a fixture whose build script generates code, optionally exposing
+/// `OUT_DIR` to the compilation.
+fn write_generated_project(directory: &Path, consume_out_dir: bool) {
+    std::fs::create_dir_all(directory.join("src")).unwrap();
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n         [lints.rust]\nunexpected_cfgs = { level = \"allow\" }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("build.rs"),
+        "use std::{env, fs, path::PathBuf};\n         fn main() {\n         \u{20}   let out = PathBuf::from(env::var(\"OUT_DIR\").unwrap());\n         \u{20}   fs::write(out.join(\"generated.rs\"), \"pub const VALUE: u32 = 7;\\n\").unwrap();\n         \u{20}   println!(\"cargo:rustc-cfg=generated\");\n         }\n",
+    )
+    .unwrap();
+    let lib = if consume_out_dir {
+        "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\npub fn value() -> u32 { VALUE }\n"
+    } else {
+        "#[cfg(generated)]\npub fn value() -> u32 { 7 }\n"
+    };
+    std::fs::write(directory.join("src/lib.rs"), lib).unwrap();
+    let status = Command::new(cargo())
+        .current_dir(directory)
+        .args(["generate-lockfile", "--offline"])
+        .status()
+        .expect("cargo should run");
+    assert!(status.success());
+}
+
+/// A build script alone does not stop two checkouts sharing a cache. Consuming
+/// `OUT_DIR` does, because its value is an absolute path the compilation reads
+/// and could bake into the artifact.
+#[test]
+fn out_dir_decides_whether_two_checkouts_share() {
+    for (consume_out_dir, expect_hits) in [(false, true), (true, false)] {
+        let store = tempfile::tempdir().unwrap();
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_generated_project(first.path(), consume_out_dir);
+        write_generated_project(second.path(), consume_out_dir);
+
+        build(
+            first.path(),
+            store.path(),
+            &reports.path().join("first.json"),
+        );
+        let stats = build(
+            second.path(),
+            store.path(),
+            &reports.path().join("second.json"),
+        );
+
+        assert_eq!(
+            count(&stats, "hits") > 0,
+            expect_hits,
+            "consume_out_dir={consume_out_dir} gave {stats}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
The README promised that "a second worktree of the same dependency graph builds warm". Measured on mise, it shares **533 of 824 actions — 65%**. This corrects the claim and explains the shortfall, which turned out not to be what I guessed.

## What actually causes it

I expected build-script output embedding absolute paths. Three fixtures say otherwise:

| build script | second checkout |
| --- | --- |
| exposes `OUT_DIR` via `include!`, generated content embeds the path | **miss** |
| exposes `OUT_DIR` via `include!`, generated content path-independent | **miss** |
| never exposes `OUT_DIR` — only emits a cfg | **hit** |

The content is irrelevant. The discriminator is whether the *compilation consumes `OUT_DIR`*, because that value is an absolute path and an input to the action, so two checkouts key differently. That covers any crate with a build script that generates code — a large share of a real dependency graph, which is why mise lands at 65% and not somewhere near 100%.

## Why not just map it

Mapping `OUT_DIR` to `${target}/…` the way argument paths are mapped would lift the hit rate immediately. It would also be unsound: a crate is free to bake that path into its artifact, and **nothing in the inputs distinguishes one that does from one that does not** — rows one and two of that table are identical from the cache's point of view and differ only in output. Map the value and row one silently restores an rlib containing the other checkout's path.

So this is the conservative branch of a real trade-off rather than a bug, and it belongs in the docs as a limitation instead of being quietly absent. `PLAN.md` records the reasoning next to the path-mapping design, since "environment values are deliberately unmapped" is exactly the kind of decision that looks like an oversight later.

## Tested, not just documented

`out_dir_decides_whether_two_checkouts_share` asserts both halves — the cfg-only fixture must hit, the `OUT_DIR` fixture must not. That way the boundary is checked, and if someone does find a sound way to map these values, the test tells them which half they changed.

If we ever want the hit rate back, the honest routes are an explicit opt-in for people who know their graph does not embed paths, or upstream making `OUT_DIR` relocatable — not a silent remap.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and integration tests only; no cache-key or restore-path logic changes.
> 
> **Overview**
> Qualifies the “second worktree builds warm” claim: sharing is **mostly** warm (~65% of actions on mise), not complete, because env values like `OUT_DIR` stay unmapped in cache keys.
> 
> Documents that crates which *consume* `OUT_DIR` (e.g. `include!(concat!(env!("OUT_DIR"), …))`) do not share across checkouts, while build scripts that only emit cfgs still do. Mapping `OUT_DIR` would raise hit rate but could restore artifacts that baked another checkout’s path.
> 
> Adds `out_dir_decides_whether_two_checkouts_share` to lock both sides of that boundary, plus a restore-path existence check so a hit counter cannot hide a failed materialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4260e69c6761bb63100b4e8c174b2bffe43d9c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->