### PR TITLE
feat(target): place target directories so a deleted checkout frees them

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -19,7 +19,9 @@ a standalone home. mise will eventually consume mbx and drop its embedded copy.
    content-addressed store, materializes them into target dirs via
    reflink/hardlink, and evicts with a byte-budget LRU that a build runs on its
    own schedule (`mbx gc`, or automatically). Eviction prefers what no checkout
-   on disk still needs, so deleting a worktree releases what only it used.
+   on disk still needs, so deleting a worktree releases what only it used, and
+   mbx can place the target directories themselves so the outputs of a checkout
+   that is gone are collected rather than stranded.
 3. **Git worktrees build cold.** Fingerprints embed absolute paths, so a fresh
    worktree rebuilds everything. mbx's action keys use path mapping, so a new
    worktree starts mostly warm while keeping its own target dir (no cargo lock
@@ -166,7 +168,8 @@ Protocol version stays 1; nothing in the wild speaks the old names.
 - `mbx gc [--max-size <bytes|human>]` — LRU-evict the store to a byte budget,
   defaulting to the configured one. `mbx build` does the same when a sweep is
   due.
-- `mbx cache dir` / `mbx cache stats` — store location and contents summary.
+- `mbx cache dir` / `mbx cache stats` — store location and contents summary,
+  including the managed target directories.
 - `mbx setup` — install the persistent standalone shim and wire
   `build.rustc-wrapper` in `~/.cargo/config.toml`. If that key already names
   another wrapper, such as sccache, setup reports it and changes nothing:
@@ -192,6 +195,8 @@ Env vars first, optional `~/.config/mbx/config.toml` second, defaults last.
 | `MBX_GC_AUTO` | `gc.auto` | `true` | sweep the store after a build |
 | `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | size the store is swept back to |
 | `MBX_GC_INTERVAL` | `gc.interval` | `1h` | how often a build may sweep |
+| `MBX_TARGET_VIEWS` | `target.views` | `false` | let mbx place target directories |
+| `MBX_TARGET_ROOT` | `target.root` | `<cache dir>/targets` | where it places them |
 | `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect/read timeout |
 | `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
 | `MBX_HTTP_RETRIES` | `http.retries` | `3` | request retries |
@@ -210,6 +215,18 @@ Credentials are never sent in the clear: an authenticated remote must be HTTPS,
 with an exception for loopback development servers. Redirects are not followed at
 all, so a bearer token or OIDC assertion cannot be forwarded to a host the
 operator did not configure.
+
+### Target-dir views
+
+Opt-in, because moving where a build writes is not a decision to make for
+someone. `MBX_TARGET_VIEWS` places the default target directory at
+`<target root>/v1/<digest of the workspace root>` and symlinks `target` to it,
+keyed by path alone so one checkout keeps one target directory whatever it
+builds. A record beside the directory names the checkout it belongs to -- beside
+and not inside, since `cargo clean` empties the directory and an untraceable
+target directory could never be collected. Placement declines whenever it would
+overrule a flag, the environment, a cargo configuration, or an existing real
+`target/`.
 
 ### Concurrency
 
@@ -261,9 +278,6 @@ env vars, and wire constants to match `mbx-cache-core` exactly.
 - **Predictive prefetch by default** — download the predicted action set for
   the whole dep graph in parallel at build start (the prediction plumbing
   already exists in the agent).
-- **Target-dir views** — manage `CARGO_TARGET_DIR` placement. The other half of
-  this item shipped: a build records its checkout, and collection prefers what
-  no surviving checkout needs.
 - **Deferred materialization** — leave artifacts in the CAS until read
   (biggest win for `cargo check`-heavy workflows).
 - **Decide the `CARGO_INCREMENTAL` default.** `MBX_INCREMENTAL=1` now opts into

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ See [PLAN.md](PLAN.md) for the design and the road to v1.
 
 - **Caches each rustc action once.** A compilation you have done before is
   restored instead of repeated, whatever directory you are in.
+- **Manages target directories.** Optionally places them under a root of its
+  own, so a checkout you delete stops leaving gigabytes behind and `target/`
+  becomes a link rather than a pile.
 - **Deduplicates across checkouts.** Cache keys hold no absolute paths, so a
   second worktree of the same dependency graph builds largely warm — measured at
   65% of actions on mise, with the shortfall explained under limits below. Each
@@ -134,6 +137,8 @@ defaults.
 | `MBX_GC_AUTO` | `gc.auto` | `true` | sweep the store after a build |
 | `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | size the store is swept back to |
 | `MBX_GC_INTERVAL` | `gc.interval` | `1h` | how often a build may sweep |
+| `MBX_TARGET_VIEWS` | `target.views` | `false` | let mbx place target directories |
+| `MBX_TARGET_ROOT` | `target.root` | `<cache dir>/targets` | where it places them |
 | `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect and read timeout |
 | `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
 | `MBX_HTTP_RETRIES` | `http.retries` | `3` | request retries |
@@ -146,6 +151,35 @@ defaults.
 url = "https://cache.example.com"
 namespace = "acme/backend"
 ```
+
+## Target directories
+
+Cargo writes build outputs to `<workspace>/target`, which ties them to the
+checkout: delete a worktree and the outputs go with it, and nothing else ever
+reclaims them. Turn on `MBX_TARGET_VIEWS` and mbx places them under a root of
+its own instead, leaving `target` behind as a symlink so every path you type
+still works:
+
+```sh
+MBX_TARGET_VIEWS=1 mbx build build
+ls -l target          # target -> ~/.cache/mbx/targets/v1/<digest of this checkout>
+```
+
+Now the outputs outlive the checkout, so collecting them becomes mbx's job: a
+target directory whose checkout no longer exists is unambiguous garbage, and
+`mbx gc` frees it along with everything else. That is usually the largest thing
+collection reclaims.
+
+Relocating costs nothing in cache hits. The shim maps the target directory to
+`${target}` before anything else, so an action keys the same wherever its
+outputs land -- turning this on does not cold-start a warm cache.
+
+mbx declines rather than guessing when placement would overrule someone:
+
+- a target directory named by `--target-dir`, `CARGO_TARGET_DIR`, or
+  `build.target-dir` stays where it was asked for;
+- a real `target/` directory is somebody's build outputs, so it is left alone.
+  Remove it first if you want a managed one.
 
 ## Remote caching
 
@@ -188,7 +222,7 @@ slower than either, and it is how the cache is qualified.
 ## Status and limits
 
 Working today: local caching, cross-checkout reuse, remote push and pull,
-automatic garbage collection.
+automatic garbage collection, managed target directories.
 
 Not yet:
 
@@ -245,9 +279,14 @@ Not yet:
   is what keeps that from mattering much: a wrong order inside the set nothing
   has abandoned costs a recompile.
 - **The budget covers cached objects and their results**, not the whole cache
-  directory. Prediction manifests, checkout records, and remote download
-  staging sit outside it, so the directory is always somewhat larger than the
-  number you set.
+  directory. Prediction manifests, checkout records, managed target
+  directories, and remote download staging sit outside it, so the directory is
+  always somewhat larger than the number you set. Target directories are
+  collected when their checkout is gone rather than against a budget.
+- **Managed target directories need a symlink**, which Windows only lets a
+  privileged or developer-mode process create. Where the link cannot be made,
+  mbx says so and leaves the target directory where cargo put it. A directory
+  junction would work without privileges and is not implemented yet.
 
 ## License
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -112,7 +112,12 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will
     // actually write to.
-    let placed = target::place(config, &roots.workspace_root, &roots.target_dir);
+    let placed = target::place(
+        config,
+        &roots.workspace_root,
+        &roots.target_dir,
+        roots.target_dir_requested,
+    );
     if let Some(directory) = &placed {
         roots.target_dir = directory.clone();
     }
@@ -323,6 +328,15 @@ fn workspace_root(start: &Path) -> PathBuf {
 struct Roots {
     workspace_root: PathBuf,
     target_dir: PathBuf,
+    /// Whether a flag or the environment named the target directory outright.
+    ///
+    /// Cargo prefers `--target-dir` over `CARGO_TARGET_DIR`, so a build carrying
+    /// that flag cannot be moved by setting the environment: cargo would write
+    /// where the flag says while the shim had been told the managed path, and
+    /// the whole build would stop keying against anything it could reuse. The
+    /// value can equal the default location and still have been asked for, so
+    /// comparing paths cannot answer this.
+    target_dir_requested: bool,
 }
 
 /// Carry a `RUSTC_WRAPPER` the caller already configured into the session.
@@ -389,8 +403,11 @@ fn resolve_roots_with(
         .as_ref()
         .map(|roots| roots.workspace_root.clone())
         .unwrap_or_else(|| workspace_root(&invocation_dir));
+    let flagged = target_dir_argument(arguments);
+    let from_environment = target_dir_env.as_ref().is_some_and(|dir| !dir.is_empty());
+    let target_dir_requested = flagged.is_some() || from_environment;
     // An explicit flag outranks anything cargo reports from configuration.
-    let target_dir = target_dir_argument(arguments)
+    let target_dir = flagged
         .map(|value| absolute(&invocation_dir, value))
         .or_else(|| reported.map(|roots| roots.target_dir))
         .or_else(|| {
@@ -403,6 +420,7 @@ fn resolve_roots_with(
     Roots {
         workspace_root,
         target_dir,
+        target_dir_requested,
     }
 }
 
@@ -513,6 +531,10 @@ fn parse_cargo_roots(metadata: &[u8]) -> Option<Roots> {
     Some(Roots {
         workspace_root: PathBuf::from(metadata.get("workspace_root")?.as_str()?),
         target_dir: PathBuf::from(metadata.get("target_directory")?.as_str()?),
+        // What cargo reports has folded configuration in already, so it cannot
+        // say whether anyone asked. Only the caller's own flags and environment
+        // answer that, and `resolve_roots_with` reads them itself.
+        target_dir_requested: false,
     })
 }
 
@@ -606,7 +628,50 @@ mod tests {
             Roots {
                 workspace_root: PathBuf::from("/elsewhere/project"),
                 target_dir: PathBuf::from("/var/cache/shared-target"),
+                target_dir_requested: false,
             }
+        );
+    }
+
+    #[test]
+    fn records_whether_anyone_asked_where_the_target_directory_goes() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let plain = ["build".to_string(), "--offline".to_string()];
+
+        assert!(
+            !resolve_roots_with(std::ffi::OsStr::new("cargo"), &plain, root, None)
+                .target_dir_requested,
+            "nothing asked, so placement is free to move it"
+        );
+
+        // The value is the default location, and the flag still means the caller
+        // chose it. Cargo prefers the flag over the `CARGO_TARGET_DIR` a
+        // placement would set, so this is the case that must not be moved.
+        let flagged = [
+            "build".to_string(),
+            "--offline".to_string(),
+            "--target-dir".to_string(),
+            "target".to_string(),
+        ];
+        assert!(
+            resolve_roots_with(std::ffi::OsStr::new("cargo"), &flagged, root, None)
+                .target_dir_requested
+        );
+
+        assert!(
+            resolve_roots_with(
+                std::ffi::OsStr::new("cargo"),
+                &plain,
+                root,
+                Some("/somewhere/else".into())
+            )
+            .target_dir_requested
+        );
+        assert!(
+            !resolve_roots_with(std::ffi::OsStr::new("cargo"), &plain, root, Some("".into()))
+                .target_dir_requested,
+            "an empty variable names nothing, which is how cargo reads it too"
         );
     }
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -205,7 +205,25 @@ fn exit_code(status: std::process::ExitStatus) -> ExitCode {
 
 fn gc(config: &Config, max_bytes: u64) -> Result<()> {
     let store = config.store_dir();
-    let outcome = store::gc(&store, max_bytes)?;
+    let outcome = store::gc(&store, max_bytes);
+    // Independent collections: a broken action store must not prevent the
+    // command from freeing the usually much larger target directories.
+    let pruned = target::prune(&config.target.root);
+    let outcome = match outcome {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            match pruned {
+                Ok(pruned) if pruned.removed_views > 0 => {
+                    println!("{}", target_removals(&pruned));
+                }
+                Ok(_) => {}
+                Err(prune_error) => {
+                    log::warn!("target directories were not collected: {prune_error}");
+                }
+            }
+            return Err(error);
+        }
+    };
     println!("{}", evictions(&outcome));
     if outcome.removed_checkout_records > 0 {
         println!(
@@ -213,7 +231,7 @@ fn gc(config: &Config, max_bytes: u64) -> Result<()> {
             outcome.removed_checkout_records
         );
     }
-    let pruned = target::prune(&config.target.root)?;
+    let pruned = pruned?;
     if pruned.removed_views > 0 {
         println!("{}", target_removals(&pruned));
     }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -2,7 +2,7 @@
 
 use crate::config::Config;
 use crate::session::CacheSession;
-use crate::{policy, store};
+use crate::{policy, store, target};
 use bytesize::ByteSize;
 use clap::{Args, Parser, Subcommand};
 use eyre::{Context, Result, bail};
@@ -108,7 +108,14 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     let config = &config;
 
     let working_dir = std::env::current_dir()?;
-    let roots = resolve_roots(&cargo, arguments, &working_dir);
+    let mut roots = resolve_roots(&cargo, arguments, &working_dir);
+    // Placed before the session starts, because the target directory is what
+    // the shim maps out of its cache keys and it has to be the one cargo will
+    // actually write to.
+    let placed = target::place(config, &roots.workspace_root, &roots.target_dir);
+    if let Some(directory) = &placed {
+        roots.target_dir = directory.clone();
+    }
     let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -117,6 +124,12 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     let status = runtime.block_on(async {
         let session = CacheSession::start(session_dir.path(), config).await?;
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
+        if let Some(directory) = &placed {
+            environment.insert(
+                CARGO_TARGET_DIR_ENV.into(),
+                directory.to_string_lossy().into_owned(),
+            );
+        }
         let run = session
             .begin(
                 &roots.workspace_root,
@@ -195,7 +208,20 @@ fn gc(config: &Config, max_bytes: u64) -> Result<()> {
             outcome.removed_checkout_records
         );
     }
+    let pruned = target::prune(&config.target.root)?;
+    if pruned.removed_views > 0 {
+        println!("{}", target_removals(&pruned));
+    }
     Ok(())
+}
+
+/// One line describing the target directories a sweep freed.
+fn target_removals(outcome: &target::PruneOutcome) -> String {
+    format!(
+        "freed {} target directories of checkouts that are gone ({})",
+        outcome.removed_views,
+        ByteSize::b(outcome.removed_bytes).display().iec(),
+    )
 }
 
 /// One line describing what a sweep evicted.
@@ -222,10 +248,22 @@ fn sweep_store(config: &Config) {
         return;
     }
     match store::sweep_if_due(&config.store_dir(), config.gc.max_bytes, config.gc.interval) {
-        Ok(Some(outcome)) if outcome.removed_bytes > 0 => {
-            crate::session::note(&format!("gc: {}", evictions(&outcome)));
+        Ok(Some(outcome)) => {
+            if outcome.removed_bytes > 0 {
+                crate::session::note(&format!("gc: {}", evictions(&outcome)));
+            }
+            // Inside the same throttled sweep: a target directory whose
+            // checkout is gone is the largest thing collection ever frees, and
+            // walking for it on every build would be the slowest.
+            match target::prune(&config.target.root) {
+                Ok(pruned) if pruned.removed_views > 0 => {
+                    crate::session::note(&format!("gc: {}", target_removals(&pruned)));
+                }
+                Ok(_) => {}
+                Err(error) => log::warn!("target directories were not collected: {error}"),
+            }
         }
-        Ok(_) => {}
+        Ok(None) => {}
         Err(error) => log::warn!("the store was not swept: {error}"),
     }
 }
@@ -251,6 +289,12 @@ fn cache_stats(config: &Config) -> Result<()> {
     println!(
         "checkouts: {} live, {} stale",
         stats.live_checkouts, stats.stale_checkouts
+    );
+    let views = target::stats(&config.target.root)?;
+    println!(
+        "target directories: {} ({})",
+        views.views,
+        ByteSize::b(views.bytes).display().iec()
     );
     Ok(())
 }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -257,19 +257,30 @@ fn sweep_store(config: &Config) {
             if outcome.removed_bytes > 0 {
                 crate::session::note(&format!("gc: {}", evictions(&outcome)));
             }
-            // Inside the same throttled sweep: a target directory whose
-            // checkout is gone is the largest thing collection ever frees, and
-            // walking for it on every build would be the slowest.
-            match target::prune(&config.target.root) {
-                Ok(pruned) if pruned.removed_views > 0 => {
-                    crate::session::note(&format!("gc: {}", target_removals(&pruned)));
-                }
-                Ok(_) => {}
-                Err(error) => log::warn!("target directories were not collected: {error}"),
-            }
+            prune_targets(config);
         }
         Ok(None) => {}
-        Err(error) => log::warn!("the store was not swept: {error}"),
+        Err(error) => {
+            log::warn!("the store was not swept: {error}");
+            // `sweep_if_due` stamps before collecting. If collection fails,
+            // target views are still due now and will otherwise wait through
+            // the full interval before getting another chance.
+            prune_targets(config);
+        }
+    }
+}
+
+/// Collect target views as the other half of a due automatic sweep.
+fn prune_targets(config: &Config) {
+    // A target directory whose checkout is gone is the largest thing
+    // collection ever frees, and walking for it on every build would be the
+    // slowest, so callers keep this inside the store sweep's throttle.
+    match target::prune(&config.target.root) {
+        Ok(pruned) if pruned.removed_views > 0 => {
+            crate::session::note(&format!("gc: {}", target_removals(&pruned)));
+        }
+        Ok(_) => {}
+        Err(error) => log::warn!("target directories were not collected: {error}"),
     }
 }
 

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -191,10 +191,14 @@ impl Config {
         let target = TargetSettings {
             views: optional_bool("MBX_TARGET_VIEWS", &get_env, file.target.views)?
                 .unwrap_or_default(),
-            root: get_env("MBX_TARGET_ROOT")
+            root: match get_env("MBX_TARGET_ROOT")
                 .map(PathBuf::from)
                 .or(file.target.root)
-                .unwrap_or_else(|| cache_dir.join("targets")),
+            {
+                Some(root) if root.is_absolute() => root,
+                Some(root) => cache_dir.join(root),
+                None => cache_dir.join("targets"),
+            },
         };
         Ok(Self {
             cache_dir,
@@ -392,6 +396,20 @@ mod tests {
             "moving where a build writes is opted into, never assumed"
         );
         assert_eq!(config.target.root, config.cache_dir.join("targets"));
+    }
+
+    #[test]
+    fn relative_target_roots_are_anchored_to_the_cache_directory() {
+        let config = Config::from_parts(
+            ConfigFile::default(),
+            env(&[
+                ("MBX_CACHE_DIR", "/cache"),
+                ("MBX_TARGET_ROOT", "target-views"),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(config.target.root, PathBuf::from("/cache/target-views"));
     }
 
     #[test]

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -27,6 +27,7 @@ struct ConfigFile {
     remote: RemoteFile,
     http: HttpFile,
     gc: GcFile,
+    target: TargetFile,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -38,6 +39,13 @@ struct RemoteFile {
     token_file: Option<PathBuf>,
     oidc_audience: Option<String>,
     mode: Option<RemoteCacheMode>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+struct TargetFile {
+    views: Option<bool>,
+    root: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -73,6 +81,7 @@ pub struct Config {
     pub remote: RemoteSettings,
     pub http: HttpSettings,
     pub gc: GcSettings,
+    pub target: TargetSettings,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -90,6 +99,13 @@ pub struct HttpSettings {
     pub timeout: Duration,
     pub download_timeout: Duration,
     pub retries: i64,
+}
+
+/// Where build outputs are written, and whether mbx places them.
+#[derive(Debug, Clone)]
+pub struct TargetSettings {
+    pub views: bool,
+    pub root: PathBuf,
 }
 
 /// How the store is kept inside its budget.
@@ -172,9 +188,18 @@ impl Config {
             interval: optional_duration("MBX_GC_INTERVAL", &get_env, file.gc.interval.as_deref())?
                 .unwrap_or(DEFAULT_GC_INTERVAL),
         };
+        let target = TargetSettings {
+            views: optional_bool("MBX_TARGET_VIEWS", &get_env, file.target.views)?
+                .unwrap_or_default(),
+            root: get_env("MBX_TARGET_ROOT")
+                .map(PathBuf::from)
+                .or(file.target.root)
+                .unwrap_or_else(|| cache_dir.join("targets")),
+        };
         Ok(Self {
             cache_dir,
             gc,
+            target,
             stats_report: get_env("MBX_STATS_REPORT")
                 .map(PathBuf::from)
                 .or(file.stats_report),
@@ -315,6 +340,9 @@ mod tests {
             auto = false
             max_size = "1GiB"
             interval = "6h"
+            [target]
+            views = true
+            root = "/from/file/targets"
             "#,
         )
         .unwrap();
@@ -326,6 +354,7 @@ mod tests {
                 ("MBX_REMOTE_MODE", "write-only"),
                 ("MBX_HTTP_TIMEOUT", "250ms"),
                 ("MBX_GC_MAX_SIZE", "2GiB"),
+                ("MBX_TARGET_ROOT", "/from/env/targets"),
             ]),
         )
         .unwrap();
@@ -340,6 +369,8 @@ mod tests {
         assert_eq!(config.http.retries, 9);
         assert!(!config.gc.auto);
         assert_eq!(config.gc.interval, Duration::from_secs(6 * 60 * 60));
+        assert_eq!(config.target.root, PathBuf::from("/from/env/targets"));
+        assert!(config.target.views);
     }
 
     #[test]
@@ -356,6 +387,11 @@ mod tests {
         assert!(config.gc.auto, "collection runs until it is turned off");
         assert_eq!(config.gc.max_bytes, DEFAULT_GC_MAX_SIZE);
         assert_eq!(config.gc.interval, DEFAULT_GC_INTERVAL);
+        assert!(
+            !config.target.views,
+            "moving where a build writes is opted into, never assumed"
+        );
+        assert_eq!(config.target.root, config.cache_dir.join("targets"));
     }
 
     #[test]
@@ -387,6 +423,13 @@ mod tests {
         // worse than saying so.
         assert!(
             Config::from_parts(ConfigFile::default(), env(&[("MBX_GC_AUTO", "maybe")])).is_err()
+        );
+        assert!(
+            Config::from_parts(
+                ConfigFile::default(),
+                env(&[("MBX_TARGET_VIEWS", "sometimes")])
+            )
+            .is_err()
         );
     }
 

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod policy;
 pub mod session;
 pub mod store;
+pub mod target;
 pub mod util;
 
 mod rustc;

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1016,6 +1016,10 @@ mod tests {
             remote: Default::default(),
             http: Default::default(),
             gc: Default::default(),
+            target: crate::config::TargetSettings {
+                views: false,
+                root: cache_dir.join("targets"),
+            },
         }
     }
 

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -307,7 +307,7 @@ fn claim_has_expired(record: &CheckoutRecord) -> bool {
 /// an error at either step means live. Being wrong in that direction only
 /// delays collection; the other way round throws away a warm cache someone is
 /// still using.
-fn checkout_is_live(workspace_root: &Path) -> bool {
+pub(crate) fn checkout_is_live(workspace_root: &Path) -> bool {
     if !matches!(workspace_root.try_exists(), Ok(false)) {
         return true;
     }

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -58,14 +58,32 @@ pub struct PruneOutcome {
 /// reason not to be clever:
 ///
 /// - the feature is off, which is the default;
+/// - a flag or the environment named the target directory, so moving it would
+///   be overriding the person who said where it goes. This is asked separately
+///   from where the directory actually is, because `--target-dir target` names
+///   the default location and still means the caller chose it -- and cargo
+///   prefers that flag over the `CARGO_TARGET_DIR` placement would set, so
+///   relocating anyway leaves cargo writing one place while the shim maps
+///   another and the build quietly stops using the cache at all;
 /// - the target directory is not the one cargo would have picked by default,
-///   which means a flag, the environment, or a cargo configuration named it,
-///   and moving it would be overriding the person who said where it goes;
+///   which means a cargo configuration named it;
 /// - `<workspace>/target` is a real directory, which is somebody's build
 ///   outputs. Replacing it with a link would strand them, and deleting it is
 ///   not this function's business.
-pub fn place(config: &Config, workspace_root: &Path, target_dir: &Path) -> Option<PathBuf> {
+pub fn place(
+    config: &Config,
+    workspace_root: &Path,
+    target_dir: &Path,
+    requested: bool,
+) -> Option<PathBuf> {
     if !config.target.views {
+        return None;
+    }
+    if requested {
+        log::debug!(
+            "leaving the target directory at {} where it was asked for",
+            target_dir.display()
+        );
         return None;
     }
     if target_dir != workspace_root.join("target") {
@@ -383,7 +401,7 @@ mod tests {
         let config = test_config(directory.path(), true);
         let workspace = checkout(directory.path(), "project");
 
-        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+        let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
 
         assert!(managed.is_absolute(), "the shim maps only absolute roots");
         assert!(managed.starts_with(views_root(&config.target.root)));
@@ -402,8 +420,8 @@ mod tests {
         let config = test_config(directory.path(), true);
         let workspace = checkout(directory.path(), "project");
 
-        let first = place(&config, &workspace, &workspace.join("target")).unwrap();
-        let second = place(&config, &workspace, &workspace.join("target")).unwrap();
+        let first = place(&config, &workspace, &workspace.join("target"), false).unwrap();
+        let second = place(&config, &workspace, &workspace.join("target"), false).unwrap();
 
         assert_eq!(first, second);
         assert_eq!(stats(&config.target.root).unwrap().views, 1);
@@ -415,8 +433,25 @@ mod tests {
         let config = test_config(directory.path(), false);
         let workspace = checkout(directory.path(), "project");
 
-        assert!(place(&config, &workspace, &workspace.join("target")).is_none());
+        assert!(place(&config, &workspace, &workspace.join("target"), false).is_none());
         assert!(!workspace.join("target").exists());
+    }
+
+    #[test]
+    fn leaves_a_requested_target_directory_alone_even_at_the_default_place() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+
+        // `--target-dir target` names the default location and still means the
+        // caller chose it. Cargo prefers that flag over the CARGO_TARGET_DIR
+        // placement would set, so relocating would leave cargo writing one
+        // place while the shim mapped another -- measured as a build that
+        // looked nothing up and stored almost nothing.
+        assert!(place(&config, &workspace, &workspace.join("target"), true).is_none());
+
+        assert!(!workspace.join("target").exists());
+        assert_eq!(stats(&config.target.root).unwrap(), ViewStats::default());
     }
 
     #[test]
@@ -428,7 +463,7 @@ mod tests {
         // A flag, the environment, or a cargo configuration put it here, and
         // that outranks any placement of ours.
         let elsewhere = directory.path().join("chosen");
-        assert!(place(&config, &workspace, &elsewhere).is_none());
+        assert!(place(&config, &workspace, &elsewhere, false).is_none());
         assert_eq!(stats(&config.target.root).unwrap(), ViewStats::default());
     }
 
@@ -441,7 +476,7 @@ mod tests {
         std::fs::create_dir_all(existing.join("debug")).unwrap();
         std::fs::write(existing.join("debug/libfixture.rlib"), b"outputs").unwrap();
 
-        assert!(place(&config, &workspace, &existing).is_none());
+        assert!(place(&config, &workspace, &existing, false).is_none());
 
         assert!(
             existing.join("debug/libfixture.rlib").exists(),
@@ -460,7 +495,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let config = test_config(directory.path(), true);
         let workspace = checkout(directory.path(), "project");
-        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+        let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
         std::fs::write(managed.join("artifact"), b"outputs").unwrap();
 
         // Somebody replaced the link with a directory of their own. The
@@ -470,7 +505,7 @@ mod tests {
         remove_link(&workspace.join("target")).unwrap();
         std::fs::create_dir_all(workspace.join("target")).unwrap();
 
-        assert!(place(&config, &workspace, &workspace.join("target")).is_none());
+        assert!(place(&config, &workspace, &workspace.join("target"), false).is_none());
 
         assert_eq!(stats(&config.target.root).unwrap().views, 1);
         assert!(managed.join("artifact").exists());
@@ -489,8 +524,8 @@ mod tests {
         let gone = checkout(directory.path(), "gone");
         let staying = checkout(directory.path(), "staying");
 
-        let removed = place(&config, &gone, &gone.join("target")).unwrap();
-        let kept = place(&config, &staying, &staying.join("target")).unwrap();
+        let removed = place(&config, &gone, &gone.join("target"), false).unwrap();
+        let kept = place(&config, &staying, &staying.join("target"), false).unwrap();
         std::fs::write(removed.join("artifact"), vec![0_u8; 512]).unwrap();
         std::fs::write(kept.join("artifact"), vec![0_u8; 256]).unwrap();
         std::fs::remove_dir_all(&gone).unwrap();
@@ -514,7 +549,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let config = test_config(directory.path(), true);
         let workspace = checkout(directory.path(), "project");
-        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+        let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
         std::fs::write(managed.join("artifact"), b"outputs").unwrap();
 
         let outcome = prune(&config.target.root).unwrap();
@@ -528,7 +563,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let config = test_config(directory.path(), true);
         let workspace = checkout(directory.path(), "project");
-        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+        let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
         std::fs::remove_dir_all(&workspace).unwrap();
         // `cargo clean` cannot reach the record, but a corrupt one still must
         // not turn into a licence to delete a directory full of outputs.

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -121,24 +121,23 @@ pub fn place(
     // `prune` has no way to see.
     if let Err(error) = record_view(&config.target.root, workspace_root) {
         log::warn!("the managed target directory was not recorded: {error}");
-        if matches!(link, Link::Created) {
-            // Undo this call's own link and nothing else. Left behind it would
-            // redirect every later build into a directory no record names.
-            if let Err(error) = remove_link(target_dir) {
-                log::warn!(
-                    "the unused link {} was not removed: {error}",
-                    target_dir.display()
-                );
-            }
+        // Undo this call's own link and nothing else. Left behind it would
+        // redirect every later build into a directory no record names. A link
+        // replaced during recovery goes back to its previous managed view.
+        if let Err(error) = rollback_link(target_dir, &link) {
+            log::warn!(
+                "the unused link {} was not rolled back: {error}",
+                target_dir.display()
+            );
         }
         return None;
     }
     // Cargo would create this itself on the way to writing in it. Doing it here
     // keeps the link from dangling in the meantime, which is what someone
     // listing the workspace would see.
-    if let Err(error) = std::fs::create_dir_all(&managed) {
+    if let Err(error) = prepare_view(&managed, &link) {
         log::warn!(
-            "the managed target directory {} was not created: {error}",
+            "the managed target directory {} was not prepared: {error}",
             managed.display()
         );
     }
@@ -149,6 +148,7 @@ pub fn place(
 enum Link {
     Existing,
     Created,
+    Replaced(PathBuf),
 }
 
 /// Point `target_dir` at `managed` so the paths people type keep working.
@@ -166,8 +166,7 @@ fn link_view(target_dir: &Path, managed: &Path) -> Result<Link> {
         Ok(existing) if managed_link_target(&existing, managed) => {
             // This is one of our links, but no longer the view this checkout
             // should use. That happens after a checkout moves, its old view is
-            // pruned, or the configured target root changes. Replace the link
-            // and leave the old directory and record for their own collector.
+            // pruned, or the configured target root changes.
             remove_link(target_dir).wrap_err_with(|| {
                 format!(
                     "could not replace the outdated managed target link {}",
@@ -207,7 +206,56 @@ fn link_view(target_dir: &Path, managed: &Path) -> Result<Link> {
             )
         });
     }
-    Ok(Link::Created)
+    Ok(replaced.map_or(Link::Created, Link::Replaced))
+}
+
+/// Put a link back the way it was before this placement attempt.
+fn rollback_link(target_dir: &Path, link: &Link) -> Result<()> {
+    match link {
+        Link::Existing => Ok(()),
+        Link::Created => remove_link(target_dir).map_err(Into::into),
+        Link::Replaced(previous) => {
+            remove_link(target_dir)?;
+            symlink_dir(previous, target_dir).wrap_err("could not restore the previous link")
+        }
+    }
+}
+
+/// Create a new view, carrying forward and retiring an outdated one.
+fn prepare_view(managed: &Path, link: &Link) -> Result<()> {
+    let Link::Replaced(previous) = link else {
+        return std::fs::create_dir_all(managed).map_err(Into::into);
+    };
+    match std::fs::rename(previous, managed) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(managed)?;
+        }
+        Err(_) => {
+            // A root can cross filesystems, where rename cannot carry the old
+            // view forward. Establish the new view before retiring the old
+            // one; a rebuild is preferable to an orphan nothing will scan.
+            std::fs::create_dir_all(managed)?;
+            std::fs::remove_dir_all(previous).wrap_err_with(|| {
+                format!(
+                    "could not retire the old target view {}",
+                    previous.display()
+                )
+            })?;
+        }
+    }
+    let record = previous.with_extension("json");
+    if let Err(error) = std::fs::remove_file(&record)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(error).wrap_err_with(|| {
+            format!(
+                "could not retire the old target record {}",
+                record.display()
+            )
+        });
+    }
+    Ok(())
 }
 
 /// Whether a link target is a view mbx previously placed.
@@ -476,12 +524,16 @@ mod tests {
         let second = test_config(&directory.path().join("second"), true);
         let workspace = checkout(directory.path(), "project");
         let old = place(&first, &workspace, &workspace.join("target"), false).unwrap();
+        std::fs::write(old.join("artifact"), b"outputs").unwrap();
 
         let new = place(&second, &workspace, &workspace.join("target"), false).unwrap();
 
         assert_ne!(old, new);
         assert_eq!(std::fs::read_link(workspace.join("target")).unwrap(), new);
-        assert!(new.is_dir());
+        assert!(new.join("artifact").is_file(), "the old view should move");
+        assert!(!old.exists(), "the old root must not retain an orphan");
+        assert_eq!(stats(&first.target.root).unwrap(), ViewStats::default());
+        assert_eq!(stats(&second.target.root).unwrap().views, 1);
     }
 
     #[test]

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -110,7 +110,7 @@ pub fn place(
     // for a checkout nothing manages, and worse, a refusal must not disturb a
     // record an earlier placement wrote -- the directory that one names may be
     // full of outputs, and the record is the only thing that can trace it.
-    let link = match link_view(target_dir, &managed) {
+    let link = match link_view(target_dir, &managed, workspace_root) {
         Ok(link) => link,
         Err(error) => {
             log::warn!("{error}");
@@ -158,12 +158,12 @@ enum Link {
 /// already there, and Windows only allows a symlink to be created by a
 /// privileged or developer-mode process, where the honest answer is to leave
 /// the outputs where cargo would have put them.
-fn link_view(target_dir: &Path, managed: &Path) -> Result<Link> {
+fn link_view(target_dir: &Path, managed: &Path, workspace_root: &Path) -> Result<Link> {
     let replaced = match std::fs::read_link(target_dir) {
         // Already pointing where it should. Re-linking would race a concurrent
         // build for no gain.
         Ok(existing) if existing == managed => return Ok(Link::Existing),
-        Ok(existing) if managed_link_target(&existing, managed) => {
+        Ok(existing) if replaceable_managed_link(&existing, managed, workspace_root) => {
             // This is one of our links, but no longer the view this checkout
             // should use. That happens after a checkout moves, its old view is
             // pruned, or the configured target root changes.
@@ -264,18 +264,24 @@ fn prepare_view(managed: &Path, link: &Link) -> Result<()> {
 /// has lost that record and directory, so its digest-shaped path under the
 /// configured views root is the remaining evidence. Other symlinks are never
 /// replaced, including dangling ones.
-fn managed_link_target(existing: &Path, managed: &Path) -> bool {
+fn replaceable_managed_link(existing: &Path, managed: &Path, workspace_root: &Path) -> bool {
     let Some(name) = existing.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
     if !mbx_cache_core::is_task_identity(name) {
         return false;
     }
-    if existing.parent() == managed.parent() {
-        return true;
+    if let Some(record) = read_view_record(&existing.with_extension("json"))
+        && view_key(&record.workspace_root) == name
+    {
+        return record.workspace_root == workspace_root
+            || !crate::store::checkout_is_live(&record.workspace_root);
     }
-    read_view_record(&existing.with_extension("json"))
-        .is_some_and(|record| view_key(&record.workspace_root) == name)
+    // A collector removes the record and directory together. With neither
+    // left, a digest-shaped dangling link under this root is safe to recover;
+    // a directory with a missing or corrupt record is not evidence of ours to
+    // move, and uncertainty must leave it alone.
+    existing.parent() == managed.parent() && matches!(existing.try_exists(), Ok(false))
 }
 
 /// Unlink a directory symlink without following it.
@@ -547,6 +553,23 @@ mod tests {
 
         assert!(place(&config, &workspace, &target, false).is_none());
         assert_eq!(std::fs::read_link(target).unwrap(), elsewhere);
+    }
+
+    #[test]
+    fn leaves_another_live_checkouts_view_alone() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let original = checkout(directory.path(), "original");
+        let copied = checkout(directory.path(), "copied");
+        let managed = place(&config, &original, &original.join("target"), false).unwrap();
+        std::fs::write(managed.join("artifact"), b"outputs").unwrap();
+        symlink_dir(&managed, &copied.join("target")).unwrap();
+
+        assert!(place(&config, &copied, &copied.join("target"), false).is_none());
+
+        assert_eq!(std::fs::read_link(copied.join("target")).unwrap(), managed);
+        assert!(managed.join("artifact").exists());
+        assert_eq!(stats(&config.target.root).unwrap().views, 1);
     }
 
     #[test]

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -1,0 +1,478 @@
+//! Managed target directories.
+//!
+//! Cargo puts build outputs in `<workspace>/target`, which means a checkout's
+//! outputs live and die with the checkout, and nothing but `rm -rf` ever
+//! reclaims them. A managed target directory moves them under a root mbx owns,
+//! keyed by the checkout that builds there, and leaves a symlink behind so the
+//! paths people type still work.
+//!
+//! What that buys is collection. A target directory whose checkout no longer
+//! exists is unambiguous garbage -- nothing can ever ask for it again -- and it
+//! is usually the largest thing on the disk by an order of magnitude. It costs
+//! nothing in cache hits: the shim maps the target directory to `${target}`
+//! before anything else, so an action keys the same wherever its outputs land.
+//!
+//! ```text
+//! <root>/v1/<digest of the workspace root>/       the target directory itself
+//! <root>/v1/<digest of the workspace root>.json   which checkout it belongs to
+//! ```
+//!
+//! The record sits beside the directory rather than inside it because `cargo
+//! clean` empties the directory, and a target directory nothing can trace back
+//! to a checkout could never be collected.
+
+use crate::config::Config;
+use eyre::{Context, Result};
+use mbx_cache_core::CacheDigest;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const VIEWS_DIR: &str = "v1";
+const VIEW_RECORD_VERSION: u8 = 1;
+
+/// Which checkout a managed target directory belongs to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ViewRecord {
+    version: u8,
+    workspace_root: PathBuf,
+    updated_secs: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ViewStats {
+    pub views: u64,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct PruneOutcome {
+    pub removed_views: u64,
+    pub removed_bytes: u64,
+}
+
+/// Where this checkout's outputs should be written, if mbx is placing them.
+///
+/// `None` leaves cargo's own answer alone, and every reason for that is a
+/// reason not to be clever:
+///
+/// - the feature is off, which is the default;
+/// - the target directory is not the one cargo would have picked by default,
+///   which means a flag, the environment, or a cargo configuration named it,
+///   and moving it would be overriding the person who said where it goes;
+/// - `<workspace>/target` is a real directory, which is somebody's build
+///   outputs. Replacing it with a link would strand them, and deleting it is
+///   not this function's business.
+pub fn place(config: &Config, workspace_root: &Path, target_dir: &Path) -> Option<PathBuf> {
+    if !config.target.views {
+        return None;
+    }
+    if target_dir != workspace_root.join("target") {
+        log::debug!(
+            "leaving the target directory at {} where it was asked for",
+            target_dir.display()
+        );
+        return None;
+    }
+    let managed = view_dir(&config.target.root, workspace_root);
+    if !managed.is_absolute() {
+        // This path becomes the shim's `${target}` mapping, and the shim runs
+        // with cargo's working directory rather than this one, so a relative
+        // one would map nothing and bypass the cache for the whole build.
+        log::warn!(
+            "the managed target directory {} is not absolute, so the target directory was left alone",
+            managed.display()
+        );
+        return None;
+    }
+    if let Err(error) = std::fs::create_dir_all(&managed) {
+        log::warn!(
+            "the managed target directory {} was not created: {error}",
+            managed.display()
+        );
+        return None;
+    }
+    if let Err(error) = record_view(&config.target.root, workspace_root) {
+        // Without the record the directory cannot be collected later, which is
+        // the entire point of managing it.
+        log::warn!("the managed target directory was not recorded: {error}");
+        return None;
+    }
+    match link_view(target_dir, &managed) {
+        Ok(()) => Some(managed),
+        Err(error) => {
+            log::warn!("{error}");
+            None
+        }
+    }
+}
+
+/// Point `target_dir` at `managed` so the paths people type keep working.
+///
+/// A missing link is not fatal on its own -- cargo is told where to write
+/// either way -- but it is refused rather than forced when something real is
+/// already there, and Windows only allows a symlink to be created by a
+/// privileged or developer-mode process, where the honest answer is to leave
+/// the outputs where cargo would have put them.
+fn link_view(target_dir: &Path, managed: &Path) -> Result<()> {
+    match std::fs::read_link(target_dir) {
+        // Already pointing where it should. Re-linking would race a concurrent
+        // build for no gain.
+        Ok(existing) if existing == managed => return Ok(()),
+        Ok(existing) => {
+            eyre::bail!(
+                "{} already links to {}, so it was left alone",
+                target_dir.display(),
+                existing.display()
+            );
+        }
+        Err(_) if target_dir.exists() => {
+            eyre::bail!(
+                "{} is a real directory holding build outputs, so it was left alone; remove it to use a managed target directory",
+                target_dir.display()
+            );
+        }
+        Err(_) => {}
+    }
+    symlink_dir(managed, target_dir).wrap_err_with(|| {
+        format!(
+            "could not link {} to a managed target directory",
+            target_dir.display()
+        )
+    })
+}
+
+#[cfg(unix)]
+fn symlink_dir(source: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(source, link)
+}
+
+#[cfg(windows)]
+fn symlink_dir(source: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(source, link)
+}
+
+/// Summarize the managed target directories under `root`.
+pub fn stats(root: &Path) -> Result<ViewStats> {
+    let mut stats = ViewStats::default();
+    for (_, directory) in views(root)? {
+        stats.views += 1;
+        stats.bytes += tree_bytes(&directory);
+    }
+    Ok(stats)
+}
+
+/// Remove the target directories of checkouts that no longer exist.
+///
+/// Only the checkout being gone counts. A checkout that is merely idle keeps
+/// its outputs: collecting those would cost a rebuild of work the cache can
+/// usually serve, but it would also delete something the person who owns that
+/// directory can still see, which is a different kind of surprise.
+pub fn prune(root: &Path) -> Result<PruneOutcome> {
+    let mut outcome = PruneOutcome::default();
+    for (record_path, directory) in views(root)? {
+        let Some(record) = read_view_record(&record_path) else {
+            // A record this build cannot read names no checkout, and a target
+            // directory nobody can trace is not one to delete on a guess.
+            continue;
+        };
+        if crate::store::checkout_is_live(&record.workspace_root) {
+            continue;
+        }
+        let bytes = tree_bytes(&directory);
+        match std::fs::remove_dir_all(&directory) {
+            Ok(()) => {
+                outcome.removed_views += 1;
+                outcome.removed_bytes += bytes;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                outcome.removed_views += 1;
+            }
+            Err(error) => {
+                log::warn!(
+                    "could not remove the target directory {}: {error}",
+                    directory.display()
+                );
+                continue;
+            }
+        }
+        // Last, so a failed removal above leaves the record to try again with.
+        if let Err(error) = std::fs::remove_file(&record_path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            log::warn!(
+                "could not remove the target record {}: {error}",
+                record_path.display()
+            );
+        }
+    }
+    Ok(outcome)
+}
+
+/// Every managed target directory under `root`, as record and directory.
+fn views(root: &Path) -> Result<Vec<(PathBuf, PathBuf)>> {
+    let directory = views_root(root);
+    let listing = match std::fs::read_dir(&directory) {
+        Ok(listing) => listing,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error).wrap_err_with(|| format!("failed to read {}", directory.display()));
+        }
+    };
+    let mut views = Vec::new();
+    for entry in listing {
+        let entry = entry?;
+        let path = entry.path();
+        if path
+            .extension()
+            .is_some_and(|extension| extension == "json")
+        {
+            views.push((path.clone(), path.with_extension("")));
+        }
+    }
+    Ok(views)
+}
+
+fn record_view(root: &Path, workspace_root: &Path) -> Result<()> {
+    let record = ViewRecord {
+        version: VIEW_RECORD_VERSION,
+        workspace_root: workspace_root.to_path_buf(),
+        updated_secs: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|since| since.as_secs())
+            .unwrap_or_default(),
+    };
+    let mut contents = serde_json::to_vec(&record)?;
+    contents.push(b'\n');
+    crate::util::write_atomic(&view_record_path(root, workspace_root), &contents)
+}
+
+fn read_view_record(path: &Path) -> Option<ViewRecord> {
+    let bytes = std::fs::read(path).ok()?;
+    let record = serde_json::from_slice::<ViewRecord>(&bytes).ok()?;
+    (record.version == VIEW_RECORD_VERSION).then_some(record)
+}
+
+/// The directory holding every managed target directory.
+///
+/// Absolutized lexically, because these paths are handed to cargo and to the
+/// shim, which run with a working directory of their own. Lexically and not by
+/// canonicalizing: the directory may not exist yet, and resolving symlinks here
+/// would break the very mapping it exists to serve.
+fn views_root(root: &Path) -> PathBuf {
+    let views = root.join(VIEWS_DIR);
+    std::path::absolute(&views).unwrap_or(views)
+}
+
+fn view_dir(root: &Path, workspace_root: &Path) -> PathBuf {
+    views_root(root).join(view_key(workspace_root))
+}
+
+fn view_record_path(root: &Path, workspace_root: &Path) -> PathBuf {
+    views_root(root).join(format!("{}.json", view_key(workspace_root)))
+}
+
+/// Name a checkout's directory after a digest of its path.
+///
+/// Keyed by path and nothing else, so one checkout has one target directory
+/// whatever it builds -- unlike a cache identity, which covers one command line
+/// against one lockfile and would give the same checkout a fresh directory
+/// every time either changed.
+fn view_key(workspace_root: &Path) -> String {
+    CacheDigest::blake3(workspace_root.to_string_lossy().as_bytes()).hash
+}
+
+fn tree_bytes(directory: &Path) -> u64 {
+    let mut total = 0;
+    let mut pending = vec![directory.to_path_buf()];
+    while let Some(next) = pending.pop() {
+        let Ok(listing) = std::fs::read_dir(&next) else {
+            continue;
+        };
+        for entry in listing.flatten() {
+            // Symlinks are not followed: a link's target is either inside this
+            // tree and already counted, or outside it and not ours to count.
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.is_dir() {
+                pending.push(entry.path());
+            } else if metadata.is_file() {
+                total += metadata.len();
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TargetSettings;
+
+    fn test_config(root: &Path, views: bool) -> Config {
+        Config {
+            cache_dir: root.join("cache"),
+            stats_report: None,
+            verify: false,
+            incremental: false,
+            share_out_dir: false,
+            remote: Default::default(),
+            http: Default::default(),
+            gc: Default::default(),
+            target: TargetSettings {
+                views,
+                root: root.join("targets"),
+            },
+        }
+    }
+
+    /// A checkout with the default target directory, ready to be managed.
+    fn checkout(root: &Path, name: &str) -> PathBuf {
+        let workspace = root.join(name);
+        std::fs::create_dir_all(&workspace).unwrap();
+        workspace
+    }
+
+    #[test]
+    fn places_the_default_target_directory_under_the_managed_root() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+
+        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+
+        assert!(managed.is_absolute(), "the shim maps only absolute roots");
+        assert!(managed.starts_with(views_root(&config.target.root)));
+        assert!(managed.is_dir());
+        assert_eq!(
+            std::fs::read_link(workspace.join("target")).unwrap(),
+            managed,
+            "the workspace should still have a target directory to reach"
+        );
+        assert_eq!(stats(&config.target.root).unwrap().views, 1);
+    }
+
+    #[test]
+    fn placing_a_target_directory_twice_reaches_the_same_one() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+
+        let first = place(&config, &workspace, &workspace.join("target")).unwrap();
+        let second = place(&config, &workspace, &workspace.join("target")).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(stats(&config.target.root).unwrap().views, 1);
+    }
+
+    #[test]
+    fn leaves_the_target_directory_alone_unless_asked() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), false);
+        let workspace = checkout(directory.path(), "project");
+
+        assert!(place(&config, &workspace, &workspace.join("target")).is_none());
+        assert!(!workspace.join("target").exists());
+    }
+
+    #[test]
+    fn leaves_a_target_directory_someone_else_chose_where_it_is() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+
+        // A flag, the environment, or a cargo configuration put it here, and
+        // that outranks any placement of ours.
+        let elsewhere = directory.path().join("chosen");
+        assert!(place(&config, &workspace, &elsewhere).is_none());
+        assert_eq!(stats(&config.target.root).unwrap(), ViewStats::default());
+    }
+
+    #[test]
+    fn refuses_to_displace_real_build_outputs() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let existing = workspace.join("target");
+        std::fs::create_dir_all(existing.join("debug")).unwrap();
+        std::fs::write(existing.join("debug/libfixture.rlib"), b"outputs").unwrap();
+
+        assert!(place(&config, &workspace, &existing).is_none());
+
+        assert!(
+            existing.join("debug/libfixture.rlib").exists(),
+            "somebody's build outputs are not ours to move or delete"
+        );
+    }
+
+    #[test]
+    fn frees_the_target_directory_of_a_checkout_that_is_gone() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let gone = checkout(directory.path(), "gone");
+        let staying = checkout(directory.path(), "staying");
+
+        let removed = place(&config, &gone, &gone.join("target")).unwrap();
+        let kept = place(&config, &staying, &staying.join("target")).unwrap();
+        std::fs::write(removed.join("artifact"), vec![0_u8; 512]).unwrap();
+        std::fs::write(kept.join("artifact"), vec![0_u8; 256]).unwrap();
+        std::fs::remove_dir_all(&gone).unwrap();
+
+        let outcome = prune(&config.target.root).unwrap();
+
+        assert_eq!(
+            outcome,
+            PruneOutcome {
+                removed_views: 1,
+                removed_bytes: 512,
+            }
+        );
+        assert!(!removed.exists());
+        assert!(kept.join("artifact").exists());
+        assert_eq!(stats(&config.target.root).unwrap().views, 1);
+    }
+
+    #[test]
+    fn keeps_the_target_directory_of_an_idle_checkout() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+        std::fs::write(managed.join("artifact"), b"outputs").unwrap();
+
+        let outcome = prune(&config.target.root).unwrap();
+
+        assert_eq!(outcome, PruneOutcome::default());
+        assert!(managed.join("artifact").exists());
+    }
+
+    #[test]
+    fn leaves_a_target_directory_it_cannot_trace() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+        std::fs::remove_dir_all(&workspace).unwrap();
+        // `cargo clean` cannot reach the record, but a corrupt one still must
+        // not turn into a licence to delete a directory full of outputs.
+        std::fs::write(view_record_path(&config.target.root, &workspace), b"{").unwrap();
+
+        assert_eq!(prune(&config.target.root).unwrap(), PruneOutcome::default());
+        assert!(managed.exists());
+    }
+
+    #[test]
+    fn counts_nothing_before_anything_is_placed() {
+        let directory = tempfile::tempdir().unwrap();
+        assert_eq!(
+            stats(&directory.path().join("targets")).unwrap(),
+            ViewStats::default()
+        );
+        assert_eq!(
+            prune(&directory.path().join("targets")).unwrap(),
+            PruneOutcome::default()
+        );
+    }
+}

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -86,26 +86,51 @@ pub fn place(config: &Config, workspace_root: &Path, target_dir: &Path) -> Optio
         );
         return None;
     }
+    // The link is what decides whether placement happens at all, so it goes
+    // first and nothing is written until it is in place. A refusal has to leave
+    // no trace: an unused directory and record would be counted and reported
+    // for a checkout nothing manages, and worse, a refusal must not disturb a
+    // record an earlier placement wrote -- the directory that one names may be
+    // full of outputs, and the record is the only thing that can trace it.
+    let link = match link_view(target_dir, &managed) {
+        Ok(link) => link,
+        Err(error) => {
+            log::warn!("{error}");
+            return None;
+        }
+    };
+    // Recorded before the directory exists, so a directory can never exist that
+    // `prune` has no way to see.
+    if let Err(error) = record_view(&config.target.root, workspace_root) {
+        log::warn!("the managed target directory was not recorded: {error}");
+        if matches!(link, Link::Created) {
+            // Undo this call's own link and nothing else. Left behind it would
+            // redirect every later build into a directory no record names.
+            if let Err(error) = remove_link(target_dir) {
+                log::warn!(
+                    "the unused link {} was not removed: {error}",
+                    target_dir.display()
+                );
+            }
+        }
+        return None;
+    }
+    // Cargo would create this itself on the way to writing in it. Doing it here
+    // keeps the link from dangling in the meantime, which is what someone
+    // listing the workspace would see.
     if let Err(error) = std::fs::create_dir_all(&managed) {
         log::warn!(
             "the managed target directory {} was not created: {error}",
             managed.display()
         );
-        return None;
     }
-    if let Err(error) = record_view(&config.target.root, workspace_root) {
-        // Without the record the directory cannot be collected later, which is
-        // the entire point of managing it.
-        log::warn!("the managed target directory was not recorded: {error}");
-        return None;
-    }
-    match link_view(target_dir, &managed) {
-        Ok(()) => Some(managed),
-        Err(error) => {
-            log::warn!("{error}");
-            None
-        }
-    }
+    Some(managed)
+}
+
+/// Whether a link had to be made, or was already pointing the right way.
+enum Link {
+    Existing,
+    Created,
 }
 
 /// Point `target_dir` at `managed` so the paths people type keep working.
@@ -115,11 +140,11 @@ pub fn place(config: &Config, workspace_root: &Path, target_dir: &Path) -> Optio
 /// already there, and Windows only allows a symlink to be created by a
 /// privileged or developer-mode process, where the honest answer is to leave
 /// the outputs where cargo would have put them.
-fn link_view(target_dir: &Path, managed: &Path) -> Result<()> {
+fn link_view(target_dir: &Path, managed: &Path) -> Result<Link> {
     match std::fs::read_link(target_dir) {
         // Already pointing where it should. Re-linking would race a concurrent
         // build for no gain.
-        Ok(existing) if existing == managed => return Ok(()),
+        Ok(existing) if existing == managed => return Ok(Link::Existing),
         Ok(existing) => {
             eyre::bail!(
                 "{} already links to {}, so it was left alone",
@@ -135,12 +160,29 @@ fn link_view(target_dir: &Path, managed: &Path) -> Result<()> {
         }
         Err(_) => {}
     }
-    symlink_dir(managed, target_dir).wrap_err_with(|| {
-        format!(
-            "could not link {} to a managed target directory",
-            target_dir.display()
-        )
-    })
+    symlink_dir(managed, target_dir)
+        .map(|()| Link::Created)
+        .wrap_err_with(|| {
+            format!(
+                "could not link {} to a managed target directory",
+                target_dir.display()
+            )
+        })
+}
+
+/// Unlink a directory symlink without following it.
+///
+/// Windows unlinks one with `remove_dir` -- it removes the link, never what the
+/// link points at -- while `remove_file` refuses. Unix is the other way round.
+fn remove_link(path: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        std::fs::remove_dir(path)
+    }
+    #[cfg(not(windows))]
+    {
+        std::fs::remove_file(path)
+    }
 }
 
 #[cfg(unix)]
@@ -404,6 +446,39 @@ mod tests {
         assert!(
             existing.join("debug/libfixture.rlib").exists(),
             "somebody's build outputs are not ours to move or delete"
+        );
+        assert_eq!(
+            stats(&config.target.root).unwrap(),
+            ViewStats::default(),
+            "a refusal that leaves a directory and a record behind would report \
+             a managed target directory for a checkout nothing manages"
+        );
+    }
+
+    #[test]
+    fn a_refusal_leaves_an_earlier_placement_alone() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let managed = place(&config, &workspace, &workspace.join("target")).unwrap();
+        std::fs::write(managed.join("artifact"), b"outputs").unwrap();
+
+        // Somebody replaced the link with a directory of their own. The
+        // placement already on disk still owns a full target directory, and
+        // dropping its record would leave that directory untraceable -- which
+        // means never collected.
+        remove_link(&workspace.join("target")).unwrap();
+        std::fs::create_dir_all(workspace.join("target")).unwrap();
+
+        assert!(place(&config, &workspace, &workspace.join("target")).is_none());
+
+        assert_eq!(stats(&config.target.root).unwrap().views, 1);
+        assert!(managed.join("artifact").exists());
+        std::fs::remove_dir_all(&workspace).unwrap();
+        assert_eq!(
+            prune(&config.target.root).unwrap().removed_views,
+            1,
+            "the earlier placement must still be collectable"
         );
     }
 

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -159,10 +159,23 @@ enum Link {
 /// privileged or developer-mode process, where the honest answer is to leave
 /// the outputs where cargo would have put them.
 fn link_view(target_dir: &Path, managed: &Path) -> Result<Link> {
-    match std::fs::read_link(target_dir) {
+    let replaced = match std::fs::read_link(target_dir) {
         // Already pointing where it should. Re-linking would race a concurrent
         // build for no gain.
         Ok(existing) if existing == managed => return Ok(Link::Existing),
+        Ok(existing) if managed_link_target(&existing, managed) => {
+            // This is one of our links, but no longer the view this checkout
+            // should use. That happens after a checkout moves, its old view is
+            // pruned, or the configured target root changes. Replace the link
+            // and leave the old directory and record for their own collector.
+            remove_link(target_dir).wrap_err_with(|| {
+                format!(
+                    "could not replace the outdated managed target link {}",
+                    target_dir.display()
+                )
+            })?;
+            Some(existing)
+        }
         Ok(existing) => {
             eyre::bail!(
                 "{} already links to {}, so it was left alone",
@@ -176,16 +189,45 @@ fn link_view(target_dir: &Path, managed: &Path) -> Result<Link> {
                 target_dir.display()
             );
         }
-        Err(_) => {}
-    }
-    symlink_dir(managed, target_dir)
-        .map(|()| Link::Created)
-        .wrap_err_with(|| {
+        Err(_) => None,
+    };
+    if let Err(error) = symlink_dir(managed, target_dir) {
+        if let Some(previous) = replaced
+            && let Err(restore_error) = symlink_dir(&previous, target_dir)
+        {
+            eyre::bail!(
+                "could not link {} to a managed target directory: {error}; its previous managed link could not be restored: {restore_error}",
+                target_dir.display()
+            );
+        }
+        return Err(error).wrap_err_with(|| {
             format!(
                 "could not link {} to a managed target directory",
                 target_dir.display()
             )
-        })
+        });
+    }
+    Ok(Link::Created)
+}
+
+/// Whether a link target is a view mbx previously placed.
+///
+/// A view still carrying its record proves ownership directly. A pruned view
+/// has lost that record and directory, so its digest-shaped path under the
+/// configured views root is the remaining evidence. Other symlinks are never
+/// replaced, including dangling ones.
+fn managed_link_target(existing: &Path, managed: &Path) -> bool {
+    let Some(name) = existing.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if !mbx_cache_core::is_task_identity(name) {
+        return false;
+    }
+    if existing.parent() == managed.parent() {
+        return true;
+    }
+    read_view_record(&existing.with_extension("json"))
+        .is_some_and(|record| view_key(&record.workspace_root) == name)
 }
 
 /// Unlink a directory symlink without following it.
@@ -425,6 +467,34 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(stats(&config.target.root).unwrap().views, 1);
+    }
+
+    #[test]
+    fn replaces_an_outdated_managed_target_link() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = test_config(&directory.path().join("first"), true);
+        let second = test_config(&directory.path().join("second"), true);
+        let workspace = checkout(directory.path(), "project");
+        let old = place(&first, &workspace, &workspace.join("target"), false).unwrap();
+
+        let new = place(&second, &workspace, &workspace.join("target"), false).unwrap();
+
+        assert_ne!(old, new);
+        assert_eq!(std::fs::read_link(workspace.join("target")).unwrap(), new);
+        assert!(new.is_dir());
+    }
+
+    #[test]
+    fn leaves_somebody_elses_dangling_link_alone() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let target = workspace.join("target");
+        let elsewhere = directory.path().join("missing");
+        symlink_dir(&elsewhere, &target).unwrap();
+
+        assert!(place(&config, &workspace, &target, false).is_none());
+        assert_eq!(std::fs::read_link(target).unwrap(), elsewhere);
     }
 
     #[test]

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -700,6 +700,45 @@ mod target_views {
     }
 
     #[test]
+    fn explicit_gc_still_frees_targets_when_store_collection_fails() {
+        let store = tempfile::tempdir().unwrap();
+        let gone = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_project(gone.path());
+
+        build_with(
+            gone.path(),
+            store.path(),
+            &reports.path().join("gone.json"),
+            &[("MBX_TARGET_VIEWS", "1")],
+        );
+        let directory = managed(gone.path());
+        std::fs::remove_dir_all(gone.path()).unwrap();
+        let cas = store.path().join("actions/cas/v1");
+        std::fs::remove_dir_all(&cas).unwrap();
+        std::fs::write(&cas, b"not a directory").unwrap();
+
+        let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+            .args(["gc", "--max-size", "20GiB"])
+            .env("MBX_CACHE_DIR", store.path())
+            .output()
+            .expect("mbx should run");
+
+        assert!(
+            !output.status.success(),
+            "the broken store should be reported"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("freed 1 target directories"),
+            "successful target collection should still be reported"
+        );
+        assert!(
+            !directory.exists(),
+            "explicit gc should collect targets independently of the store"
+        );
+    }
+
+    #[test]
     fn a_real_target_directory_is_never_displaced() {
         let store = tempfile::tempdir().unwrap();
         let project = tempfile::tempdir().unwrap();

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -561,3 +561,132 @@ fn deleting_a_checkout_releases_what_only_it_used() {
         "the surviving checkout should still be warm: {warm}"
     );
 }
+
+/// Managed target directories rest on a symlink standing in for `target`, and
+/// Windows only lets a privileged or developer-mode process create one, so mbx
+/// leaves the target directory where cargo put it there. These cover the
+/// platforms where the feature is available.
+#[cfg(unix)]
+mod target_views {
+    use super::*;
+
+    fn managed(project: &Path) -> std::path::PathBuf {
+        std::fs::read_link(project.join("target")).expect("target should be a link")
+    }
+
+    #[test]
+    fn a_managed_target_directory_keeps_the_workspace_clean() {
+        let store = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_project(project.path());
+
+        build_with(
+            project.path(),
+            store.path(),
+            &reports.path().join("cold.json"),
+            &[("MBX_TARGET_VIEWS", "1")],
+        );
+
+        let directory = managed(project.path());
+        assert!(
+            directory.starts_with(store.path().join("targets")),
+            "outputs should land under the managed root, not the workspace: {}",
+            directory.display()
+        );
+        // The link is the point: a relocation that breaks the paths people type
+        // would not be worth the disk it reclaims.
+        assert!(
+            project.path().join("target/debug/libfixture.rlib").exists(),
+            "the workspace should still reach its own build outputs"
+        );
+    }
+
+    #[test]
+    fn a_managed_target_directory_still_hits_the_cache() {
+        let store = tempfile::tempdir().unwrap();
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_project(first.path());
+        write_project(second.path());
+
+        build(
+            first.path(),
+            store.path(),
+            &reports.path().join("first.json"),
+        );
+        let (warm, _) = build_with(
+            second.path(),
+            store.path(),
+            &reports.path().join("second.json"),
+            &[("MBX_TARGET_VIEWS", "1")],
+        );
+
+        // The shim maps the target directory out of its keys before anything
+        // else, so moving it must not cost a single hit.
+        assert!(
+            count(&warm, "hits") > 0,
+            "a relocated target directory should still reuse the first build: {warm}"
+        );
+    }
+
+    #[test]
+    fn deleting_a_checkout_frees_its_managed_target_directory() {
+        let store = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_project(project.path());
+
+        build_with(
+            project.path(),
+            store.path(),
+            &reports.path().join("cold.json"),
+            &[("MBX_TARGET_VIEWS", "1")],
+        );
+        let directory = managed(project.path());
+        assert!(tree_bytes(&directory) > 0);
+
+        // Outputs used to live inside the checkout and die with it. Now that
+        // they outlive it, collecting them is mbx's job.
+        std::fs::remove_dir_all(project.path()).unwrap();
+        let output = mbx(store.path(), &["gc", "--max-size", "20GiB"]);
+
+        assert!(
+            !directory.exists(),
+            "the target directory of a checkout that is gone should be freed"
+        );
+        assert!(
+            output.contains("freed 1 target directories"),
+            "gc should say what it freed: {output}"
+        );
+    }
+
+    #[test]
+    fn a_real_target_directory_is_never_displaced() {
+        let store = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_project(project.path());
+        // A build that ran before the feature was turned on.
+        build(
+            project.path(),
+            store.path(),
+            &reports.path().join("cold.json"),
+        );
+        assert!(project.path().join("target").is_dir());
+
+        build_with(
+            project.path(),
+            store.path(),
+            &reports.path().join("warm.json"),
+            &[("MBX_TARGET_VIEWS", "1")],
+        );
+
+        assert!(
+            std::fs::read_link(project.path().join("target")).is_err(),
+            "existing build outputs are not ours to move"
+        );
+        assert!(project.path().join("target/debug/libfixture.rlib").exists());
+    }
+}

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -663,6 +663,43 @@ mod target_views {
     }
 
     #[test]
+    fn a_store_sweep_failure_still_frees_managed_target_directories() {
+        let store = tempfile::tempdir().unwrap();
+        let gone = tempfile::tempdir().unwrap();
+        let current = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_named_project(gone.path(), "gone");
+        write_named_project(current.path(), "current");
+
+        build_with(
+            gone.path(),
+            store.path(),
+            &reports.path().join("gone.json"),
+            &[("MBX_TARGET_VIEWS", "1")],
+        );
+        let directory = managed(gone.path());
+        std::fs::remove_dir_all(gone.path()).unwrap();
+
+        // Make the due store sweep fail after it writes its throttle stamp.
+        // Target collection is independent and must not be skipped with it.
+        let cas = store.path().join("actions/cas/v1");
+        std::fs::remove_dir_all(&cas).unwrap();
+        std::fs::write(&cas, b"not a directory").unwrap();
+        let (_, stderr) = build_with(
+            current.path(),
+            store.path(),
+            &reports.path().join("current.json"),
+            &[("MBX_TARGET_VIEWS", "1"), ("MBX_GC_INTERVAL", "0")],
+        );
+
+        assert!(stderr.contains("the store was not swept"), "{stderr}");
+        assert!(
+            !directory.exists(),
+            "target collection should still run when store collection fails"
+        );
+    }
+
+    #[test]
     fn a_real_target_directory_is_never_displaced() {
         let store = tempfile::tempdir().unwrap();
         let project = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Cargo writes build outputs to `<workspace>/target`, which ties them to the
checkout: `git worktree remove` takes them with it and nothing else ever
reclaims them. That was fine until collection started caring about which
checkouts still exist. `MBX_TARGET_VIEWS` places the default target directory
at `<target root>/v1/<digest of the workspace root>` and symlinks `target` to
it, so the outputs outlive the checkout -- and then `mbx gc` frees the ones
whose checkout is gone, which is by far the largest thing collection reclaims.

Keyed by path alone, so one checkout keeps one target directory whatever it
builds. A cache identity would not do: it covers one command line against one
lockfile, so `build` and `test` would each get their own, and every lockfile
change would abandon another.

The record naming the checkout sits *beside* the directory rather than inside
it, because `cargo clean` empties the directory and a target directory nothing
can trace back to a checkout could never be collected.

## It costs no hits

The shim maps the target directory to `${target}` ahead of everything else, so
an action keys the same wherever its outputs land. Verified rather than
assumed: a build with the target directory outside the workspace hits a store
populated by one with it inside. Turning this on does not cold-start a warm
cache, which is what makes it worth offering at all.

The placed path must be absolute, and is absolutized lexically rather than
canonicalized -- the directory may not exist yet, and resolving symlinks would
break the mapping it exists to serve. A relative one silently bypasses the
cache for the entire build, which is how this was found.

## It declines rather than guessing

Off by default: moving where a build writes is not a decision to make for
someone. And even when on, placement steps aside whenever it would overrule a
person -- a target directory named by `--target-dir`, `CARGO_TARGET_DIR`, or
`build.target-dir` stays where it was asked for, and a real `target/` directory
is somebody's build outputs, left alone with a note saying why.

Collection is equally conservative. Only the checkout being *gone* counts; an
idle checkout keeps its outputs. A record that no longer parses names no
checkout, and a target directory nobody can trace is not one to delete on a
guess.

## Known gap

The link is what keeps `./target/debug/...` working, and Windows only lets a
privileged or developer-mode process create a symlink. Where it cannot be made,
mbx says so and leaves the target directory alone -- a silent relocation that
broke every path someone types would be worse than not relocating. A directory
junction needs no privileges and would close this; it needs `DeviceIoControl`
and is left for later. The integration tests covering the link are `cfg(unix)`
for the same reason.

*AI-assisted -- Tool: Claude Code; model: claude-opus-5*

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Filesystem placement, symlink replacement, and GC deletion of target trees can strand or remove build outputs if ownership checks fail. Off by default and conservative about existing dirs, flags, and unreadable records.
> 
> **Overview**
> Adds **opt-in managed target directories** (`MBX_TARGET_VIEWS`, default off). When enabled, `mbx build` places the default `target/` under `<cache>/targets/v1/<digest of workspace path>`, symlinks `target` to it, and sets `CARGO_TARGET_DIR` so cargo and the shim agree. Relocating does not change cache keys.
> 
> **Placement declines** if `--target-dir`, `CARGO_TARGET_DIR`, or cargo config already named a dir (including `--target-dir target`), if `target/` is a real directory, or if a symlink cannot be created (Windows without privileges). Records live *beside* the view so `cargo clean` cannot make them uncollectable.
> 
> **GC** (`mbx gc` and the throttled post-build sweep) now prunes views whose checkout is gone, independently of store collection so a broken CAS still frees the large trees. `mbx cache stats` reports view count and size. Views sit outside the store byte budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e90ce37c34f0b74e21a0783ac582ff4427c57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->