### PR TITLE
feat(store): collect automatically, and release deleted checkouts first

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -188,6 +188,7 @@ Env vars first, optional `~/.config/mbx/config.toml` second, defaults last.
 | `MBX_REMOTE_OIDC_AUDIENCE` | `remote.oidc_audience` | unset | CI OIDC auth |
 | `MBX_REMOTE_MODE` | `remote.mode` | `read-write` | or `read-only`/`write-only` |
 | `MBX_STATS_REPORT` | `stats_report` | unset | write JSON stats to path |
+| `MBX_SHARE_OUT_DIR` | `share_out_dir` | off | share compilations that read `OUT_DIR` |
 | `MBX_GC_AUTO` | `gc.auto` | `true` | sweep the store after a build |
 | `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | size the store is swept back to |
 | `MBX_GC_INTERVAL` | `gc.interval` | `1h` | how often a build may sweep |

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,9 @@ a standalone home. mise will eventually consume mbx and drop its embedded copy.
 2. **Target directories fill disks.** Cargo never garbage-collects and never
    deduplicates across checkouts. mbx stores artifacts once in a
    content-addressed store, materializes them into target dirs via
-   reflink/hardlink, and evicts with a byte-budget LRU (`mbx gc`).
+   reflink/hardlink, and evicts with a byte-budget LRU that a build runs on its
+   own schedule (`mbx gc`, or automatically). Eviction prefers what no checkout
+   on disk still needs, so deleting a worktree releases what only it used.
 3. **Git worktrees build cold.** Fingerprints embed absolute paths, so a fresh
    worktree rebuilds everything. mbx's action keys use path mapping, so a new
    worktree starts mostly warm while keeping its own target dir (no cargo lock
@@ -161,7 +163,9 @@ Protocol version stays 1; nothing in the wild speaks the old names.
 ## Command surface (v1)
 
 - `mbx build [-- <cargo args>]` — run cargo under a cache session.
-- `mbx gc [--max-size <bytes|human>]` — LRU-evict the store to a byte budget.
+- `mbx gc [--max-size <bytes|human>]` — LRU-evict the store to a byte budget,
+  defaulting to the configured one. `mbx build` does the same when a sweep is
+  due.
 - `mbx cache dir` / `mbx cache stats` — store location and contents summary.
 - `mbx setup` — install the persistent standalone shim and wire
   `build.rustc-wrapper` in `~/.cargo/config.toml`. If that key already names
@@ -184,6 +188,9 @@ Env vars first, optional `~/.config/mbx/config.toml` second, defaults last.
 | `MBX_REMOTE_OIDC_AUDIENCE` | `remote.oidc_audience` | unset | CI OIDC auth |
 | `MBX_REMOTE_MODE` | `remote.mode` | `read-write` | or `read-only`/`write-only` |
 | `MBX_STATS_REPORT` | `stats_report` | unset | write JSON stats to path |
+| `MBX_GC_AUTO` | `gc.auto` | `true` | sweep the store after a build |
+| `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | size the store is swept back to |
+| `MBX_GC_INTERVAL` | `gc.interval` | `1h` | how often a build may sweep |
 | `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect/read timeout |
 | `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
 | `MBX_HTTP_RETRIES` | `http.retries` | `3` | request retries |
@@ -208,7 +215,11 @@ operator did not configure.
 Sessions do not coordinate. Several `mbx build` runs and an `mbx gc` can share
 one store: manifest updates take a file lock, CAS writes are content-addressed
 and idempotent, and an eviction racing a restore turns that action into a miss.
-The failure mode is a recompile, never a wrong result.
+The automatic sweep is throttled by a stamp file rather than coordinated, so two
+builds finishing together may both sweep; checkout records are written whole,
+one file per checkout and identity, so there is nothing for them to race over.
+The failure mode is a recompile, never a wrong result -- the automatic sweep
+makes that race routine rather than rare, not worse.
 
 ## CI story
 
@@ -249,8 +260,9 @@ env vars, and wire constants to match `mbx-cache-core` exactly.
 - **Predictive prefetch by default** — download the predicted action set for
   the whole dep graph in parallel at build start (the prediction plumbing
   already exists in the agent).
-- **Target-dir views** — manage `CARGO_TARGET_DIR` placement; GC roots per
-  checkout so deleting a worktree releases its artifacts.
+- **Target-dir views** — manage `CARGO_TARGET_DIR` placement. The other half of
+  this item shipped: a build records its checkout, and collection prefers what
+  no surviving checkout needs.
 - **Deferred materialization** — leave artifacts in the CAS until read
   (biggest win for `cargo check`-heavy workflows).
 - **Decide the `CARGO_INCREMENTAL` default.** `MBX_INCREMENTAL=1` now opts into

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ See [PLAN.md](PLAN.md) for the design and the road to v1.
   65% of actions on mise, with the shortfall explained under limits below. Each
   keeps its own `target/` directory, so there is no cargo lock contention
   between them.
-- **Collects garbage.** `mbx gc` evicts to a size budget, which cargo has never
-  done for `target/`.
+- **Collects garbage.** The store has a size budget, and a build sweeps it back
+  under that budget on its own -- something cargo has never done for `target/`.
+  A checkout that no longer exists loses its artifacts before a live project
+  does.
 - **Shares through a remote.** CI and teammates can restore from a
   [self-hosted server](https://github.com/jdx/mbx-cache); an ephemeral runner
   with an empty store pulls only the actions its build needs.
@@ -89,8 +91,23 @@ Store management:
 ```sh
 mbx cache dir       # where the store lives
 mbx cache stats     # what it holds
-mbx gc --max-size 20GB
+mbx gc              # sweep to the configured budget
+mbx gc --max-size 20GiB
 ```
+
+A build sweeps the store itself when one is due -- at most once per
+`MBX_GC_INTERVAL`, and only reporting when it evicted something:
+
+```
+gc: evicted 128 objects and 3 action results (1.2 GiB); 18.9 GiB remain
+```
+
+A store inside its budget is never touched. When one is over budget, the
+objects that go first are the ones no checkout on disk still needs: `mbx build`
+records the checkout it ran in, and a checkout that has been deleted stops
+protecting what only it used. Worktrees of one `Cargo.lock` share their cached
+compilations, so removing one of those releases nothing while a sibling remains
+-- the sibling genuinely still needs them.
 
 Evicting an object that is still in use costs a recompile and nothing else, so
 `gc` is always safe to run.
@@ -112,6 +129,9 @@ defaults.
 | `MBX_SHARE_OUT_DIR` | `share_out_dir` | off | share compilations that read `OUT_DIR` |
 | `MBX_STATS_REPORT` | `stats_report` | unset | write a JSON report here |
 | `MBX_INCREMENTAL` | `incremental` | off | let cargo compile workspace members incrementally |
+| `MBX_GC_AUTO` | `gc.auto` | `true` | sweep the store after a build |
+| `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | size the store is swept back to |
+| `MBX_GC_INTERVAL` | `gc.interval` | `1h` | how often a build may sweep |
 | `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect and read timeout |
 | `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
 | `MBX_HTTP_RETRIES` | `http.retries` | `3` | request retries |
@@ -166,7 +186,7 @@ slower than either, and it is how the cache is qualified.
 ## Status and limits
 
 Working today: local caching, cross-checkout reuse, remote push and pull,
-garbage collection.
+automatic garbage collection.
 
 Not yet:
 
@@ -216,6 +236,16 @@ Not yet:
   setting stops overriding `CARGO_INCREMENTAL` rather than setting it, a `0`
   already in your environment still wins, and `mbx` says so rather than leaving
   you to wonder.
+- **Eviction order is an approximation.** Within what a sweep is willing to
+  evict, the oldest goes first by access time -- which `relatime` coarsens to
+  roughly a day and `noatime` suppresses altogether, leaving the order to fall
+  back on when an object was stored. Recording which checkouts are still here
+  is what keeps that from mattering much: a wrong order inside the set nothing
+  has abandoned costs a recompile.
+- **The budget covers cached objects and their results**, not the whole cache
+  directory. Prediction manifests, checkout records, and remote download
+  staging sit outside it, so the directory is always somewhat larger than the
+  number you set.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -98,16 +98,18 @@ mbx gc --max-size 20GiB
 A build sweeps the store itself when one is due -- at most once per
 `MBX_GC_INTERVAL`, and only reporting when it evicted something:
 
-```
+```text
 gc: evicted 128 objects and 3 action results (1.2 GiB); 18.9 GiB remain
 ```
 
-A store inside its budget is never touched. When one is over budget, the
-objects that go first are the ones no checkout on disk still needs: `mbx build`
-records the checkout it ran in, and a checkout that has been deleted stops
-protecting what only it used. Worktrees of one `Cargo.lock` share their cached
-compilations, so removing one of those releases nothing while a sibling remains
--- the sibling genuinely still needs them.
+A store inside its budget loses no cached compilations; a sweep that finds one
+there still tidies its own bookkeeping, dropping the records of checkouts that
+have gone. When a store is over budget, the objects that go first are the ones
+no checkout on disk still needs: `mbx build` records the checkout it ran in, and
+a checkout that has been deleted stops protecting what only it used. Worktrees
+of one `Cargo.lock` share their cached compilations, so removing one of those
+releases nothing while a sibling remains -- the sibling genuinely still needs
+them.
 
 Evicting an object that is still in use costs a recompile and nothing else, so
 `gc` is always safe to run.

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -3,7 +3,7 @@ use crate::{
     ManifestPutOutcome, RemoteActionResult, RemoteCacheClient, RemoteCacheMode, RustcMetadata,
     canonical_json,
 };
-use eyre::{Result, bail};
+use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -409,7 +409,7 @@ impl CacheAgent {
             action_locks: Arc::new(Mutex::new(BTreeMap::new())),
             stats: Arc::new(AtomicAgentStats::default()),
             executable_identities: Arc::new(Mutex::new(BTreeMap::new())),
-            manifest_dir: Arc::new(cache_dir.join("task-manifests").join("v1")),
+            manifest_dir: Arc::new(task_manifest_dir(&cache_dir)),
             task_actions: Arc::new(Mutex::new(BTreeMap::new())),
             next_task_run: Arc::new(AtomicU64::new(0)),
             manifest_write_lock: Arc::new(Mutex::new(())),
@@ -1858,15 +1858,58 @@ where
     }
 }
 
-fn validate_task_identity(task: &str) -> Result<()> {
-    if task.len() != 64
-        || !task
+/// Whether `task` is a well-formed task action identity.
+///
+/// Identities name files and directories in the store, so anything that reads
+/// the store back has to be able to tell an identity from whatever else a user
+/// left lying there.
+pub fn is_task_identity(task: &str) -> bool {
+    task.len() == 64
+        && task
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    {
+}
+
+fn validate_task_identity(task: &str) -> Result<()> {
+    if !is_task_identity(task) {
         bail!("invalid task action identity");
     }
     Ok(())
+}
+
+/// Where a store keeps its task prediction manifests.
+fn task_manifest_dir(store: &Path) -> PathBuf {
+    store.join("task-manifests").join("v1")
+}
+
+/// The action digests a task's prediction manifest recorded.
+///
+/// Read straight off disk rather than through an agent, because a collector
+/// needs the action set of tasks no session is running. A manifest that is
+/// missing or no longer parseable yields no actions rather than an error: this
+/// is a prediction index, so the worst a thin answer costs is a cold prefetch,
+/// or an object collected earlier than it deserved.
+pub fn task_manifest_actions(store: &Path, task: &str) -> Result<Vec<CacheDigest>> {
+    validate_task_identity(task)?;
+    let path = task_manifest_dir(store).join(format!("{task}.json"));
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error).wrap_err_with(|| format!("failed to read {}", path.display()));
+        }
+    };
+    let Ok(manifest) = serde_json::from_slice::<TaskActionManifest>(&bytes) else {
+        return Ok(Vec::new());
+    };
+    if validate_task_manifest(&manifest, task).is_err() {
+        return Ok(Vec::new());
+    }
+    Ok(manifest
+        .predictions
+        .into_iter()
+        .map(|prediction| prediction.action)
+        .collect())
 }
 
 fn validate_action_prediction(prediction: &ActionPrediction) -> Result<()> {
@@ -3678,5 +3721,74 @@ mod tests {
             AgentResponse::Error { .. }
         ));
         task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_the_action_digests_a_task_manifest_recorded() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache");
+        let task = "b".repeat(64);
+        let action = CacheDigest::blake3(b"recorded action");
+
+        let agent = CacheAgent::new(&cache, "test-version");
+        let run = agent.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: run.clone(),
+                    prediction: ActionPrediction {
+                        invocation: CacheDigest::blake3(b"an invocation"),
+                        action: action.clone(),
+                        adapter: "rustc".into(),
+                        payload: "{}".into(),
+                    },
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+        agent.commit_task(&run).await.unwrap();
+
+        assert_eq!(task_manifest_actions(&cache, &task).unwrap(), vec![action]);
+    }
+
+    #[test]
+    fn reports_no_actions_for_a_task_without_a_usable_manifest() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path();
+        let task = "c".repeat(64);
+        assert!(task_manifest_actions(cache, &task).unwrap().is_empty());
+
+        // A manifest the current code can no longer parse is worth exactly as
+        // much as a missing one, and neither is worth failing a sweep over.
+        let path = task_manifest_dir(cache).join(format!("{task}.json"));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"not json").unwrap();
+        assert!(task_manifest_actions(cache, &task).unwrap().is_empty());
+
+        // A manifest naming a different task is somebody else's; claiming its
+        // actions would root objects this task never used.
+        fs::write(
+            &path,
+            serde_json::to_vec(&TaskActionManifest {
+                version: TASK_ACTION_MANIFEST_VERSION,
+                task: "d".repeat(64),
+                predictions: Vec::new(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(task_manifest_actions(cache, &task).unwrap().is_empty());
+
+        assert!(task_manifest_actions(cache, "not-an-identity").is_err());
+    }
+
+    #[test]
+    fn recognizes_only_well_formed_task_identities() {
+        assert!(is_task_identity(&"a".repeat(64)));
+        assert!(is_task_identity(&"0123456789abcdef".repeat(4)));
+        assert!(!is_task_identity(&"A".repeat(64)));
+        assert!(!is_task_identity(&"g".repeat(64)));
+        assert!(!is_task_identity(&"a".repeat(63)));
+        assert!(!is_task_identity(""));
     }
 }

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -423,7 +423,7 @@ impl CacheAgent {
         }
     }
 
-    /// Load the last successful action manifest for a task into this session.
+    /// Load the last committed action manifest for a task into this session.
     pub async fn begin_task(&self, task: &str) -> Result<String> {
         validate_task_identity(task)?;
         let (remote_manifest, mut remote_etag) = if self.remote_mode.reads() {
@@ -512,7 +512,7 @@ impl CacheAgent {
         }
     }
 
-    /// Atomically publish the candidate manifest collected by a successful task.
+    /// Atomically publish the completed actions collected by a task run.
     pub async fn commit_task(&self, run: &str) -> Result<()> {
         validate_task_identity(run)?;
         let state = self

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -24,7 +24,7 @@ mod local;
 
 pub use agent::{
     AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRemoteCache, AgentRequest, AgentResponse,
-    AgentStats, CacheAgent, RestoreStats,
+    AgentStats, CacheAgent, RestoreStats, is_task_identity, task_manifest_actions,
 };
 pub use local::{LocalActionCache, LocalCas};
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -36,9 +36,10 @@ struct BuildArgs {
 
 #[derive(Args)]
 struct GcArgs {
-    /// Size the store may occupy afterwards, for example 20GB.
+    /// Size the store may occupy afterwards, for example 20GiB. Defaults to the
+    /// configured budget.
     #[arg(long, value_name = "SIZE")]
-    max_size: ByteSize,
+    max_size: Option<ByteSize>,
 }
 
 #[derive(Args)]
@@ -61,7 +62,12 @@ pub fn run() -> Result<ExitCode> {
     let config = Config::load()?;
     match cli.command {
         Commands::Build(args) => build(&config, &args.arguments),
-        Commands::Gc(args) => gc(&config, args.max_size.as_u64()).map(|()| ExitCode::SUCCESS),
+        Commands::Gc(args) => gc(
+            &config,
+            args.max_size
+                .map_or(config.gc.max_bytes, |requested| requested.as_u64()),
+        )
+        .map(|()| ExitCode::SUCCESS),
         Commands::Cache(args) => match args.command {
             CacheCommands::Dir => {
                 println!("{}", config.store_dir().display());
@@ -108,7 +114,7 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
         .enable_all()
         .build()?;
 
-    runtime.block_on(async {
+    let status = runtime.block_on(async {
         let session = CacheSession::start(session_dir.path(), config).await?;
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
         let run = session
@@ -138,7 +144,12 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
             Err(error) => log::warn!("the cache session did not shut down cleanly: {error}"),
         }
         status
-    })
+    });
+    // Outside the runtime, so a walk of the whole store cannot occupy a worker
+    // thread, and after cargo has exited, so it adds nothing to the build the
+    // user is waiting on.
+    sweep_store(config);
+    status
 }
 
 fn run_cargo(
@@ -178,14 +189,46 @@ fn exit_code(status: std::process::ExitStatus) -> ExitCode {
 fn gc(config: &Config, max_bytes: u64) -> Result<()> {
     let store = config.store_dir();
     let outcome = store::gc(&store, max_bytes)?;
-    println!(
+    println!("{}", evictions(&outcome));
+    if outcome.removed_checkout_records > 0 {
+        println!(
+            "dropped {} checkout records whose checkout is gone",
+            outcome.removed_checkout_records
+        );
+    }
+    Ok(())
+}
+
+/// One line describing what a sweep evicted.
+///
+/// Shared so the explicit command and the automatic sweep cannot drift into
+/// describing the same outcome two different ways.
+fn evictions(outcome: &store::GcOutcome) -> String {
+    format!(
         "evicted {} objects and {} action results ({}); {} remain",
         outcome.removed_objects,
         outcome.removed_action_results,
         ByteSize::b(outcome.removed_bytes).display().iec(),
         ByteSize::b(outcome.remaining_bytes).display().iec(),
-    );
-    Ok(())
+    )
+}
+
+/// Keep the store inside its budget, at most once per configured interval.
+///
+/// Reported like the cache summary beside it: a sweep that evicted nothing says
+/// nothing. A sweep that fails is logged and forgotten -- the build is already
+/// over, and its exit status is the build's answer, not the collector's.
+fn sweep_store(config: &Config) {
+    if !config.gc.auto {
+        return;
+    }
+    match store::sweep_if_due(&config.store_dir(), config.gc.max_bytes, config.gc.interval) {
+        Ok(Some(outcome)) if outcome.removed_bytes > 0 => {
+            crate::session::note(&format!("gc: {}", evictions(&outcome)));
+        }
+        Ok(_) => {}
+        Err(error) => log::warn!("the store was not swept: {error}"),
+    }
 }
 
 fn cache_stats(config: &Config) -> Result<()> {
@@ -205,6 +248,10 @@ fn cache_stats(config: &Config) -> Result<()> {
     println!(
         "total: {}",
         ByteSize::b(stats.total_bytes()).display().iec()
+    );
+    println!(
+        "checkouts: {} live, {} gone",
+        stats.live_checkouts, stats.stale_checkouts
     );
     Ok(())
 }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -128,15 +128,14 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
 
         let status = run_cargo(&cargo, arguments, environment);
 
-        // A failed build has nothing to publish, and its manifest would record
-        // actions that never completed.
-        match (&status, run) {
-            (Ok(code), Some(run)) if *code == ExitCode::SUCCESS => {
-                if let Err(error) = run.commit().await {
-                    log::warn!("the build manifest was not committed: {error}");
-                }
-            }
-            _ => {}
+        // The shim records a prediction only after a compilation has either
+        // been restored or published successfully. Preserve that completed
+        // portion even when a later compilation makes cargo fail: it is still
+        // useful to the retry, and the collector must know it is reachable.
+        if let Some(run) = run
+            && let Err(error) = run.commit().await
+        {
+            log::warn!("the build manifest was not committed: {error}");
         }
 
         match session.finish().await {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -192,7 +192,7 @@ fn gc(config: &Config, max_bytes: u64) -> Result<()> {
     println!("{}", evictions(&outcome));
     if outcome.removed_checkout_records > 0 {
         println!(
-            "dropped {} checkout records whose checkout is gone",
+            "dropped {} stale checkout records",
             outcome.removed_checkout_records
         );
     }
@@ -250,7 +250,7 @@ fn cache_stats(config: &Config) -> Result<()> {
         ByteSize::b(stats.total_bytes()).display().iec()
     );
     println!(
-        "checkouts: {} live, {} gone",
+        "checkouts: {} live, {} stale",
         stats.live_checkouts, stats.stale_checkouts
     );
     Ok(())

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -3,6 +3,7 @@
 //! Precedence is environment, then `~/.config/mbx/config.toml`, then defaults.
 
 use crate::util::parse_duration;
+use bytesize::ByteSize;
 use eyre::{Context, Result};
 use mbx_cache_core::RemoteCacheMode;
 use serde::Deserialize;
@@ -12,6 +13,9 @@ use std::time::Duration;
 const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_HTTP_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 const DEFAULT_HTTP_RETRIES: i64 = 3;
+/// Stated in IEC units so the budget reads the way `mbx gc` reports it back.
+const DEFAULT_GC_MAX_SIZE: u64 = 20 * 1024 * 1024 * 1024;
+const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields, default)]
@@ -22,6 +26,7 @@ struct ConfigFile {
     share_out_dir: Option<bool>,
     remote: RemoteFile,
     http: HttpFile,
+    gc: GcFile,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -33,6 +38,14 @@ struct RemoteFile {
     token_file: Option<PathBuf>,
     oidc_audience: Option<String>,
     mode: Option<RemoteCacheMode>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+struct GcFile {
+    auto: Option<bool>,
+    max_size: Option<String>,
+    interval: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -59,6 +72,7 @@ pub struct Config {
     pub share_out_dir: bool,
     pub remote: RemoteSettings,
     pub http: HttpSettings,
+    pub gc: GcSettings,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -76,6 +90,24 @@ pub struct HttpSettings {
     pub timeout: Duration,
     pub download_timeout: Duration,
     pub retries: i64,
+}
+
+/// How the store is kept inside its budget.
+#[derive(Debug, Clone)]
+pub struct GcSettings {
+    pub auto: bool,
+    pub max_bytes: u64,
+    pub interval: Duration,
+}
+
+impl Default for GcSettings {
+    fn default() -> Self {
+        Self {
+            auto: true,
+            max_bytes: DEFAULT_GC_MAX_SIZE,
+            interval: DEFAULT_GC_INTERVAL,
+        }
+    }
 }
 
 impl Default for HttpSettings {
@@ -128,8 +160,21 @@ impl Config {
                 None => file.http.retries.unwrap_or(DEFAULT_HTTP_RETRIES),
             },
         };
+        let gc = GcSettings {
+            auto: optional_bool("MBX_GC_AUTO", &get_env, file.gc.auto)?
+                .unwrap_or(GcSettings::default().auto),
+            max_bytes: optional_byte_size(
+                "MBX_GC_MAX_SIZE",
+                &get_env,
+                file.gc.max_size.as_deref(),
+            )?
+            .unwrap_or(DEFAULT_GC_MAX_SIZE),
+            interval: optional_duration("MBX_GC_INTERVAL", &get_env, file.gc.interval.as_deref())?
+                .unwrap_or(DEFAULT_GC_INTERVAL),
+        };
         Ok(Self {
             cache_dir,
+            gc,
             stats_report: get_env("MBX_STATS_REPORT")
                 .map(PathBuf::from)
                 .or(file.stats_report),
@@ -167,6 +212,47 @@ impl Config {
 /// Whether an environment value asks for a feature. Empty and `0` do not.
 fn enabled(value: &str) -> bool {
     !value.is_empty() && value != "0"
+}
+
+/// Resolve a byte size, written either plainly or with a unit.
+///
+/// Both IEC and SI spellings parse -- `20GiB` and `20GB` are different numbers,
+/// and sizes are reported back in IEC, so the two are not interchangeable.
+fn optional_byte_size(
+    name: &str,
+    get_env: &impl Fn(&str) -> Option<String>,
+    from_file: Option<&str>,
+) -> Result<Option<u64>> {
+    let Some(value) = get_env(name).or_else(|| from_file.map(str::to_owned)) else {
+        return Ok(None);
+    };
+    // `ByteSize`'s parse error is a bare `String`, so it cannot be a source.
+    value
+        .trim()
+        .parse::<ByteSize>()
+        .map(|size| Some(size.as_u64()))
+        .map_err(|error| eyre::eyre!("invalid {name}: {error}"))
+}
+
+/// Resolve a setting that is on unless it is turned off.
+///
+/// `MBX_VERIFY` reads its own environment variable as "set to anything but
+/// zero", which can only express a default of off. A setting that defaults to
+/// on has to be able to say no, and has to reject a value it cannot read
+/// rather than guess which way the user meant it.
+fn optional_bool(
+    name: &str,
+    get_env: &impl Fn(&str) -> Option<String>,
+    from_file: Option<bool>,
+) -> Result<Option<bool>> {
+    let Some(value) = get_env(name) else {
+        return Ok(from_file);
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(Some(true)),
+        "0" | "false" | "no" | "off" | "" => Ok(Some(false)),
+        other => Err(eyre::eyre!("invalid {name}: {other}")),
+    }
 }
 
 fn optional_duration(
@@ -225,6 +311,10 @@ mod tests {
             [http]
             timeout = "5s"
             retries = 9
+            [gc]
+            auto = false
+            max_size = "1GiB"
+            interval = "6h"
             "#,
         )
         .unwrap();
@@ -235,6 +325,7 @@ mod tests {
                 ("MBX_REMOTE_URL", "https://env.example"),
                 ("MBX_REMOTE_MODE", "write-only"),
                 ("MBX_HTTP_TIMEOUT", "250ms"),
+                ("MBX_GC_MAX_SIZE", "2GiB"),
             ]),
         )
         .unwrap();
@@ -243,9 +334,12 @@ mod tests {
         assert_eq!(config.remote.url.unwrap(), "https://env.example");
         assert_eq!(config.remote.mode, RemoteCacheMode::WriteOnly);
         assert_eq!(config.http.timeout, Duration::from_millis(250));
+        assert_eq!(config.gc.max_bytes, 2 * 1024 * 1024 * 1024);
         // Values absent from the environment still come from the file.
         assert_eq!(config.remote.namespace.unwrap(), "file");
         assert_eq!(config.http.retries, 9);
+        assert!(!config.gc.auto);
+        assert_eq!(config.gc.interval, Duration::from_secs(6 * 60 * 60));
     }
 
     #[test]
@@ -259,6 +353,9 @@ mod tests {
         assert!(!config.verify);
         assert!(!config.incremental);
         assert!(config.store_dir().ends_with("actions"));
+        assert!(config.gc.auto, "collection runs until it is turned off");
+        assert_eq!(config.gc.max_bytes, DEFAULT_GC_MAX_SIZE);
+        assert_eq!(config.gc.interval, DEFAULT_GC_INTERVAL);
     }
 
     #[test]
@@ -278,6 +375,49 @@ mod tests {
             Config::from_parts(ConfigFile::default(), env(&[("MBX_HTTP_RETRIES", "many")]))
                 .is_err()
         );
+        assert!(
+            Config::from_parts(ConfigFile::default(), env(&[("MBX_GC_MAX_SIZE", "lots")])).is_err()
+        );
+        assert!(
+            Config::from_parts(ConfigFile::default(), env(&[("MBX_GC_INTERVAL", "later")]))
+                .is_err()
+        );
+        // A budget that cannot be read must not be guessed at, and neither must
+        // a switch: silently collecting to the wrong number, or not at all, is
+        // worse than saying so.
+        assert!(
+            Config::from_parts(ConfigFile::default(), env(&[("MBX_GC_AUTO", "maybe")])).is_err()
+        );
+    }
+
+    #[test]
+    fn collection_runs_until_it_is_turned_off() {
+        for value in ["0", "false", "no", "off", ""] {
+            let config =
+                Config::from_parts(ConfigFile::default(), env(&[("MBX_GC_AUTO", value)])).unwrap();
+            assert!(!config.gc.auto, "MBX_GC_AUTO={value:?} should disable");
+        }
+        for value in ["1", "true", "yes", "on", "ON"] {
+            let config =
+                Config::from_parts(ConfigFile::default(), env(&[("MBX_GC_AUTO", value)])).unwrap();
+            assert!(config.gc.auto, "MBX_GC_AUTO={value:?} should enable");
+        }
+    }
+
+    #[test]
+    fn reads_a_budget_in_either_unit_convention() {
+        // `20GB` and `20GiB` are different numbers and sizes are reported back
+        // in IEC, so both spellings have to mean exactly what they say.
+        for (value, expected) in [
+            ("20GiB", 20 * 1024 * 1024 * 1024),
+            ("20GB", 20_000_000_000),
+            ("1024", 1024),
+        ] {
+            let config =
+                Config::from_parts(ConfigFile::default(), env(&[("MBX_GC_MAX_SIZE", value)]))
+                    .unwrap();
+            assert_eq!(config.gc.max_bytes, expected, "{value} should parse");
+        }
     }
 
     #[test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -44,6 +44,7 @@ pub struct CacheSession {
     incremental: bool,
     share_out_dir: bool,
     agent: CacheAgent,
+    store: PathBuf,
     started: Instant,
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
     server: Mutex<Option<JoinHandle<Result<()>>>>,
@@ -60,9 +61,9 @@ impl CacheSession {
         std::fs::create_dir(&staging)?;
         let store = config.store_dir();
         let agent = if let Some(remote) = action_remote_cache(config, &store)? {
-            CacheAgent::new_remote(store, VERSION, remote)
+            CacheAgent::new_remote(store.clone(), VERSION, remote)
         } else {
-            CacheAgent::new(store, VERSION)
+            CacheAgent::new(store.clone(), VERSION)
         };
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (socket, server) = spawn_server(session_dir, agent.clone(), shutdown_rx).await?;
@@ -74,6 +75,7 @@ impl CacheSession {
             incremental: config.incremental,
             share_out_dir: config.share_out_dir,
             agent,
+            store,
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),
             server: Mutex::new(Some(server)),
@@ -95,6 +97,14 @@ impl CacheSession {
         environment: &mut BTreeMap<String, String>,
     ) -> Option<ActionRun> {
         let identity = build_identity(workspace_root, command);
+        // Recorded before the build rather than after it: a build that fails
+        // still means this checkout is here and using the store, and the record
+        // is what stops the collector treating its artifacts as abandoned.
+        if let Err(error) =
+            crate::store::record_checkout(&self.store, &identity, workspace_root, target_dir)
+        {
+            warn!("this checkout was not recorded as a cache root: {error}");
+        }
         let (protocol_build, action_run) = match self.agent.begin_task(&identity).await {
             Ok(run) => (
                 run.clone(),
@@ -413,7 +423,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
 }
 
 /// Write to stderr without failing the build when the pipe is closed.
-fn note(message: &str) {
+pub(crate) fn note(message: &str) {
     use std::io::Write as _;
     let _ = writeln!(std::io::stderr(), "{message}");
 }
@@ -1005,6 +1015,7 @@ mod tests {
             share_out_dir: false,
             remote: Default::default(),
             http: Default::default(),
+            gc: Default::default(),
         }
     }
 

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -197,7 +197,7 @@ impl Drop for CacheSession {
     }
 }
 
-/// An in-flight build's action manifest, committed when the build succeeds.
+/// An in-flight build's completed action manifest.
 pub struct ActionRun {
     run: String,
     agent: CacheAgent,

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -41,6 +41,10 @@ pub struct StoreStats {
     pub action_results: u64,
     pub action_result_bytes: u64,
     pub live_checkouts: u64,
+    /// Claims that root nothing any more: a checkout that is gone, or one that
+    /// is still there but has not renewed this claim inside the retention
+    /// window. Reported as stale rather than gone because those are different
+    /// things and only one of them means the directory is missing.
     pub stale_checkouts: u64,
 }
 
@@ -288,20 +292,23 @@ fn claim_has_expired(record: &CheckoutRecord) -> bool {
 
 /// Whether the checkout a record names is still on disk.
 ///
-/// Absence is believed only when the checkout's parent directory is still
-/// there. Deleting a worktree, or a whole project directory, leaves the parent
-/// behind; a volume being ejected or a network mount going away takes several
-/// levels with it, and that is the case worth being careful about -- a
-/// temporarily absent mount must not un-root a checkout that is really there.
-/// An error counts as present for the same reason. Being wrong in this
-/// direction only delays collection; the other way round throws away a warm
-/// cache someone is still using.
+/// Absence is believed only when the checkout is definitely absent *and* its
+/// parent directory is definitely still there. Deleting a worktree, or a whole
+/// project directory, leaves the parent behind; a volume being ejected or a
+/// network mount going away takes several levels with it, and that is the case
+/// worth being careful about -- a temporarily absent mount must not un-root a
+/// checkout that is really there.
+///
+/// So both questions are asked the same way: only a definite answer counts, and
+/// an error at either step means live. Being wrong in that direction only
+/// delays collection; the other way round throws away a warm cache someone is
+/// still using.
 fn checkout_is_live(workspace_root: &Path) -> bool {
-    if workspace_root.try_exists().unwrap_or(true) {
+    if !matches!(workspace_root.try_exists(), Ok(false)) {
         return true;
     }
     match workspace_root.parent() {
-        Some(parent) => !parent.try_exists().unwrap_or(true),
+        Some(parent) => !matches!(parent.try_exists(), Ok(true)),
         // A root directory has no parent to corroborate anything with.
         None => true,
     }
@@ -859,7 +866,9 @@ mod tests {
 
         assert_eq!(stats(&store).unwrap().live_checkouts, 1);
         std::fs::remove_dir_all(&gone).unwrap();
-        assert_eq!(stats(&store).unwrap().stale_checkouts, 1);
+        let after = stats(&store).unwrap();
+        assert_eq!(after.stale_checkouts, 1);
+        assert_eq!(after.live_checkouts, 0);
 
         let outcome = gc(&store, u64::MAX).unwrap();
 
@@ -926,6 +935,27 @@ mod tests {
             LocalCas::new(&store).find(&orphan).unwrap().is_none(),
             "an expired claim roots nothing"
         );
+    }
+
+    #[test]
+    fn keeps_a_checkout_whose_absence_it_cannot_corroborate() {
+        let directory = tempfile::tempdir().unwrap();
+
+        // A checkout that is gone from a parent that is still there is the one
+        // case worth believing: that is what deleting a worktree looks like.
+        let parent = directory.path().join("worktrees");
+        std::fs::create_dir_all(&parent).unwrap();
+        assert!(!checkout_is_live(&parent.join("removed")));
+
+        // A checkout whose parent went with it looks like an ejected volume or a
+        // mount that is temporarily away, and un-rooting those would throw away
+        // a cache somebody is still using.
+        assert!(checkout_is_live(
+            &directory.path().join("gone/deeper/still")
+        ));
+
+        // And anything still on disk is live whatever its parent says.
+        assert!(checkout_is_live(directory.path()));
     }
 
     #[test]

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -159,7 +159,7 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
     // last sweep stops protecting its artifacts during this one.
     let checkouts = scan_checkouts(store)?;
     for path in &checkouts.stale_records {
-        if remove(path)? {
+        if matches!(remove(path)?, Removal::Removed) {
             outcome.removed_checkout_records += 1;
         }
         // The identity directory is left behind empty otherwise. It may hold
@@ -178,16 +178,10 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
         // each class goes oldest-first. A store with no records at all roots
         // nothing and this is exactly the LRU it was before.
         objects.sort_by_cached_key(|entry| (rooted.contains(&entry.path), entry.used));
-        for entry in &objects {
-            if live_bytes <= max_bytes {
-                break;
-            }
-            if remove(&entry.path)? {
-                live_bytes = live_bytes.saturating_sub(entry.size);
-                outcome.removed_objects += 1;
-                outcome.removed_bytes += entry.size;
-            }
-        }
+        let evicted = evict_objects(&objects, &rooted, live_bytes, max_bytes, remove)?;
+        live_bytes = evicted.remaining_bytes;
+        outcome.removed_objects += evicted.removed_objects;
+        outcome.removed_bytes += evicted.removed_bytes;
     }
 
     // An action result whose objects are gone can only produce a miss, so drop
@@ -196,10 +190,16 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
     // store that is over budget on results alone still needs the sweep.
     let cas = LocalCas::new(store);
     for entry in &results {
-        if action_result_is_dangling(&cas, &entry.path)? && remove(&entry.path)? {
-            live_bytes = live_bytes.saturating_sub(entry.size);
-            outcome.removed_action_results += 1;
-            outcome.removed_bytes += entry.size;
+        if action_result_is_dangling(&cas, &entry.path)? {
+            match remove(&entry.path)? {
+                Removal::Removed => {
+                    live_bytes = live_bytes.saturating_sub(entry.size);
+                    outcome.removed_action_results += 1;
+                    outcome.removed_bytes += entry.size;
+                }
+                Removal::Missing => live_bytes = live_bytes.saturating_sub(entry.size),
+                Removal::Blocked => {}
+            }
         }
     }
 
@@ -414,21 +414,72 @@ fn root_digest(cas: &LocalCas, rooted: &mut HashSet<PathBuf>, digest: &CacheDige
     }
 }
 
-fn remove(path: &Path) -> Result<bool> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Removal {
+    Removed,
+    Missing,
+    Blocked,
+}
+
+fn remove(path: &Path) -> Result<Removal> {
     match std::fs::remove_file(path) {
-        Ok(()) => Ok(true),
+        Ok(()) => Ok(Removal::Removed),
         // A concurrent build may have evicted or replaced it already.
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Removal::Missing),
         // Windows refuses to unlink a file another process holds open, which is
         // what a concurrent build reading this blob looks like. Skipping it
         // leaves the store over budget until the next sweep; failing would
         // abandon the sweep and leave it over budget for longer.
         Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
             log::debug!("could not evict {}: {error}", path.display());
-            Ok(false)
+            Ok(Removal::Blocked)
         }
         Err(error) => Err(error).wrap_err_with(|| format!("failed to evict {}", path.display())),
     }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ObjectEvictions {
+    removed_objects: u64,
+    removed_bytes: u64,
+    remaining_bytes: u64,
+}
+
+/// Evict sorted objects without crossing the checkout-protection boundary
+/// when an unrooted object cannot be removed.
+fn evict_objects(
+    objects: &[Entry],
+    rooted: &HashSet<PathBuf>,
+    mut live_bytes: u64,
+    max_bytes: u64,
+    mut remove_file: impl FnMut(&Path) -> Result<Removal>,
+) -> Result<ObjectEvictions> {
+    let mut outcome = ObjectEvictions::default();
+    let mut blocked_unrooted = false;
+    for entry in objects {
+        if live_bytes <= max_bytes {
+            break;
+        }
+        let is_rooted = rooted.contains(&entry.path);
+        if is_rooted && blocked_unrooted {
+            // A locked unrooted blob is temporarily part of the irreducible
+            // store. Deleting a live checkout's artifacts in its place would
+            // invert the protection ordering this collector promises.
+            break;
+        }
+        match remove_file(&entry.path)? {
+            Removal::Removed => {
+                live_bytes = live_bytes.saturating_sub(entry.size);
+                outcome.removed_objects += 1;
+                outcome.removed_bytes += entry.size;
+            }
+            Removal::Missing => live_bytes = live_bytes.saturating_sub(entry.size),
+            Removal::Blocked if !is_rooted => blocked_unrooted = true,
+            Removal::Blocked => {}
+        }
+    }
+    outcome.remaining_bytes = live_bytes;
+    Ok(outcome)
 }
 
 /// Whether an action result references an object the store no longer has.
@@ -667,6 +718,44 @@ mod tests {
             }
         );
         assert_eq!(stats(store).unwrap().objects, 1);
+    }
+
+    #[test]
+    fn a_blocked_unrooted_object_does_not_cost_a_rooted_one() {
+        let locked = PathBuf::from("locked-unrooted");
+        let removable = PathBuf::from("removable-unrooted");
+        let protected = PathBuf::from("rooted");
+        let objects = [&locked, &removable, &protected]
+            .into_iter()
+            .map(|path| Entry {
+                path: path.clone(),
+                size: 10,
+                used: SystemTime::UNIX_EPOCH,
+            })
+            .collect::<Vec<_>>();
+        let rooted = HashSet::from([protected.clone()]);
+        let mut attempted = Vec::new();
+
+        let outcome = evict_objects(&objects, &rooted, 30, 5, |path| {
+            attempted.push(path.to_path_buf());
+            Ok(if path == locked {
+                Removal::Blocked
+            } else {
+                Removal::Removed
+            })
+        })
+        .unwrap();
+
+        assert_eq!(attempted, vec![locked, removable]);
+        assert_eq!(
+            outcome,
+            ObjectEvictions {
+                removed_objects: 1,
+                removed_bytes: 10,
+                remaining_bytes: 20,
+            },
+            "a locked unrooted blob should leave the store over budget before protected objects are evicted"
+        );
     }
 
     #[test]

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -249,8 +249,12 @@ fn scan_checkouts(store: &Path) -> Result<CheckoutScan> {
     for entry in listing {
         let entry = entry?;
         let name = entry.file_name().to_string_lossy().into_owned();
-        // Anything that is not an identity was not written by mbx.
-        if !is_task_identity(&name) {
+        // Anything that is not a directory named for an identity was not written
+        // by mbx. Both halves matter: `walk_files` tolerates only a missing
+        // directory, so a plain file whose name happens to look like an identity
+        // would fail the whole scan -- and that scan runs inside every sweep,
+        // including the automatic one after a build.
+        if !is_task_identity(&name) || !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
             continue;
         }
         for record in walk_files(&entry.path())? {
@@ -935,6 +939,25 @@ mod tests {
             LocalCas::new(&store).find(&orphan).unwrap().is_none(),
             "an expired claim roots nothing"
         );
+    }
+
+    #[test]
+    fn ignores_what_it_did_not_write_beside_the_checkout_records() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let checkout = directory.path().join("project");
+        std::fs::create_dir_all(&checkout).unwrap();
+        record_checkout(&store, &"3".repeat(64), &checkout, &checkout.join("target")).unwrap();
+
+        // A plain file whose name reads like an identity used to fail the scan,
+        // and with it every sweep and every `cache stats`.
+        let intruder = store.join(CHECKOUTS_DIR).join("4".repeat(64));
+        std::fs::write(&intruder, b"not a directory of records").unwrap();
+        std::fs::write(store.join(CHECKOUTS_DIR).join("notes.txt"), b"nor this").unwrap();
+
+        assert_eq!(stats(&store).unwrap().live_checkouts, 1);
+        assert_eq!(gc(&store, u64::MAX).unwrap().removed_checkout_records, 0);
+        assert!(intruder.exists(), "and nothing of theirs is deleted either");
     }
 
     #[test]

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -1,17 +1,38 @@
 //! Store inspection and garbage collection.
 //!
-//! The store holds three trees: `cas/v1` for content-addressed objects,
-//! `action-results/v1` for the results that reference them, and
-//! `task-manifests/v1` for the prediction index. Only the first two are
-//! collected; manifests are small and are what makes a cold build fast.
+//! The store holds four trees: `cas/v1` for content-addressed objects,
+//! `action-results/v1` for the results that reference them, `task-manifests/v1`
+//! for the prediction index, and `checkouts/v1` for the checkouts that have
+//! built each identity. Only the first two are collected for size; manifests
+//! are small and are what makes a cold build fast, and a checkout record is
+//! dropped when its checkout is gone rather than when the store is full.
 
 use eyre::{Context, Result};
-use mbx_cache_core::{LocalCas, RemoteActionResult};
+use mbx_cache_core::{
+    CacheDigest, CacheDirectory, LocalCas, RemoteActionResult, RustcMetadata, is_task_identity,
+    task_manifest_actions,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const CAS_DIR: &str = "cas/v1";
 const ACTION_RESULTS_DIR: &str = "action-results/v1";
+const CHECKOUTS_DIR: &str = "checkouts/v1";
+const SWEEP_STAMP: &str = "gc/v1/last-sweep";
+const CHECKOUT_RECORD_VERSION: u8 = 1;
+
+/// How long a checkout's claim outlives the last build that renewed it.
+///
+/// Existence alone is not enough to keep a claim alive. An identity covers one
+/// exact command line against one exact lockfile, so a checkout that lives for
+/// years accumulates an identity per lockfile it ever had -- and every one of
+/// them would go on rooting the actions of a build nobody will run again.
+/// Without this bound the rooted set only grows, until everything is rooted and
+/// the ordering means nothing. A build renews the claims it uses, so anything
+/// this stale belongs to a command that has moved on.
+const CHECKOUT_RETENTION: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct StoreStats {
@@ -19,6 +40,8 @@ pub struct StoreStats {
     pub object_bytes: u64,
     pub action_results: u64,
     pub action_result_bytes: u64,
+    pub live_checkouts: u64,
+    pub stale_checkouts: u64,
 }
 
 impl StoreStats {
@@ -31,28 +54,92 @@ impl StoreStats {
 pub struct GcOutcome {
     pub removed_objects: u64,
     pub removed_action_results: u64,
+    pub removed_checkout_records: u64,
     pub removed_bytes: u64,
     pub remaining_bytes: u64,
+}
+
+/// One checkout's claim on the actions a build identity recorded.
+///
+/// The target directory is not read back by anything yet; it is recorded
+/// because it is the other half of what the shim mapped, and a record that
+/// names only half of it would have to be rewritten to answer where the
+/// artifacts went.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CheckoutRecord {
+    version: u8,
+    workspace_root: PathBuf,
+    target_dir: PathBuf,
+    updated_secs: u64,
 }
 
 /// Summarize what the store currently holds.
 pub fn stats(store: &Path) -> Result<StoreStats> {
     let objects = walk_files(&store.join(CAS_DIR))?;
     let results = walk_files(&store.join(ACTION_RESULTS_DIR))?;
+    let checkouts = scan_checkouts(store)?;
     Ok(StoreStats {
         objects: objects.len() as u64,
         object_bytes: objects.iter().map(|entry| entry.size).sum(),
         action_results: results.len() as u64,
         action_result_bytes: results.iter().map(|entry| entry.size).sum(),
+        live_checkouts: checkouts.live_records,
+        stale_checkouts: checkouts.stale_records.len() as u64,
     })
+}
+
+/// Record that `workspace_root` built `identity`.
+///
+/// Identities are shared by every checkout of one dependency graph, so this is
+/// what later tells the collector whether anything still needs what a build
+/// cached: one file per checkout under the identity it built. Writing a whole
+/// file per checkout rather than merging a list into one keeps concurrent
+/// builds out of each other's way -- there is nothing to merge, so there is no
+/// lock and no lost update.
+pub fn record_checkout(
+    store: &Path,
+    identity: &str,
+    workspace_root: &Path,
+    target_dir: &Path,
+) -> Result<()> {
+    let record = CheckoutRecord {
+        version: CHECKOUT_RECORD_VERSION,
+        workspace_root: workspace_root.to_path_buf(),
+        target_dir: target_dir.to_path_buf(),
+        updated_secs: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|since| since.as_secs())
+            .unwrap_or_default(),
+    };
+    let mut contents = serde_json::to_vec(&record)?;
+    contents.push(b'\n');
+    crate::util::write_atomic(
+        &checkout_record_path(store, identity, workspace_root),
+        &contents,
+    )
+}
+
+fn checkout_record_path(store: &Path, identity: &str, workspace_root: &Path) -> PathBuf {
+    // The path is hashed rather than escaped: it is only ever compared against
+    // the same hash of the same path, and every filesystem in play disagrees
+    // about which characters a name may hold.
+    let key = CacheDigest::blake3(workspace_root.to_string_lossy().as_bytes()).hash;
+    store
+        .join(CHECKOUTS_DIR)
+        .join(identity)
+        .join(format!("{key}.json"))
 }
 
 /// Evict objects until the store fits within `max_bytes`.
 ///
-/// Eviction is least-recently-used by access time where the filesystem records
-/// it, falling back to modification time. Restores hard-link or reflink out of
-/// the store rather than reading through it, so this ordering is only an
-/// approximation -- evicting a live object costs a recompile, never correctness.
+/// Objects no live checkout can reach are evicted first, so deleting a worktree
+/// releases what only that worktree needed. Within each class eviction is
+/// least-recently-used by access time where the filesystem records it, falling
+/// back to modification time. A restore verifies the blob it serves, which
+/// means it reads the whole file and the access time is real -- but only where
+/// the mount records one, so the ordering is an approximation either way.
+/// Evicting a live object costs a recompile, never correctness.
 pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
     let mut objects = walk_files(&store.join(CAS_DIR))?;
     let results = walk_files(&store.join(ACTION_RESULTS_DIR))?;
@@ -63,8 +150,30 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
         .sum::<u64>();
 
     let mut outcome = GcOutcome::default();
+
+    // Prune before deciding what is rooted, so a checkout deleted since the
+    // last sweep stops protecting its artifacts during this one.
+    let checkouts = scan_checkouts(store)?;
+    for path in &checkouts.stale_records {
+        if remove(path)? {
+            outcome.removed_checkout_records += 1;
+        }
+        // The identity directory is left behind empty otherwise. It may hold
+        // other checkouts, in which case this fails and that is the answer.
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+
     if live_bytes > max_bytes {
-        objects.sort_by_key(|entry| entry.used);
+        // Reachability costs a read per action result and per output tree, so
+        // it is computed only when something is actually about to be evicted.
+        // Under budget a sweep stays a directory walk and nothing more.
+        let rooted = rooted_objects(store, &checkouts.live_identities)?;
+        // `false` sorts first, so unrooted objects go before rooted ones and
+        // each class goes oldest-first. A store with no records at all roots
+        // nothing and this is exactly the LRU it was before.
+        objects.sort_by_cached_key(|entry| (rooted.contains(&entry.path), entry.used));
         for entry in &objects {
             if live_bytes <= max_bytes {
                 break;
@@ -94,11 +203,219 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
     Ok(outcome)
 }
 
+/// Sweep the store if `interval` has passed since the last attempt.
+///
+/// The stamp is written before the sweep, not after. Two builds finishing
+/// together should cost one sweep between them, and a sweep that dies partway
+/// should wait its turn like any other rather than retry on every build.
+pub fn sweep_if_due(store: &Path, max_bytes: u64, interval: Duration) -> Result<Option<GcOutcome>> {
+    let stamp = store.join(SWEEP_STAMP);
+    if let Ok(metadata) = std::fs::metadata(&stamp)
+        && let Ok(modified) = metadata.modified()
+        && let Ok(since) = modified.elapsed()
+        && since < interval
+    {
+        return Ok(None);
+    }
+    crate::util::write_atomic(&stamp, b"")?;
+    gc(store, max_bytes).map(Some)
+}
+
+/// What the checkout registry says about the identities in this store.
+struct CheckoutScan {
+    live_identities: BTreeSet<String>,
+    live_records: u64,
+    stale_records: Vec<PathBuf>,
+}
+
+fn scan_checkouts(store: &Path) -> Result<CheckoutScan> {
+    let root = store.join(CHECKOUTS_DIR);
+    let mut scan = CheckoutScan {
+        live_identities: BTreeSet::new(),
+        live_records: 0,
+        stale_records: Vec::new(),
+    };
+    let listing = match std::fs::read_dir(&root) {
+        Ok(listing) => listing,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(scan),
+        Err(error) => {
+            return Err(error).wrap_err_with(|| format!("failed to read {}", root.display()));
+        }
+    };
+    for entry in listing {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        // Anything that is not an identity was not written by mbx.
+        if !is_task_identity(&name) {
+            continue;
+        }
+        for record in walk_files(&entry.path())? {
+            match read_checkout_record(&record.path) {
+                Some(checkout) if claim_is_live(&checkout) => {
+                    scan.live_identities.insert(name.clone());
+                    scan.live_records += 1;
+                }
+                Some(_) => scan.stale_records.push(record.path),
+                // A record this build cannot read claims nothing, but it is not
+                // evidence the checkout is gone either, so leave it alone.
+                None => {}
+            }
+        }
+    }
+    Ok(scan)
+}
+
+fn read_checkout_record(path: &Path) -> Option<CheckoutRecord> {
+    let bytes = std::fs::read(path).ok()?;
+    let record = serde_json::from_slice::<CheckoutRecord>(&bytes).ok()?;
+    (record.version == CHECKOUT_RECORD_VERSION).then_some(record)
+}
+
+/// Whether a recorded claim still speaks for a checkout that is using this
+/// store.
+fn claim_is_live(record: &CheckoutRecord) -> bool {
+    checkout_is_live(&record.workspace_root) && !claim_has_expired(record)
+}
+
+fn claim_has_expired(record: &CheckoutRecord) -> bool {
+    let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+        return false;
+    };
+    now.as_secs()
+        .saturating_sub(record.updated_secs)
+        .gt(&CHECKOUT_RETENTION.as_secs())
+}
+
+/// Whether the checkout a record names is still on disk.
+///
+/// Absence is believed only when the checkout's parent directory is still
+/// there. Deleting a worktree, or a whole project directory, leaves the parent
+/// behind; a volume being ejected or a network mount going away takes several
+/// levels with it, and that is the case worth being careful about -- a
+/// temporarily absent mount must not un-root a checkout that is really there.
+/// An error counts as present for the same reason. Being wrong in this
+/// direction only delays collection; the other way round throws away a warm
+/// cache someone is still using.
+fn checkout_is_live(workspace_root: &Path) -> bool {
+    if workspace_root.try_exists().unwrap_or(true) {
+        return true;
+    }
+    match workspace_root.parent() {
+        Some(parent) => !parent.try_exists().unwrap_or(true),
+        // A root directory has no parent to corroborate anything with.
+        None => true,
+    }
+}
+
+/// CAS paths reachable from the builds that live checkouts still depend on.
+///
+/// Recursing into output trees is the point: the descriptor blobs are tiny and
+/// the leaf artifacts are where the bytes are, so rooting that stopped at the
+/// top level would protect nothing worth protecting. Every read here is
+/// tolerant -- a blob that has already been evicted, or that no longer parses,
+/// simply roots less, and rooting less can only mean collecting sooner.
+fn rooted_objects(store: &Path, identities: &BTreeSet<String>) -> Result<HashSet<PathBuf>> {
+    let cas = LocalCas::new(store);
+    let mut rooted = HashSet::new();
+    let mut visited = BTreeSet::new();
+    for identity in identities {
+        // One manifest this build cannot read is not worth abandoning a sweep
+        // over. It roots nothing, which can only mean collecting sooner.
+        let actions = match task_manifest_actions(store, identity) {
+            Ok(actions) => actions,
+            Err(error) => {
+                log::debug!("could not read the manifest for {identity}: {error}");
+                continue;
+            }
+        };
+        for action in actions {
+            let Some(result) = read_action_result(store, &action) else {
+                continue;
+            };
+            root_digest(&cas, &mut rooted, &result.action);
+            if let Some(metadata) = &result.metadata {
+                root_digest(&cas, &mut rooted, metadata);
+                // The metadata blob is a descriptor too: it names the captured
+                // stdout and stderr, and a restore reads both. Stopping at the
+                // descriptor would leave the diagnostics of every action
+                // unrooted -- including the one empty blob that every silent
+                // compilation shares, which is enough on its own to turn a
+                // rooted hit back into a miss.
+                if let Some(rustc) = read_rustc_metadata(&cas, metadata) {
+                    root_digest(&cas, &mut rooted, &rustc.stdout);
+                    root_digest(&cas, &mut rooted, &rustc.stderr);
+                }
+            }
+            if let Some(output_root) = &result.output_root {
+                root_digest(&cas, &mut rooted, output_root);
+                root_tree(&cas, output_root, &mut rooted, &mut visited);
+            }
+        }
+    }
+    Ok(rooted)
+}
+
+fn read_action_result(store: &Path, action: &CacheDigest) -> Option<RemoteActionResult> {
+    let path = mbx_cache_core::LocalActionCache::new(store)
+        .path_for(action)
+        .ok()?;
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn root_tree(
+    cas: &LocalCas,
+    output_root: &CacheDigest,
+    rooted: &mut HashSet<PathBuf>,
+    visited: &mut BTreeSet<CacheDigest>,
+) {
+    let mut pending = vec![output_root.clone()];
+    while let Some(digest) = pending.pop() {
+        if !visited.insert(digest.clone()) {
+            continue;
+        }
+        let Some(directory) = read_directory(cas, &digest) else {
+            continue;
+        };
+        for file in &directory.files {
+            root_digest(cas, rooted, &file.digest);
+        }
+        for child in &directory.directories {
+            root_digest(cas, rooted, &child.digest);
+            pending.push(child.digest.clone());
+        }
+    }
+}
+
+fn read_rustc_metadata(cas: &LocalCas, digest: &CacheDigest) -> Option<RustcMetadata> {
+    let bytes = std::fs::read(cas.path_for(digest).ok()?).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn read_directory(cas: &LocalCas, digest: &CacheDigest) -> Option<CacheDirectory> {
+    let bytes = std::fs::read(cas.path_for(digest).ok()?).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn root_digest(cas: &LocalCas, rooted: &mut HashSet<PathBuf>, digest: &CacheDigest) {
+    if let Ok(path) = cas.path_for(digest) {
+        rooted.insert(path);
+    }
+}
+
 fn remove(path: &Path) -> Result<bool> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(true),
         // A concurrent build may have evicted or replaced it already.
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        // Windows refuses to unlink a file another process holds open, which is
+        // what a concurrent build reading this blob looks like. Skipping it
+        // leaves the store over budget until the next sweep; failing would
+        // abandon the sweep and leave it over budget for longer.
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            log::debug!("could not evict {}: {error}", path.display());
+            Ok(false)
+        }
         Err(error) => Err(error).wrap_err_with(|| format!("failed to evict {}", path.display())),
     }
 }
@@ -109,6 +426,14 @@ fn remove(path: &Path) -> Result<bool> {
 /// requires. If the sweep checked fewer, eviction could leave an entry that
 /// cannot be republished -- `store` would reject the identical result for a
 /// missing blob while the index still claimed to hold it.
+///
+/// Presence is all that is checked, not content. Verifying would re-hash a
+/// large fraction of the store on every sweep, which a chore could afford and
+/// an automatic sweep cannot; it would also refresh the access time of every
+/// descriptor blob while leaving the artifacts alone, biasing the very
+/// ordering this module depends on. A blob that is present but corrupt now
+/// keeps its result and turns into a miss on restore, and both CAS write paths
+/// republish over a corrupt blob rather than trusting it.
 ///
 /// Only the top-level objects are checked; a result whose output tree lost a
 /// nested object still restores as a miss, which is safe.
@@ -132,9 +457,14 @@ fn action_result_is_dangling(cas: &LocalCas, path: &Path) -> Result<bool> {
     .into_iter()
     .flatten()
     {
-        // A verification failure leaves the object unusable, same as missing.
-        if cas.find(digest).unwrap_or(None).is_none() {
-            return Ok(true);
+        match cas.path_for(digest) {
+            Ok(path) => {
+                if !path.exists() {
+                    return Ok(true);
+                }
+            }
+            // A digest the CAS cannot even address is not one it can hold.
+            Err(_) => return Ok(true),
         }
     }
     Ok(false)
@@ -187,8 +517,7 @@ fn walk_files(root: &Path) -> Result<Vec<Entry>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mbx_cache_core::{CacheDigest, LocalActionCache};
-    use std::time::Duration;
+    use mbx_cache_core::{ActionPrediction, CacheFileNode, LocalActionCache};
 
     fn store_object(store: &Path, contents: &[u8]) -> CacheDigest {
         let digest = CacheDigest::blake3(contents);
@@ -202,6 +531,74 @@ mod tests {
         let when = SystemTime::now() - age;
         let time = filetime::FileTime::from_system_time(when);
         filetime::set_file_times(path, time, time).unwrap();
+    }
+
+    /// Publish an action result whose output tree holds `outputs`.
+    fn store_result(store: &Path, name: &str, outputs: &[CacheDigest]) -> CacheDigest {
+        let directory = CacheDirectory {
+            directories: Vec::new(),
+            files: outputs
+                .iter()
+                .enumerate()
+                .map(|(index, digest)| CacheFileNode {
+                    digest: digest.clone(),
+                    executable: false,
+                    mode: 0o644,
+                    name: format!("output-{index}"),
+                })
+                .collect(),
+            symlinks: Vec::new(),
+            version: 1,
+        };
+        let encoded = serde_json::to_vec(&directory).unwrap();
+        let output_root = store_object(store, &encoded);
+        let action = store_object(store, name.as_bytes());
+        LocalActionCache::new(store)
+            .store(&RemoteActionResult {
+                version: 1,
+                action: action.clone(),
+                metadata: None,
+                output_root: Some(output_root),
+            })
+            .unwrap();
+        action
+    }
+
+    /// Record a checkout of `identity` and the manifest that roots `actions`.
+    ///
+    /// The agent only accepts predictions over its socket, so the manifest is
+    /// written here instead. The predictions come from the public type rather
+    /// than hand-rolled JSON, leaving only the two wrapper fields to drift --
+    /// and `mbx_cache_core`'s own tests write a manifest through the agent and
+    /// read it back with the same accessor this uses, so drift shows up there.
+    fn record_build(store: &Path, identity: &str, workspace_root: &Path, actions: &[CacheDigest]) {
+        record_checkout(
+            store,
+            identity,
+            workspace_root,
+            &workspace_root.join("target"),
+        )
+        .unwrap();
+        let predictions = actions
+            .iter()
+            .enumerate()
+            .map(|(index, action)| ActionPrediction {
+                invocation: CacheDigest::blake3(format!("{identity}-{index}").as_bytes()),
+                action: action.clone(),
+                adapter: "rustc".into(),
+                payload: "{}".into(),
+            })
+            .collect::<Vec<_>>();
+        let manifest = serde_json::json!({
+            "version": 1,
+            "task": identity,
+            "predictions": predictions,
+        });
+        let path = store
+            .join("task-manifests")
+            .join("v1")
+            .join(format!("{identity}.json"));
+        crate::util::write_atomic(&path, &serde_json::to_vec(&manifest).unwrap()).unwrap();
     }
 
     #[test]
@@ -288,6 +685,30 @@ mod tests {
     }
 
     #[test]
+    fn keeps_an_action_result_whose_blob_is_present_but_corrupt() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        let action = store_object(store, b"action key");
+        LocalActionCache::new(store)
+            .store(&RemoteActionResult {
+                version: 1,
+                action: action.clone(),
+                metadata: None,
+                output_root: None,
+            })
+            .unwrap();
+        let path = LocalCas::new(store).path_for(&action).unwrap();
+        std::fs::write(&path, b"corrupted!").unwrap();
+
+        let outcome = gc(store, u64::MAX).unwrap();
+
+        // The sweep does not read content, so this result survives and costs a
+        // miss on restore. Verifying instead would re-hash the whole store.
+        assert_eq!(outcome.removed_action_results, 0);
+        assert!(path.exists());
+    }
+
+    #[test]
     fn drops_action_results_left_without_their_objects() {
         let directory = tempfile::tempdir().unwrap();
         let store = directory.path();
@@ -312,5 +733,237 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn evicts_objects_no_live_checkout_needs_before_older_rooted_ones() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let live = directory.path().join("live");
+        let deleted = directory.path().join("deleted");
+        std::fs::create_dir_all(&live).unwrap();
+        std::fs::create_dir_all(&deleted).unwrap();
+
+        let kept = store_object(&store, b"0123456789");
+        let dropped = store_object(&store, b"abcdefghij");
+        record_build(
+            &store,
+            &"a".repeat(64),
+            &live,
+            &[store_result(
+                &store,
+                "live action",
+                std::slice::from_ref(&kept),
+            )],
+        );
+        record_build(
+            &store,
+            &"b".repeat(64),
+            &deleted,
+            &[store_result(
+                &store,
+                "deleted action",
+                std::slice::from_ref(&dropped),
+            )],
+        );
+        // The rooted object is the older one, so plain LRU would take it first.
+        age(&store, &kept, Duration::from_secs(60 * 60));
+        age(&store, &dropped, Duration::from_secs(1));
+        std::fs::remove_dir_all(&deleted).unwrap();
+
+        gc(&store, stats(&store).unwrap().total_bytes() - 10).unwrap();
+
+        let cas = LocalCas::new(&store);
+        assert!(
+            cas.find(&kept).unwrap().is_some(),
+            "a live checkout still needs this object"
+        );
+        assert!(
+            cas.find(&dropped).unwrap().is_none(),
+            "nothing that still exists needs this object"
+        );
+    }
+
+    #[test]
+    fn keeps_rooting_when_a_sibling_worktree_survives() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let first = directory.path().join("first");
+        let second = directory.path().join("second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+
+        // Worktrees of one dependency graph share an identity by design, so the
+        // survivor's claim has to keep the whole identity rooted.
+        let identity = "c".repeat(64);
+        let shared = store_object(&store, b"shared artifact");
+        let action = store_result(&store, "shared action", std::slice::from_ref(&shared));
+        record_build(&store, &identity, &first, std::slice::from_ref(&action));
+        record_build(&store, &identity, &second, &[action]);
+        let spare = store_object(&store, b"unrooted spare");
+        std::fs::remove_dir_all(&second).unwrap();
+
+        let outcome = gc(&store, stats(&store).unwrap().total_bytes() - 1).unwrap();
+
+        assert_eq!(outcome.removed_checkout_records, 1);
+        let cas = LocalCas::new(&store);
+        assert!(cas.find(&shared).unwrap().is_some());
+        assert!(cas.find(&spare).unwrap().is_none());
+    }
+
+    #[test]
+    fn roots_objects_nested_in_an_output_tree() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let checkout = directory.path().join("checkout");
+        std::fs::create_dir_all(&checkout).unwrap();
+
+        // The leaf artifact, not the descriptor, is where a build's bytes are.
+        let artifact = store_object(&store, b"the compiled artifact");
+        let action = store_result(&store, "an action", std::slice::from_ref(&artifact));
+        record_build(&store, &"d".repeat(64), &checkout, &[action]);
+        let spare = store_object(&store, b"unrooted spare");
+
+        gc(&store, stats(&store).unwrap().total_bytes() - 1).unwrap();
+
+        let cas = LocalCas::new(&store);
+        assert!(cas.find(&artifact).unwrap().is_some());
+        assert!(cas.find(&spare).unwrap().is_none());
+    }
+
+    #[test]
+    fn treats_a_store_with_no_checkout_records_as_plain_lru() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        // A store written before checkouts were recorded roots nothing, so it
+        // has to keep collecting exactly as it did.
+        let old = store_object(store, b"0123456789");
+        let recent = store_object(store, b"abcdefghij");
+        age(store, &old, Duration::from_secs(60 * 60));
+        age(store, &recent, Duration::from_secs(1));
+
+        gc(store, 10).unwrap();
+
+        let cas = LocalCas::new(store);
+        assert!(cas.find(&old).unwrap().is_none());
+        assert!(cas.find(&recent).unwrap().is_some());
+    }
+
+    #[test]
+    fn drops_checkout_records_whose_worktree_is_gone() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let gone = directory.path().join("gone");
+        std::fs::create_dir_all(&gone).unwrap();
+        record_checkout(&store, &"e".repeat(64), &gone, &gone.join("target")).unwrap();
+
+        assert_eq!(stats(&store).unwrap().live_checkouts, 1);
+        std::fs::remove_dir_all(&gone).unwrap();
+        assert_eq!(stats(&store).unwrap().stale_checkouts, 1);
+
+        let outcome = gc(&store, u64::MAX).unwrap();
+
+        assert_eq!(outcome.removed_checkout_records, 1);
+        assert_eq!(stats(&store).unwrap(), StoreStats::default());
+    }
+
+    #[test]
+    fn keeps_a_checkout_recorded_while_its_worktree_exists() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let live = directory.path().join("live");
+        std::fs::create_dir_all(&live).unwrap();
+        record_checkout(&store, &"f".repeat(64), &live, &live.join("target")).unwrap();
+
+        let outcome = gc(&store, u64::MAX).unwrap();
+
+        assert_eq!(outcome.removed_checkout_records, 0);
+        assert_eq!(stats(&store).unwrap().live_checkouts, 1);
+    }
+
+    #[test]
+    fn forgets_a_claim_no_build_has_renewed() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let checkout = directory.path().join("checkout");
+        std::fs::create_dir_all(&checkout).unwrap();
+
+        // The checkout is still there, but this identity names a command line
+        // against a lockfile that has since moved on, so nothing renews it.
+        let identity = "2".repeat(64);
+        let orphan = store_object(&store, b"what that command built");
+        record_build(
+            &store,
+            &identity,
+            &checkout,
+            &[store_result(
+                &store,
+                "stale action",
+                std::slice::from_ref(&orphan),
+            )],
+        );
+        let stale = CheckoutRecord {
+            version: CHECKOUT_RECORD_VERSION,
+            workspace_root: checkout.clone(),
+            target_dir: checkout.join("target"),
+            updated_secs: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                - CHECKOUT_RETENTION.as_secs()
+                - 1,
+        };
+        crate::util::write_atomic(
+            &checkout_record_path(&store, &identity, &checkout),
+            &serde_json::to_vec(&stale).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(stats(&store).unwrap().stale_checkouts, 1);
+        gc(&store, stats(&store).unwrap().total_bytes() - 1).unwrap();
+
+        assert!(
+            LocalCas::new(&store).find(&orphan).unwrap().is_none(),
+            "an expired claim roots nothing"
+        );
+    }
+
+    #[test]
+    fn sweeps_only_once_within_the_interval() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path();
+        store_object(store, b"kept");
+
+        assert!(
+            sweep_if_due(store, u64::MAX, Duration::from_secs(3600))
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            sweep_if_due(store, u64::MAX, Duration::from_secs(3600))
+                .unwrap()
+                .is_none(),
+            "the interval has not passed"
+        );
+        assert!(
+            sweep_if_due(store, u64::MAX, Duration::ZERO)
+                .unwrap()
+                .is_some(),
+            "a zero interval always sweeps"
+        );
+    }
+
+    #[test]
+    fn does_not_count_its_own_bookkeeping_against_the_budget() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store");
+        let checkout = directory.path().join("checkout");
+        std::fs::create_dir_all(&checkout).unwrap();
+        record_checkout(&store, &"1".repeat(64), &checkout, &checkout.join("target")).unwrap();
+        sweep_if_due(&store, u64::MAX, Duration::ZERO).unwrap();
+
+        // Checkout records and the sweep stamp live outside the collected
+        // trees; counting them would make the budget mean something else.
+        assert_eq!(stats(&store).unwrap().total_bytes(), 0);
     }
 }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -38,6 +38,39 @@ fn write_named_project(directory: &Path, name: &str) {
     assert!(status.success(), "the fixture should resolve offline");
 }
 
+/// Write a workspace whose dependency builds before a member that fails.
+fn write_partially_failing_project(directory: &Path) {
+    std::fs::create_dir_all(directory.join("good/src")).unwrap();
+    std::fs::create_dir_all(directory.join("bad/src")).unwrap();
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"good\", \"bad\"]\nresolver = \"2\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("good/Cargo.toml"),
+        "[package]\nname = \"good\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(directory.join("good/src/lib.rs"), "pub fn good() {}\n").unwrap();
+    std::fs::write(
+        directory.join("bad/Cargo.toml"),
+        "[package]\nname = \"bad\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\ngood = { path = \"../good\" }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("bad/src/lib.rs"),
+        "use good as _;\ncompile_error!(\"expected failure\");\n",
+    )
+    .unwrap();
+    let status = Command::new(cargo())
+        .current_dir(directory)
+        .args(["generate-lockfile", "--offline"])
+        .status()
+        .expect("cargo should run");
+    assert!(status.success(), "the fixture should resolve offline");
+}
+
 fn cargo() -> std::ffi::OsString {
     std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into())
 }
@@ -401,6 +434,29 @@ fn a_build_records_the_checkout_it_ran_in() {
         tree_bytes(&records) > 0,
         "the build should record its checkout under {}",
         records.display()
+    );
+}
+
+#[test]
+fn a_failed_build_records_the_compilations_it_completed() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    write_partially_failing_project(project.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .args(["build", "build", "--workspace", "--offline"])
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_GC_AUTO", "0")
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("CARGO_INCREMENTAL")
+        .output()
+        .expect("mbx should run");
+
+    assert!(!output.status.success(), "the bad member should fail");
+    assert!(
+        tree_bytes(&store.path().join("actions/task-manifests/v1")) > 0,
+        "the successful dependency should still be recorded as reachable"
     );
 }
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -7,10 +7,19 @@ use std::path::Path;
 use std::process::Command;
 
 fn write_project(directory: &Path) {
+    write_named_project(directory, "fixture");
+}
+
+/// Write the fixture under `name`.
+///
+/// The name reaches the lockfile, and the lockfile is what the build identity
+/// is keyed on, so two differently named fixtures are two different identities
+/// -- which is what it takes to tell one checkout's artifacts from another's.
+fn write_named_project(directory: &Path, name: &str) {
     std::fs::create_dir_all(directory.join("src")).unwrap();
     std::fs::write(
         directory.join("Cargo.toml"),
-        "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"),
     )
     .unwrap();
     std::fs::write(
@@ -35,16 +44,19 @@ fn cargo() -> std::ffi::OsString {
 
 /// Build `project` against `store`, returning the run's statistics.
 fn build(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
-    build_with(project, store, report, &[])
+    build_with(project, store, report, &[]).0
 }
 
 /// Build as `build` does, with `settings` added to the environment.
+///
+/// Returns what the build said on stderr alongside its statistics, because some
+/// of what mbx reports -- a sweep, for one -- is only ever said there.
 fn build_with(
     project: &Path,
     store: &Path,
     report: &Path,
     settings: &[(&str, &str)],
-) -> serde_json::Value {
+) -> (serde_json::Value, String) {
     let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
     command
         .current_dir(project)
@@ -74,8 +86,51 @@ fn build_with(
         "build failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let report = std::fs::read(report).expect("a statistics report should be written");
-    serde_json::from_slice(&report).expect("the report should be JSON")
+    let stats = std::fs::read(report).expect("a statistics report should be written");
+    (
+        serde_json::from_slice(&stats).expect("the report should be JSON"),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Run `mbx` against `store` and return its stdout.
+fn mbx(store: &Path, arguments: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .args(arguments)
+        .env("MBX_CACHE_DIR", store)
+        .output()
+        .expect("mbx should run");
+    assert!(
+        output.status.success(),
+        "{arguments:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// The bytes `mbx gc` weighs against its budget.
+fn store_bytes(store: &Path) -> u64 {
+    tree_bytes(&store.join("actions/cas")) + tree_bytes(&store.join("actions/action-results"))
+}
+
+/// Total size of every file under `directory`.
+fn tree_bytes(directory: &Path) -> u64 {
+    let mut total = 0;
+    let mut pending = vec![directory.to_path_buf()];
+    while let Some(next) = pending.pop() {
+        let Ok(listing) = std::fs::read_dir(&next) else {
+            continue;
+        };
+        for entry in listing.flatten() {
+            let metadata = entry.metadata().expect("the entry should be readable");
+            if metadata.is_dir() {
+                pending.push(entry.path());
+            } else if metadata.is_file() {
+                total += metadata.len();
+            }
+        }
+    }
+    total
 }
 
 fn count(stats: &serde_json::Value, field: &str) -> u64 {
@@ -102,7 +157,7 @@ fn incremental_is_opt_in_and_reaches_cargo() {
         "the default build should still force CARGO_INCREMENTAL=0"
     );
 
-    let stats = build_with(
+    let (stats, _) = build_with(
         project.path(),
         store.path(),
         &reports.path().join("incremental.json"),
@@ -303,7 +358,7 @@ fn two_checkouts_share(generated: Generated, settings: &[(&str, &str)]) -> bool 
         &reports.path().join("first.json"),
         settings,
     );
-    let stats = build_with(
+    let (stats, _) = build_with(
         second.path(),
         store.path(),
         &reports.path().join("second.json"),
@@ -324,4 +379,129 @@ fn an_empty_store_reports_nothing() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("objects: 0"), "unexpected output: {stdout}");
+}
+
+#[test]
+fn a_build_records_the_checkout_it_ran_in() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    build(
+        project.path(),
+        store.path(),
+        &reports.path().join("cold.json"),
+    );
+
+    // The record is what later tells the collector this checkout exists, so a
+    // build that leaves none has silently opted out of being protected.
+    let records = store.path().join("actions/checkouts/v1");
+    assert!(
+        tree_bytes(&records) > 0,
+        "the build should record its checkout under {}",
+        records.display()
+    );
+}
+
+#[test]
+fn a_build_sweeps_the_store_to_its_budget() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    let (_, stderr) = build_with(
+        project.path(),
+        store.path(),
+        &reports.path().join("cold.json"),
+        // A one-byte budget swept every build: nothing this build stored can
+        // stay, so the sweep is unambiguous.
+        &[("MBX_GC_MAX_SIZE", "1"), ("MBX_GC_INTERVAL", "0")],
+    );
+
+    assert!(
+        stderr.contains("gc: evicted"),
+        "the sweep should say what it evicted: {stderr}"
+    );
+    let stats = mbx(store.path(), &["cache", "stats"]);
+    assert!(
+        stats.contains("objects: 0"),
+        "the store should be swept empty: {stats}"
+    );
+}
+
+#[test]
+fn automatic_sweeps_can_be_turned_off() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    let (_, stderr) = build_with(
+        project.path(),
+        store.path(),
+        &reports.path().join("cold.json"),
+        &[
+            ("MBX_GC_MAX_SIZE", "1"),
+            ("MBX_GC_INTERVAL", "0"),
+            ("MBX_GC_AUTO", "0"),
+        ],
+    );
+
+    assert!(!stderr.contains("gc:"), "no sweep should run: {stderr}");
+    let stats = mbx(store.path(), &["cache", "stats"]);
+    assert!(
+        !stats.contains("objects: 0"),
+        "the store should be left alone: {stats}"
+    );
+}
+
+/// Two checkouts, one deleted, a budget that fits only one of them.
+///
+/// Plain recency would keep the deleted checkout's newer artifacts and evict
+/// the surviving one's, so the survivor coming back warm is the whole claim.
+#[test]
+fn deleting_a_checkout_releases_what_only_it_used() {
+    let store = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    let surviving = tempfile::tempdir().unwrap();
+    let deleted = tempfile::tempdir().unwrap();
+    write_named_project(surviving.path(), "surviving");
+    write_named_project(deleted.path(), "deleted");
+
+    build(
+        surviving.path(),
+        store.path(),
+        &reports.path().join("surviving.json"),
+    );
+    // Budget the store as it stood with one checkout in it, plus slack. The
+    // slack matters: an action result is only dropped once its objects are
+    // gone, which happens after eviction has already decided how deep to go, so
+    // a budget set to the exact byte forces eviction one object further than
+    // the arithmetic suggests. At a real budget that rounding is noise; at this
+    // scale it is the whole margin.
+    let budget = store_bytes(store.path()) + 4096;
+    build(
+        deleted.path(),
+        store.path(),
+        &reports.path().join("deleted.json"),
+    );
+    std::fs::remove_dir_all(deleted.path()).unwrap();
+
+    mbx(store.path(), &["gc", "--max-size", &budget.to_string()]);
+
+    // Load-bearing, not cleanup: the wipe is what forces the next build to go
+    // to the store, which is the only way to see what survived the sweep.
+    std::fs::remove_dir_all(surviving.path().join("target")).unwrap();
+    let warm = build(
+        surviving.path(),
+        store.path(),
+        &reports.path().join("warm.json"),
+    );
+
+    assert!(
+        count(&warm, "hits") > 0,
+        "the surviving checkout should still be warm: {warm}"
+    );
 }


### PR DESCRIPTION
`mbx gc` existed but nothing ever called it: `--max-size` was required, no
budget lived in the configuration, and keeping the store bounded was a chore to
remember. Eviction was also pure LRU, so artifacts that only a deleted worktree
ever needed still looked recently used and outranked a live project's. Deleting
a worktree released nothing.

This is the "GC roots per checkout so deleting a worktree releases its
artifacts" half of PLAN's target-dir views item. The other half — placing the
target directories themselves — is #24 on top of this.

## Automatic sweeps

`mbx build` sweeps the store when one is due, after cargo has exited and outside
the tokio runtime, so it adds nothing to the build the user is waiting on. The
throttle is the mtime of `gc/v1/last-sweep`, one stat in the common case,
stamped before the sweep so two builds finishing together cost one sweep between
them. Budget defaults to 20GiB and the interval to 1h; `MBX_GC_AUTO=0` turns it
off. `mbx gc` no longer needs a flag.

## Checkout roots

`CacheSession::begin` records the checkout it is building in, under the identity
it is building, one whole file per checkout so there is nothing for concurrent
builds to merge. A sweep drops records whose checkout is gone, and objects no
surviving checkout can reach are evicted before the rest.

Reachability follows every edge a restore does — action descriptor, metadata,
the stdout and stderr the metadata names, and the output tree recursively.
Stopping at the descriptors protects nothing worth protecting, and the one empty
blob every silent compilation shares is enough on its own to turn a rooted hit
back into a miss.

Three properties this keeps:

- **Rooting only reorders.** The loop still stops at the budget, so it can never
  evict more than plain LRU would, and a store inside its budget is untouched.
- **A store with no records roots nothing**, so stores written before this change
  collect exactly as they did.
- **Identities are shared by worktrees of one `Cargo.lock` by design**, so
  removing one of two worktrees releases nothing while its sibling remains.

Existence alone cannot keep a claim alive: an identity covers one command line
against one lockfile, so a long-lived checkout accumulates one per lockfile it
ever had. A claim no build has renewed in 30 days stops counting. Absence,
meanwhile, is believed only when the checkout's parent directory is still there
— deleting a worktree leaves the parent, while ejecting a volume takes several
levels with it.

## Cheaper sweeps

The dangling check went through `LocalCas::find`, which verifies content, so
every sweep re-hashed every descriptor and refreshed their access times while
leaving the artifacts alone — biasing the very ordering eviction depends on. It
now checks presence only. Eviction also stops abandoning a sweep when a file
will not unlink, which Windows turns from rare into routine once a sweep runs
after every build.

## Verification

`mise run ci` green. Two checkouts, deleted one, swept to 60% of the store, and
the survivor rebuilt **1 hit, 0 misses** from a wiped `target/` — under plain LRU
its older objects would have gone first and it would have come back cold.

Two limits are documented rather than fixed: eviction order degrades toward
store-order under `relatime`/`noatime`, and the budget covers cached objects and
their results, not the whole cache directory.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cached artifacts are deleted after every build, including reachability from checkout records. A wrong live/stale decision can evict a warm cache (recompile only), not corrupt results.
> 
> **Overview**
> The cache store now stays inside a configured budget without a manual `mbx gc`. After cargo exits, `mbx build` sweeps at most once per interval (default 20GiB / 1h; `MBX_GC_AUTO=0` disables it). `mbx gc` defaults to that same budget.
> 
> Eviction is no longer pure LRU. Each build records its checkout under the identity it built; objects no surviving checkout can reach go first, so deleting a worktree releases what only it used. Sibling worktrees of one lockfile still share an identity and keep those artifacts rooted. Claims expire after 30 days without a renewing build, and a missing checkout is trusted only when its parent directory is still there.
> 
> Failed builds now commit the actions they did complete, so the collector can treat them as reachable. Dangling-result cleanup checks blob presence instead of re-hashing, and a blocked unlink (Windows) no longer aborts the sweep or evicts a rooted object in its place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2388711a0f90af5f09009065a97baa509d29129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cache garbage collection during builds with configurable size limits and sweep intervals.
  * Added checkout-aware artifact retention, stale-record cleanup, and improved eviction reporting.
  * Added manual `mbx gc` support and expanded cache statistics.
  * Added optional sharing of compiled output directories across checkouts, with validation and documented limitations.
  * Added negotiated compression for remote cache transfers.

* **Documentation**
  * Updated configuration, garbage-collection behavior, output sharing, reporting, usage, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->