### PR TITLE
feat(session): share compilations that read OUT_DIR across checkouts

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -110,13 +110,24 @@ elsewhere entirely.
 
 Environment *values* are a deliberate exception: they enter the key verbatim,
 unmapped. The one that matters is `OUT_DIR`, which every crate that includes
-build-script output consumes, and which differs per checkout. Mapping it would
-lift cross-checkout sharing — measured at 65% of actions on mise — but a crate
-may bake that path into its artifact, and no input distinguishes one that does
-from one that does not. Both fixtures behave identically from the cache's point
-of view, so mapping the value could restore an artifact carrying another
-checkout's path. The conservative choice costs hits; the alternative can be
-wrong.
+build-script output consumes, and which differs per checkout. Mapping it lifts
+cross-checkout sharing — measured at 65% of actions on mise — but a crate may
+bake that path into its artifact, and no *input* distinguishes one that does
+from one that does not.
+
+`MBX_SHARE_OUT_DIR` (off by default) resolves that by not relying on the inputs
+alone. It makes the compilation independent of the value with
+`--remap-path-prefix`, so rustc records the placeholder wherever it records a
+path itself, and then reads the outputs before publishing: a compilation whose
+artifact still carries the value keeps its own checkout's key. Both halves are
+load-bearing. Without the remap the outputs always carry the path, in rmeta and
+in debug info, and nothing shares; without reading the outputs, a crate that
+keeps `env!("OUT_DIR")` in a string constant would be shared wrongly.
+
+What that does not cover is a value a crate derives from `OUT_DIR` instead of
+embedding — its length, or a hash of it. That is why the default stays off, and
+why flipping it is gated on verify-mode qualification over a real workspace
+rather than on the measurement alone.
 
 ### Cache identity
 
@@ -259,6 +270,19 @@ env vars, and wire constants to match `mbx-cache-core` exactly.
   target directory does not have — so the feature is not worth shipping until
   runs can be shared. Either make the run id deterministic per identity, or
   persist predictions as they are recorded instead of at commit.
+- **Default `MBX_SHARE_OUT_DIR` on**, once a verify-mode run over a real
+  workspace has qualified it. Blocked on the verify-mode gap below rather than
+  on the feature itself.
+- **Verify mode across checkouts.** `MBX_VERIFY=1` compares restored outputs to
+  a fresh compilation byte for byte, which a cross-checkout restore of a
+  *workspace member* cannot pass: cargo compiles members in place, so each
+  checkout's artifact records its own source path, and the cache serves one
+  checkout's bytes to the other. That is true today, without
+  `MBX_SHARE_OUT_DIR`, and it is why the canary cannot currently qualify
+  cross-checkout sharing. Remapping `${workspace}` the way `OUT_DIR` is now
+  remapped would fix it, at the cost of every backtrace into your own code
+  naming a placeholder — a much larger change in what a build produces, and its
+  own decision.
 - **Link caching** — cache bin/dylib link outputs (hardest correctness
   surface, deliberately last).
 - **Shared protocol crate** between client and server.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ defaults.
 | `MBX_REMOTE_TOKEN_FILE` | `remote.token_file` | unset | token read from a file |
 | `MBX_REMOTE_OIDC_AUDIENCE` | `remote.oidc_audience` | unset | CI OIDC audience |
 | `MBX_REMOTE_MODE` | `remote.mode` | `read-write` | or `read-only`, `write-only` |
+| `MBX_SHARE_OUT_DIR` | `share_out_dir` | off | share compilations that read `OUT_DIR` |
 | `MBX_STATS_REPORT` | `stats_report` | unset | write a JSON report here |
 | `MBX_INCREMENTAL` | `incremental` | off | let cargo compile workspace members incrementally |
 | `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect and read timeout |
@@ -174,14 +175,30 @@ Not yet:
   across the many rustc processes cargo spawns, so `build.rustc-wrapper` and an
   `mbx setup` command are waiting on that. Use `mbx build`.
 - **A crate whose compilation consumes `OUT_DIR` does not share across
-  checkouts.** That covers any crate with a build script that generates code
-  included via `include!(concat!(env!("OUT_DIR"), …))`. `OUT_DIR` is an absolute
-  path and an input to the compilation, so two checkouts produce different keys.
-  This is deliberate rather than an oversight: a crate is free to bake that path
-  into its artifact, and nothing in the inputs distinguishes one that does from
-  one that does not, so treating the value as interchangeable could hand you an
-  artifact containing another checkout's path. Crates whose build scripts only
-  emit cfgs or link directives share normally.
+  checkouts by default.** That covers any crate with a build script that
+  generates code included via `include!(concat!(env!("OUT_DIR"), …))`. `OUT_DIR`
+  is an absolute path and an input to the compilation, so two checkouts produce
+  different keys. Crates whose build scripts only emit cfgs or link directives
+  share normally.
+
+  `MBX_SHARE_OUT_DIR=1` lifts this. It does two things, and needs both:
+  it passes `--remap-path-prefix` so rustc records the cache placeholder rather
+  than the real path — which covers debug info, spans, and diagnostics — and
+  then, before publishing, it reads the outputs and only uses the shared key if
+  none of them carries the value anyway. The second half is not redundant: a
+  crate that keeps `env!("OUT_DIR")` in a string constant puts the real path in
+  its artifact, where no remapping reaches it, and such a compilation stays
+  keyed to its own checkout.
+
+  The cost is that generated sources appear in debug info as
+  `${target}/debug/build/…` instead of a path a debugger can open, which is why
+  this is opt-in. The residual gap is a value a crate *derives* from `OUT_DIR`
+  rather than embedding — its length, say, or a hash of it. Reading the outputs
+  cannot see that, so it is not covered.
+
+  On this repository's own dependency graph (285 crates), a second checkout hit
+  139 of the 147 compilations it looked up by default, and all 147 with the
+  option on.
 - **Linking is not cached**, so binaries and dylibs always link.
 - **Incremental compilation is off by default** inside `mbx build`. Cargo builds
   dependencies non-incrementally anyway, which is where the cache earns its

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -569,6 +569,7 @@ mod tests {
             working_dir: root.to_path_buf(),
             path_mappings: vec![crate::PathMapping::new(root, "workspace")],
             environment: BTreeMap::new(),
+            portable_environment: BTreeSet::new(),
             inputs: Vec::new(),
         };
         discovered.clone().apply_to(&mut context).unwrap();

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -336,6 +336,44 @@ impl PathMapping {
             placeholder: placeholder.into(),
         }
     }
+
+    /// Order mappings deepest root first, which is what normalization needs:
+    /// a target directory inside the workspace has to win over the workspace.
+    pub fn ordered(mappings: &[PathMapping]) -> Vec<PathMapping> {
+        let mut ordered = mappings.to_vec();
+        ordered.sort_by_key(|mapping| std::cmp::Reverse(mapping.root.components().count()));
+        ordered
+    }
+}
+
+/// Map an absolute path to its cache-key placeholder form.
+///
+/// `mappings` must already be ordered by [`PathMapping::ordered`]. Exposed for
+/// callers that need the placeholder text before an action exists -- notably to
+/// build the `--remap-path-prefix` flag that makes a compilation independent of
+/// a path in its environment.
+pub fn normalize_mapped_path(
+    path: &Path,
+    working_dir: &Path,
+    mappings: &[PathMapping],
+) -> Result<String, BypassReason> {
+    let absolute = if path.is_absolute() {
+        normalize_components(path)
+    } else {
+        normalize_components(&working_dir.join(path))
+    };
+    for mapping in mappings {
+        let root = normalize_components(&mapping.root);
+        if let Ok(relative) = absolute.strip_prefix(&root) {
+            let suffix = slash_path(relative)?;
+            return Ok(if suffix.is_empty() {
+                format!("${{{}}}", mapping.placeholder)
+            } else {
+                format!("${{{}}}/{suffix}", mapping.placeholder)
+            });
+        }
+    }
+    Err(BypassReason::UnmappedAbsolutePath(absolute))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -357,6 +395,13 @@ pub struct ActionContext {
     pub working_dir: PathBuf,
     pub path_mappings: Vec<PathMapping>,
     pub environment: BTreeMap<String, Option<String>>,
+    /// Environment inputs whose absolute values the compilation has been made
+    /// independent of, and whose values the key therefore normalizes.
+    ///
+    /// Naming one here is a claim about the compilation, not a preference: the
+    /// caller must both neutralize the value inside it (with
+    /// `--remap-path-prefix`) and confirm no output carries the value anyway.
+    pub portable_environment: BTreeSet<String>,
     pub inputs: Vec<ActionInput>,
 }
 
@@ -803,9 +848,7 @@ struct ActionBuilder<'a> {
 
 impl<'a> ActionBuilder<'a> {
     fn new(invocation: &'a RustcInvocation, mut context: ActionContext) -> Self {
-        context
-            .path_mappings
-            .sort_by_key(|mapping| std::cmp::Reverse(mapping.root.components().count()));
+        context.path_mappings = PathMapping::ordered(&context.path_mappings);
         Self {
             invocation,
             mappings: context.path_mappings.clone(),
@@ -816,9 +859,7 @@ impl<'a> ActionBuilder<'a> {
     fn build(self) -> Result<RustcAction, BypassReason> {
         self.validate_mappings()?;
         let invocation = self.invocation_descriptor()?;
-        // rustc may embed these values verbatim through `env!`; unlike paths
-        // used to locate inputs and outputs, changing them changes the artifact.
-        let environment = self.context.environment.clone();
+        let environment = self.environment_descriptor()?;
 
         let mut inputs = BTreeMap::<String, CacheDigest>::new();
         for input in &self.context.inputs {
@@ -952,24 +993,30 @@ impl<'a> ActionBuilder<'a> {
         }
     }
 
+    /// Environment values enter the key verbatim, because rustc may embed one
+    /// through `env!`: unlike a path used to locate an input, changing the value
+    /// changes the artifact.
+    ///
+    /// A name in `portable_environment` is the exception the caller has earned.
+    /// Its value normalizes like any other path, so two checkouts agree on it.
+    fn environment_descriptor(&self) -> Result<BTreeMap<String, Option<String>>, BypassReason> {
+        self.context
+            .environment
+            .iter()
+            .map(|(name, value)| {
+                let value = match value {
+                    Some(value) if self.context.portable_environment.contains(name) => {
+                        Some(self.normalize_path(Path::new(value))?)
+                    }
+                    value => value.clone(),
+                };
+                Ok((name.clone(), value))
+            })
+            .collect()
+    }
+
     fn normalize_path(&self, path: &Path) -> Result<String, BypassReason> {
-        let absolute = if path.is_absolute() {
-            normalize_components(path)
-        } else {
-            normalize_components(&self.context.working_dir.join(path))
-        };
-        for mapping in &self.mappings {
-            let root = normalize_components(&mapping.root);
-            if let Ok(relative) = absolute.strip_prefix(&root) {
-                let suffix = slash_path(relative)?;
-                return Ok(if suffix.is_empty() {
-                    format!("${{{}}}", mapping.placeholder)
-                } else {
-                    format!("${{{}}}/{suffix}", mapping.placeholder)
-                });
-            }
-        }
-        Err(BypassReason::UnmappedAbsolutePath(absolute))
+        normalize_mapped_path(path, &self.context.working_dir, &self.mappings)
     }
 }
 
@@ -1107,6 +1154,7 @@ mod tests {
                 PathMapping::new(sysroot(), "sysroot"),
             ],
             environment: BTreeMap::from([("CARGO_PKG_VERSION".into(), Some("1.0.0".into()))]),
+            portable_environment: BTreeSet::new(),
             inputs: inputs
                 .iter()
                 .map(|(path, contents)| ActionInput {
@@ -1331,6 +1379,7 @@ mod tests {
             working_dir: workspace.clone(),
             path_mappings: vec![PathMapping::new(&workspace, "workspace")],
             environment: BTreeMap::new(),
+            portable_environment: BTreeSet::new(),
             inputs: Vec::new(),
         };
         let dep_info = RustcDepInfo {
@@ -1405,6 +1454,87 @@ mod tests {
                 .unwrap();
         assert!(descriptor.contains(&expected), "{descriptor}");
         assert_ne!(first.digest, second.digest);
+    }
+
+    /// The counterpart to the test above. Naming `OUT_DIR` portable normalizes
+    /// its value like any other path, which is what lets two checkouts agree on
+    /// a compilation that reads it. The caller earns the claim by remapping the
+    /// value inside the compilation and reading the outputs; the key only
+    /// records that it was made.
+    #[test]
+    fn portable_environment_values_normalize_across_checkouts() {
+        let other = absolute(&["other", "checkout"]);
+        let output = other.join("target/debug/deps");
+        let relocated = RustcInvocation::parse(&[
+            "--crate-name=widget".into(),
+            "--edition=2024".into(),
+            "src/lib.rs".into(),
+            "--crate-type=lib".into(),
+            "--emit=dep-info,metadata,link".into(),
+            "-Cembed-bitcode=no".into(),
+            "-Cmetadata=abc123".into(),
+            format!("--out-dir={}", output.display()).into(),
+            format!("-Ldependency={}", output.display()).into(),
+            format!("--extern=serde={}", output.join("libserde.rlib").display()).into(),
+            format!("--sysroot={}", sysroot().display()).into(),
+            "--cap-lints=allow".into(),
+        ])
+        .unwrap();
+
+        let here = |portable: bool| {
+            let mut context = context(&[
+                ("src/lib.rs", "source"),
+                ("target/debug/deps/libserde.rlib", "serde"),
+            ]);
+            context.environment.insert(
+                "OUT_DIR".into(),
+                Some(
+                    workspace()
+                        .join("target/debug/build/widget/out")
+                        .display()
+                        .to_string(),
+                ),
+            );
+            if portable {
+                context.portable_environment.insert("OUT_DIR".into());
+            }
+            common_invocation().action(context).unwrap().digest
+        };
+        let there = |portable: bool| {
+            let mut context = context(&[]);
+            context.working_dir = other.clone();
+            context.path_mappings[0].root = other.join("target");
+            context.path_mappings[1].root = other.clone();
+            context.inputs = vec![
+                ActionInput {
+                    path: "src/lib.rs".into(),
+                    digest: digest("source"),
+                },
+                ActionInput {
+                    path: "target/debug/deps/libserde.rlib".into(),
+                    digest: digest("serde"),
+                },
+            ];
+            context.environment.insert(
+                "OUT_DIR".into(),
+                Some(
+                    other
+                        .join("target/debug/build/widget/out")
+                        .display()
+                        .to_string(),
+                ),
+            );
+            if portable {
+                context.portable_environment.insert("OUT_DIR".into());
+            }
+            relocated.action(context).unwrap().digest
+        };
+
+        assert_ne!(here(false), there(false));
+        assert_eq!(here(true), there(true));
+        // A different key, not a relabelled one: an artifact compiled without
+        // the remapping must never be restored under the portable key.
+        assert_ne!(here(false), here(true));
     }
 
     #[test]

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -19,6 +19,7 @@ struct ConfigFile {
     cache_dir: Option<PathBuf>,
     stats_report: Option<PathBuf>,
     incremental: Option<bool>,
+    share_out_dir: Option<bool>,
     remote: RemoteFile,
     http: HttpFile,
 }
@@ -50,6 +51,12 @@ pub struct Config {
     /// Let cargo compile workspace members incrementally, rather than forcing
     /// `CARGO_INCREMENTAL=0` for the whole build.
     pub incremental: bool,
+    /// Let a compilation that reads `OUT_DIR` be shared between checkouts.
+    ///
+    /// Off by default: it changes the compilation, remapping the generated
+    /// sources out of debug info, and its safety rests on reading the outputs
+    /// rather than on the inputs alone.
+    pub share_out_dir: bool,
     pub remote: RemoteSettings,
     pub http: HttpSettings,
 }
@@ -132,6 +139,10 @@ impl Config {
                 // there turns off what the file turned on.
                 Some(value) => enabled(&value),
                 None => file.incremental.unwrap_or(false),
+            },
+            share_out_dir: match get_env("MBX_SHARE_OUT_DIR") {
+                Some(value) => enabled(&value),
+                None => file.share_out_dir.unwrap_or(false),
             },
             remote: RemoteSettings {
                 url: get_env("MBX_REMOTE_URL").or(file.remote.url),

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -6,7 +6,7 @@ use mbx_cache_core::{
 };
 use mbx_cache_rustc::{
     ActionContext, CompilerIdentity, DiscoveredInputs, PathMapping, RustcAction, RustcDepInfo,
-    RustcInputPrediction, RustcInvocation, RustcOutputs,
+    RustcInputPrediction, RustcInvocation, RustcOutputs, normalize_mapped_path,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -36,21 +36,35 @@ struct StagedOutputs {
 }
 
 pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
-    let invocation = RustcInvocation::parse(arguments)?;
     let working_dir = std::env::current_dir()?;
+    let portable = Portable::detect(&working_dir);
+    let arguments = portable.applied_to(arguments);
+    let invocation = RustcInvocation::parse(&arguments)?;
     let outputs = invocation.outputs(&working_dir)?;
 
     let verify = session::verify_requested();
     let mut verification = None;
     let mut action_lookup_attempted = false;
     if outputs.dep_info.is_file()
-        && let Ok((action, discovered)) =
-            action_from_current_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)
+        && let Ok((candidates, discovered)) = action_from_current_dep_info(
+            rustc,
+            &invocation,
+            &outputs.dep_info,
+            &working_dir,
+            &portable,
+        )
     {
         action_lookup_attempted = true;
-        match restore_result(&action, &outputs, &discovered, !verify) {
-            Ok(Some(cached)) => {
-                record_prediction(rustc, &invocation, &action, &discovered, &working_dir);
+        match restore_candidates(&candidates, &outputs, &discovered, !verify) {
+            Ok(Some((action, cached))) => {
+                record_prediction(
+                    rustc,
+                    &invocation,
+                    &action,
+                    &discovered,
+                    &working_dir,
+                    &portable,
+                );
                 if verify {
                     verification = Some(cached);
                 } else {
@@ -65,7 +79,14 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
         }
     }
     if !action_lookup_attempted {
-        match restore_predicted_result(rustc, &invocation, &outputs, &working_dir, !verify) {
+        match restore_predicted_result(
+            rustc,
+            &invocation,
+            &outputs,
+            &working_dir,
+            &portable,
+            !verify,
+        ) {
             Ok(Some(cached)) => {
                 if verify {
                     verification = Some(cached);
@@ -83,7 +104,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
 
     let compilation_started = SystemTime::now();
     let output = Command::new(rustc)
-        .args(arguments)
+        .args(&arguments)
         .current_dir(&working_dir)
         .output()
         .wrap_err("failed to execute rustc")?;
@@ -98,14 +119,27 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     }
     if output.status.success() {
         let publication: Result<()> = (|| {
-            let (action, discovered) =
-                action_from_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)?;
+            let (candidates, discovered) = action_from_dep_info(
+                rustc,
+                &invocation,
+                &outputs.dep_info,
+                &working_dir,
+                &portable,
+            )?;
             discovered.verify_not_modified_since(compilation_started)?;
             discovered.verify()?;
             let mut cacheable_outputs = outputs.files.clone();
             cacheable_outputs.push(outputs.dep_info.clone());
+            let action = candidates.publishable(&portable, &outputs.files)?;
             publish_result(&action.digest, &action.bytes, &cacheable_outputs, &output)?;
-            record_prediction(rustc, &invocation, &action, &discovered, &working_dir);
+            record_prediction(
+                rustc,
+                &invocation,
+                &action.digest,
+                &discovered,
+                &working_dir,
+                &portable,
+            );
             Ok(())
         })();
         if let Err(error) = publication {
@@ -120,11 +154,12 @@ fn restore_predicted_result(
     invocation: &RustcInvocation,
     outputs: &RustcOutputs,
     working_dir: &Path,
+    portable: &Portable,
     restore_outputs: bool,
 ) -> Result<Option<CachedCompilation>> {
     let task = std::env::var(session::BUILD_ENV)
         .wrap_err_with(|| format!("{} is not set", session::BUILD_ENV))?;
-    let mut context = base_action_context(rustc, working_dir)?;
+    let mut context = base_action_context(rustc, working_dir, portable)?;
     let invocation_digest = invocation.invocation_digest(&context)?;
     let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
         task,
@@ -159,12 +194,86 @@ fn restore_predicted_result(
     }
     let discovered = input_prediction.discover(working_dir, &context.path_mappings)?;
     discovered.clone().apply_to(&mut context)?;
-    let action = invocation.action(context)?;
-    let restored = restore_result(&action, outputs, &discovered, restore_outputs)?;
-    if restored.is_some() {
-        record_prediction_value(invocation_digest, action.digest.clone(), prediction.payload);
+    let candidates = ActionCandidates::build(invocation, context)?;
+    let restored = restore_candidates(&candidates, outputs, &discovered, restore_outputs)?;
+    match restored {
+        Some((action, cached)) => {
+            record_prediction_value(invocation_digest, action, prediction.payload);
+            Ok(Some(cached))
+        }
+        None => Ok(None),
     }
-    Ok(restored)
+}
+
+/// The keys one compilation may be published under, most portable first.
+///
+/// A compilation whose environment holds nothing portable has exactly one key,
+/// the literal one, which is what every action looked like before
+/// [`Portable`] existed.
+struct ActionCandidates {
+    /// Normalizes the portable environment values, so two checkouts agree.
+    portable: Option<RustcAction>,
+    /// What the compilation falls back to when an output carries one of those
+    /// values anyway.
+    literal: RustcAction,
+}
+
+impl ActionCandidates {
+    fn build(invocation: &RustcInvocation, context: ActionContext) -> Result<Self> {
+        // Only worth a second key if a portable name is actually an input here.
+        // Crates that never read one keep the key they always had.
+        let applies = context
+            .portable_environment
+            .iter()
+            .any(|name| context.environment.contains_key(name));
+        let literal_context = ActionContext {
+            portable_environment: BTreeSet::new(),
+            ..context.clone()
+        };
+        Ok(Self {
+            portable: applies.then(|| invocation.action(context)).transpose()?,
+            literal: invocation.action(literal_context)?,
+        })
+    }
+
+    /// The key this compilation is published under.
+    ///
+    /// The portable key is only honest if no output carries the value it
+    /// normalized away. `--remap-path-prefix` covers the paths rustc records
+    /// itself, but not one a crate reads through `env!` and keeps as a string,
+    /// and nothing in the inputs distinguishes the two shapes -- so the outputs
+    /// are read.
+    fn publishable(&self, portable: &Portable, outputs: &[PathBuf]) -> Result<&RustcAction> {
+        match &self.portable {
+            Some(action) if portable.outputs_are_clean(outputs)? => Ok(action),
+            _ => Ok(&self.literal),
+        }
+    }
+
+    /// Every key to look up, most portable first.
+    fn ordered(&self) -> impl Iterator<Item = &RustcAction> {
+        self.portable.iter().chain(std::iter::once(&self.literal))
+    }
+}
+
+/// Try each candidate key, returning the digest that hit alongside its result.
+///
+/// Both keys are tried because either shape may be on the other side of the
+/// lookup: a crate that keeps `OUT_DIR` in a string was published literally,
+/// and without the second lookup it would never hit, not even in the checkout
+/// that compiled it.
+fn restore_candidates(
+    candidates: &ActionCandidates,
+    outputs: &RustcOutputs,
+    discovered: &DiscoveredInputs,
+    restore_outputs: bool,
+) -> Result<Option<(CacheDigest, CachedCompilation)>> {
+    for action in candidates.ordered() {
+        if let Some(cached) = restore_result(action, outputs, discovered, restore_outputs)? {
+            return Ok(Some((action.digest.clone(), cached)));
+        }
+    }
+    Ok(None)
 }
 
 fn action_from_dep_info(
@@ -172,9 +281,10 @@ fn action_from_dep_info(
     invocation: &RustcInvocation,
     dep_info: &Path,
     working_dir: &Path,
-) -> Result<(RustcAction, DiscoveredInputs)> {
+    portable: &Portable,
+) -> Result<(ActionCandidates, DiscoveredInputs)> {
     let dep_info = RustcDepInfo::read(dep_info)?;
-    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir)
+    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir, portable)
 }
 
 fn action_from_current_dep_info(
@@ -182,10 +292,11 @@ fn action_from_current_dep_info(
     invocation: &RustcInvocation,
     dep_info: &Path,
     working_dir: &Path,
-) -> Result<(RustcAction, DiscoveredInputs)> {
+    portable: &Portable,
+) -> Result<(ActionCandidates, DiscoveredInputs)> {
     let dep_info = RustcDepInfo::read(dep_info)?;
     verify_environment(&dep_info.environment)?;
-    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir)
+    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir, portable)
 }
 
 fn action_from_parsed_dep_info(
@@ -193,20 +304,26 @@ fn action_from_parsed_dep_info(
     invocation: &RustcInvocation,
     dep_info: &RustcDepInfo,
     working_dir: &Path,
-) -> Result<(RustcAction, DiscoveredInputs)> {
+    portable: &Portable,
+) -> Result<(ActionCandidates, DiscoveredInputs)> {
     let discovered = invocation.discover_inputs(dep_info, working_dir)?;
-    let mut context = base_action_context(rustc, working_dir)?;
+    let mut context = base_action_context(rustc, working_dir, portable)?;
     discovered.clone().apply_to(&mut context)?;
-    let action = invocation.action(context)?;
-    Ok((action, discovered))
+    let candidates = ActionCandidates::build(invocation, context)?;
+    Ok((candidates, discovered))
 }
 
-fn base_action_context(rustc: &OsStr, working_dir: &Path) -> Result<ActionContext> {
+fn base_action_context(
+    rustc: &OsStr,
+    working_dir: &Path,
+    portable: &Portable,
+) -> Result<ActionContext> {
     Ok(ActionContext {
         compiler: compiler_identity(rustc)?,
         working_dir: working_dir.to_path_buf(),
-        path_mappings: path_mappings(working_dir),
+        path_mappings: portable.mappings.clone(),
         environment: BTreeMap::new(),
+        portable_environment: portable.names.clone(),
         inputs: Vec::new(),
     })
 }
@@ -214,16 +331,17 @@ fn base_action_context(rustc: &OsStr, working_dir: &Path) -> Result<ActionContex
 fn record_prediction(
     rustc: &OsStr,
     invocation: &RustcInvocation,
-    action: &RustcAction,
+    action: &CacheDigest,
     discovered: &DiscoveredInputs,
     working_dir: &Path,
+    portable: &Portable,
 ) {
     let result = (|| {
-        let context = base_action_context(rustc, working_dir)?;
+        let context = base_action_context(rustc, working_dir, portable)?;
         let invocation_digest = invocation.invocation_digest(&context)?;
         let prediction = invocation.prediction(&context, discovered)?;
         let payload = String::from_utf8(canonical_json(&prediction)?)?;
-        record_prediction_value(invocation_digest, action.digest.clone(), payload);
+        record_prediction_value(invocation_digest, action.clone(), payload);
         Result::<()>::Ok(())
     })();
     if let Err(error) = result {
@@ -655,6 +773,129 @@ fn identity_field<'a>(verbose: &'a str, field: &str) -> Result<&'a str> {
         .ok_or_else(|| eyre::eyre!("rustc identity is missing {field}"))
 }
 
+/// Environment inputs eligible for remapping.
+///
+/// Deliberately just the one. `OUT_DIR` lives under the target directory, so
+/// remapping it confines the change to generated sources, and it is the value
+/// the plan identifies as the cross-checkout shortfall. Widening this list
+/// widens which paths disappear from debug info, which is its own decision.
+const PORTABLE_ENVIRONMENT: &[&str] = &["OUT_DIR"];
+
+/// The environment values whose absolute paths this compilation was made
+/// independent of.
+///
+/// `OUT_DIR` is the one that matters: every crate that includes build-script
+/// output reads it, its value differs per checkout, and keeping it in the key
+/// verbatim is what stops those compilations sharing between checkouts.
+///
+/// Two things must hold before a key may normalize such a value, and this type
+/// is responsible for both. `--remap-path-prefix` makes rustc record the
+/// placeholder instead of the real path, which covers debug info, spans, and
+/// diagnostics -- everything rustc writes itself. It does not cover a value the
+/// crate reads through `env!` and keeps as a string, so the outputs are read
+/// before publishing and the portable key is used only if none carries it.
+struct Portable {
+    /// Path mappings for this compilation, ordered as keys need them.
+    mappings: Vec<PathMapping>,
+    /// Flags appended to the real rustc invocation, one per remapped value.
+    arguments: Vec<OsString>,
+    /// Names whose values an action key may normalize.
+    names: BTreeSet<String>,
+    /// The literal values, for the check before publishing.
+    values: Vec<String>,
+}
+
+impl Portable {
+    fn detect(working_dir: &Path) -> Self {
+        let mut portable = Self {
+            mappings: PathMapping::ordered(&path_mappings(working_dir)),
+            arguments: Vec::new(),
+            names: BTreeSet::new(),
+            values: Vec::new(),
+        };
+        if !session::share_out_dir_requested() {
+            return portable;
+        }
+        for name in PORTABLE_ENVIRONMENT {
+            let Some(value) = std::env::var(name)
+                .ok()
+                .filter(|value| Path::new(value).is_absolute())
+            else {
+                continue;
+            };
+            // A value under no known root is one no key could agree on anyway,
+            // so there is nothing to remap and nothing to promise.
+            let Ok(placeholder) =
+                normalize_mapped_path(Path::new(&value), working_dir, &portable.mappings)
+            else {
+                continue;
+            };
+            let mut flag = OsString::from("--remap-path-prefix=");
+            flag.push(&value);
+            flag.push("=");
+            flag.push(&placeholder);
+            portable.arguments.push(flag);
+            portable.names.insert((*name).to_string());
+            portable.values.push(value);
+        }
+        portable
+    }
+
+    /// The compiler arguments, with the remapping flags appended.
+    fn applied_to(&self, arguments: &[OsString]) -> Vec<OsString> {
+        let mut applied = arguments.to_vec();
+        applied.extend(self.arguments.iter().cloned());
+        applied
+    }
+
+    /// Whether the outputs are free of every value a portable key normalized.
+    ///
+    /// The dep-info file is not one of them: it records absolute input paths by
+    /// construction, and is restored as written for every action that already
+    /// shares across checkouts today. Judging the artifact by it would reject
+    /// every compilation.
+    fn outputs_are_clean(&self, outputs: &[PathBuf]) -> Result<bool> {
+        if self.values.is_empty() {
+            return Ok(false);
+        }
+        for output in outputs {
+            let contents = std::fs::read(output)
+                .wrap_err_with(|| format!("failed to read rustc output {}", output.display()))?;
+            if self.values.iter().any(|value| carries(&contents, value)) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+}
+
+/// Whether `contents` holds `value` anywhere, in either separator spelling.
+///
+/// rustc writes paths with the platform separator in some places and forward
+/// slashes in others, and a value missed here becomes a wrong answer rather
+/// than a slow one, so both spellings are searched.
+fn carries(contents: &[u8], value: &str) -> bool {
+    if contains(contents, value.as_bytes()) {
+        return true;
+    }
+    value.contains('\\') && contains(contents, value.replace('\\', "/").as_bytes())
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    let Some((first, rest)) = needle.split_first() else {
+        return false;
+    };
+    let mut offset = 0;
+    while let Some(index) = haystack[offset..].iter().position(|byte| byte == first) {
+        let start = offset + index;
+        if haystack[start + 1..].starts_with(rest) {
+            return true;
+        }
+        offset = start + 1;
+    }
+    false
+}
+
 fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     let mut roots = BTreeSet::new();
@@ -907,6 +1148,65 @@ fn exit_code(status: ExitStatus) -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn portable_for(values: &[&str]) -> Portable {
+        Portable {
+            mappings: Vec::new(),
+            arguments: Vec::new(),
+            names: values.iter().map(|_| "OUT_DIR".to_string()).collect(),
+            values: values.iter().map(|value| (*value).to_string()).collect(),
+        }
+    }
+
+    /// `--remap-path-prefix` covers the paths rustc writes itself, so most
+    /// artifacts come out clean. A crate that keeps the value as a string does
+    /// not, and that is the case the outputs are read to catch.
+    #[test]
+    fn an_output_carrying_a_normalized_value_is_not_portable() {
+        let root = tempfile::tempdir().unwrap();
+        let out_dir = "/checkout/target/debug/build/widget-abc/out";
+        let clean = root.path().join("clean.rlib");
+        std::fs::write(
+            &clean,
+            b"rustc output naming ${target}/debug/build/widget-abc/out",
+        )
+        .unwrap();
+        let carries = root.path().join("carries.rlib");
+        std::fs::write(&carries, format!("compiled in {out_dir} at some offset")).unwrap();
+
+        let portable = portable_for(&[out_dir]);
+        assert!(
+            portable
+                .outputs_are_clean(std::slice::from_ref(&clean))
+                .unwrap()
+        );
+        assert!(
+            !portable
+                .outputs_are_clean(std::slice::from_ref(&carries))
+                .unwrap()
+        );
+        // One dirty output is enough: the artifact is published as a set.
+        assert!(!portable.outputs_are_clean(&[clean, carries]).unwrap());
+    }
+
+    /// Nothing was made portable, so there is no portable key to publish under
+    /// and no claim to check.
+    #[test]
+    fn nothing_portable_is_never_clean() {
+        assert!(!portable_for(&[]).outputs_are_clean(&[]).unwrap());
+    }
+
+    #[test]
+    fn a_value_is_found_at_any_offset_and_in_either_spelling() {
+        assert!(carries(b"/a/b", "/a/b"));
+        assert!(carries(b"...../a/b.....", "/a/b"));
+        assert!(carries(b"/a/a/b", "/a/b"));
+        assert!(!carries(b"/a/", "/a/b"));
+        assert!(!carries(b"", "/a/b"));
+        // A Windows value may have been written with forward slashes.
+        assert!(carries(b"c:/a/b", "c:\\a\\b"));
+        assert!(!carries(b"c:/a/c", "c:\\a\\b"));
+    }
 
     fn staged_outputs(root: &Path, entries: Vec<(&[u8], PathBuf)>) -> StagedOutputs {
         let directory = tempfile::tempdir_in(root).unwrap();

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -27,6 +27,7 @@ const SOCKET_ENV: &str = "MBX_SOCKET";
 pub(crate) const STAGING_ENV: &str = "MBX_STAGING_DIR";
 pub(crate) const BUILD_ENV: &str = "MBX_BUILD";
 pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
+pub(crate) const SHARE_OUT_DIR_ENV: &str = "MBX_SHARE_OUT_DIR";
 pub(crate) const WORKSPACE_ROOT_ENV: &str = "MBX_WORKSPACE_ROOT";
 pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
@@ -41,6 +42,7 @@ pub struct CacheSession {
     staging: PathBuf,
     verify: bool,
     incremental: bool,
+    share_out_dir: bool,
     agent: CacheAgent,
     started: Instant,
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
@@ -70,6 +72,7 @@ impl CacheSession {
             staging,
             verify: config.verify,
             incremental: config.incremental,
+            share_out_dir: config.share_out_dir,
             agent,
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),
@@ -127,6 +130,10 @@ impl CacheSession {
         environment.insert(
             VERIFY_ENV.into(),
             if self.verify { "1" } else { "0" }.into(),
+        );
+        environment.insert(
+            SHARE_OUT_DIR_ENV.into(),
+            if self.share_out_dir { "1" } else { "0" }.into(),
         );
         if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), shim.clone())
             && previous != shim
@@ -799,6 +806,12 @@ pub(crate) fn verify_requested() -> bool {
     std::env::var_os(VERIFY_ENV).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
+/// Whether the shim may make a compilation independent of its `OUT_DIR` so two
+/// checkouts can share it. Read the same way as verify mode.
+pub(crate) fn share_out_dir_requested() -> bool {
+    std::env::var_os(SHARE_OUT_DIR_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
 /// Tell the session that this compilation was not cacheable.
 ///
 /// Bypasses never reach the agent otherwise, so without this they are invisible
@@ -989,6 +1002,7 @@ mod tests {
             stats_report: None,
             verify: false,
             incremental: false,
+            share_out_dir: false,
             remote: Default::default(),
             http: Default::default(),
         }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -61,7 +61,10 @@ fn build_with(
         // job, so leaving it would make this suite pass locally and fail in CI.
         .env_remove("MBX_INCREMENTAL")
         .env_remove("CARGO_INCREMENTAL")
-        .env_remove("CI");
+        .env_remove("CI")
+        // Same reason: a test asserting the default cross-checkout behaviour
+        // must not read an answer out of the developer's environment.
+        .env_remove("MBX_SHARE_OUT_DIR");
     for (name, value) in settings {
         command.env(name, value);
     }
@@ -203,9 +206,21 @@ fn a_second_checkout_starts_warm() {
     );
 }
 
-/// Write a fixture whose build script generates code, optionally exposing
-/// `OUT_DIR` to the compilation.
-fn write_generated_project(directory: &Path, consume_out_dir: bool) {
+/// How a fixture's library uses its build script's output.
+#[derive(Clone, Copy)]
+enum Generated {
+    /// A cfg only, so the compilation never reads `OUT_DIR`.
+    Cfg,
+    /// Includes the generated file. `OUT_DIR` becomes an input, but only rustc
+    /// records the path, so `--remap-path-prefix` can take it back out.
+    Include,
+    /// Keeps `OUT_DIR` in a string constant. That lands in the artifact itself,
+    /// where no remapping reaches it.
+    Text,
+}
+
+/// Write a fixture whose build script generates code, used as `generated` says.
+fn write_generated_project(directory: &Path, generated: Generated) {
     std::fs::create_dir_all(directory.join("src")).unwrap();
     std::fs::write(
         directory.join("Cargo.toml"),
@@ -217,10 +232,18 @@ fn write_generated_project(directory: &Path, consume_out_dir: bool) {
         "use std::{env, fs, path::PathBuf};\n         fn main() {\n         \u{20}   let out = PathBuf::from(env::var(\"OUT_DIR\").unwrap());\n         \u{20}   fs::write(out.join(\"generated.rs\"), \"pub const VALUE: u32 = 7;\\n\").unwrap();\n         \u{20}   println!(\"cargo:rustc-cfg=generated\");\n         }\n",
     )
     .unwrap();
-    let lib = if consume_out_dir {
-        "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\npub fn value() -> u32 { VALUE }\n"
-    } else {
-        "#[cfg(generated)]\npub fn value() -> u32 { 7 }\n"
+    let lib = match generated {
+        Generated::Cfg => "#[cfg(generated)]\npub fn value() -> u32 { 7 }\n".to_string(),
+        Generated::Include => {
+            "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\npub fn value() -> u32 { VALUE }\n"
+                .to_string()
+        }
+        Generated::Text => {
+            "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\n\
+             pub const WHERE: &str = env!(\"OUT_DIR\");\n\
+             pub fn value() -> u32 { VALUE }\n"
+                .to_string()
+        }
     };
     std::fs::write(directory.join("src/lib.rs"), lib).unwrap();
     let status = Command::new(cargo())
@@ -236,31 +259,57 @@ fn write_generated_project(directory: &Path, consume_out_dir: bool) {
 /// and could bake into the artifact.
 #[test]
 fn out_dir_decides_whether_two_checkouts_share() {
-    for (consume_out_dir, expect_hits) in [(false, true), (true, false)] {
-        let store = tempfile::tempdir().unwrap();
-        let first = tempfile::tempdir().unwrap();
-        let second = tempfile::tempdir().unwrap();
-        let reports = tempfile::tempdir().unwrap();
-        write_generated_project(first.path(), consume_out_dir);
-        write_generated_project(second.path(), consume_out_dir);
-
-        build(
-            first.path(),
-            store.path(),
-            &reports.path().join("first.json"),
-        );
-        let stats = build(
-            second.path(),
-            store.path(),
-            &reports.path().join("second.json"),
-        );
-
+    for (generated, expect_hits) in [(Generated::Cfg, true), (Generated::Include, false)] {
         assert_eq!(
-            count(&stats, "hits") > 0,
+            two_checkouts_share(generated, &[]),
             expect_hits,
-            "consume_out_dir={consume_out_dir} gave {stats}"
+            "the default should not share a compilation that reads OUT_DIR"
         );
     }
+}
+
+/// With sharing on, the compilation is remapped so rustc records the
+/// placeholder instead of the real `OUT_DIR`, and the include-only shape crosses
+/// checkouts. The shape that keeps the value in a string still does not: the
+/// remapping cannot reach into the artifact, and mbx reads the outputs rather
+/// than assuming it can.
+///
+/// The pair is the test. Either half alone would pass for the wrong reason.
+#[test]
+fn sharing_out_dir_crosses_checkouts_only_where_the_artifact_allows_it() {
+    let sharing = [("MBX_SHARE_OUT_DIR", "1")];
+    for (generated, expect_hits) in [(Generated::Include, true), (Generated::Text, false)] {
+        assert_eq!(
+            two_checkouts_share(generated, &sharing),
+            expect_hits,
+            "sharing changed the wrong shape"
+        );
+    }
+}
+
+/// Build the same fixture in two checkouts, reporting whether the second one
+/// reused anything from the first.
+fn two_checkouts_share(generated: Generated, settings: &[(&str, &str)]) -> bool {
+    let store = tempfile::tempdir().unwrap();
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_generated_project(first.path(), generated);
+    write_generated_project(second.path(), generated);
+
+    build_with(
+        first.path(),
+        store.path(),
+        &reports.path().join("first.json"),
+        settings,
+    );
+    let stats = build_with(
+        second.path(),
+        store.path(),
+        &reports.path().join("second.json"),
+        settings,
+    );
+    count(&stats, "hits") > 0
 }
 
 #[test]


### PR DESCRIPTION
A crate that includes build-script output takes `OUT_DIR` as an input. Its value differs per checkout, so those compilations have never shared — the shortfall behind mbx's cross-checkout hit rate. [PLAN.md](PLAN.md) declined to normalize the value because a crate may bake the path into its artifact, and no *input* distinguishes one that does from one that does not.

## What the measurement changed

I started with the obvious guard: compile, read the outputs, and share only when the path is absent. That does not work. The path is in **every** artifact of such a crate — rlib and rmeta, debug and release — because rustc records the included file's source path. A probe alone refuses essentially every compilation, so the inputs were never the missing piece.

Making the compilation independent of the value does work. `--remap-path-prefix=$OUT_DIR=${target}/…` removes every occurrence, and the resulting dependency artifact is identical across checkouts apart from rustc's own per-run CGU naming.

But remap alone is also not enough: rustc does not remap `env!()`, so a crate that keeps `env!("OUT_DIR")` in a string constant still ships the real path in `.rodata`.

So this does both, and needs both:

- **Remap.** The shim appends `--remap-path-prefix` so rustc records the cache placeholder wherever it records a path itself, and the action key normalizes the value like any other path.
- **Read the outputs.** Before publishing, the artifacts are scanned for the literal value. One that carries it keeps its own checkout's key.

Both keys are looked up, most portable first — otherwise a crate of the second shape would never hit at all, not even in the checkout that compiled it.

Two things the design depends on, both confirmed rather than assumed: `--remap-path-prefix` does not rewrite dep-info, so input discovery still works; and cargo's build-dir hash inside `OUT_DIR` is stable across checkouts, so the normalized value actually matches.

## Result

On this repository's own graph (285 crates), a second checkout hit **139 of the 147** compilations it looked up by default, and **all 147** with the option on. No dep artifact in the second checkout carries the first's path; the shared crates carry `${target}/debug/build/…` as intended.

`MBX_SHARE_OUT_DIR` is **off by default**. It changes what the build produces — generated sources appear in debug info as a placeholder rather than a path a debugger can open — and it does not cover a value a crate *derives* from `OUT_DIR` rather than embedding (its length, a hash of it), which reading the outputs cannot see. All 58 pre-existing tests pass unchanged, so the default path is byte-identical.

## Tests

`sharing_out_dir_crosses_checkouts_only_where_the_artifact_allows_it` is the paired case: with sharing on, the `include!` shape crosses checkouts and the string-keeping shape still does not. Either half alone would pass for the wrong reason.

## Noted, not fixed

Verify mode could not qualify this, and the reason predates it: `MBX_VERIFY=1` already diverges on every cross-checkout restore of a **workspace member**, with the flag off. Cargo compiles members in place, so each checkout's artifact records its own source path, and the cache serves one checkout's bytes to the other — the same hazard the plan cites as the reason not to normalize `OUT_DIR`, already accepted for `${workspace}`. Written up under future work; flipping this option's default should probably wait on it, since the canary cannot currently certify cross-checkout sharing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache identity and, when enabled, the compiler invocation and which artifacts are restored across checkouts. Default-off plus an output scan limits blast radius, but a missed embedded path would still be a wrong restore.
> 
> **Overview**
> Adds opt-in `MBX_SHARE_OUT_DIR` so crates that consume `OUT_DIR` (typically via `include!(concat!(env!("OUT_DIR"), …))`) can share rustc artifacts across checkouts. Default stays off: remapping generated sources into debug info as `${target}/…` changes what the build produces, and derived values (length/hash of `OUT_DIR`) still cannot be detected.
> 
> When enabled, the shim appends `--remap-path-prefix` so rustc records the cache placeholder, and action keys may normalize `OUT_DIR` like any other mapped path. Before publish, outputs are scanned for the literal value; if it is still embedded (e.g. `env!("OUT_DIR")` in a string), the compilation keeps the checkout-specific key. Lookups try the portable key first, then the literal one, so both shapes still hit.
> 
> Documents the residual verify-mode gap (workspace members already fail byte-for-byte across checkouts) and gates turning the option on by default on that canary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4121f7faa1766cec12dfb6015c8d82029d67e3d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in `MBX_SHARE_OUT_DIR` support to share eligible compilation artifacts across checkouts.
  * Added path remapping and output validation to prevent publishing artifacts containing checkout-specific paths.
  * Sharing remains disabled by default.

* **Documentation**
  * Documented configuration, limitations, cache-hit results, and planned verification improvements.

* **Bug Fixes**
  * Improved handling of portable environment values and path mappings during cache lookup and publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->