### PR TITLE
feat(session): count the compilations the cache was never asked about

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,22 @@ activity prints nothing:
 
 ```
 cache: 12 hits, 3 misses, 12 prefetched; 4.1 MiB downloaded, 0 B uploaded, 1.2 MiB stored locally
+cache could not look up 4 compilations: no dep-info from an earlier build and no prediction to derive a key from
 cache bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
 ```
 
-The second line accounts for compilations mbx declined to cache, grouped by
+The last line accounts for compilations mbx declined to cache, grouped by
 reason. It is the honest counterpart to the hit rate: a build can hit every
 action it looked up and still spend most of its time on work that never entered
 the cache.
+
+The line above it is the other half of that honesty, and it dominates a genuinely
+cold build. An action key comes from a dep-info file an earlier build left
+behind, or from a prediction recorded by one; with neither, mbx has nothing to
+look up and compiles without asking. Those compilations are stored afterwards,
+so they are not bypasses, and they are not misses either -- a miss is a lookup
+that found nothing. Counting them as neither is what once made a cold build
+report `0 hits, 0 misses` while writing a gigabyte into the store.
 
 Store management:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ activity prints nothing:
 
 ```
 cache: 12 hits, 3 misses, 12 prefetched; 4.1 MiB downloaded, 0 B uploaded, 1.2 MiB stored locally
-cache could not look up 4 compilations: no dep-info from an earlier build and no prediction to derive a key from
+cache could not look up 4 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from
 cache bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
 ```
 
@@ -77,11 +77,12 @@ the cache.
 
 The line above it is the other half of that honesty, and it dominates a genuinely
 cold build. An action key comes from a dep-info file an earlier build left
-behind, or from a prediction recorded by one; with neither, mbx has nothing to
-look up and compiles without asking. Those compilations are stored afterwards,
-so they are not bypasses, and they are not misses either -- a miss is a lookup
-that found nothing. Counting them as neither is what once made a cold build
-report `0 hits, 0 misses` while writing a gigabyte into the store.
+behind, or from a prediction recorded by one. Without a usable key from either
+-- no dep-info at all, or dep-info that does not yield one -- mbx has nothing to
+look up and compiles without making the lookup. Those compilations are stored
+afterwards, so they are not bypasses, and they are not misses either: a miss is
+a lookup that found nothing. Counting them as neither is what once made a cold
+build report `0 hits, 0 misses` while writing a gigabyte into the store.
 
 Store management:
 

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -74,6 +74,9 @@ pub enum AgentRequest {
     RecordBypass {
         kind: String,
     },
+    /// A compilation the adapter could not look up, having no key to look up
+    /// with. Distinct from a bypass: these are cached once compiled.
+    RecordUnconsulted,
     RecordActionVerification {
         matched: bool,
         restore: RestoreStats,
@@ -137,6 +140,7 @@ pub enum AgentResponse {
     ActionHitRecorded,
     ActionVerificationRecorded,
     BypassRecorded,
+    UnconsultedRecorded,
     ActionStored {
         path: PathBuf,
     },
@@ -159,6 +163,11 @@ pub struct AgentStats {
     pub session_duration_ns: u64,
     /// Number of action-result lookups.
     pub lookups: u64,
+    /// Compilations no lookup was possible for, because nothing supplied a key.
+    ///
+    /// Counted separately from a miss, which is a lookup that found nothing.
+    /// Both compile, but only a miss says the cache was asked.
+    pub unconsulted: u64,
     /// Number of lookups that found a valid local action result.
     pub hits: u64,
     /// Number of newly stored content-addressed objects.
@@ -221,6 +230,7 @@ pub struct ActionPrediction {
 #[derive(Default)]
 struct AtomicAgentStats {
     lookups: AtomicU64,
+    unconsulted: AtomicU64,
     hits: AtomicU64,
     stores: AtomicU64,
     stored_bytes: AtomicU64,
@@ -690,6 +700,7 @@ impl CacheAgent {
         AgentStats {
             session_duration_ns: 0,
             lookups: self.stats.lookups.load(Ordering::Relaxed),
+            unconsulted: self.stats.unconsulted.load(Ordering::Relaxed),
             hits: self.stats.hits.load(Ordering::Relaxed),
             stores: self.stats.stores.load(Ordering::Relaxed),
             stored_bytes: self.stats.stored_bytes.load(Ordering::Relaxed),
@@ -1389,6 +1400,10 @@ impl CacheAgent {
                 *self.stats.bypasses.lock().unwrap().entry(kind).or_insert(0) += 1;
                 Ok(AgentResponse::BypassRecorded)
             }
+            AgentRequest::RecordUnconsulted => {
+                self.stats.unconsulted.fetch_add(1, Ordering::Relaxed);
+                Ok(AgentResponse::UnconsultedRecorded)
+            }
             AgentRequest::RecordActionVerification { matched, restore } => {
                 self.record_materialization(restore);
                 self.stats.verifications.fetch_add(1, Ordering::Relaxed);
@@ -2016,6 +2031,23 @@ mod tests {
             error.to_string().contains("exceeded"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn counts_compilations_it_could_not_look_up() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+
+        for _ in 0..3 {
+            agent.respond(AgentRequest::RecordUnconsulted).await;
+        }
+
+        let stats = agent.stats();
+        assert_eq!(stats.unconsulted, 3);
+        // Not a miss: nothing was looked up, and a hit rate computed over these
+        // would be a rate over lookups that never happened.
+        assert_eq!(stats.lookups, 0);
+        assert_eq!(stats.hits, 0);
     }
 
     #[tokio::test]

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -163,10 +163,11 @@ pub struct AgentStats {
     pub session_duration_ns: u64,
     /// Number of action-result lookups.
     pub lookups: u64,
-    /// Compilations no lookup was possible for, because nothing supplied a key.
+    /// Compilations no action-result lookup was possible for, because no usable
+    /// action key was available.
     ///
     /// Counted separately from a miss, which is a lookup that found nothing.
-    /// Both compile, but only a miss says the cache was asked.
+    /// Both compile, but only a miss says a lookup happened.
     pub unconsulted: u64,
     /// Number of lookups that found a valid local action result.
     pub hits: u64,

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -137,7 +137,15 @@ fn restore_predicted_result(
         AgentResponse::ActionPrediction {
             prediction: Some(prediction),
         } => prediction,
-        AgentResponse::ActionPrediction { prediction: None } => return Ok(None),
+        AgentResponse::ActionPrediction { prediction: None } => {
+            // Nothing supplied a key: no dep-info from an earlier build, and no
+            // prediction to derive one from. This compilation is about to run
+            // without the cache ever being asked, which is not a miss and has
+            // to be counted as its own thing or the summary reads as though the
+            // cache was consulted and came up empty.
+            session::record_unconsulted();
+            return Ok(None);
+        }
         AgentResponse::Error { message } => bail!(message),
         _ => bail!("cache agent returned an unexpected action prediction response"),
     };

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -138,11 +138,12 @@ fn restore_predicted_result(
             prediction: Some(prediction),
         } => prediction,
         AgentResponse::ActionPrediction { prediction: None } => {
-            // Nothing supplied a key: no dep-info from an earlier build, and no
-            // prediction to derive one from. This compilation is about to run
-            // without the cache ever being asked, which is not a miss and has
-            // to be counted as its own thing or the summary reads as though the
-            // cache was consulted and came up empty.
+            // No usable action key: either no dep-info from an earlier build or
+            // dep-info that did not yield one, and now no prediction either.
+            // This compilation runs without an action-result lookup ever being
+            // made, which is not a miss and has to be counted as its own thing
+            // or the summary reads as though a lookup happened and found
+            // nothing.
             session::record_unconsulted();
             return Ok(None);
         }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -264,6 +264,7 @@ struct StatsReport {
     lookups: u64,
     hits: u64,
     misses: u64,
+    unconsulted: u64,
     compiler_invocations_avoided: u64,
     verifications: u64,
     divergences: u64,
@@ -296,6 +297,7 @@ impl From<&AgentStats> for StatsReport {
             lookups: stats.lookups,
             hits: stats.hits,
             misses: cache_misses(stats),
+            unconsulted: stats.unconsulted,
             compiler_invocations_avoided: stats.hits,
             verifications: stats.verifications,
             divergences: stats.divergences,
@@ -333,6 +335,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         );
     }
     if stats.lookups == 0
+        && stats.unconsulted == 0
         && stats.stores == 0
         && stats.verifications == 0
         && stats.downloaded_bytes == 0
@@ -350,6 +353,16 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         ByteSize::b(stats.uploaded_bytes).display().iec(),
         ByteSize::b(stats.stored_bytes).display().iec(),
     ));
+    if stats.unconsulted > 0 {
+        // A cold target directory hits this for everything it compiles, and
+        // reporting only hits and misses there says "0 hits, 0 misses" -- which
+        // reads as though the cache was asked and had nothing, rather than that
+        // it was never asked. These compilations are still stored afterwards.
+        note(&format!(
+            "cache could not look up {} compilations: no dep-info from an earlier build and no prediction to derive a key from",
+            stats.unconsulted,
+        ));
+    }
     if !stats.bypasses.is_empty() {
         let total: u64 = stats.bypasses.values().sum();
         // Most frequent first: the head of this list is where the next win is.
@@ -788,6 +801,12 @@ fn record_bypass(error: &eyre::Report) {
     append_bypass_log(kind, error);
     // A shim running outside a session has nowhere to report, which is fine.
     let _ = request_agent(&[AgentRequest::RecordBypass { kind: kind.into() }]);
+}
+
+/// Record a compilation the cache had no key to look up with.
+pub(crate) fn record_unconsulted() {
+    // A shim running outside a session has nowhere to report, which is fine.
+    let _ = request_agent(&[AgentRequest::RecordUnconsulted]);
 }
 
 /// Append the full reason to `MBX_BYPASS_LOG`, when one is configured.

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -359,7 +359,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         // reads as though the cache was asked and had nothing, rather than that
         // it was never asked. These compilations are still stored afterwards.
         note(&format!(
-            "cache could not look up {} compilations: no dep-info from an earlier build and no prediction to derive a key from",
+            "cache could not look up {} compilations: no usable dep-info from an earlier build and no prediction to derive an action key from",
             stats.unconsulted,
         ));
     }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -77,6 +77,19 @@ fn restores_a_wiped_target_directory_from_the_store() {
         count(&cold, "stored_bytes") > 0,
         "a cold build should publish its outputs: {cold}"
     );
+    // A cold target directory leaves nothing to derive an action key from, so
+    // these compilations run without the cache ever being consulted. Reported
+    // apart from misses: counting them as zero of both says the cache was asked
+    // and found nothing, which is not what happened.
+    assert_eq!(
+        count(&cold, "misses"),
+        0,
+        "a cold build looks nothing up, so it cannot miss: {cold}"
+    );
+    assert!(
+        count(&cold, "unconsulted") > 0,
+        "a cold build should report the compilations it had no key for: {cold}"
+    );
 
     // Load-bearing, not cleanup: the wipe is what forces the warm build to
     // restore from the store. Left in place, cargo would find the cold build's


### PR DESCRIPTION
Running mbx against [jdx/usage](https://github.com/jdx/usage/pull/1194) — a 26-member workspace it did not ship with — the cold build reported this:

```
cache: 0 hits, 0 misses, 0 prefetched; 0 B downloaded, 0 B uploaded, 1.0 GiB stored locally
```

Both numbers are true. The pair is misleading. It reads as *the cache was consulted and had nothing*, when the cache was **never consulted**.

## Why there is nothing to count

An action key comes from a dep-info file an earlier build left behind, or from a prediction recorded by one. A cold target directory has neither, so the shim has nothing to look up with and goes straight to rustc. No `FindActionResult` is sent, `lookups` stays zero, and `misses` — `lookups - hits - verifications` — stays zero with it.

These are not bypasses. A bypassed compilation never enters the cache; these are stored the moment they finish. Folding them into either number would be wrong in a different direction, so they get their own count and their own line:

```
cache could not look up 206 compilations: no dep-info from an earlier build and no prediction to derive a key from
```

## It made something already broken legible

While checking the output I hit this on a fresh fixture:

| run | state | result |
| --- | --- | --- |
| 1 | no `Cargo.lock` yet | stores 2 actions, identity falls back to the directory name |
| 2 | lockfile now exists | **0 hits** — identity is now the lock digest, so run 1's predictions are invisible |
| 3 | identity stable | 2 hits |

A project's very first build changes its own cache identity by creating the lockfile, so its predictions are recorded under a name no later build uses and the second build restores nothing. Run 2 used to report `0 hits, 0 misses`. It now says it had no key, which is the difference between a silent wasted build and a visible one. Not fixed here — this only makes it observable.

## Checked

`fmt`, `clippy --all-features --all-targets -D warnings`, 140 tests. Three new ones: an agent unit test that the counter is not a miss and not a hit, and an integration assertion that a cold build reports zero misses *and* a nonzero unconsulted count — pinning the distinction rather than just the new field. The README's stats section documents the line alongside the bypass one.

`StatsReport` gains a field and stays at `version: 1`; it is additive and the report is not a wire protocol.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: a new stats counter and stderr line, with no change to lookup, restore, or store behavior.
> 
> **Overview**
> Cold builds no longer look like `0 hits, 0 misses` while still filling the store. Compilations that never had an action key (no usable dep-info and no prediction) are now counted as **unconsulted**, not as misses or bypasses.
> 
> When rustc has nothing to look up, the shim records `RecordUnconsulted` instead of implying a failed lookup. Session stderr prints a dedicated line, and the JSON stats report adds an additive `unconsulted` field. Tests pin that a cold build has zero misses and a nonzero unconsulted count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a327e7b66d19c35450b17f7726e2382463c6a68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a distinct “unconsulted” compilation category for builds without sufficient dependency or prediction information.
  - Reports now include unconsulted compilation counts and explain why the cache was not consulted.
  - Bypass statistics are grouped by reason.

- **Bug Fixes**
  - Cold builds are no longer incorrectly reported as cache misses when no cache lookup was possible.

- **Documentation**
  - Updated usage guidance to clarify cache hits, misses, bypasses, and unconsulted compilations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->