### PR TITLE
feat(release): publish prebuilt binaries on a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+# A release is not cancellable: a half-uploaded set of assets is worse than a
+# slow one.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Check the tag matches the crate version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          crate="$(cargo metadata --format-version 1 --no-deps |
+            jq -r '.packages[] | select(.name == "mbx") | .version')"
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$crate" != "$tag" ]; then
+            echo "tag $GITHUB_REF_NAME does not match crate version $crate" >&2
+            exit 1
+          fi
+
+  build:
+    needs: version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            bin: mbx
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            bin: mbx
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            bin: mbx
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            bin: mbx
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            bin: mbx.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install the musl toolchain
+        if: endsWith(matrix.target, '-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - run: rustup target add ${{ matrix.target }}
+
+      - name: Build
+        shell: bash
+        # rustls brings in aws-lc-sys, which compiles C: cc-rs looks for a
+        # target-prefixed compiler, and Debian's musl-tools only ships
+        # `musl-gcc`. Naming it for both musl targets is harmless elsewhere,
+        # since nothing else consults these variables.
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
+        run: cargo build --release --locked --package mbx --target ${{ matrix.target }}
+
+      - name: Check the binary runs
+        # Every target but this one is native to its runner.
+        if: matrix.target != 'x86_64-apple-darwin'
+        shell: bash
+        run: ./target/${{ matrix.target }}/release/${{ matrix.bin }} --version
+
+      # The archive is flat and holds only the binary, so extracting it
+      # straight into a directory on PATH is the whole install.
+      - name: Archive
+        if: runner.os != 'Windows'
+        run: tar -czf "mbx-${{ matrix.target }}.tar.gz" -C "target/${{ matrix.target }}/release" ${{ matrix.bin }}
+
+      - name: Archive
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cd "target/${{ matrix.target }}/release"
+          7z a "$GITHUB_WORKSPACE/mbx-${{ matrix.target }}.zip" ${{ matrix.bin }}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: mbx-${{ matrix.target }}
+          path: mbx-${{ matrix.target }}.*
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: dist
+          pattern: mbx-*
+          merge-multiple: true
+
+      - name: Checksum every archive
+        run: |
+          cd dist
+          sha256sum -- * >"$RUNNER_TEMP/SHA256SUMS"
+          mv "$RUNNER_TEMP/SHA256SUMS" .
+          cat SHA256SUMS
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --verify-tag \
+            --generate-notes \
+            dist/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bytesize",
  "clap",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "base64 0.23.1",
  "blake3",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "mbx-cache-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = ["crates/mbx", "crates/mbx-cache-core", "crates/mbx-cache-rustc"]
 
 [workspace.package]
+version = "0.1.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/jdx/mr-boxington"

--- a/PLAN.md
+++ b/PLAN.md
@@ -222,6 +222,9 @@ The failure mode is a recompile, never a wrong result.
 6. `feat: mbx CLI` — `build`, `gc`, and `cache` commands, plus the cold/warm and
    second-checkout integration tests.
 7. `docs: usage` — real README behind an experimental banner.
+8. `feat: release binaries` — tagged release workflow producing one
+   self-contained archive per target, checksummed, so installing mbx in CI
+   is a single download.
 
 Server repo follow-up (separate stack in `jdx/mbx-cache`): rebrand crate,
 env vars, and wire constants to match `mbx-cache-core` exactly.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # mr boxington
 
 > **Please ignore this project.** It is an experiment and is not intended for
-> others to use yet. Nothing here is stable or supported, the protocol may
-> change without notice, and there are no releases.
+> others to use yet. Nothing here is stable or supported, and the protocol may
+> change without notice. Releases exist so CI can install a binary, not as a
+> promise that any of it keeps working.
 
 `mbx` is a build cache for Rust projects. It wraps cargo, caches individual
 rustc compilations in a content-addressed store shared by every project and
@@ -29,10 +30,30 @@ See [PLAN.md](PLAN.md) for the design and the road to v1.
 It is a cargo wrapper, not a cargo replacement. Cargo keeps resolution, feature
 unification, build planning, and linking.
 
+## Install
+
+Every release attaches one archive per target, holding the `mbx` binary and
+nothing else, so extracting it into a directory on `PATH` is the whole install.
+The Linux binaries are statically linked against musl and need nothing from the
+host.
+
+```sh
+curl -fsSL https://github.com/jdx/mr-boxington/releases/latest/download/mbx-x86_64-unknown-linux-musl.tar.gz | tar -xzf - -C ~/.local/bin
+```
+
+Targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`,
+`aarch64-apple-darwin`, `x86_64-apple-darwin`, and `x86_64-pc-windows-msvc`
+(a `.zip`). `SHA256SUMS` on the release covers all of them.
+
+Asset names carry no version, so pin one in CI by swapping `latest/download`
+for a tag: `releases/download/v0.1.0/mbx-x86_64-unknown-linux-musl.tar.gz`.
+`mbx --version` reports which build you have.
+
+Building from source works too: `cargo build --release`.
+
 ## Usage
 
 ```sh
-cargo build --release            # build mbx itself, for now
 mbx build build                  # == cargo build
 mbx build test --all-features    # == cargo test --all-features
 ```

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.0.0"
+version.workspace = true
 description = "Action cache protocol, CAS, authentication, and transport primitives for mbx"
 edition.workspace = true
 license.workspace = true

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.0.0"
+version.workspace = true
 description = "Conservative rustc action analysis and key construction for mbx"
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.0.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.1.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "0.0.0"
+version.workspace = true
 description = "A build cache for Rust projects"
 edition.workspace = true
 license.workspace = true
@@ -14,8 +14,8 @@ env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.0.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.0.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.1.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.1.0", default-features = false }
 rand = "0.10"
 reflink-copy = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
The README told you to install mbx by building it: `cargo build --release  # build mbx itself, for now`. That is the bootstrap problem extraction from mise was supposed to solve — **CI cannot use the cache to build the thing that provides the cache** — and it is the one item in the CI story with no code behind it. A tag now produces one self-contained archive per target.

## Static musl is not just `--target x86_64-unknown-linux-musl`

I expected the Linux job to be a target flag and a `rustup target add`. It is not, and the reason is worth recording because the failure is immediate and opaque:

```
error occurred in cc-rs: failed to find tool "x86_64-linux-musl-gcc"
```

rustls pulls in `aws-lc-sys`, which compiles C. `cc-rs` looks for a target-prefixed compiler; Debian's `musl-tools` installs one under the name `musl-gcc` and no other. So the build dies at the first C file on a stock runner, before anything Rust-specific is even attempted. `musl-tools` plus `CC_<target>=musl-gcc` is the fix, and it is commented in the workflow so the next person does not rediscover it.

Verified rather than assumed — installed the toolchain locally and built it:

| | |
| --- | --- |
| linkage | statically linked, nothing required from the host |
| `mbx --version` | `mbx 0.1.0` |
| archive round-trip | extracted with the exact README one-liner, ran `mbx cache stats` |

## What a tag does

Three jobs, ordered so that failure is cheap and partial success is impossible:

- **version** — fails if the tag disagrees with the crate version, before anything compiles.
- **build** — five targets: `x86_64`/`aarch64-unknown-linux-musl`, `aarch64`/`x86_64-apple-darwin`, `x86_64-pc-windows-msvc`. Each archive is flat and holds only the binary, so extracting it into a directory on `PATH` is the entire install.
- **publish** — tags only, and needs the whole matrix, so one broken target leaves no half-populated release behind.

Workspace crates move to `0.1.0` on the way past. `0.0.0` is not a version to hand someone in a bug report.

## Two choices worth arguing with

**Asset names carry no version** (`mbx-x86_64-unknown-linux-musl.tar.gz`). That is what makes `releases/latest/download/…` a permanent URL — the one-step install the plan asks for — while pinning still works through `releases/download/v0.1.0/…`. The cost is that a downloaded archive does not self-identify; only `mbx --version` does.

**Releases are not marked prerelease**, because `releases/latest` skips prereleases and that breaks the one-liner. The experimental stance rides on the README banner and the `0.x` version instead, and the banner now says what a release does and does not promise rather than claiming there are none.

## What this does not prove

CI on this PR exercises the code changes, not the workflow: `release.yml` triggers on `v*` tags and `workflow_dispatch`, neither of which fires for a pull request. `workflow_dispatch` builds and uploads every archive *without* publishing and is the way to rehearse this — but GitHub only offers it once the workflow is on the default branch, so the first real exercise is necessarily after merge, not before it.

Every target builds natively except `x86_64-apple-darwin`, which cross-compiles from the arm64 macOS runner and is therefore the one archive not smoke-tested by running it. Windows arm64 is absent deliberately rather than added untested.

## Verified

`cargo fmt --check`, `clippy --all-features --all-targets -D warnings`, and 137 tests pass.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
