### PR TITLE
chore(release): hand versioning and publishing to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,137 @@
+name: release-plz
+
+# release-plz watches main, opens a release PR that bumps versions and writes
+# the changelog, and on merge tags, publishes to crates.io and drafts the
+# GitHub release. `release.yml` then attaches binaries and this workflow
+# publishes the draft.
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release-plz-release:
+    name: Release
+    runs-on: ubuntu-latest
+    # Forks should never attempt to publish.
+    if: ${{ github.repository_owner == 'jdx' }}
+    permissions:
+      contents: write
+      # Required for crates.io trusted publishing: the OIDC token proves this
+      # workflow, in this repository, is the configured publisher. No
+      # long-lived CARGO_REGISTRY_TOKEN exists anywhere.
+      id-token: write
+      pull-requests: read
+    outputs:
+      tag: ${{ steps.mbx-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      # Exchanges the OIDC token for a short-lived crates.io token. Each crate
+      # needs a Trusted Publisher naming this repository and this workflow
+      # file, so renaming this file breaks publishing.
+      - name: Authenticate with crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Run release-plz
+        id: release-plz
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+
+      # This is a workspace: a run can release `mbx`, either library, or all of
+      # them, in whatever order release-plz reports. Taking `releases[0]` would
+      # sometimes hand the binary-upload job a library's tag — attaching `mbx`
+      # binaries to the wrong release and leaving the real one drafted forever.
+      # Select by name instead.
+      - name: Find the mbx tag
+        id: mbx-tag
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+        run: |
+          tag=""
+          if [ -n "$RELEASES" ]; then
+            tag=$(jq -r '[.[] | select(.package_name == "mbx")][0].tag // ""' <<<"$RELEASES")
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "mbx tag: ${tag:-<none released>}"
+
+      # Merging a release PR and getting nothing back means the release did not
+      # happen. Without this the run goes green and the omission is only
+      # noticed when someone looks for the release.
+      - name: Reject an empty release result for a merged release PR
+        if: steps.mbx-tag.outputs.tag == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_pr=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '[.[] | select(.merged_at != null) | select(.head.ref | startswith("release-plz-"))][0].number // ""')
+          if [ -n "$release_pr" ]; then
+            echo "::error::release-plz returned no release after merging release PR #$release_pr"
+            exit 1
+          fi
+
+  # Binaries are attached to the draft, then the draft is published — so a
+  # release is never visible without its assets.
+  upload-assets:
+    name: Upload assets
+    needs: release-plz-release
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-plz-release.outputs.tag }}
+
+  publish-release:
+    name: Publish release
+    needs: [release-plz-release, upload-assets]
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Undraft the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false
+
+  release-plz-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'jdx' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    # Never run two of these at once: they would race the same branch.
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Run release-plz
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,37 @@
 name: release
 
+# Builds a binary per target and attaches them to an existing release.
+#
+# Normally called by release-plz.yml against the draft it just created, so the
+# release is only published once its assets are in place. `workflow_dispatch`
+# is there for re-running a build that failed after the tag already existed.
+
+permissions: {}
+
 on:
-  push:
-    tags: ["v*"]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
   workflow_dispatch:
-
-# A release is not cancellable: a half-uploaded set of assets is worse than a
-# slow one.
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
-
-permissions:
-  contents: read
+    inputs:
+      tag:
+        description: "Tag to attach binaries to, e.g. v0.1.0"
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Check the tag matches the crate version
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          crate="$(cargo metadata --format-version 1 --no-deps |
-            jq -r '.packages[] | select(.name == "mbx") | .version')"
-          tag="${GITHUB_REF_NAME#v}"
-          if [ "$crate" != "$tag" ]; then
-            echo "tag $GITHUB_REF_NAME does not match crate version $crate" >&2
-            exit 1
-          fi
-
   build:
-    needs: version
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
+      # One target failing should not deny the others their artifacts.
       fail-fast: false
       matrix:
         include:
@@ -54,17 +50,25 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             bin: mbx.exe
-    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          key: ${{ matrix.target }}
 
       - name: Install the musl toolchain
         if: endsWith(matrix.target, '-musl')
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-
-      - run: rustup target add ${{ matrix.target }}
 
       - name: Build
         shell: bash
@@ -84,7 +88,8 @@ jobs:
         run: ./target/${{ matrix.target }}/release/${{ matrix.bin }} --version
 
       # The archive is flat and holds only the binary, so extracting it
-      # straight into a directory on PATH is the whole install.
+      # straight into a directory on PATH is the whole install. Names carry no
+      # version, which is what makes `releases/latest/download/…` a stable URL.
       - name: Archive
         if: runner.os != 'Windows'
         run: tar -czf "mbx-${{ matrix.target }}.tar.gz" -C "target/${{ matrix.target }}/release" ${{ matrix.bin }}
@@ -96,39 +101,59 @@ jobs:
           cd "target/${{ matrix.target }}/release"
           7z a "$GITHUB_WORKSPACE/mbx-${{ matrix.target }}.zip" ${{ matrix.bin }}
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: mbx-${{ matrix.target }}
+          name: binary-${{ matrix.target }}
           path: mbx-${{ matrix.target }}.*
+          # Only needed long enough for the attach job to collect them.
+          retention-days: 1
           if-no-files-found: error
 
-  publish:
+  attach:
+    name: Attach to release
+    # Needs every target: a release carrying four of five archives is worse
+    # than one that arrives late, and the draft stays unpublished either way.
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: dist
-          pattern: mbx-*
+          path: artifacts
+          pattern: binary-*
           merge-multiple: true
 
-      - name: Checksum every archive
+      - name: Collect assets
         run: |
-          cd dist
-          sha256sum -- * >"$RUNNER_TEMP/SHA256SUMS"
-          mv "$RUNNER_TEMP/SHA256SUMS" .
+          mkdir -p release-assets
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) \
+            -exec mv {} release-assets/ \;
+          ls -la release-assets/
+          # An empty upload would silently produce a release with no binaries.
+          [ -n "$(ls -A release-assets/)" ] || {
+            echo "::error::no binaries were produced"; exit 1; }
+
+      - name: Generate checksums
+        run: |
+          cd release-assets
+          sha256sum -- * > SHA256SUMS
           cat SHA256SUMS
 
-      - name: Publish the release
+      - name: Attach to release
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$GITHUB_REF_NAME" \
-            --verify-tag \
-            --generate-notes \
-            dist/*
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: gh release upload "$TAG" release-assets/* --repo "${{ github.repository }}" --clobber
+
+      # Called from release-plz.yml, undrafting is that workflow's job — it
+      # happens after this one returns. Run by hand, nothing else will do it,
+      # and the release would sit drafted forever. Since manual dispatch is the
+      # documented recovery for a build that failed after the tag existed, that
+      # would leave the recovery path itself broken.
+      - name: Publish the release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,11 +140,27 @@ jobs:
           sha256sum -- * > SHA256SUMS
           cat SHA256SUMS
 
+      # Called from release-plz.yml the release always exists, drafted, and
+      # `gh` resolves a draft by tag fine. Dispatched by hand it may not: the
+      # documented recovery is for a tag that exists whose release does not,
+      # because release-plz failed after tagging or someone deleted the draft.
+      # Uploading into nothing would fail there, so create it first. Same guard
+      # as jdx/mbx-cache. `--verify-tag` keeps a mistyped tag from conjuring a
+      # release for a ref that does not exist.
       - name: Attach to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
-        run: gh release upload "$TAG" release-assets/* --repo "${{ github.repository }}" --clobber
+        run: |
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --draft \
+              --generate-notes \
+              --title "$TAG" \
+              --verify-tag
+          fi
+          gh release upload "$TAG" release-assets/* --repo "${{ github.repository }}" --clobber
 
       # Called from release-plz.yml, undrafting is that workflow's job — it
       # happens after this one returns. Run by hand, nothing else will do it,

--- a/PLAN.md
+++ b/PLAN.md
@@ -225,6 +225,9 @@ The failure mode is a recompile, never a wrong result.
 8. `feat: release binaries` — tagged release workflow producing one
    self-contained archive per target, checksummed, so installing mbx in CI
    is a single download.
+9. `chore: release-plz` — versioning, changelog, tagging, and crates.io
+   publishing move to release-plz, matching the other jdx.dev CLIs. See
+   [RELEASING.md](RELEASING.md).
 
 Server repo follow-up (separate stack in `jdx/mbx-cache`): rebrand crate,
 env vars, and wire constants to match `mbx-cache-core` exactly.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ for a tag: `releases/download/v0.1.0/mbx-x86_64-unknown-linux-musl.tar.gz`.
 
 Building from source works too: `cargo build --release`.
 
+Releases are cut by release-plz; see [RELEASING.md](RELEASING.md).
+
 ## Usage
 
 ```sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,4 +42,6 @@ Two things live outside the repository, and releases fail without them:
 If the tag was created but the binaries failed to build, fix the problem and
 run the `release` workflow manually with that tag. It rebuilds, re-attaches
 with `--clobber`, and undrafts the release itself — dispatching by hand is the
-one path where nothing else would.
+one path where nothing else would. If the tag exists but its release does not,
+because release-plz failed after tagging or the draft was deleted, that run
+recreates it rather than failing.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+Releases are driven by [release-plz](https://release-plz.dev). Nobody tags by
+hand.
+
+## The flow
+
+1. Commits land on `main`. `release-plz-pr` opens (or updates) a release PR
+   that bumps versions and writes `CHANGELOG.md`.
+2. Merging that PR runs `release-plz-release`, which tags, publishes the crates
+   to crates.io, and creates the GitHub release **as a draft**.
+3. `release.yml` builds a binary per target and attaches the archives plus
+   `SHA256SUMS` to that draft.
+4. `publish-release` undrafts it. A release is therefore never visible without
+   its assets.
+
+`release_always = false`, so a push to `main` that merely carries a version
+bump does not release — only merging a release PR does.
+
+## Tags and asset names
+
+The `mbx` crate is tagged `v{version}`; the two library crates are published to
+crates.io but get no GitHub release of their own. Asset names carry no version
+(`mbx-x86_64-unknown-linux-musl.tar.gz`), which is what keeps
+`releases/latest/download/…` a stable URL.
+
+## Setup this depends on
+
+Two things live outside the repository, and releases fail without them:
+
+- **`RELEASE_PLZ_TOKEN`** — a PAT with `contents: write` and
+  `pull-requests: write`. The default `GITHUB_TOKEN` cannot be used: pushes made
+  with it do not trigger workflows, so the release PR would never run CI.
+- **A crates.io Trusted Publisher for each of `mbx`, `mbx-cache-core`, and
+  `mbx-cache-rustc`**, naming this repository and the workflow file
+  `release-plz.yml`. Publishing uses OIDC, so no `CARGO_REGISTRY_TOKEN` exists
+  anywhere. **Renaming `release-plz.yml` breaks publishing** until the trusted
+  publishers are updated to match.
+
+## When a release goes wrong
+
+If the tag was created but the binaries failed to build, fix the problem and
+run the `release` workflow manually with that tag. It rebuilds, re-attaches
+with `--clobber`, and undrafts the release itself — dispatching by hand is the
+one path where nothing else would.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,30 @@
+[workspace]
+# Releases happen by merging a release PR, not by any push that happens to
+# carry a version bump. Same choice as jdx/mbx-cache.
+release_always = false
+git_release_enable = true
+# Drafted so release.yml can attach binaries before anyone sees it — a release
+# that appears without its assets is worse than one that appears a minute
+# later. release-plz.yml undrafts it once the upload succeeds.
+git_release_draft = true
+
+[[package]]
+name = "mbx"
+publish = true
+# release-plz would otherwise tag the binary crate `mbx-vX.Y.Z`. The README's
+# install URLs are written against `v{version}`, and this is the tag people
+# reference, so it takes the bare name. Same workaround as jdx/tak.
+git_tag_name = "v{{ version }}"
+git_release_enable = true
+
+[[package]]
+name = "mbx-cache-core"
+publish = true
+# A library: crates.io is its distribution. A GitHub release for it would carry
+# no assets and would sit drafted forever, since only the `mbx` tag is undrafted.
+git_release_enable = false
+
+[[package]]
+name = "mbx-cache-rustc"
+publish = true
+git_release_enable = false


### PR DESCRIPTION
I cut `v0.1.0` by hand out of #14 — wrong process. The other jdx.dev CLIs let release-plz own versions, changelog, tags, and crates.io publishing, and this repo should too. Modelled on [jdx/tak](https://github.com/jdx/tak), which has the same shape as this one: a workspace whose binary crate is the thing people download, and whose libraries are only distributed through crates.io.

## The flow

Commits land on `main` → release-plz opens a release PR that bumps versions and writes the changelog → merging it tags, publishes the three crates, and drafts the GitHub release → `release.yml` attaches the archives and `SHA256SUMS` to that draft → `publish-release` undrafts it. A release is therefore never visible without its assets.

`release_always = false`, so a push to `main` carrying a version bump does not release on its own; only merging a release PR does.

## What changed in `release.yml`

The build matrix and the musl handling are untouched — that part was verified green against all five targets on a `workflow_dispatch` dry run. Only the edges move: it is *called with* a tag rather than *triggered by* one, uploads to an existing release rather than creating one, and loses the tag-versus-crate-version check, which release-plz now makes impossible to get wrong.

## Three traps this is written around

- **The binary crate takes the bare `v{version}` tag.** release-plz tags workspace members `{package}-vX.Y.Z` by default, and the README's install URLs are written against `v{version}`.
- **The libraries publish to crates.io but get no GitHub release.** Theirs would carry no assets and would sit drafted forever, since only the `mbx` tag is ever undrafted.
- **The tag is selected out of release-plz's output by package name, not `releases[0]`.** A run can release any subset of the three crates in any order, so index zero would sometimes attach `mbx` binaries to a library's release and leave the real one drafted.

## Setup this needs before merge

Two things live outside the repository, and I cannot see or configure either:

- **`RELEASE_PLZ_TOKEN`** — a PAT with `contents: write` and `pull-requests: write`. `GITHUB_TOKEN` will not do: pushes made with it do not trigger workflows, so the release PR would never run CI.
- **A crates.io trusted publisher for each of `mbx`, `mbx-cache-core`, and `mbx-cache-rustc`**, naming this repository and `release-plz.yml`. All four names are already reserved at `0.0.0`, so the names are yours; it is the publisher config that has to exist. Renaming that workflow file breaks publishing until they are updated.

Both are recorded in `RELEASING.md`, since neither fails in a way that explains itself.

## What merging does

Nothing immediately: `release_always = false` means the merge itself does not release. It opens a release PR proposing the first version, and merging *that* produces the release. If the two prerequisites above are not in place yet, the `release-plz-release` job fails loudly on the next push to `main` rather than silently skipping.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches publishing to crates.io and GitHub releases (OIDC trusted publishers, PAT, draft/undraft). Misconfiguration could publish the wrong tag or skip assets, but application code is unchanged.
> 
> **Overview**
> Hands versioning, changelog, tagging, and crates.io publishing to **release-plz**, matching the other jdx.dev CLIs. Releases only happen when a release PR is merged (`release_always = false`).
> 
> The GitHub release is created as a **draft**. `release.yml` is now a reusable workflow that builds the five target archives, attaches them plus `SHA256SUMS`, then the parent workflow undrafts so a release is never public without binaries. Manual `workflow_dispatch` remains the recovery path (re-attach with `--clobber` and undraft).
> 
> Workspace specifics: `mbx` uses the bare `v{version}` tag; the two library crates publish to crates.io with no GitHub release. The mbx tag is selected by package name, not `releases[0]`. Publishing uses crates.io trusted publishers (OIDC); renaming `release-plz.yml` would break that. Requires `RELEASE_PLZ_TOKEN` and trusted-publisher setup documented in `RELEASING.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a8711ed913f17c0354daac9ae767edf80fdf58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->