### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytesize",
  "clap",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "mbx-cache-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/mbx", "crates/mbx-cache-core", "crates/mbx-cache-rustc"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/jdx/mr-boxington"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.1.0...mbx-cache-core-v0.2.0) - 2026-08-22
+
+### Added
+
+- *(cache-core)* compress remote transfers with zstd ([#22](https://github.com/jdx/mr-boxington/pull/22))
+- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
+
 ## [0.1.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.0.0...mbx-cache-core-v0.1.0) - 2026-08-21
 
 ### Added

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.1.0...mbx-cache-rustc-v0.2.0) - 2026-08-22
+
+### Added
+
+- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
+
 ## [0.1.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.0.0...mbx-cache-rustc-v0.1.0) - 2026-08-21
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.1.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.2.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jdx/mr-boxington/compare/v0.1.0...v0.2.0) - 2026-08-22
+
+### Added
+
+- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
+- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
+- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
+
 ## [0.1.0](https://github.com/jdx/mr-boxington/compare/v0.0.0...v0.1.0) - 2026-08-21
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -14,8 +14,8 @@ env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.1.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.1.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.2.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.2.0", default-features = false }
 rand = "0.10"
 reflink-copy = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `mbx-cache-rustc`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `mbx`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AgentStats.unconsulted in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:171

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant AgentResponse::ActionStored 8 -> 9 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:144
  variant AgentResponse::ActionPrediction 9 -> 10 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:147
  variant AgentResponse::ActionPredictionRecorded 10 -> 11 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:150
  variant AgentResponse::ExecutableIdentity 11 -> 12 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:151
  variant AgentResponse::Error 12 -> 13 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:154
  variant AgentRequest::RecordActionVerification 7 -> 8 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:80
  variant AgentRequest::StoreActionResult 8 -> 9 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:84
  variant AgentRequest::FindActionPrediction 9 -> 10 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:87
  variant AgentRequest::RecordActionPrediction 10 -> 11 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:91
  variant AgentRequest::FindExecutableIdentity 11 -> 12 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:95
  variant AgentRequest::StoreExecutableIdentity 12 -> 13 in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:99

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:UnconsultedRecorded in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:143
  variant AgentRequest:RecordUnconsulted in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-core/src/agent.rs:79
```

### ⚠ `mbx-cache-rustc` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ActionContext.portable_environment in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx-cache-rustc/src/lib.rs:404
```

### ⚠ `mbx` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.incremental in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx/src/config.rs:53
  field Config.share_out_dir in /tmp/.tmpCSM1Ds/mr-boxington/crates/mbx/src/config.rs:59
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.1.0...mbx-cache-core-v0.2.0) - 2026-08-22

### Added

- *(cache-core)* compress remote transfers with zstd ([#22](https://github.com/jdx/mr-boxington/pull/22))
- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.1.0...mbx-cache-rustc-v0.2.0) - 2026-08-22

### Added

- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
</blockquote>

## `mbx`

<blockquote>

## [0.2.0](https://github.com/jdx/mr-boxington/compare/v0.1.0...v0.2.0) - 2026-08-22

### Added

- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release bump; no runtime or security logic is changed in this PR.
> 
> **Overview**
> Cuts **v0.2.0** for the workspace crates (`mbx`, `mbx-cache-core`, `mbx-cache-rustc`).
> 
> Workspace version and internal path-dep pins move from `0.1.0` to `0.2.0`. Each crate changelog gets a 0.2.0 section covering zstd remote transfers, unconsulted compilation counts, optional incremental compilation, and sharing `OUT_DIR` reads across checkouts. Semver-checks flags public API additions (new fields/enum variants) as breaking, which is why this is a minor bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0122c295deba7ea947374fcf4b70b965ffa72d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->