### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytesize",
  "clap",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "mbx-cache-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/mbx", "crates/mbx-cache-core", "crates/mbx-cache-rustc"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/jdx/mr-boxington"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.2.0...mbx-cache-core-v0.3.0) - 2026-08-23
+
+### Added
+
+- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
+
 ## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.1.0...mbx-cache-core-v0.2.0) - 2026-08-22
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.2.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/jdx/mr-boxington/compare/v0.2.0...v0.3.0) - 2026-08-23
+
+### Added
+
+- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
+- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
+
 ## [0.2.0](https://github.com/jdx/mr-boxington/compare/v0.1.0...v0.2.0) - 2026-08-22
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -14,8 +14,8 @@ env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.2.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.2.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.3.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.3.0", default-features = false }
 rand = "0.10"
 reflink-copy = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.2.0 -> 0.3.0
* `mbx`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `mbx` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GcOutcome.removed_checkout_records in /tmp/.tmpcsn9Ub/mr-boxington/crates/mbx/src/store.rs:61
  field Config.gc in /tmp/.tmpcsn9Ub/mr-boxington/crates/mbx/src/config.rs:83
  field Config.target in /tmp/.tmpcsn9Ub/mr-boxington/crates/mbx/src/config.rs:84
  field StoreStats.live_checkouts in /tmp/.tmpcsn9Ub/mr-boxington/crates/mbx/src/store.rs:43
  field StoreStats.stale_checkouts in /tmp/.tmpcsn9Ub/mr-boxington/crates/mbx/src/store.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.3.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.2.0...mbx-cache-core-v0.3.0) - 2026-08-23

### Added

- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.1.0...mbx-cache-rustc-v0.2.0) - 2026-08-22

### Added

- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
</blockquote>

## `mbx`

<blockquote>

## [0.3.0](https://github.com/jdx/mr-boxington/compare/v0.2.0...v0.3.0) - 2026-08-23

### Added

- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version, changelog, and dependency-pin updates only; no runtime or security logic changes in this PR.
> 
> **Overview**
> Bumps the workspace crates (`mbx`, `mbx-cache-core`, `mbx-cache-rustc`) from **0.2.0** to **0.3.0**, including lockfile and path-dep version pins.
> 
> Changelogs record automatic store GC (preferring deleted checkouts) and target-dir placement that frees space when a checkout is removed. `mbx` is a **semver-breaking** bump due to new public fields on `Config`, `StoreStats`, and `GcOutcome`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55de64beabf68f3c84530b2eddbfc8ee00d192a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->