### PR TITLE
test(cli): stop the target-dir probe test reading the ambient environment

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -248,10 +248,31 @@ fn inherited_environment(
 /// move the whole build elsewhere. Inference is kept as a fallback, and costs
 /// only cache hits when it is wrong, since an unmapped path bypasses.
 fn resolve_roots(cargo: &std::ffi::OsStr, arguments: &[String], working_dir: &Path) -> Roots {
+    resolve_roots_with(
+        cargo,
+        arguments,
+        working_dir,
+        std::env::var_os(CARGO_TARGET_DIR_ENV),
+    )
+}
+
+/// The environment name cargo reads for the target directory. It outranks a
+/// config-set `build.target-dir`, so both the probe and the fallback below have
+/// to agree on one value for it.
+const CARGO_TARGET_DIR_ENV: &str = "CARGO_TARGET_DIR";
+
+/// [`resolve_roots`] with the ambient `CARGO_TARGET_DIR` passed in rather than
+/// read here, so a caller can resolve as if the variable were unset.
+fn resolve_roots_with(
+    cargo: &std::ffi::OsStr,
+    arguments: &[String],
+    working_dir: &Path,
+    target_dir_env: Option<std::ffi::OsString>,
+) -> Roots {
     // Everything below inspects cargo's own flags only; the real build still
     // receives the full argument list untouched.
     let arguments = cargo_arguments(arguments);
-    let reported = cargo_roots(cargo, arguments);
+    let reported = cargo_roots(cargo, arguments, target_dir_env.as_deref());
     // `-C` moves the directory cargo resolves relative paths against, so the
     // fallbacks below have to follow it rather than this process's cwd.
     let invocation_dir = invocation_dir(arguments, working_dir);
@@ -264,7 +285,7 @@ fn resolve_roots(cargo: &std::ffi::OsStr, arguments: &[String], working_dir: &Pa
         .map(|value| absolute(&invocation_dir, value))
         .or_else(|| reported.map(|roots| roots.target_dir))
         .or_else(|| {
-            std::env::var_os("CARGO_TARGET_DIR")
+            target_dir_env
                 .map(PathBuf::from)
                 .filter(|dir| !dir.as_os_str().is_empty())
                 .map(|dir| absolute(&invocation_dir, &dir.to_string_lossy()))
@@ -345,8 +366,19 @@ fn invocation_dir(arguments: &[String], working_dir: &Path) -> PathBuf {
         .unwrap_or_else(|| working_dir.to_path_buf())
 }
 
-fn cargo_roots(cargo: &std::ffi::OsStr, arguments: &[String]) -> Option<Roots> {
+fn cargo_roots(
+    cargo: &std::ffi::OsStr,
+    arguments: &[String],
+    target_dir_env: Option<&std::ffi::OsStr>,
+) -> Option<Roots> {
     let mut command = Command::new(cargo);
+    // Say what the probe should see rather than letting it inherit: cargo lets
+    // this variable outrank configuration, so a probe that disagrees with the
+    // caller about it describes a different target directory than the build's.
+    match target_dir_env {
+        Some(dir) => command.env(CARGO_TARGET_DIR_ENV, dir),
+        None => command.env_remove(CARGO_TARGET_DIR_ENV),
+    };
     // Globals come first; cargo rejects them after the subcommand.
     command.args(forwarded_flags(arguments, &PROBE_GLOBAL_FLAGS));
     command.args(["metadata", "--no-deps", "--format-version", "1"]);
@@ -631,13 +663,19 @@ mod tests {
         // Without the override cargo reports the default; with it the probe has
         // to report the same directory the build will write to, or the outputs
         // go unmapped and every action bypasses the cache.
+        //
+        // Both halves resolve as if `CARGO_TARGET_DIR` were unset. Cargo lets
+        // that variable outrank a config-set `build.target-dir`, so leaving the
+        // ambient one in place would make the probe correctly report it instead
+        // of what is under test -- and the test would fail for anyone who
+        // exports it, which plenty of developers do.
         let arguments = [
             "build".to_string(),
             "--offline".to_string(),
             "--manifest-path".to_string(),
             manifest.display().to_string(),
         ];
-        let default = resolve_roots(std::ffi::OsStr::new("cargo"), &arguments, root);
+        let default = resolve_roots_with(std::ffi::OsStr::new("cargo"), &arguments, root, None);
         assert_eq!(default.target_dir, root.join("target"));
 
         let overridden = [
@@ -651,7 +689,7 @@ mod tests {
             ],
         ]
         .concat();
-        let roots = resolve_roots(std::ffi::OsStr::new("cargo"), &overridden, root);
+        let roots = resolve_roots_with(std::ffi::OsStr::new("cargo"), &overridden, root, None);
         assert_eq!(roots.target_dir, configured);
     }
 


### PR DESCRIPTION
`cli::tests::a_config_set_target_dir_reaches_the_probe` fails for any developer who exports `CARGO_TARGET_DIR`, and would fail in CI if that variable were ever set there:

```
CARGO_TARGET_DIR=/tmp/some-dir cargo test -p mbx --lib a_config_set_target_dir

panicked at crates/mbx/src/cli.rs:641:9
  left: "/tmp/some-dir"   right: "/tmp/.tmpPEfzRC/target"
```

Nothing is wrong with the product here. Cargo lets `CARGO_TARGET_DIR` outrank a config-set `build.target-dir`, the probe reported exactly that, and `resolve_roots` is supposed to believe it — an unmapped target directory bypasses, so the probe agreeing with the build is the whole point. What was wrong is that a test asserting on *configuration* let the developer's environment answer the question, and the first assertion — the plain default, before the override is even applied — is the one that breaks.

## What changed

The probe used to inherit the environment implicitly, so a test had no way to ask "resolve as if this variable were unset" without reaching for the process environment. Two options, and the obvious one is worse than it looks:

| approach | why not / why |
| --- | --- |
| `remove_var` in the test, restore on drop | `unsafe` on edition 2024, and unsound in practice — sibling tests in this binary read environment variables on other threads |
| pass the value in | matches how the rest of the crate already injects its environment |

So `CARGO_TARGET_DIR` is now read once in `resolve_roots` and threaded through `resolve_roots_with(..)`, the same `*_with` seam as `release_context_with` and `effective_remote_cache_mode_with`. `cargo_roots` states the variable on the child command instead of inheriting it silently — `.env(..)` with the caller's value, `.env_remove(..)` when there is none — which is the idiom `compiler_identity` already uses for `RUSTUP_HOME`/`RUSTUP_TOOLCHAIN`. The test passes `None` for both halves and now describes the fixture and nothing else.

**Product behavior is unchanged by construction**: passing the inherited value is what inheriting already did, and `env_remove` of an unset variable is a no-op. The fallback that reads the variable when the probe fails now consumes the same value, so probe and fallback can no longer disagree about it.

## Verified

Pre-fix, the failure reproduces exactly as reported; post-fix, both directions pass.

| | variable unset | variable set |
| --- | --- | --- |
| the target test | pass | pass |
| `mbx` lib suite (51 tests) | pass | pass |
| `mbx` integration, `tests/build.rs` (4 tests) | pass | pass |

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets` are clean. For the right-hand column the test binaries were built against the default target directory and then run with `CARGO_TARGET_DIR` exported, which is the inherited-environment condition the bug needs, without a relocated rebuild.

**Siblings checked.** This is the only test in the module — and the only test in the crate — that shells out to cargo. `tests/build.rs` already does `.env_remove("CARGO_TARGET_DIR")` on its `mbx` invocations, and its two `cargo generate-lockfile --offline` calls write only `Cargo.lock`, so they are unaffected; the passing run above confirms that rather than assuming it.

## One residual exposure, deliberately not fixed

A `$CARGO_HOME/config.toml` that sets `build.target-dir` still breaks the same test, verified with a synthetic `CARGO_HOME`:

```
panicked at crates/mbx/src/cli.rs:679:9
  left: "/tmp/home-config-target"   right: "/tmp/.tmpWPTOcZ/target"
```

Only the default half fails — the `--config` half survives, which incidentally pins the precedence this test depends on: environment beats `--config`, and `--config` beats config files. Neutralizing a home config means pointing the probe at a scratch `CARGO_HOME`, which changes more about the probe's world than an isolation fix should; the alternative is dropping the default-half assertion as untestable in a dirty environment. Happy to do either if a reviewer prefers one.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test isolation plus an equivalent env-injection seam; production still forwards the inherited CARGO_TARGET_DIR, so cache mapping behavior is unchanged.
> 
> **Overview**
> Stops the `build.target-dir` probe test from failing when a developer (or CI) has `CARGO_TARGET_DIR` set.
> 
> `CARGO_TARGET_DIR` is now read once in `resolve_roots` and passed through `resolve_roots_with` into the cargo metadata probe, which sets or removes the variable on the child instead of inheriting it. The test calls that helper with `None` so it asserts on the fixture, not the ambient environment. Probe and fallback now share the same value; production still passes through the inherited env, so product behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0b69152a86d18bb9c25cf9526b7117e4243cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->