### PR TITLE
feat(cache-core): compress remote transfers with zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +296,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "const-oid"
@@ -1115,6 +1144,7 @@ dependencies = [
 name = "mbx-cache-core"
 version = "0.1.0"
 dependencies = [
+ "async-compression",
  "base64 0.23.1",
  "blake3",
  "eyre",
@@ -1135,6 +1165,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "zstd",
 ]
 
 [[package]]
@@ -2172,12 +2203,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2764,3 +2800,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -17,9 +17,14 @@ hex = "0.4"
 log = "0.4"
 rand = "0.10"
 reflink-copy = "0.1"
+async-compression = { version = "0.4", default-features = false, features = [
+  "tokio",
+  "zstd",
+] }
 reqwest = { version = "0.13", default-features = false, features = [
   "json",
   "stream",
+  "zstd",
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -33,6 +38,7 @@ url = "2"
 
 [dev-dependencies]
 mockito = "1"
+zstd = "0.13"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 
 [features]

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -4,8 +4,8 @@ use futures_util::TryStreamExt as _;
 use log::warn;
 use reqwest::StatusCode;
 use reqwest::header::{
-    ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, ETAG, HeaderMap, HeaderValue, IF_MATCH,
-    IF_NONE_MATCH,
+    ACCEPT, AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, ETAG, HeaderMap,
+    HeaderValue, IF_MATCH, IF_NONE_MATCH,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
@@ -375,6 +375,10 @@ struct RemoteCacheCapabilities {
     features: CapabilityFeatures,
     #[serde(default)]
     limits: CapabilityLimits,
+    /// Content codings the server accepts and produces; always includes
+    /// `identity`, and compression is used only when `zstd` is offered.
+    #[serde(default)]
+    compressors: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -402,6 +406,17 @@ struct BlobPackLimits {
     max_bytes: u64,
 }
 
+/// What one capabilities exchange settled, cached for the session.
+///
+/// `Default` is also the answer for a server with no capabilities endpoint:
+/// no blob packs and no compression, which is exactly how every request
+/// behaved before either feature existed.
+#[derive(Debug, Clone, Copy, Default)]
+struct NegotiatedCapabilities {
+    blob_packs: Option<BlobPackLimits>,
+    zstd_uploads: bool,
+}
+
 #[derive(Serialize)]
 struct DigestList<'a> {
     digests: &'a [CacheDigest],
@@ -420,7 +435,7 @@ pub struct RemoteCacheClient {
     credential: RemoteCacheCredential,
     download_timeout: Duration,
     retries: i64,
-    capabilities: tokio::sync::OnceCell<Option<BlobPackLimits>>,
+    capabilities: tokio::sync::OnceCell<NegotiatedCapabilities>,
     blob_packs_disabled: AtomicBool,
 }
 
@@ -516,6 +531,10 @@ impl RemoteCacheClient {
     }
 
     async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
+        Ok(self.negotiated_capabilities().await?.blob_packs)
+    }
+
+    async fn negotiated_capabilities(&self) -> Result<NegotiatedCapabilities> {
         self.capabilities
             .get_or_try_init(|| async {
                 let url = self.capabilities_endpoint()?;
@@ -530,7 +549,7 @@ impl RemoteCacheClient {
                         | StatusCode::METHOD_NOT_ALLOWED
                         | StatusCode::NOT_IMPLEMENTED
                 ) {
-                    return Ok(None);
+                    return Ok(NegotiatedCapabilities::default());
                 }
                 let bytes =
                     read_bounded_json(response.error_for_status()?, "capabilities").await?;
@@ -541,25 +560,39 @@ impl RemoteCacheClient {
                         capabilities.protocol.major
                     );
                 }
-                if !capabilities.features.blob_packs {
-                    return Ok(None);
-                }
-                let max_items = usize::try_from(capabilities.limits.max_batch_items)
-                    .ok()
-                    .filter(|limit| *limit > 0)
-                    .ok_or_else(|| {
-                        eyre!("remote cache blob packs require a positive max_batch_items limit")
-                    })?;
-                if capabilities.limits.max_pack_bytes == 0 {
-                    bail!("remote cache blob packs require a positive max_pack_bytes limit");
-                }
-                Ok(Some(BlobPackLimits {
-                    max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
-                    max_bytes: capabilities
-                        .limits
-                        .max_pack_bytes
-                        .min(MAX_STAGED_BLOB_PACK_BYTES),
-                }))
+                // Compression is negotiated, never assumed: a body sent with a
+                // coding the server did not offer would be stored corrupt or
+                // rejected, so absence of the advertisement means identity.
+                let zstd_uploads = capabilities
+                    .compressors
+                    .iter()
+                    .any(|compressor| compressor == "zstd");
+                let blob_packs = if capabilities.features.blob_packs {
+                    let max_items = usize::try_from(capabilities.limits.max_batch_items)
+                        .ok()
+                        .filter(|limit| *limit > 0)
+                        .ok_or_else(|| {
+                            eyre!(
+                                "remote cache blob packs require a positive max_batch_items limit"
+                            )
+                        })?;
+                    if capabilities.limits.max_pack_bytes == 0 {
+                        bail!("remote cache blob packs require a positive max_pack_bytes limit");
+                    }
+                    Some(BlobPackLimits {
+                        max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
+                        max_bytes: capabilities
+                            .limits
+                            .max_pack_bytes
+                            .min(MAX_STAGED_BLOB_PACK_BYTES),
+                    })
+                } else {
+                    None
+                };
+                Ok(NegotiatedCapabilities {
+                    blob_packs,
+                    zstd_uploads,
+                })
             })
             .await
             .copied()
@@ -835,33 +868,59 @@ impl RemoteCacheClient {
 
     pub async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
         let url = self.blob_endpoint(&upload.digest)?;
+        // A failed negotiation downgrades to identity rather than failing the
+        // upload: compression is an economy, not a requirement.
+        let compress = self
+            .negotiated_capabilities()
+            .await
+            .map(|capabilities| capabilities.zstd_uploads)
+            .unwrap_or(false);
         retry_async("PUT", &url, self.retries, || async {
-            let (length, body) = match &upload.source {
-                BlobSource::Bytes(bytes) => {
-                    (bytes.len() as u64, reqwest::Body::from(bytes.clone()))
-                }
-                BlobSource::File(file) => {
-                    let file = tokio::fs::File::open(file.path()).await?;
-                    let length = file.metadata().await?.len();
-                    let stream = tokio_util::io::ReaderStream::new(file);
-                    (length, reqwest::Body::wrap_stream(stream))
-                }
-                BlobSource::Path(path) => {
-                    let file = tokio::fs::File::open(path).await?;
-                    let length = file.metadata().await?.len();
-                    let stream = tokio_util::io::ReaderStream::new(file);
-                    (length, reqwest::Body::wrap_stream(stream))
-                }
-            };
-            let response = self
+            let request = self
                 .request(reqwest::Method::PUT, url.clone(), BLOB_MEDIA_TYPE)
                 .await?
                 .header(CONTENT_TYPE, BLOB_MEDIA_TYPE)
-                .header(CONTENT_LENGTH, length)
-                .header(IF_NONE_MATCH, "*")
-                .body(body)
-                .send()
-                .await?;
+                .header(IF_NONE_MATCH, "*");
+            let request = if compress {
+                // Compressed and therefore chunked: the length of the encoded
+                // stream is not known up front, and the digest already tells
+                // the server the decompressed size it must enforce.
+                let reader: Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin> = match &upload
+                    .source
+                {
+                    BlobSource::Bytes(bytes) => Box::new(std::io::Cursor::new(bytes.clone())),
+                    BlobSource::File(file) => Box::new(tokio::fs::File::open(file.path()).await?),
+                    BlobSource::Path(path) => Box::new(tokio::fs::File::open(path).await?),
+                };
+                let encoder = async_compression::tokio::bufread::ZstdEncoder::new(
+                    tokio::io::BufReader::new(reader),
+                );
+                request
+                    .header(CONTENT_ENCODING, "zstd")
+                    .body(reqwest::Body::wrap_stream(
+                        tokio_util::io::ReaderStream::new(encoder),
+                    ))
+            } else {
+                let (length, body) = match &upload.source {
+                    BlobSource::Bytes(bytes) => {
+                        (bytes.len() as u64, reqwest::Body::from(bytes.clone()))
+                    }
+                    BlobSource::File(file) => {
+                        let file = tokio::fs::File::open(file.path()).await?;
+                        let length = file.metadata().await?.len();
+                        let stream = tokio_util::io::ReaderStream::new(file);
+                        (length, reqwest::Body::wrap_stream(stream))
+                    }
+                    BlobSource::Path(path) => {
+                        let file = tokio::fs::File::open(path).await?;
+                        let length = file.metadata().await?.len();
+                        let stream = tokio_util::io::ReaderStream::new(file);
+                        (length, reqwest::Body::wrap_stream(stream))
+                    }
+                };
+                request.header(CONTENT_LENGTH, length).body(body)
+            };
+            let response = request.send().await?;
             if response.status() != StatusCode::PRECONDITION_FAILED {
                 response.error_for_status()?;
             }
@@ -1915,6 +1974,105 @@ mod tests {
                 "unexpected error: {error}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn uploads_compress_when_the_server_offers_zstd() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "protocol":{"major":1},
+                    "compressors":["identity","zstd"]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let payload = b"compressible cached output ".repeat(64);
+        let expected = payload.clone();
+        let put = server
+            .mock("PUT", mockito::Matcher::Regex("^/v1/blobs/".into()))
+            .match_header("content-encoding", "zstd")
+            .match_request(move |request| {
+                let body = request.body().expect("upload body");
+                // Smaller on the wire, and decoding returns the exact payload:
+                // the compression is real, not just a header.
+                body.len() < expected.len()
+                    && zstd::decode_all(body.as_slice()).ok().as_deref() == Some(&expected[..])
+            })
+            .with_status(201)
+            .create_async()
+            .await;
+
+        let client = test_client(&server);
+        client
+            .put_blob(&BlobUpload {
+                digest: CacheDigest::blake3(&payload),
+                source: BlobSource::Bytes(payload.clone()),
+            })
+            .await
+            .unwrap();
+        put.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn uploads_stay_identity_without_the_advertisement() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/capabilities")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({"protocol":{"major":1}}).to_string())
+            .create_async()
+            .await;
+        let payload = b"uncompressed cached output".to_vec();
+        let put = server
+            .mock("PUT", mockito::Matcher::Regex("^/v1/blobs/".into()))
+            .match_body(mockito::Matcher::from(payload.clone()))
+            .match_request(|request| request.header("content-encoding").is_empty())
+            .with_status(201)
+            .create_async()
+            .await;
+
+        let client = test_client(&server);
+        client
+            .put_blob(&BlobUpload {
+                digest: CacheDigest::blake3(&payload),
+                source: BlobSource::Bytes(payload.clone()),
+            })
+            .await
+            .unwrap();
+        put.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn downloads_decompress_zstd_responses() {
+        let mut server = mockito::Server::new_async().await;
+        let payload = b"compressible cached output ".repeat(64);
+        let digest = CacheDigest::blake3(&payload);
+        let compressed = zstd::encode_all(payload.as_slice(), 0).unwrap();
+        assert!(compressed.len() < payload.len());
+        server
+            .mock(
+                "GET",
+                format!("/v1/blobs/blake3/{}/{}", digest.hash, digest.size).as_str(),
+            )
+            .with_status(200)
+            .with_header("content-type", BLOB_MEDIA_TYPE)
+            .with_header("content-encoding", "zstd")
+            .with_body(compressed)
+            .create_async()
+            .await;
+
+        let client = test_client(&server);
+        // Digest verification runs on what the transport hands back, so this
+        // passes only if the zstd body was transparently decompressed.
+        let bytes = client.get_blob(&digest, BLOB_MEDIA_TYPE).await.unwrap();
+        assert_eq!(bytes, payload);
     }
 
     fn test_client(server: &mockito::ServerGuard) -> RemoteCacheClient {


### PR DESCRIPTION
The dogfood run on jdx/usage put a number on the remote path, and it is not flattering: a fresh runner restoring 206 actions spent **172s of cumulative blob transfer moving 1.3 GiB**, and the publishing build spent ~200s uploading 1.0 GiB — against a 124s from-scratch compile. The remote restore currently saves ~24% wall clock; nearly all of the shortfall is uncompressed bytes on the wire. rustc artifacts compress ~2.5–3× with zstd.

Server counterpart: [jdx/mbx-cache#37](https://github.com/jdx/mbx-cache/pull/37). Either side ships first safely — each is inert until the other arrives.

## Downloads

One Cargo feature: `reqwest/zstd` advertises `Accept-Encoding: zstd` and transparently decompresses when the server compresses. The blob-pack decoder needs no change — reqwest strips `Content-Length` when it decompresses, and the pack metadata check already treats that header as optional (which is *why* it was optional). A server that never compresses keeps sending identity bytes.

## Uploads

Negotiated, never assumed: blobs go up with `Content-Encoding: zstd` only when the server's capabilities advertise `"zstd"` in `compressors` — a coding the server does not expect would be stored corrupt or rejected. The capabilities exchange that already gated blob packs settles both features in one request, and a failed negotiation downgrades to identity rather than failing the upload. Compressed uploads are chunked; the digest in the URL already tells the server the decompressed size it must enforce.

## What does not change

The wire protocol: same `MBXPACK1` frame format, same media types, same protocol version 1. Compression lives entirely in HTTP content codings, so a v0.1.0 client against a new server, or this client against the old server, both work today — identity both ways.

## Tests

Three, each pinning the part that could silently regress:

- `uploads_compress_when_the_server_offers_zstd` — decodes the actual request body and compares to the payload, so it proves real compression, not just a header.
- `uploads_stay_identity_without_the_advertisement` — exact raw body, no `content-encoding`.
- `downloads_decompress_zstd_responses` — asserts by **digest**, which can only pass if the zstd body was really decompressed.

## Expected effect

~2.5–3× less on the wire: the 1.3 GiB restore becomes ~450–550 MiB. Reaches the dogfood once this is released and `MBX_VERSION` in jdx/usage is bumped — the job pins its mbx deliberately.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the remote CAS upload/download path (chunked compressed bodies vs Content-Length). Negotiation is conservative and protocol-compatible, but a mismatch could store or verify blobs incorrectly.
> 
> **Overview**
> Adds **zstd HTTP content coding** for remote CAS blob transfers so rustc artifacts move ~2.5–3× less on the wire, without changing protocol version, media types, or the `MBXPACK1` pack format.
> 
> **Downloads** enable `reqwest`’s `zstd` feature so `Accept-Encoding: zstd` is advertised and compressed responses are decompressed before digest checks. **Uploads** stay identity unless capabilities advertise `"zstd"` in `compressors`; then `put_blob` streams a chunked `Content-Encoding: zstd` body (no `Content-Length`). A missing capabilities endpoint or failed negotiation falls back to uncompressed uploads rather than failing.
> 
> The session-cached capabilities cell now holds both blob-pack limits and `zstd_uploads`. Tests cover real compressed PUT bodies, identity when zstd is not advertised, and digest-verified GET decompression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa4447dac5539faa2a28c17c9832f5f80a192e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->