### PR TITLE
chore: release v0.1.0

### DIFF
--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.0.0...mbx-cache-core-v0.1.0) - 2026-08-21
+
+### Added
+
+- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
+- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
+- *(cache-core)* add action cache protocol and transport ([#4](https://github.com/jdx/mr-boxington/pull/4))
+
+### Other
+
+- *(cache-core)* stop fsyncing every stored object ([#13](https://github.com/jdx/mr-boxington/pull/13))

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.0.0...mbx-cache-rustc-v0.1.0) - 2026-08-21
+
+### Added
+
+- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
+- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
+- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
+- *(cache-rustc)* add rustc action analysis ([#5](https://github.com/jdx/mr-boxington/pull/5))

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jdx/mr-boxington/compare/v0.0.0...v0.1.0) - 2026-08-21
+
+### Added
+
+- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
+- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
+- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
+- *(cli)* add build, gc, and cache commands ([#7](https://github.com/jdx/mr-boxington/pull/7))
+- *(session)* add the cache session and rustc shim ([#6](https://github.com/jdx/mr-boxington/pull/6))
+
+### Other
+
+- *(cli)* stop the target-dir probe test reading the ambient environment ([#15](https://github.com/jdx/mr-boxington/pull/15))
+- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
+- *(session)* stop fsyncing restored outputs ([#9](https://github.com/jdx/mr-boxington/pull/9))
+- add workspace scaffolding and CI ([#2](https://github.com/jdx/mr-boxington/pull/2))


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.0.0 -> 0.1.0
* `mbx-cache-rustc`: 0.0.0 -> 0.1.0
* `mbx`: 0.0.0 -> 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.1.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.0.0...mbx-cache-core-v0.1.0) - 2026-08-21

### Added

- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
- *(cache-core)* add action cache protocol and transport ([#4](https://github.com/jdx/mr-boxington/pull/4))

### Other

- *(cache-core)* stop fsyncing every stored object ([#13](https://github.com/jdx/mr-boxington/pull/13))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.1.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.0.0...mbx-cache-rustc-v0.1.0) - 2026-08-21

### Added

- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
- *(cache-rustc)* add rustc action analysis ([#5](https://github.com/jdx/mr-boxington/pull/5))
</blockquote>

## `mbx`

<blockquote>

## [0.1.0](https://github.com/jdx/mr-boxington/compare/v0.0.0...v0.1.0) - 2026-08-21

### Added

- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
- *(cli)* add build, gc, and cache commands ([#7](https://github.com/jdx/mr-boxington/pull/7))
- *(session)* add the cache session and rustc shim ([#6](https://github.com/jdx/mr-boxington/pull/6))

### Other

- *(cli)* stop the target-dir probe test reading the ambient environment ([#15](https://github.com/jdx/mr-boxington/pull/15))
- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
- *(session)* stop fsyncing restored outputs ([#9](https://github.com/jdx/mr-boxington/pull/9))
- add workspace scaffolding and CI ([#2](https://github.com/jdx/mr-boxington/pull/2))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog additions with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds Keep a Changelog files for `mbx`, `mbx-cache-core`, and `mbx-cache-rustc`, documenting the first **0.1.0** release notes generated by release-plz.
> 
> No crate versions, code, or release workflow changes are in this diff—only the new `CHANGELOG.md` files with Unreleased and 0.1.0 sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f5aa5b6bc37156d5249bbdc92786effde40a1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->