### PR TITLE
feat(session): let a build opt into incremental compilation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -35,7 +35,8 @@ a standalone home. mise will eventually consume mbx and drop its embedded copy.
 - Caching linking or non-rlib/metadata artifacts (future work).
 - Competing with rustc incremental for workspace members. Cargo builds
   dependencies non-incrementally by default; mbx caches those. Incremental
-  compilations bypass the cache by design.
+  compilations bypass the cache by design, and `MBX_INCREMENTAL=1` opts into
+  that trade rather than trying to cache them.
 - A daemon. The agent lives for the duration of one `mbx build`.
 
 ## Architecture
@@ -241,10 +242,14 @@ env vars, and wire constants to match `mbx-cache-core` exactly.
   checkout so deleting a worktree releases its artifacts.
 - **Deferred materialization** — leave artifacts in the CAS until read
   (biggest win for `cargo check`-heavy workflows).
-- **Revisit `CARGO_INCREMENTAL=0`.** The session disables incremental
-  compilation for everything, workspace members included. Incremental actions
-  bypass the cache anyway, so leaving members incremental may simply be better
-  for the inner loop; settle it with the measurement on a real workspace.
+- **Decide the `CARGO_INCREMENTAL` default.** `MBX_INCREMENTAL=1` now opts into
+  leaving members incremental (off by default, forced off in CI), so the
+  measurement is finally possible; the default itself is still unsettled. It
+  cannot be decided per crate: extern rlibs enter the action key by content, and
+  an incrementally built member emits different rlib bytes, so turning it on for
+  one member cold-misses its whole dependent subtree. Measure on a multi-member
+  workspace — mise is one crate, so nearly all of its 65% is dependencies and
+  the trade-off will not show there.
 - **Standalone shim mode**, so `build.rustc-wrapper` helps plain `cargo build`
   and `mbx setup` becomes worth having. This needs cross-process prefetch
   manifests first: `begin_task` derives its run id from the process id, so each

--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ Not yet:
   crate above it in the graph misses too. Worth it when you rebuild one leaf
   crate repeatedly; not worth it when a second worktree of the same workspace is
   what you want warm. CI ignores the setting: a fresh runner has no earlier
-  build to build on, so there is nothing to gain and reuse to lose.
+  build to build on, so there is nothing to gain and reuse to lose. Since the
+  setting stops overriding `CARGO_INCREMENTAL` rather than setting it, a `0`
+  already in your environment still wins, and `mbx` says so rather than leaving
+  you to wonder.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ defaults.
 | `MBX_REMOTE_OIDC_AUDIENCE` | `remote.oidc_audience` | unset | CI OIDC audience |
 | `MBX_REMOTE_MODE` | `remote.mode` | `read-write` | or `read-only`, `write-only` |
 | `MBX_STATS_REPORT` | `stats_report` | unset | write a JSON report here |
+| `MBX_INCREMENTAL` | `incremental` | off | let cargo compile workspace members incrementally |
 | `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect and read timeout |
 | `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
 | `MBX_HTTP_RETRIES` | `http.retries` | `3` | request retries |
@@ -172,9 +173,19 @@ Not yet:
   artifact containing another checkout's path. Crates whose build scripts only
   emit cfgs or link directives share normally.
 - **Linking is not cached**, so binaries and dylibs always link.
-- **Incremental compilation is disabled** inside `mbx build`. Cargo builds
+- **Incremental compilation is off by default** inside `mbx build`. Cargo builds
   dependencies non-incrementally anyway, which is where the cache earns its
-  keep.
+  keep, and an incremental compilation is never cacheable.
+
+  `MBX_INCREMENTAL=1` stops forcing it off and hands the decision back to cargo,
+  which trades cache reuse for a faster edit-rebuild loop. Members you just
+  edited were going to miss regardless, so incremental recompiles them faster
+  than the cache can — but a member built incrementally emits a different rlib
+  than a cached one, and extern rlibs enter the action key by content, so every
+  crate above it in the graph misses too. Worth it when you rebuild one leaf
+  crate repeatedly; not worth it when a second worktree of the same workspace is
+  what you want warm. CI ignores the setting: a fresh runner has no earlier
+  build to build on, so there is nothing to gain and reuse to lose.
 
 ## License
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -89,6 +89,15 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
             "incremental compilation is disabled here; it needs an earlier build to build on"
         );
     }
+    // An enabled build stops overriding CARGO_INCREMENTAL rather than setting
+    // it, so a 0 already in the environment still wins -- which CI images and
+    // rust-cache set as a matter of course. Say so, because the alternative is
+    // a setting that silently does nothing.
+    if incremental && std::env::var("CARGO_INCREMENTAL").as_deref() == Ok("0") {
+        log::warn!(
+            "CARGO_INCREMENTAL=0 is set in the environment, so this build is not incremental after all"
+        );
+    }
     config.incremental = incremental;
     let config = &config;
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -82,6 +82,16 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
         return run_cargo(&cargo, arguments, BTreeMap::new());
     }
 
+    let mut config = config.clone();
+    let incremental = policy::incremental_allowed(config.incremental);
+    if config.incremental && !incremental {
+        log::warn!(
+            "incremental compilation is disabled here; it needs an earlier build to build on"
+        );
+    }
+    config.incremental = incremental;
+    let config = &config;
+
     let working_dir = std::env::current_dir()?;
     let roots = resolve_roots(&cargo, arguments, &working_dir);
     let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -18,6 +18,7 @@ const DEFAULT_HTTP_RETRIES: i64 = 3;
 struct ConfigFile {
     cache_dir: Option<PathBuf>,
     stats_report: Option<PathBuf>,
+    incremental: Option<bool>,
     remote: RemoteFile,
     http: HttpFile,
 }
@@ -46,6 +47,9 @@ pub struct Config {
     pub cache_dir: PathBuf,
     pub stats_report: Option<PathBuf>,
     pub verify: bool,
+    /// Let cargo compile workspace members incrementally, rather than forcing
+    /// `CARGO_INCREMENTAL=0` for the whole build.
+    pub incremental: bool,
     pub remote: RemoteSettings,
     pub http: HttpSettings,
 }
@@ -122,7 +126,13 @@ impl Config {
             stats_report: get_env("MBX_STATS_REPORT")
                 .map(PathBuf::from)
                 .or(file.stats_report),
-            verify: get_env("MBX_VERIFY").is_some_and(|value| !value.is_empty() && value != "0"),
+            verify: get_env("MBX_VERIFY").is_some_and(|value| enabled(&value)),
+            incremental: match get_env("MBX_INCREMENTAL") {
+                // The environment decides outright when it is set, so a `0`
+                // there turns off what the file turned on.
+                Some(value) => enabled(&value),
+                None => file.incremental.unwrap_or(false),
+            },
             remote: RemoteSettings {
                 url: get_env("MBX_REMOTE_URL").or(file.remote.url),
                 namespace: get_env("MBX_REMOTE_NAMESPACE").or(file.remote.namespace),
@@ -141,6 +151,11 @@ impl Config {
     pub fn store_dir(&self) -> PathBuf {
         self.cache_dir.join("actions")
     }
+}
+
+/// Whether an environment value asks for a feature. Empty and `0` do not.
+fn enabled(value: &str) -> bool {
+    !value.is_empty() && value != "0"
 }
 
 fn optional_duration(
@@ -231,6 +246,7 @@ mod tests {
         assert_eq!(config.remote.mode, RemoteCacheMode::ReadWrite);
         assert!(config.remote.url.is_none());
         assert!(!config.verify);
+        assert!(!config.incremental);
         assert!(config.store_dir().ends_with("actions"));
     }
 
@@ -251,6 +267,15 @@ mod tests {
             Config::from_parts(ConfigFile::default(), env(&[("MBX_HTTP_RETRIES", "many")]))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn the_environment_can_turn_off_what_the_file_turned_on() {
+        let file: ConfigFile = toml::from_str("incremental = true").unwrap();
+        let config = Config::from_parts(file.clone(), env(&[])).unwrap();
+        assert!(config.incremental);
+        let config = Config::from_parts(file, env(&[("MBX_INCREMENTAL", "0")])).unwrap();
+        assert!(!config.incremental);
     }
 
     #[test]

--- a/crates/mbx/src/policy.rs
+++ b/crates/mbx/src/policy.rs
@@ -1,8 +1,9 @@
-//! Remote-cache write policy.
+//! What the surrounding context permits, whatever the configuration asks for.
 //!
 //! Cache writes are only trusted from a CI context that a pull request cannot
 //! influence, so untrusted contexts read the remote cache but never publish to
-//! it. Release builds do not participate at all.
+//! it. Release builds do not participate at all, and CI never compiles
+//! incrementally.
 
 use mbx_cache_core::RemoteCacheMode;
 
@@ -29,6 +30,20 @@ fn effective_remote_cache_mode_with(
 /// Whether this is a release build, which never uses the cache.
 pub fn release_context() -> bool {
     release_context_with(|name| std::env::var(name).ok())
+}
+
+/// Whether incremental compilation is worth allowing here.
+///
+/// CI is the one place the answer is no regardless of configuration: a runner
+/// starts with no incremental state to build on, and an incrementally built
+/// member emits a different rlib than a cached one, so every crate above it in
+/// the graph misses. The inner loop is the only thing incremental buys.
+pub fn incremental_allowed(configured: bool) -> bool {
+    incremental_allowed_with(configured, |name| std::env::var(name).ok())
+}
+
+fn incremental_allowed_with(configured: bool, get_env: impl Fn(&str) -> Option<String>) -> bool {
+    configured && !env_truthy(get_env("CI"))
 }
 
 fn trusted_cache_writer(get_env: &impl Fn(&str) -> Option<String>) -> bool {
@@ -123,6 +138,13 @@ mod tests {
             effective_remote_cache_mode_with(RemoteCacheMode::ReadWrite, &merge_request),
             Some(RemoteCacheMode::ReadOnly)
         );
+    }
+
+    #[test]
+    fn ci_never_compiles_incrementally() {
+        assert!(!incremental_allowed_with(true, env(&[("CI", "true")])));
+        assert!(incremental_allowed_with(true, env(&[])));
+        assert!(!incremental_allowed_with(false, env(&[])));
     }
 
     #[test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -40,6 +40,7 @@ pub struct CacheSession {
     rustc_shim: PathBuf,
     staging: PathBuf,
     verify: bool,
+    incremental: bool,
     agent: CacheAgent,
     started: Instant,
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
@@ -68,6 +69,7 @@ impl CacheSession {
             rustc_shim: shim,
             staging,
             verify: config.verify,
+            incremental: config.incremental,
             agent,
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),
@@ -137,9 +139,17 @@ impl CacheSession {
             );
             environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
         }
-        // Incremental compilation is never cacheable, so it is disabled rather
-        // than left to bypass every action.
-        environment.insert("CARGO_INCREMENTAL".into(), "0".into());
+        if self.incremental {
+            // Hand the decision back to cargo, which compiles local packages
+            // incrementally in dev profiles and never in release. Not
+            // overriding is the whole of the feature: the actions themselves
+            // still bypass, they are just faster to recompile.
+            environment.remove("CARGO_INCREMENTAL");
+        } else {
+            // Incremental compilation is never cacheable, so it is disabled
+            // rather than left to bypass every action.
+            environment.insert("CARGO_INCREMENTAL".into(), "0".into());
+        }
         action_run
     }
 
@@ -959,6 +969,7 @@ mod tests {
             cache_dir: cache_dir.to_path_buf(),
             stats_report: None,
             verify: false,
+            incremental: false,
             remote: Default::default(),
             http: Default::default(),
         }
@@ -993,6 +1004,34 @@ mod tests {
         assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
         assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");
         assert_eq!(values.get(VERIFY_ENV).unwrap(), "0");
+
+        session.finish().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn incremental_builds_leave_cargo_incremental_alone() {
+        let cache = tempfile::tempdir().unwrap();
+        let session_dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(cache.path());
+        config.incremental = true;
+        let session = CacheSession::start(session_dir.path(), &config)
+            .await
+            .unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        let mut values = BTreeMap::new();
+        session
+            .begin(
+                workspace.path(),
+                &workspace.path().join("target"),
+                &["build".to_string()],
+                &mut values,
+            )
+            .await;
+
+        // Absent, not "1": cargo's own per-profile default is what we want, and
+        // forcing the value on would turn incremental on for release too.
+        assert!(!values.contains_key("CARGO_INCREMENTAL"));
 
         session.finish().await.unwrap();
     }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -35,7 +35,18 @@ fn cargo() -> std::ffi::OsString {
 
 /// Build `project` against `store`, returning the run's statistics.
 fn build(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
-    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+    build_with(project, store, report, &[])
+}
+
+/// Build as `build` does, with `settings` added to the environment.
+fn build_with(
+    project: &Path,
+    store: &Path,
+    report: &Path,
+    settings: &[(&str, &str)],
+) -> serde_json::Value {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
+    command
         .current_dir(project)
         .args(["build", "build", "--offline"])
         .env("MBX_CACHE_DIR", store)
@@ -43,8 +54,15 @@ fn build(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
         // Cargo's own environment for this test would otherwise redirect the
         // fixture's output into this crate's target directory.
         .env_remove("CARGO_TARGET_DIR")
-        .output()
-        .expect("mbx should run");
+        // Both of these decide whether cargo compiles incrementally, so a test
+        // that says nothing about it must not inherit an answer from the
+        // machine it runs on -- least of all from CI.
+        .env_remove("MBX_INCREMENTAL")
+        .env_remove("CI");
+    for (name, value) in settings {
+        command.env(name, value);
+    }
+    let output = command.output().expect("mbx should run");
     assert!(
         output.status.success(),
         "build failed: {}",
@@ -58,6 +76,45 @@ fn count(stats: &serde_json::Value, field: &str) -> u64 {
     stats[field]
         .as_u64()
         .unwrap_or_else(|| panic!("{field} should be a number"))
+}
+
+#[test]
+fn incremental_is_opt_in_and_reaches_cargo() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    build(
+        project.path(),
+        store.path(),
+        &reports.path().join("default.json"),
+    );
+    assert_eq!(
+        incremental_sessions(project.path()),
+        0,
+        "the default build should still force CARGO_INCREMENTAL=0"
+    );
+
+    let stats = build_with(
+        project.path(),
+        store.path(),
+        &reports.path().join("incremental.json"),
+        &[("MBX_INCREMENTAL", "1")],
+    );
+    assert!(
+        incremental_sessions(project.path()) > 0,
+        "cargo should have compiled the member incrementally: {stats}"
+    );
+}
+
+/// How many incremental sessions rustc left behind. Cargo creates the directory
+/// either way, so its contents are the only evidence that anything used it.
+fn incremental_sessions(project: &Path) -> usize {
+    match std::fs::read_dir(project.join("target/debug/incremental")) {
+        Ok(entries) => entries.count(),
+        Err(_) => 0,
+    }
 }
 
 #[test]

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -54,10 +54,13 @@ fn build_with(
         // Cargo's own environment for this test would otherwise redirect the
         // fixture's output into this crate's target directory.
         .env_remove("CARGO_TARGET_DIR")
-        // Both of these decide whether cargo compiles incrementally, so a test
-        // that says nothing about it must not inherit an answer from the
-        // machine it runs on -- least of all from CI.
+        // All three decide whether cargo compiles incrementally, so a test that
+        // says nothing about it must not inherit an answer from the machine it
+        // runs on. CARGO_INCREMENTAL is the one that bites: an enabled build
+        // defers to it, and `Swatinem/rust-cache` sets it to 0 for the whole
+        // job, so leaving it would make this suite pass locally and fail in CI.
         .env_remove("MBX_INCREMENTAL")
+        .env_remove("CARGO_INCREMENTAL")
         .env_remove("CI");
     for (name, value) in settings {
         command.env(name, value);


### PR DESCRIPTION
## What

`MBX_INCREMENTAL=1`, or `incremental = true` in `~/.config/mbx/config.toml`, stops the session from forcing `CARGO_INCREMENTAL=0`. Off by default, so nothing changes for anyone who does not set it.

## Why

The session disabled incremental compilation for the whole build, workspace members included. That made `mbx build` *slower* than plain cargo in the edit-rebuild loop: a member you just edited misses the cache either way, and forcing incremental off gave up the one thing that would have made recompiling it cheap. Cargo builds registry dependencies non-incrementally regardless, so the cache's main territory is untouched by the change.

This is the `PLAN.md` "revisit `CARGO_INCREMENTAL=0`" item, turned into a knob so the measurement it asks for is actually possible.

## Notes for review

**The override is removed, not set to `1`.** Setting `1` would force incremental on for release profiles too, which plain cargo does not do. Removing it lets cargo's per-profile default decide, and leaves an ambient `CARGO_INCREMENTAL` as the user's to set.

**The default is deliberately unchanged.** The trade cannot be made per crate: extern rlibs enter the action key by content, and a member built incrementally emits different rlib bytes than a cached one, so enabling it for one member cold-misses its entire dependent subtree. Deciding the default wants a measurement on a multi-member workspace — mise is a single crate, so nearly all of its 65% is dependencies and the trade-off will not show there. `PLAN.md` now records that.

**CI ignores the setting**, with a warning ([`policy.rs`](crates/mbx/src/policy.rs)). A fresh runner has no earlier build to build on, so there is nothing to gain and the subtree invalidation is pure loss.

**Test isolation.** Cargo creates `target/debug/incremental` whether or not anything uses it, so the end-to-end test counts session directories inside it rather than checking that it exists. The integration helper also now clears `CI` and `MBX_INCREMENTAL`, so no test inherits an answer to this from the machine it runs on — the same failure mode as #15.

## Testing

`cargo test --workspace` and `cargo clippy --all-targets --all-features` are clean. New coverage: config precedence (env `0` overrides a file `true`), the CI gate, the session env, and an end-to-end build proving the flag reaches cargo and that the default still does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cargo is invoked and can invalidate cache keys for dependent crates when incremental rlibs differ; CI still forces incremental off.
> 
> **Overview**
> Adds an opt-in so `mbx build` can stop forcing `CARGO_INCREMENTAL=0`. `MBX_INCREMENTAL=1` (or `incremental = true` in config) removes the override and lets cargo’s per-profile default decide, which speeds the edit-rebuild loop for workspace members at the cost of cache reuse for dependents.
> 
> Default remains off. CI (`CI` set) always disables it, with a warning. Enabling does not set `CARGO_INCREMENTAL=1`, so an ambient `0` still wins and is logged. Env `0` overrides a file `true`.
> 
> Documents the trade-off (incrementally built rlibs change action keys for the whole dependent subtree) and adds config, policy, session, and end-to-end tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b39a51769bcb4d064ce32ca18ae3c2d5a783118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->