### PR TITLE
feat: add direct cargo wrapper and docs website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,61 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "Cargo.toml"
+      - "mise.toml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "Cargo.toml"
+      - "mise.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+        if: github.event_name != 'pull_request'
+      - name: Build with VitePress
+        run: |
+          mise run build:docs
+          touch docs/.vitepress/dist/.nojekyll
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        if: github.event_name != 'pull_request'
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,18 +35,18 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main'
       - name: Build with VitePress
         run: |
           mise run build:docs
           touch docs/.vitepress/dist/.nojekyll
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main'
         with:
           path: docs/.vitepress/dist
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +404,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "demand"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7f0bec8d94f8eb4d2efec0325ef991480abab44dc42f2f3cbf10c41aeb73fc"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "itertools",
+ "libc",
+ "signal-hook",
+ "termcolor",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +465,18 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
@@ -616,6 +654,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -957,6 +1004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1178,7 @@ version = "0.3.0"
 dependencies = [
  "bytesize",
  "clap",
+ "demand",
  "dirs",
  "env_logger",
  "eyre",
@@ -1900,6 +1957,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2115,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2141,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2268,6 +2363,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,46 +224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1137,6 @@ name = "mbx"
 version = "0.3.0"
 dependencies = [
  "bytesize",
- "clap",
  "demand",
  "dirs",
  "env_logger",
@@ -1193,6 +1152,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "usage-rs",
  "which",
  "windows-sys 0.61.2",
 ]
@@ -2027,12 +1987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,6 +2340,33 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usage-argv"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb8bc2270df585912b1c3eca56c1319c441b6c4e4f977a107e93e709d5e7650"
+
+[[package]]
+name = "usage-derive"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ba84e10f41a34ec00b52e8a4f1c875b2811a0a4c65b0d352ab180138d6e491"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "usage-rs"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da081ad5fff1d9a3e5d8ef4e2cb90a212fe23387682c99302f6562cb641b896f"
+dependencies = [
+ "usage-argv",
+ "usage-derive",
 ]
 
 [[package]]

--- a/PLAN.md
+++ b/PLAN.md
@@ -195,7 +195,7 @@ Env vars first, optional `~/.config/mbx/config.toml` second, defaults last.
 | `MBX_GC_AUTO` | `gc.auto` | `true` | sweep the store after a build |
 | `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | size the store is swept back to |
 | `MBX_GC_INTERVAL` | `gc.interval` | `1h` | how often a build may sweep |
-| `MBX_TARGET_VIEWS` | `target.views` | `false` | let mbx place target directories |
+| `MBX_TARGET_VIEWS` | `target.views` | `true` | let mbx place target directories |
 | `MBX_TARGET_ROOT` | `target.root` | `<cache dir>/targets` | where it places them |
 | `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect/read timeout |
 | `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
@@ -218,8 +218,8 @@ operator did not configure.
 
 ### Target-dir views
 
-Opt-in, because moving where a build writes is not a decision to make for
-someone. `MBX_TARGET_VIEWS` places the default target directory at
+Enabled by default, with `MBX_TARGET_VIEWS=0` as the opt-out.
+`MBX_TARGET_VIEWS` places the default target directory at
 `<target root>/v1/<digest of the workspace root>` and symlinks `target` to it,
 keyed by path alone so one checkout keeps one target directory whatever it
 builds. A record beside the directory names the checkout it belongs to -- beside

--- a/PLAN.md
+++ b/PLAN.md
@@ -41,12 +41,12 @@ a standalone home. mise will eventually consume mbx and drop its embedded copy.
   dependencies non-incrementally by default; mbx caches those. Incremental
   compilations bypass the cache by design, and `MBX_INCREMENTAL=1` opts into
   that trade rather than trying to cache them.
-- A daemon. The agent lives for the duration of one `mbx build`.
+- A daemon. The agent lives for the duration of one cached Cargo command.
 
 ## Architecture
 
 ```text
-mbx build [-- <cargo args>]
+mbx <cargo subcommand> [cargo args]
   └─ session (tempdir)
      ├─ shim install: hardlink/copy of the mbx binary named `mbx-rustc`
      ├─ agent: in-process, serves a unix socket / windows named pipe
@@ -85,7 +85,7 @@ the same binary, the agent handshake can require strict version equality.
 
 Two modes:
 
-- **Session mode** (under `mbx build`): talks to the agent over the socket;
+- **Session mode** (under an mbx-wrapped Cargo command): talks to the agent over the socket;
   gets prefetch, batched uploads, and staged blob packs. This is the only mode
   today.
 - **Standalone mode** (no `MBX_SOCKET`): would read and write the local store
@@ -164,9 +164,9 @@ Protocol version stays 1; nothing in the wild speaks the old names.
 
 ## Command surface (v1)
 
-- `mbx build [-- <cargo args>]` — run cargo under a cache session.
+- `mbx <cargo subcommand> [cargo args]` — run Cargo under a cache session.
 - `mbx gc [--max-size <bytes|human>]` — LRU-evict the store to a byte budget,
-  defaulting to the configured one. `mbx build` does the same when a sweep is
+  defaulting to the configured one. A cached Cargo command does the same when a sweep is
   due.
 - `mbx cache dir` / `mbx cache stats` — store location and contents summary,
   including the managed target directories.
@@ -230,7 +230,7 @@ overrule a flag, the environment, a cargo configuration, or an existing real
 
 ### Concurrency
 
-Sessions do not coordinate. Several `mbx build` runs and an `mbx gc` can share
+Sessions do not coordinate. Several cached Cargo commands and an `mbx gc` can share
 one store: manifest updates take a file lock, CAS writes are content-addressed
 and idempotent, and an eviction racing a restore turns that action into a miss.
 The automatic sweep is throttled by a stamp file rather than coordinated, so two

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Build it once.</strong><br>
-  A Cargo wrapper that warms worktrees and keeps Rust build storage under control.
+  A Cargo wrapper that shares compiled work across worktrees and CI—and prunes build storage automatically.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mr boxington
 
+[Documentation](https://mr-boxington.jdx.dev) · [Releases](https://github.com/jdx/mr-boxington/releases)
+
 > **Please ignore this project.** It is an experiment and is not intended for
 > others to use yet. Nothing here is stable or supported, and the protocol may
 > change without notice. Releases exist so CI can install a binary, not as a

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ still resolves dependencies, plans builds, and links outputs; mbx restores
 supported compilations it has seen before.
 
 ```sh
-mbx build build                  # cargo build, with caching
-mbx build test --all-features    # cargo test --all-features, with caching
-mbx build clippy --workspace     # cargo clippy --workspace, with caching
+mbx build                  # cargo build, with caching
+mbx test --all-features    # cargo test --all-features, with caching
+mbx clippy --workspace     # cargo clippy --workspace, with caching
 ```
 
 ## Why mbx?
@@ -88,15 +88,17 @@ For a checkout without an existing `target/`, managed target directories are
 enabled automatically:
 
 ```sh
-mbx build build
+mbx build
 ```
 
 mbx places the target directory under its cache root and leaves `target` as a
 symlink, so familiar paths still work. Once the checkout is gone, `mbx gc` can
 remove its target directory too.
 
-An existing real `target/` is never replaced. Remove it to opt that checkout
-into managed targets, or set `MBX_TARGET_VIEWS=0` to disable placement.
+For an existing real `target/`, an interactive `mbx` asks before removing the
+old outputs and replacing the directory with a managed link. The safe default
+is to keep it. Non-interactive runs never remove it. Set `MBX_TARGET_VIEWS=0`
+to disable managed placement and the prompt.
 
 [Learn about managed targets →](https://mr-boxington.jdx.dev/managed-targets)
 
@@ -115,7 +117,7 @@ such as [`jdx/mbx-cache`](https://github.com/jdx/mbx-cache).
 
 ## How it works
 
-`mbx build` starts an in-process cache agent, points Cargo at a rustc shim with
+An `mbx` Cargo command starts an in-process cache agent, points Cargo at a rustc shim with
 `RUSTC_WRAPPER`, and exits the agent with the build—there is no daemon. The shim
 derives an action key, restores cached outputs when possible, or runs the real
 compiler and publishes a successful result.

--- a/README.md
+++ b/README.md
@@ -1,295 +1,138 @@
-# mr boxington
+<p align="center">
+  <img src="docs/public/logo.svg" alt="Mr Boxington, a friendly cache box wearing a monocle and bow tie" width="220">
+</p>
 
-[Documentation](https://mr-boxington.jdx.dev) · [Releases](https://github.com/jdx/mr-boxington/releases)
+<h1 align="center">mr boxington</h1>
 
-> **Please ignore this project.** It is an experiment and is not intended for
-> others to use yet. Nothing here is stable or supported, and the protocol may
-> change without notice. Releases exist so CI can install a binary, not as a
-> promise that any of it keeps working.
+<p align="center">
+  <strong>Build it once.</strong><br>
+  A Cargo wrapper that warms worktrees and keeps Rust build storage under control.
+</p>
 
-`mbx` is a build cache for Rust projects. It wraps cargo, caches individual
-rustc compilations in a content-addressed store shared by every project and
-worktree on your machine, and can share those compilations with CI and
-teammates through a remote cache.
+<p align="center">
+  <a href="https://mr-boxington.jdx.dev">Documentation</a>
+  ·
+  <a href="https://github.com/jdx/mr-boxington/releases">Releases</a>
+  ·
+  <a href="PLAN.md">Road to v1</a>
+</p>
 
-See [PLAN.md](PLAN.md) for the design and the road to v1.
+> [!WARNING]
+> mr boxington is pre-1.0. The cache format and behavior may change without
+> notice, and releases are not a stability promise.
 
-## What it does
+`mbx` wraps ordinary Cargo commands with a content-addressed rustc cache. Cargo
+still resolves dependencies, plans builds, and links outputs; mbx restores
+supported compilations it has seen before.
 
-- **Caches each rustc action once.** A compilation you have done before is
-  restored instead of repeated, whatever directory you are in.
-- **Manages target directories.** Optionally places them under a root of its
-  own, so a checkout you delete stops leaving gigabytes behind and `target/`
-  becomes a link rather than a pile.
-- **Deduplicates across checkouts.** Cache keys hold no absolute paths, so a
-  second worktree of the same dependency graph builds largely warm — measured at
-  65% of actions on mise, with the shortfall explained under limits below. Each
-  keeps its own `target/` directory, so there is no cargo lock contention
-  between them.
-- **Collects garbage.** The store has a size budget, and a build sweeps it back
-  under that budget on its own -- something cargo has never done for `target/`.
-  A checkout that no longer exists loses its artifacts before a live project
-  does.
-- **Shares through a remote.** CI and teammates can restore from a
-  [self-hosted server](https://github.com/jdx/mbx-cache); an ephemeral runner
-  with an empty store pulls only the actions its build needs.
+```sh
+mbx build build                  # cargo build, with caching
+mbx build test --all-features    # cargo test --all-features, with caching
+mbx build clippy --workspace     # cargo clippy --workspace, with caching
+```
 
-It is a cargo wrapper, not a cargo replacement. Cargo keeps resolution, feature
-unification, build planning, and linking.
+## Why mbx?
+
+- **Warm every worktree.** Cache keys contain no checkout-specific absolute
+  paths, so building one checkout warms its siblings automatically without
+  sharing a Cargo target lock.
+- **Prune automatically.** mbx sweeps its action store back to a size budget.
+  With managed targets enabled, it also removes target directories after their
+  checkout disappears.
+- **Warm CI safely.** GitHub Actions cache can warm fork pull requests from a
+  cache built on `main`, while a self-hosted remote can serve trusted runners
+  and teammates. Pull requests never publish remote objects.
+- **See the whole result.** mbx reports hits, misses, actions it could not look
+  up, and actions it deliberately bypassed. A high hit rate cannot hide work
+  that never entered the cache.
 
 ## Install
 
-Every release attaches one archive per target, holding the `mbx` binary and
-nothing else, so extracting it into a directory on `PATH` is the whole install.
-The Linux binaries are statically linked against musl and need nothing from the
-host.
+With [mise](https://mise.jdx.dev):
 
 ```sh
-curl -fsSL https://github.com/jdx/mr-boxington/releases/latest/download/mbx-x86_64-unknown-linux-musl.tar.gz | tar -xzf - -C ~/.local/bin
+mise use -g github:jdx/mr-boxington
 ```
 
-Targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`,
-`aarch64-apple-darwin`, `x86_64-apple-darwin`, and `x86_64-pc-windows-msvc`
-(a `.zip`). `SHA256SUMS` on the release covers all of them.
-
-Asset names carry no version, so pin one in CI by swapping `latest/download`
-for a tag: `releases/download/v0.1.0/mbx-x86_64-unknown-linux-musl.tar.gz`.
-`mbx --version` reports which build you have.
-
-Building from source works too: `cargo build --release`.
-
-Releases are cut by release-plz; see [RELEASING.md](RELEASING.md).
-
-## Usage
+With Cargo:
 
 ```sh
-mbx build build                  # == cargo build
-mbx build test --all-features    # == cargo test --all-features
+cargo install mbx
 ```
 
-`mbx build` passes everything after it to cargo unchanged. When the cache did
-anything at all, it summarises that on stderr afterwards — a build with no cache
-activity prints nothing:
-
-```
-cache: 12 hits, 3 misses, 12 prefetched; 4.1 MiB downloaded, 0 B uploaded, 1.2 MiB stored locally
-cache could not look up 4 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from
-cache bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
-```
-
-The last line accounts for compilations mbx declined to cache, grouped by
-reason. It is the honest counterpart to the hit rate: a build can hit every
-action it looked up and still spend most of its time on work that never entered
-the cache.
-
-The line above it is the other half of that honesty, and it dominates a genuinely
-cold build. An action key comes from a dep-info file an earlier build left
-behind, or from a prediction recorded by one. Without a usable key from either
--- no dep-info at all, or dep-info that does not yield one -- mbx has nothing to
-look up and compiles without making the lookup. Those compilations are stored
-afterwards, so they are not bypasses, and they are not misses either: a miss is
-a lookup that found nothing. Counting them as neither is what once made a cold
-build report `0 hits, 0 misses` while writing a gigabyte into the store.
-
-Store management:
+Or install the latest Linux x86-64 release archive:
 
 ```sh
-mbx cache dir       # where the store lives
-mbx cache stats     # what it holds
-mbx gc              # sweep to the configured budget
-mbx gc --max-size 20GiB
+mkdir -p ~/.local/bin
+curl -fsSL https://github.com/jdx/mr-boxington/releases/latest/download/mbx-x86_64-unknown-linux-musl.tar.gz \
+  | tar -xzf - -C ~/.local/bin
 ```
 
-A build sweeps the store itself when one is due -- at most once per
-`MBX_GC_INTERVAL`, and only reporting when it evicted something:
+Release archives also cover Linux ARM64, Apple Silicon, Intel macOS, and
+Windows x86-64. Every release includes `SHA256SUMS`.
 
-```text
-gc: evicted 128 objects and 3 action results (1.2 GiB); 18.9 GiB remain
+[See all installation options →](https://mr-boxington.jdx.dev/getting-started)
+
+## Automatic pruning
+
+The action store is swept automatically to a 20 GiB budget by default. Inspect
+or collect it explicitly with:
+
+```sh
+mbx cache stats
+mbx gc
+mbx gc --max-size 3GB
 ```
 
-A store inside its budget loses no cached compilations; a sweep that finds one
-there still tidies its own bookkeeping, dropping the records of checkouts that
-have gone. When a store is over budget, the objects that go first are the ones
-no checkout on disk still needs: `mbx build` records the checkout it ran in, and
-a checkout that has been deleted stops protecting what only it used. Worktrees
-of one `Cargo.lock` share their cached compilations, so removing one of those
-releases nothing while a sibling remains -- the sibling genuinely still needs
-them.
-
-Evicting an object that is still in use costs a recompile and nothing else, so
-`gc` is always safe to run.
-
-## Configuration
-
-Environment variables win over `~/.config/mbx/config.toml`, which wins over the
-defaults.
-
-| Environment | Config key | Default | Meaning |
-| --- | --- | --- | --- |
-| `MBX_CACHE_DIR` | `cache_dir` | platform cache dir | store root |
-| `MBX_REMOTE_URL` | `remote.url` | unset | remote cache base URL |
-| `MBX_REMOTE_NAMESPACE` | `remote.namespace` | unset | required with a URL |
-| `MBX_REMOTE_TOKEN` | `remote.token` | unset | bearer token |
-| `MBX_REMOTE_TOKEN_FILE` | `remote.token_file` | unset | token read from a file |
-| `MBX_REMOTE_OIDC_AUDIENCE` | `remote.oidc_audience` | unset | CI OIDC audience |
-| `MBX_REMOTE_MODE` | `remote.mode` | `read-write` | or `read-only`, `write-only` |
-| `MBX_SHARE_OUT_DIR` | `share_out_dir` | off | share compilations that read `OUT_DIR` |
-| `MBX_STATS_REPORT` | `stats_report` | unset | write a JSON report here |
-| `MBX_INCREMENTAL` | `incremental` | off | let cargo compile workspace members incrementally |
-| `MBX_GC_AUTO` | `gc.auto` | `true` | sweep the store after a build |
-| `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | size the store is swept back to |
-| `MBX_GC_INTERVAL` | `gc.interval` | `1h` | how often a build may sweep |
-| `MBX_TARGET_VIEWS` | `target.views` | `false` | let mbx place target directories |
-| `MBX_TARGET_ROOT` | `target.root` | `<cache dir>/targets` | where it places them |
-| `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | connect and read timeout |
-| `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | blob downloads |
-| `MBX_HTTP_RETRIES` | `http.retries` | `3` | request retries |
-| `MBX_VERIFY` | — | unset | compile anyway and compare against the cache |
-| `MBX_BYPASS_LOG` | — | unset | append the full reason for every uncached compilation to this file |
-
-```toml
-# ~/.config/mbx/config.toml
-[remote]
-url = "https://cache.example.com"
-namespace = "acme/backend"
-```
-
-## Target directories
-
-Cargo writes build outputs to `<workspace>/target`, which ties them to the
-checkout: delete a worktree and the outputs go with it, and nothing else ever
-reclaims them. Turn on `MBX_TARGET_VIEWS` and mbx places them under a root of
-its own instead, leaving `target` behind as a symlink so every path you type
-still works:
+Enable managed target directories to reclaim the larger build outputs left by
+deleted checkouts:
 
 ```sh
 MBX_TARGET_VIEWS=1 mbx build build
-ls -l target          # target -> ~/.cache/mbx/targets/v1/<digest of this checkout>
 ```
 
-Now the outputs outlive the checkout, so collecting them becomes mbx's job: a
-target directory whose checkout no longer exists is unambiguous garbage, and
-`mbx gc` frees it along with everything else. That is usually the largest thing
-collection reclaims.
+mbx places the target directory under its cache root and leaves `target` as a
+symlink, so familiar paths still work. Once the checkout is gone, `mbx gc` can
+remove its target directory too.
 
-Relocating costs nothing in cache hits. The shim maps the target directory to
-`${target}` before anything else, so an action keys the same wherever its
-outputs land -- turning this on does not cold-start a warm cache.
+[Learn about managed targets →](https://mr-boxington.jdx.dev/managed-targets)
 
-mbx declines rather than guessing when placement would overrule someone:
+## Worktree and CI warming
 
-- a target directory named by `--target-dir`, `CARGO_TARGET_DIR`, or
-  `build.target-dir` stays where it was asked for;
-- a real `target/` directory is somebody's build outputs, so it is left alone.
-  Remove it first if you want a managed one.
+An equivalent rustc action keys the same across checkout paths. One worktree's
+dependency build can therefore warm another while every checkout keeps its own
+target directory.
 
-## Remote caching
+For GitHub-hosted CI, save `~/.cache/mbx` from `main` with `actions/cache`, then
+restore it read-only in pull requests. This works for forks without exposing a
+private cache host. Trusted environments can instead use a compatible remote
+such as [`jdx/mbx-cache`](https://github.com/jdx/mbx-cache).
 
-Point mbx at a server and it reads from it; whether it *writes* depends on
-where it is running. Outside a trusted CI context — a push to a protected
-branch on GitHub Actions or GitLab CI — `read-write` degrades to `read-only`,
-and `write-only` disables the remote entirely. Pull requests never write, so a
-fork cannot poison the cache. Tag and release builds do not use the cache at
-all.
-
-In GitHub Actions, `MBX_REMOTE_OIDC_AUDIENCE` authorizes writes through the
-runner's OIDC token, so there is no long-lived secret to store:
-
-```yaml
-permissions:
-  contents: read
-  id-token: write
-env:
-  MBX_REMOTE_URL: https://cache.example.com
-  MBX_REMOTE_NAMESPACE: acme/backend
-  MBX_REMOTE_OIDC_AUDIENCE: mbx-cache
-```
+[Configure GitHub Actions →](https://mr-boxington.jdx.dev/github-actions)
 
 ## How it works
 
-`mbx build` starts a session that installs a rustc shim, runs an in-process
-cache agent behind a unix socket (a current-user-only named pipe on Windows),
-and points cargo at the shim through `RUSTC_WRAPPER`. Cargo then invokes the
-shim for every compilation; the shim analyses the invocation, looks up the
-action, and either restores its outputs or compiles and publishes them. The
-agent exits with the build — there is no daemon.
+`mbx build` starts an in-process cache agent, points Cargo at a rustc shim with
+`RUSTC_WRAPPER`, and exits the agent with the build—there is no daemon. The shim
+derives an action key, restores cached outputs when possible, or runs the real
+compiler and publishes a successful result.
 
-Anything the analysis does not model exactly — an unrecognised flag, a path
-that maps to no known root, incremental compilation, linking — bypasses the
-cache and runs the real compiler. Correctness comes before hit rate, always.
+Anything mbx cannot model exactly bypasses the cache. Linking is not cached,
+incremental compilation is off by default, and plain `cargo build` does not use
+mbx. Correctness comes before hit rate.
 
-Set `MBX_VERIFY=1` to compile *and* consult the cache, comparing the two. It is
-slower than either, and it is how the cache is qualified.
+[Read the architecture and limits →](https://mr-boxington.jdx.dev/how-it-works)
 
-## Status and limits
+## Documentation
 
-Working today: local caching, cross-checkout reuse, remote push and pull,
-automatic garbage collection, managed target directories.
-
-Not yet:
-
-- **Plain `cargo build` gets nothing.** A shim outside `mbx build` has no
-  session to talk to, and per-process prefetch manifests cannot be shared
-  across the many rustc processes cargo spawns, so `build.rustc-wrapper` and an
-  `mbx setup` command are waiting on that. Use `mbx build`.
-- **A crate whose compilation consumes `OUT_DIR` does not share across
-  checkouts by default.** That covers any crate with a build script that
-  generates code included via `include!(concat!(env!("OUT_DIR"), …))`. `OUT_DIR`
-  is an absolute path and an input to the compilation, so two checkouts produce
-  different keys. Crates whose build scripts only emit cfgs or link directives
-  share normally.
-
-  `MBX_SHARE_OUT_DIR=1` lifts this. It does two things, and needs both:
-  it passes `--remap-path-prefix` so rustc records the cache placeholder rather
-  than the real path — which covers debug info, spans, and diagnostics — and
-  then, before publishing, it reads the outputs and only uses the shared key if
-  none of them carries the value anyway. The second half is not redundant: a
-  crate that keeps `env!("OUT_DIR")` in a string constant puts the real path in
-  its artifact, where no remapping reaches it, and such a compilation stays
-  keyed to its own checkout.
-
-  The cost is that generated sources appear in debug info as
-  `${target}/debug/build/…` instead of a path a debugger can open, which is why
-  this is opt-in. The residual gap is a value a crate *derives* from `OUT_DIR`
-  rather than embedding — its length, say, or a hash of it. Reading the outputs
-  cannot see that, so it is not covered.
-
-  On this repository's own dependency graph (285 crates), a second checkout hit
-  139 of the 147 compilations it looked up by default, and all 147 with the
-  option on.
-- **Linking is not cached**, so binaries and dylibs always link.
-- **Incremental compilation is off by default** inside `mbx build`. Cargo builds
-  dependencies non-incrementally anyway, which is where the cache earns its
-  keep, and an incremental compilation is never cacheable.
-
-  `MBX_INCREMENTAL=1` stops forcing it off and hands the decision back to cargo,
-  which trades cache reuse for a faster edit-rebuild loop. Members you just
-  edited were going to miss regardless, so incremental recompiles them faster
-  than the cache can — but a member built incrementally emits a different rlib
-  than a cached one, and extern rlibs enter the action key by content, so every
-  crate above it in the graph misses too. Worth it when you rebuild one leaf
-  crate repeatedly; not worth it when a second worktree of the same workspace is
-  what you want warm. CI ignores the setting: a fresh runner has no earlier
-  build to build on, so there is nothing to gain and reuse to lose. Since the
-  setting stops overriding `CARGO_INCREMENTAL` rather than setting it, a `0`
-  already in your environment still wins, and `mbx` says so rather than leaving
-  you to wonder.
-- **Eviction order is an approximation.** Within what a sweep is willing to
-  evict, the oldest goes first by access time -- which `relatime` coarsens to
-  roughly a day and `noatime` suppresses altogether, leaving the order to fall
-  back on when an object was stored. Recording which checkouts are still here
-  is what keeps that from mattering much: a wrong order inside the set nothing
-  has abandoned costs a recompile.
-- **The budget covers cached objects and their results**, not the whole cache
-  directory. Prediction manifests, checkout records, managed target
-  directories, and remote download staging sit outside it, so the directory is
-  always somewhat larger than the number you set. Target directories are
-  collected when their checkout is gone rather than against a budget.
-- **Managed target directories need a symlink**, which Windows only lets a
-  privileged or developer-mode process create. Where the link cannot be made,
-  mbx says so and leaves the target directory where cargo put it. A directory
-  junction would work without privileges and is not implemented yet.
+- [Get started](https://mr-boxington.jdx.dev/getting-started)
+- [Configuration](https://mr-boxington.jdx.dev/configuration)
+- [GitHub Actions](https://mr-boxington.jdx.dev/github-actions)
+- [Remote cache](https://mr-boxington.jdx.dev/remote-cache)
+- [Cache results](https://mr-boxington.jdx.dev/cache-results)
+- [CLI reference](https://mr-boxington.jdx.dev/cli)
+- [Current limits](https://mr-boxington.jdx.dev/limits)
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ mbx build clippy --workspace     # cargo clippy --workspace, with caching
 - **Warm every worktree.** Cache keys contain no checkout-specific absolute
   paths, so building one checkout warms its siblings automatically without
   sharing a Cargo target lock.
-- **Prune automatically.** mbx sweeps its action store back to a size budget.
-  With managed targets enabled, it also removes target directories after their
-  checkout disappears.
+- **Prune automatically.** mbx sweeps its action store back to a size budget
+  and, by default, removes managed target directories after their checkout
+  disappears.
 - **Warm CI safely.** GitHub Actions cache can warm fork pull requests from a
   cache built on `main`, while a self-hosted remote can serve trusted runners
   and teammates. Pull requests never publish remote objects.
@@ -84,16 +84,19 @@ mbx gc
 mbx gc --max-size 3GB
 ```
 
-Enable managed target directories to reclaim the larger build outputs left by
-deleted checkouts:
+For a checkout without an existing `target/`, managed target directories are
+enabled automatically:
 
 ```sh
-MBX_TARGET_VIEWS=1 mbx build build
+mbx build build
 ```
 
 mbx places the target directory under its cache root and leaves `target` as a
 symlink, so familiar paths still work. Once the checkout is gone, `mbx gc` can
 remove its target directory too.
+
+An existing real `target/` is never replaced. Remove it to opt that checkout
+into managed targets, or set `MBX_TARGET_VIEWS=0` to disable placement.
 
 [Learn about managed targets →](https://mr-boxington.jdx.dev/managed-targets)
 

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 
 [dependencies]
 bytesize = "2"
-clap = { version = "4", features = ["derive"] }
 demand = "2"
 env_logger = "0.11"
 dirs = "6"
@@ -24,6 +23,7 @@ serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 toml = "0.9"
+usage = { package = "usage-rs", version = "6" }
 which = "8"
 
 [dev-dependencies]

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 bytesize = "2"
 clap = { version = "4", features = ["derive"] }
+demand = "2"
 env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -112,21 +112,31 @@ fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will
     // actually write to.
-    let placed = if migrate_existing {
-        target::migrate_existing(
+    let (placed, removed_target_bytes) = if migrate_existing {
+        let outcome = target::migrate_existing(
             config,
             &roots.workspace_root,
             &roots.target_dir,
             roots.target_dir_requested,
-        )?
+        )?;
+        (outcome.managed, outcome.removed_bytes)
     } else {
-        target::place(
-            config,
-            &roots.workspace_root,
-            &roots.target_dir,
-            roots.target_dir_requested,
+        (
+            target::place(
+                config,
+                &roots.workspace_root,
+                &roots.target_dir,
+                roots.target_dir_requested,
+            ),
+            None,
         )
     };
+    if let Some(bytes) = removed_target_bytes {
+        crate::session::note(&format!(
+            "freed {} by removing the existing target/ directory",
+            ByteSize::b(bytes).display().iec()
+        ));
+    }
     if let Some(directory) = &placed {
         roots.target_dir = directory.clone();
     }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -5,13 +5,19 @@ use crate::session::CacheSession;
 use crate::{policy, store, target};
 use bytesize::ByteSize;
 use clap::{Args, Parser, Subcommand};
-use eyre::{Context, Result, bail};
+use eyre::{Context, Result};
 use std::collections::BTreeMap;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 #[derive(Parser)]
-#[command(name = "mbx", version, about = "A build cache for Rust projects")]
+#[command(
+    name = "mbx",
+    version,
+    about = "A build cache for Rust projects",
+    after_help = "Cargo subcommands are forwarded directly.\n\nExamples:\n  mbx build --release\n  mbx test --workspace\n  mbx clippy --all-targets"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -19,19 +25,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Run cargo with the build cache enabled.
-    Build(BuildArgs),
     /// Evict cached objects until the store fits a size budget.
     Gc(GcArgs),
     /// Inspect the local store.
     Cache(CacheArgs),
-}
-
-#[derive(Args)]
-struct BuildArgs {
-    /// Arguments passed to cargo, starting with the subcommand.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    arguments: Vec<String>,
+    /// Run a cargo subcommand with the build cache enabled.
+    #[command(external_subcommand)]
+    Cargo(Vec<String>),
 }
 
 #[derive(Args)]
@@ -61,7 +61,6 @@ pub fn run() -> Result<ExitCode> {
     let cli = Cli::parse();
     let config = Config::load()?;
     match cli.command {
-        Commands::Build(args) => build(&config, &args.arguments),
         Commands::Gc(args) => gc(
             &config,
             args.max_size
@@ -75,11 +74,11 @@ pub fn run() -> Result<ExitCode> {
             }
             CacheCommands::Stats => cache_stats(&config).map(|()| ExitCode::SUCCESS),
         },
+        Commands::Cargo(arguments) => cargo(&config, &arguments),
     }
 }
 
-fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
-    validate_build_arguments(arguments)?;
+fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     // Release builds publish artifacts that must not depend on a cache, and a
     // tag build has no later build to share with anyway.
@@ -109,6 +108,7 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
 
     let working_dir = std::env::current_dir()?;
     let mut roots = resolve_roots(&cargo, arguments, &working_dir);
+    prompt_to_manage_existing_target(config, &roots, arguments)?;
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will
     // actually write to.
@@ -167,6 +167,64 @@ fn build(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     // user is waiting on.
     sweep_store(config);
     status
+}
+
+/// Offer to replace an existing default target directory with a managed one.
+///
+/// A non-interactive run must never wait for input. Refusing or cancelling the
+/// prompt leaves cargo's directory alone and the build continues normally.
+fn prompt_to_manage_existing_target(
+    config: &Config,
+    roots: &Roots,
+    arguments: &[String],
+) -> Result<()> {
+    if cargo_help_requested(arguments)
+        || !std::io::stdin().is_terminal()
+        || !std::io::stderr().is_terminal()
+    {
+        return Ok(());
+    }
+    prompt_to_manage_existing_target_with(config, roots, |directory| {
+        let description = format!(
+            "mbx can remove {} and replace it with a managed target that is pruned after this checkout is deleted.",
+            directory.display()
+        );
+        match demand::Confirm::new("Use a managed target directory?")
+            .description(&description)
+            .affirmative("Remove target/")
+            .negative("Keep it")
+            .selected(false)
+            .run()
+        {
+            Ok(answer) => Ok(answer),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => Ok(false),
+            Err(error) => Err(error.into()),
+        }
+    })
+}
+
+fn cargo_help_requested(arguments: &[String]) -> bool {
+    arguments.first().is_some_and(|argument| argument == "help")
+        || arguments
+            .iter()
+            .any(|argument| argument == "--help" || argument == "-h")
+}
+
+fn prompt_to_manage_existing_target_with(
+    config: &Config,
+    roots: &Roots,
+    prompt: impl FnOnce(&Path) -> Result<bool>,
+) -> Result<()> {
+    if !target::can_remove_existing(
+        config,
+        &roots.workspace_root,
+        &roots.target_dir,
+        roots.target_dir_requested,
+    ) || !prompt(&roots.target_dir)?
+    {
+        return Ok(());
+    }
+    target::remove_existing(&roots.target_dir)
 }
 
 fn run_cargo(
@@ -586,14 +644,6 @@ fn flag_value<'a>(arguments: &'a [String], flag: &str) -> Option<&'a str> {
     None
 }
 
-/// Reject a build invocation that cargo would not accept anyway.
-pub fn validate_build_arguments(arguments: &[String]) -> Result<()> {
-    if arguments.is_empty() {
-        bail!("mbx build expects a cargo subcommand, for example: mbx build build --release");
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -897,8 +947,79 @@ mod tests {
     }
 
     #[test]
-    fn build_requires_a_cargo_subcommand() {
-        assert!(validate_build_arguments(&[]).is_err());
-        assert!(validate_build_arguments(&["build".to_string()]).is_ok());
+    fn cargo_subcommands_are_forwarded_directly() {
+        let cli = Cli::try_parse_from(["mbx", "clippy", "--workspace"]).unwrap();
+        let Commands::Cargo(arguments) = cli.command else {
+            panic!("clippy should be treated as a cargo subcommand");
+        };
+        assert_eq!(arguments, ["clippy", "--workspace"]);
+    }
+
+    #[test]
+    fn mbx_commands_still_take_precedence() {
+        let cli = Cli::try_parse_from(["mbx", "gc", "--max-size", "1GiB"]).unwrap();
+        assert!(matches!(cli.command, Commands::Gc(_)));
+    }
+
+    #[test]
+    fn cargo_help_does_not_trigger_target_migration() {
+        assert!(cargo_help_requested(&["build".into(), "--help".into()]));
+        assert!(cargo_help_requested(&["help".into(), "build".into()]));
+        assert!(!cargo_help_requested(&["build".into(), "--release".into()]));
+    }
+
+    fn managed_target_config(root: &Path) -> Config {
+        Config {
+            cache_dir: root.join("cache"),
+            stats_report: None,
+            verify: false,
+            incremental: false,
+            share_out_dir: false,
+            remote: Default::default(),
+            http: Default::default(),
+            gc: Default::default(),
+            target: crate::config::TargetSettings {
+                views: true,
+                root: root.join("targets"),
+            },
+        }
+    }
+
+    #[test]
+    fn accepting_the_target_prompt_removes_only_the_default_real_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let workspace = directory.path().join("project");
+        let target_dir = workspace.join("target");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join("artifact"), b"old output").unwrap();
+        let config = managed_target_config(directory.path());
+        let roots = Roots {
+            workspace_root: workspace,
+            target_dir: target_dir.clone(),
+            target_dir_requested: false,
+        };
+
+        prompt_to_manage_existing_target_with(&config, &roots, |_| Ok(true)).unwrap();
+
+        assert!(!target_dir.exists());
+    }
+
+    #[test]
+    fn declining_the_target_prompt_preserves_outputs() {
+        let directory = tempfile::tempdir().unwrap();
+        let workspace = directory.path().join("project");
+        let target_dir = workspace.join("target");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join("artifact"), b"old output").unwrap();
+        let config = managed_target_config(directory.path());
+        let roots = Roots {
+            workspace_root: workspace,
+            target_dir: target_dir.clone(),
+            target_dir_requested: false,
+        };
+
+        prompt_to_manage_existing_target_with(&config, &roots, |_| Ok(false)).unwrap();
+
+        assert!(target_dir.join("artifact").is_file());
     }
 }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -662,7 +662,7 @@ fn cargo_config_may_set_target_dir(arguments: &[String], invocation_dir: &Path) 
     if config_arguments(arguments).any(|value| {
         value
             .split_once('=')
-            .is_none_or(|(key, _)| key.trim() == "build.target-dir")
+            .is_none_or(|(key, _)| matches!(key.trim(), "build.target-dir" | "include"))
     }) {
         return true;
     }
@@ -1061,6 +1061,20 @@ mod tests {
 
         assert_eq!(roots.target_dir, root.join("target"));
         assert!(roots.target_dir_requested);
+    }
+
+    #[test]
+    fn a_command_line_config_include_may_set_the_target_dir() {
+        let arguments = [
+            "build".to_string(),
+            "--config".to_string(),
+            "include='target-config.toml'".to_string(),
+        ];
+
+        assert!(cargo_config_may_set_target_dir(
+            &arguments,
+            Path::new("/workspace")
+        ));
     }
 
     #[test]

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -108,16 +108,25 @@ fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {
 
     let working_dir = std::env::current_dir()?;
     let mut roots = resolve_roots(&cargo, arguments, &working_dir);
-    prompt_to_manage_existing_target(config, &roots, arguments)?;
+    let migrate_existing = prompt_to_manage_existing_target(config, &roots, arguments)?;
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will
     // actually write to.
-    let placed = target::place(
-        config,
-        &roots.workspace_root,
-        &roots.target_dir,
-        roots.target_dir_requested,
-    );
+    let placed = if migrate_existing {
+        target::migrate_existing(
+            config,
+            &roots.workspace_root,
+            &roots.target_dir,
+            roots.target_dir_requested,
+        )?
+    } else {
+        target::place(
+            config,
+            &roots.workspace_root,
+            &roots.target_dir,
+            roots.target_dir_requested,
+        )
+    };
     if let Some(directory) = &placed {
         roots.target_dir = directory.clone();
     }
@@ -177,12 +186,12 @@ fn prompt_to_manage_existing_target(
     config: &Config,
     roots: &Roots,
     arguments: &[String],
-) -> Result<()> {
+) -> Result<bool> {
     if cargo_help_requested(arguments)
         || !std::io::stdin().is_terminal()
         || !std::io::stderr().is_terminal()
     {
-        return Ok(());
+        return Ok(false);
     }
     prompt_to_manage_existing_target_with(config, roots, |directory| {
         let description = format!(
@@ -214,17 +223,16 @@ fn prompt_to_manage_existing_target_with(
     config: &Config,
     roots: &Roots,
     prompt: impl FnOnce(&Path) -> Result<bool>,
-) -> Result<()> {
+) -> Result<bool> {
     if !target::can_remove_existing(
         config,
         &roots.workspace_root,
         &roots.target_dir,
         roots.target_dir_requested,
-    ) || !prompt(&roots.target_dir)?
-    {
-        return Ok(());
+    ) {
+        return Ok(false);
     }
-    target::remove_existing(&roots.target_dir)
+    prompt(&roots.target_dir)
 }
 
 fn run_cargo(
@@ -986,7 +994,7 @@ mod tests {
     }
 
     #[test]
-    fn accepting_the_target_prompt_removes_only_the_default_real_directory() {
+    fn accepting_the_target_prompt_requests_migration_without_removing_outputs() {
         let directory = tempfile::tempdir().unwrap();
         let workspace = directory.path().join("project");
         let target_dir = workspace.join("target");
@@ -999,9 +1007,11 @@ mod tests {
             target_dir_requested: false,
         };
 
-        prompt_to_manage_existing_target_with(&config, &roots, |_| Ok(true)).unwrap();
+        let accepted =
+            prompt_to_manage_existing_target_with(&config, &roots, |_| Ok(true)).unwrap();
 
-        assert!(!target_dir.exists());
+        assert!(accepted);
+        assert!(target_dir.join("artifact").is_file());
     }
 
     #[test]
@@ -1018,8 +1028,10 @@ mod tests {
             target_dir_requested: false,
         };
 
-        prompt_to_manage_existing_target_with(&config, &roots, |_| Ok(false)).unwrap();
+        let accepted =
+            prompt_to_manage_existing_target_with(&config, &roots, |_| Ok(false)).unwrap();
 
+        assert!(!accepted);
         assert!(target_dir.join("artifact").is_file());
     }
 }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -4,51 +4,50 @@ use crate::config::Config;
 use crate::session::CacheSession;
 use crate::{policy, store, target};
 use bytesize::ByteSize;
-use clap::{Args, Parser, Subcommand};
 use eyre::{Context, Result};
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
-#[derive(Parser)]
-#[command(
-    name = "mbx",
+#[derive(usage::Cli)]
+#[usage(
+    bin = "mbx",
     version,
     about = "A build cache for Rust projects",
-    after_help = "Cargo subcommands are forwarded directly.\n\nExamples:\n  mbx build --release\n  mbx test --workspace\n  mbx clippy --all-targets"
+    long_about = "A build cache for Rust projects\n\nCargo subcommands are forwarded directly.\n\nExamples:\n  mbx build --release\n  mbx test --workspace\n  mbx clippy --all-targets",
+    unknown_flags = "error"
 )]
 struct Cli {
-    #[command(subcommand)]
+    #[usage(subcommand)]
     command: Commands,
 }
 
-#[derive(Subcommand)]
+#[derive(usage::Subcommands)]
 enum Commands {
     /// Evict cached objects until the store fits a size budget.
     Gc(GcArgs),
     /// Inspect the local store.
     Cache(CacheArgs),
-    /// Run a cargo subcommand with the build cache enabled.
-    #[command(external_subcommand)]
+    #[usage(external_subcommand)]
     Cargo(Vec<String>),
 }
 
-#[derive(Args)]
+#[derive(usage::Args)]
 struct GcArgs {
     /// Size the store may occupy afterwards, for example 20GiB. Defaults to the
     /// configured budget.
-    #[arg(long, value_name = "SIZE")]
+    #[usage(long, value_name = "SIZE")]
     max_size: Option<ByteSize>,
 }
 
-#[derive(Args)]
+#[derive(usage::Args)]
 struct CacheArgs {
-    #[command(subcommand)]
+    #[usage(subcommand)]
     command: CacheCommands,
 }
 
-#[derive(Subcommand)]
+#[derive(usage::Subcommands)]
 enum CacheCommands {
     /// Print the store directory.
     Dir,
@@ -966,7 +965,8 @@ mod tests {
 
     #[test]
     fn cargo_subcommands_are_forwarded_directly() {
-        let cli = Cli::try_parse_from(["mbx", "clippy", "--workspace"]).unwrap();
+        let argv = ["mbx", "clippy", "--workspace"].map(std::ffi::OsStr::new);
+        let cli = Cli::try_parse_from(&argv).unwrap();
         let Commands::Cargo(arguments) = cli.command else {
             panic!("clippy should be treated as a cargo subcommand");
         };
@@ -975,8 +975,17 @@ mod tests {
 
     #[test]
     fn mbx_commands_still_take_precedence() {
-        let cli = Cli::try_parse_from(["mbx", "gc", "--max-size", "1GiB"]).unwrap();
+        let argv = ["mbx", "gc", "--max-size", "1GiB"].map(std::ffi::OsStr::new);
+        let cli = Cli::try_parse_from(&argv).unwrap();
         assert!(matches!(cli.command, Commands::Gc(_)));
+    }
+
+    #[test]
+    fn cli_exposes_its_usage_spec() {
+        let spec = Cli::to_kdl();
+        assert!(spec.contains("external_subcommand #true"));
+        assert!(spec.contains("cmd gc"));
+        assert!(spec.contains("cmd cache"));
     }
 
     #[test]

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -432,7 +432,8 @@ fn workspace_root(start: &Path) -> PathBuf {
 struct Roots {
     workspace_root: PathBuf,
     target_dir: PathBuf,
-    /// Whether a flag or the environment named the target directory outright.
+    /// Whether a flag, environment variable, or Cargo configuration named the
+    /// target directory outright.
     ///
     /// Cargo prefers `--target-dir` over `CARGO_TARGET_DIR`, so a build carrying
     /// that flag cannot be moved by setting the environment: cargo would write
@@ -509,7 +510,9 @@ fn resolve_roots_with(
         .unwrap_or_else(|| workspace_root(&invocation_dir));
     let flagged = target_dir_argument(arguments);
     let from_environment = target_dir_env.as_ref().is_some_and(|dir| !dir.is_empty());
-    let target_dir_requested = flagged.is_some() || from_environment;
+    let target_dir_requested = flagged.is_some()
+        || from_environment
+        || cargo_config_may_set_target_dir(arguments, &invocation_dir);
     // An explicit flag outranks anything cargo reports from configuration.
     let target_dir = flagged
         .map(|value| absolute(&invocation_dir, value))
@@ -636,14 +639,80 @@ fn parse_cargo_roots(metadata: &[u8]) -> Option<Roots> {
         workspace_root: PathBuf::from(metadata.get("workspace_root")?.as_str()?),
         target_dir: PathBuf::from(metadata.get("target_directory")?.as_str()?),
         // What cargo reports has folded configuration in already, so it cannot
-        // say whether anyone asked. Only the caller's own flags and environment
-        // answer that, and `resolve_roots_with` reads them itself.
+        // say whether anyone asked. The caller's flags, environment, and Cargo
+        // configuration answer that, and `resolve_roots_with` reads them itself.
         target_dir_requested: false,
     })
 }
 
 fn target_dir_argument(arguments: &[String]) -> Option<&str> {
     flag_value(arguments, "--target-dir")
+}
+
+/// Whether Cargo configuration may have named the target directory.
+///
+/// `cargo metadata` reports only the resolved path, so an explicit
+/// `build.target-dir = "target"` is otherwise indistinguishable from Cargo's
+/// default. Any explicit config file passed on the command line is treated
+/// conservatively because it may include another file.
+fn cargo_config_may_set_target_dir(arguments: &[String], invocation_dir: &Path) -> bool {
+    if std::env::var_os("CARGO_BUILD_TARGET_DIR").is_some_and(|value| !value.is_empty()) {
+        return true;
+    }
+    if config_arguments(arguments).any(|value| {
+        value
+            .split_once('=')
+            .is_none_or(|(key, _)| key.trim() == "build.target-dir")
+    }) {
+        return true;
+    }
+
+    let project_configs = invocation_dir.ancestors().flat_map(|directory| {
+        let cargo = directory.join(".cargo");
+        [cargo.join("config.toml"), cargo.join("config")]
+    });
+    let home_configs = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cargo")))
+        .into_iter()
+        .flat_map(|cargo| [cargo.join("config.toml"), cargo.join("config")]);
+    project_configs
+        .chain(home_configs)
+        .any(|path| cargo_config_file_may_set_target_dir(&path))
+}
+
+fn config_arguments(arguments: &[String]) -> impl Iterator<Item = &str> {
+    let mut values = Vec::new();
+    let mut remaining = arguments.iter();
+    while let Some(argument) = remaining.next() {
+        if let Some(value) = argument.strip_prefix("--config=") {
+            values.push(value);
+        } else if argument == "--config"
+            && let Some(value) = remaining.next()
+        {
+            values.push(value.as_str());
+        }
+    }
+    values.into_iter()
+}
+
+fn cargo_config_file_may_set_target_dir(path: &Path) -> bool {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return false,
+        Err(_) => return true,
+    };
+    let Ok(config) = toml::from_str::<toml::Value>(&contents) else {
+        // Cargo will reject it, but mbx must not mutate a target directory on
+        // the way to that error.
+        return true;
+    };
+    config
+        .get("build")
+        .and_then(|build| build.get("target-dir"))
+        .is_some()
+        // An included file may contain the setting; Cargo owns that merge.
+        || config.get("include").is_some()
 }
 
 /// Read `--flag <value>` or `--flag=<value>` out of cargo's arguments.
@@ -961,6 +1030,37 @@ mod tests {
         .concat();
         let roots = resolve_roots_with(std::ffi::OsStr::new("cargo"), &overridden, root, None);
         assert_eq!(roots.target_dir, configured);
+        assert!(roots.target_dir_requested);
+    }
+
+    #[test]
+    fn a_cargo_config_that_names_the_default_target_is_still_explicit() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join(".cargo")).unwrap();
+        std::fs::write(
+            root.join(".cargo/config.toml"),
+            "[build]\ntarget-dir = \"target\"\n",
+        )
+        .unwrap();
+        let arguments = ["build".to_string(), "--offline".to_string()];
+
+        let roots = resolve_roots_with(
+            std::ffi::OsStr::new("cargo-that-does-not-exist"),
+            &arguments,
+            root,
+            None,
+        );
+
+        assert_eq!(roots.target_dir, root.join("target"));
+        assert!(roots.target_dir_requested);
     }
 
     #[test]

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -16,6 +16,7 @@ const DEFAULT_HTTP_RETRIES: i64 = 3;
 /// Stated in IEC units so the budget reads the way `mbx gc` reports it back.
 const DEFAULT_GC_MAX_SIZE: u64 = 20 * 1024 * 1024 * 1024;
 const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const DEFAULT_TARGET_VIEWS: bool = true;
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields, default)]
@@ -190,7 +191,7 @@ impl Config {
         };
         let target = TargetSettings {
             views: optional_bool("MBX_TARGET_VIEWS", &get_env, file.target.views)?
-                .unwrap_or_default(),
+                .unwrap_or(DEFAULT_TARGET_VIEWS),
             root: match get_env("MBX_TARGET_ROOT")
                 .map(PathBuf::from)
                 .or(file.target.root)
@@ -392,10 +393,23 @@ mod tests {
         assert_eq!(config.gc.max_bytes, DEFAULT_GC_MAX_SIZE);
         assert_eq!(config.gc.interval, DEFAULT_GC_INTERVAL);
         assert!(
-            !config.target.views,
-            "moving where a build writes is opted into, never assumed"
+            config.target.views,
+            "eligible target directories are managed"
         );
         assert_eq!(config.target.root, config.cache_dir.join("targets"));
+    }
+
+    #[test]
+    fn managed_targets_can_be_turned_off() {
+        for value in ["0", "false", "no", "off", ""] {
+            let config =
+                Config::from_parts(ConfigFile::default(), env(&[("MBX_TARGET_VIEWS", value)]))
+                    .unwrap();
+            assert!(
+                !config.target.views,
+                "MBX_TARGET_VIEWS={value:?} should disable managed targets"
+            );
+        }
     }
 
     #[test]

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -237,6 +237,20 @@ pub fn place(
             return None;
         }
     };
+    let record_path = view_record_path(&config.target.root, workspace_root);
+    let previous_record = match read_record_state(&record_path) {
+        Ok(record) => record,
+        Err(error) => {
+            log::warn!("the existing target record could not be preserved: {error}");
+            if let Err(error) = rollback_link(target_dir, &link) {
+                log::warn!(
+                    "the unused link {} was not rolled back: {error}",
+                    target_dir.display()
+                );
+            }
+            return None;
+        }
+    };
     // Recorded before the directory exists, so a directory can never exist that
     // `prune` has no way to see.
     if let Err(error) = record_view(&config.target.root, workspace_root) {
@@ -260,6 +274,25 @@ pub fn place(
             "the managed target directory {} was not prepared: {error}",
             managed.display()
         );
+        // A newly created link is the migration path: nothing used it before
+        // this attempt, so both the link and record can be rolled back and an
+        // existing target backup can be restored. Replacing an older managed
+        // view may already have moved its directory, so keep the established
+        // link and record in that recovery case.
+        if matches!(&link, Link::Created) {
+            match rollback_link(target_dir, &link) {
+                Ok(()) => {
+                    if let Err(error) = restore_record_state(&record_path, previous_record) {
+                        log::warn!("the target record was not rolled back: {error}");
+                    }
+                }
+                Err(error) => log::warn!(
+                    "the unused link {} was not rolled back: {error}",
+                    target_dir.display()
+                ),
+            }
+            return None;
+        }
     }
     Some(managed)
 }
@@ -524,6 +557,25 @@ fn record_view(root: &Path, workspace_root: &Path) -> Result<()> {
     crate::util::write_atomic(&view_record_path(root, workspace_root), &contents)
 }
 
+fn read_record_state(path: &Path) -> Result<Option<Vec<u8>>> {
+    match std::fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).wrap_err_with(|| format!("could not read {}", path.display())),
+    }
+}
+
+fn restore_record_state(path: &Path, previous: Option<Vec<u8>>) -> Result<()> {
+    if let Some(contents) = previous {
+        return crate::util::write_atomic(path, &contents);
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).wrap_err_with(|| format!("could not remove {}", path.display())),
+    }
+}
+
 fn read_view_record(path: &Path) -> Option<ViewRecord> {
     let bytes = std::fs::read(path).ok()?;
     let record = serde_json::from_slice::<ViewRecord>(&bytes).ok()?;
@@ -744,6 +796,29 @@ mod tests {
             std::fs::read(target.join("artifact")).unwrap(),
             b"old output"
         );
+    }
+
+    #[test]
+    fn a_preparation_failure_restores_existing_outputs_and_record_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let target = workspace.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("artifact"), b"old output").unwrap();
+        let managed = view_dir(&config.target.root, &workspace);
+        std::fs::create_dir_all(managed.parent().unwrap()).unwrap();
+        std::fs::write(&managed, b"not a directory").unwrap();
+
+        let outcome = migrate_existing(&config, &workspace, &target, false).unwrap();
+
+        assert_eq!(outcome, MigrationOutcome::default());
+        assert_eq!(
+            std::fs::read(target.join("artifact")).unwrap(),
+            b"old output"
+        );
+        assert_eq!(std::fs::read(&managed).unwrap(), b"not a directory");
+        assert!(!view_record_path(&config.target.root, &workspace).exists());
     }
 
     #[cfg(unix)]

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -69,19 +69,87 @@ pub fn can_remove_existing(
         && std::fs::symlink_metadata(target_dir).is_ok_and(|metadata| metadata.is_dir())
 }
 
-/// Remove a target directory after an interactive confirmation.
+/// Replace a confirmed existing target directory without risking its outputs.
 ///
-/// Revalidate immediately before deletion so a directory replaced with a link
-/// between the prompt and the answer cannot redirect or broaden the removal.
-pub fn remove_existing(target_dir: &Path) -> Result<()> {
+/// The old directory is first renamed into a temporary sibling on the same
+/// filesystem. It is removed only after the managed link and record both
+/// succeed; otherwise it is restored to its original path.
+pub fn migrate_existing(
+    config: &Config,
+    workspace_root: &Path,
+    target_dir: &Path,
+    requested: bool,
+) -> Result<Option<PathBuf>> {
+    migrate_existing_with(config, workspace_root, target_dir, requested, || {
+        place(config, workspace_root, target_dir, requested)
+    })
+}
+
+fn migrate_existing_with(
+    config: &Config,
+    workspace_root: &Path,
+    target_dir: &Path,
+    requested: bool,
+    place_target: impl FnOnce() -> Option<PathBuf>,
+) -> Result<Option<PathBuf>> {
     if !std::fs::symlink_metadata(target_dir).is_ok_and(|metadata| metadata.is_dir()) {
         eyre::bail!(
-            "{} is no longer a real target directory, so it was not removed",
+            "{} is no longer a real target directory, so it was not migrated",
             target_dir.display()
         );
     }
-    std::fs::remove_dir_all(target_dir)
-        .wrap_err_with(|| format!("could not remove {}", target_dir.display()))
+    if !can_remove_existing(config, workspace_root, target_dir, requested) {
+        eyre::bail!("{} is not eligible for migration", target_dir.display());
+    }
+
+    let backup_root = tempfile::Builder::new()
+        .prefix(".mbx-target-backup-")
+        .tempdir_in(workspace_root)
+        .wrap_err("could not create a temporary target backup")?;
+    let backup = backup_root.path().join("target");
+    std::fs::rename(target_dir, &backup)
+        .wrap_err_with(|| format!("could not temporarily move {}", target_dir.display()))?;
+
+    if let Some(managed) = place_target() {
+        if let Err(error) = std::fs::remove_dir_all(&backup) {
+            let retained = backup_root.keep().join("target");
+            log::warn!(
+                "the old target directory was retained at {}: {error}",
+                retained.display()
+            );
+        }
+        return Ok(Some(managed));
+    }
+
+    let managed = view_dir(&config.target.root, workspace_root);
+    let restore = (|| -> Result<()> {
+        match std::fs::symlink_metadata(target_dir) {
+            Ok(metadata)
+                if metadata.file_type().is_symlink()
+                    && std::fs::read_link(target_dir).is_ok_and(|link| link == managed) =>
+            {
+                remove_link(target_dir).wrap_err("could not remove the failed managed link")?;
+            }
+            Ok(_) => eyre::bail!(
+                "{} was occupied while restoring the old target directory",
+                target_dir.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error).wrap_err("could not inspect the failed migration"),
+        }
+        std::fs::rename(&backup, target_dir)
+            .wrap_err_with(|| format!("could not restore {}", target_dir.display()))
+    })();
+    if let Err(error) = restore {
+        let retained = backup_root.keep().join("target");
+        return Err(error).wrap_err_with(|| {
+            format!(
+                "the old target directory was retained at {}",
+                retained.display()
+            )
+        });
+    }
+    Ok(None)
 }
 
 /// Where this checkout's outputs should be written, if mbx is placing them.
@@ -643,10 +711,48 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn a_failed_migration_restores_existing_outputs() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let target = workspace.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("artifact"), b"old output").unwrap();
+
+        let placed = migrate_existing_with(&config, &workspace, &target, false, || None).unwrap();
+
+        assert!(placed.is_none());
+        assert_eq!(
+            std::fs::read(target.join("artifact")).unwrap(),
+            b"old output"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
-    fn removing_an_existing_target_never_follows_a_replacement_link() {
+    fn a_successful_migration_removes_old_outputs_after_placement() {
         let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let target = workspace.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("artifact"), b"old output").unwrap();
+
+        let managed = migrate_existing(&config, &workspace, &target, false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(std::fs::read_link(&target).unwrap(), managed);
+        assert!(!target.join("artifact").exists());
+        assert_eq!(stats(&config.target.root).unwrap().views, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migrating_an_existing_target_never_follows_a_replacement_link() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
         let workspace = checkout(directory.path(), "project");
         let target = workspace.join("target");
         let elsewhere = directory.path().join("elsewhere");
@@ -654,7 +760,7 @@ mod tests {
         std::fs::write(elsewhere.join("keep"), b"not a build output").unwrap();
         symlink_dir(&elsewhere, &target).unwrap();
 
-        assert!(remove_existing(&target).is_err());
+        assert!(migrate_existing(&config, &workspace, &target, false).is_err());
         assert!(elsewhere.join("keep").is_file());
     }
 

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -52,6 +52,38 @@ pub struct PruneOutcome {
     pub removed_bytes: u64,
 }
 
+/// Whether an interactive caller may offer to remove this target directory.
+///
+/// Match placement's eligibility rules exactly, then require a real directory.
+/// The latter uses symlink metadata so a link to a directory is never offered
+/// for recursive deletion.
+pub fn can_remove_existing(
+    config: &Config,
+    workspace_root: &Path,
+    target_dir: &Path,
+    requested: bool,
+) -> bool {
+    config.target.views
+        && !requested
+        && target_dir == workspace_root.join("target")
+        && std::fs::symlink_metadata(target_dir).is_ok_and(|metadata| metadata.is_dir())
+}
+
+/// Remove a target directory after an interactive confirmation.
+///
+/// Revalidate immediately before deletion so a directory replaced with a link
+/// between the prompt and the answer cannot redirect or broaden the removal.
+pub fn remove_existing(target_dir: &Path) -> Result<()> {
+    if !std::fs::symlink_metadata(target_dir).is_ok_and(|metadata| metadata.is_dir()) {
+        eyre::bail!(
+            "{} is no longer a real target directory, so it was not removed",
+            target_dir.display()
+        );
+    }
+    std::fs::remove_dir_all(target_dir)
+        .wrap_err_with(|| format!("could not remove {}", target_dir.display()))
+}
+
 /// Where this checkout's outputs should be written, if mbx is placing them.
 ///
 /// `None` leaves cargo's own answer alone, and every reason for that is a
@@ -585,6 +617,45 @@ mod tests {
 
         assert!(place(&config, &workspace, &workspace.join("target"), false).is_none());
         assert!(!workspace.join("target").exists());
+    }
+
+    #[test]
+    fn only_an_unrequested_real_default_target_can_be_removed() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = test_config(directory.path(), true);
+        let workspace = checkout(directory.path(), "project");
+        let target = workspace.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        assert!(can_remove_existing(&config, &workspace, &target, false));
+        assert!(!can_remove_existing(&config, &workspace, &target, true));
+        assert!(!can_remove_existing(
+            &config,
+            &workspace,
+            &workspace.join("somewhere-else"),
+            false
+        ));
+        assert!(!can_remove_existing(
+            &test_config(directory.path(), false),
+            &workspace,
+            &target,
+            false
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn removing_an_existing_target_never_follows_a_replacement_link() {
+        let directory = tempfile::tempdir().unwrap();
+        let workspace = checkout(directory.path(), "project");
+        let target = workspace.join("target");
+        let elsewhere = directory.path().join("elsewhere");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        std::fs::write(elsewhere.join("keep"), b"not a build output").unwrap();
+        symlink_dir(&elsewhere, &target).unwrap();
+
+        assert!(remove_existing(&target).is_err());
+        assert!(elsewhere.join("keep").is_file());
     }
 
     #[test]

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -52,6 +52,13 @@ pub struct PruneOutcome {
     pub removed_bytes: u64,
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct MigrationOutcome {
+    pub managed: Option<PathBuf>,
+    /// Present only when the old directory was actually removed.
+    pub removed_bytes: Option<u64>,
+}
+
 /// Whether an interactive caller may offer to remove this target directory.
 ///
 /// Match placement's eligibility rules exactly, then require a real directory.
@@ -79,7 +86,7 @@ pub fn migrate_existing(
     workspace_root: &Path,
     target_dir: &Path,
     requested: bool,
-) -> Result<Option<PathBuf>> {
+) -> Result<MigrationOutcome> {
     migrate_existing_with(config, workspace_root, target_dir, requested, || {
         place(config, workspace_root, target_dir, requested)
     })
@@ -91,7 +98,7 @@ fn migrate_existing_with(
     target_dir: &Path,
     requested: bool,
     place_target: impl FnOnce() -> Option<PathBuf>,
-) -> Result<Option<PathBuf>> {
+) -> Result<MigrationOutcome> {
     if !std::fs::symlink_metadata(target_dir).is_ok_and(|metadata| metadata.is_dir()) {
         eyre::bail!(
             "{} is no longer a real target directory, so it was not migrated",
@@ -109,6 +116,7 @@ fn migrate_existing_with(
     let backup = backup_root.path().join("target");
     std::fs::rename(target_dir, &backup)
         .wrap_err_with(|| format!("could not temporarily move {}", target_dir.display()))?;
+    let old_bytes = tree_bytes(&backup);
 
     if let Some(managed) = place_target() {
         if let Err(error) = std::fs::remove_dir_all(&backup) {
@@ -117,8 +125,15 @@ fn migrate_existing_with(
                 "the old target directory was retained at {}: {error}",
                 retained.display()
             );
+            return Ok(MigrationOutcome {
+                managed: Some(managed),
+                removed_bytes: None,
+            });
         }
-        return Ok(Some(managed));
+        return Ok(MigrationOutcome {
+            managed: Some(managed),
+            removed_bytes: Some(old_bytes),
+        });
     }
 
     let managed = view_dir(&config.target.root, workspace_root);
@@ -149,7 +164,7 @@ fn migrate_existing_with(
             )
         });
     }
-    Ok(None)
+    Ok(MigrationOutcome::default())
 }
 
 /// Where this checkout's outputs should be written, if mbx is placing them.
@@ -554,12 +569,14 @@ fn tree_bytes(directory: &Path) -> u64 {
         for entry in listing.flatten() {
             // Symlinks are not followed: a link's target is either inside this
             // tree and already counted, or outside it and not ours to count.
-            let Ok(metadata) = entry.metadata() else {
+            let Ok(file_type) = entry.file_type() else {
                 continue;
             };
-            if metadata.is_dir() {
+            if file_type.is_dir() {
                 pending.push(entry.path());
-            } else if metadata.is_file() {
+            } else if file_type.is_file()
+                && let Ok(metadata) = entry.metadata()
+            {
                 total += metadata.len();
             }
         }
@@ -720,9 +737,9 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         std::fs::write(target.join("artifact"), b"old output").unwrap();
 
-        let placed = migrate_existing_with(&config, &workspace, &target, false, || None).unwrap();
+        let outcome = migrate_existing_with(&config, &workspace, &target, false, || None).unwrap();
 
-        assert!(placed.is_none());
+        assert_eq!(outcome, MigrationOutcome::default());
         assert_eq!(
             std::fs::read(target.join("artifact")).unwrap(),
             b"old output"
@@ -738,13 +755,18 @@ mod tests {
         let target = workspace.join("target");
         std::fs::create_dir_all(&target).unwrap();
         std::fs::write(target.join("artifact"), b"old output").unwrap();
+        let elsewhere = directory.path().join("elsewhere");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        std::fs::write(elsewhere.join("not-cleaned"), vec![0; 1024]).unwrap();
+        symlink_dir(&elsewhere, &target.join("external-link")).unwrap();
 
-        let managed = migrate_existing(&config, &workspace, &target, false)
-            .unwrap()
-            .unwrap();
+        let outcome = migrate_existing(&config, &workspace, &target, false).unwrap();
+        let managed = outcome.managed.unwrap();
 
         assert_eq!(std::fs::read_link(&target).unwrap(), managed);
         assert!(!target.join("artifact").exists());
+        assert_eq!(outcome.removed_bytes, Some(10));
+        assert!(elsewhere.join("not-cleaned").is_file());
         assert_eq!(stats(&config.target.root).unwrap().views, 1);
     }
 

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -57,7 +57,7 @@ pub struct PruneOutcome {
 /// `None` leaves cargo's own answer alone, and every reason for that is a
 /// reason not to be clever:
 ///
-/// - the feature is off, which is the default;
+/// - the feature was explicitly turned off;
 /// - a flag or the environment named the target directory, so moving it would
 ///   be overriding the person who said where it goes. This is asked separately
 ///   from where the directory actually is, because `--target-dir target` names
@@ -113,7 +113,12 @@ pub fn place(
     let link = match link_view(target_dir, &managed, workspace_root) {
         Ok(link) => link,
         Err(error) => {
-            log::warn!("{error}");
+            // Placement is best-effort: existing build outputs, a custom
+            // link, or a platform that cannot create the link are all normal
+            // reasons to let cargo keep its own target directory. This was a
+            // warning while managed targets were opt-in, but would become
+            // noise on every existing checkout now that they are the default.
+            log::debug!("{error}");
             return None;
         }
     };
@@ -573,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    fn leaves_the_target_directory_alone_unless_asked() {
+    fn leaves_the_target_directory_alone_when_disabled() {
         let directory = tempfile::tempdir().unwrap();
         let config = test_config(directory.path(), false);
         let workspace = checkout(directory.path(), "project");

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for `mbx build`.
+//! End-to-end coverage for cached cargo commands.
 //!
 //! Each test drives the real binary over a throwaway project with no
 //! dependencies, so nothing here needs the network.
@@ -93,7 +93,7 @@ fn build_with(
     let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
     command
         .current_dir(project)
-        .args(["build", "build", "--offline"])
+        .args(["build", "--offline"])
         .env("MBX_CACHE_DIR", store)
         .env("MBX_STATS_REPORT", report)
         // Cargo's own environment for this test would otherwise redirect the
@@ -452,7 +452,7 @@ fn a_failed_build_records_the_compilations_it_completed() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
         .current_dir(project.path())
-        .args(["build", "build", "--workspace", "--offline"])
+        .args(["build", "--workspace", "--offline"])
         .env("MBX_CACHE_DIR", store.path())
         .env("MBX_GC_AUTO", "0")
         .env_remove("CARGO_TARGET_DIR")
@@ -745,12 +745,13 @@ mod target_views {
     }
 
     #[test]
-    fn a_real_target_directory_is_never_displaced() {
+    fn a_noninteractive_build_never_removes_a_real_target_directory() {
         let store = tempfile::tempdir().unwrap();
         let project = tempfile::tempdir().unwrap();
         let reports = tempfile::tempdir().unwrap();
         write_project(project.path());
-        // A build that opted out before the default changed.
+        // Establish real outputs without a prompt. The next command captures
+        // its stdio, so it is non-interactive and must preserve them too.
         build_with(
             project.path(),
             store.path(),

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -172,6 +172,13 @@ fn count(stats: &serde_json::Value, field: &str) -> u64 {
         .unwrap_or_else(|| panic!("{field} should be a number"))
 }
 
+/// Remove the outputs behind a target link so the next build must restore.
+fn wipe_target(project: &Path) {
+    let target = project.join("target");
+    let outputs = std::fs::read_link(&target).unwrap_or(target);
+    std::fs::remove_dir_all(outputs).unwrap();
+}
+
 #[test]
 fn incremental_is_opt_in_and_reaches_cargo() {
     let store = tempfile::tempdir().unwrap();
@@ -245,7 +252,7 @@ fn restores_a_wiped_target_directory_from_the_store() {
     // Load-bearing, not cleanup: the wipe is what forces the warm build to
     // restore from the store. Left in place, cargo would find the cold build's
     // outputs and the test would pass without exercising the cache at all.
-    std::fs::remove_dir_all(project.path().join("target")).unwrap();
+    wipe_target(project.path());
 
     let warm = build(
         project.path(),
@@ -549,7 +556,7 @@ fn deleting_a_checkout_releases_what_only_it_used() {
 
     // Load-bearing, not cleanup: the wipe is what forces the next build to go
     // to the store, which is the only way to see what survived the sweep.
-    std::fs::remove_dir_all(surviving.path().join("target")).unwrap();
+    wipe_target(surviving.path());
     let warm = build(
         surviving.path(),
         store.path(),
@@ -581,11 +588,10 @@ mod target_views {
         let reports = tempfile::tempdir().unwrap();
         write_project(project.path());
 
-        build_with(
+        build(
             project.path(),
             store.path(),
             &reports.path().join("cold.json"),
-            &[("MBX_TARGET_VIEWS", "1")],
         );
 
         let directory = managed(project.path());
@@ -744,19 +750,19 @@ mod target_views {
         let project = tempfile::tempdir().unwrap();
         let reports = tempfile::tempdir().unwrap();
         write_project(project.path());
-        // A build that ran before the feature was turned on.
-        build(
-            project.path(),
-            store.path(),
-            &reports.path().join("cold.json"),
-        );
-        assert!(project.path().join("target").is_dir());
-
+        // A build that opted out before the default changed.
         build_with(
             project.path(),
             store.path(),
+            &reports.path().join("cold.json"),
+            &[("MBX_TARGET_VIEWS", "0")],
+        );
+        assert!(project.path().join("target").is_dir());
+
+        build(
+            project.path(),
+            store.path(),
             &reports.path().join("warm.json"),
-            &[("MBX_TARGET_VIEWS", "1")],
         );
 
         assert!(

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+.vitepress/cache
+.vitepress/dist
+node_modules

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitepress";
+
+const configDir = dirname(fileURLToPath(import.meta.url));
+const cargoToml = readFileSync(resolve(configDir, "../../Cargo.toml"), "utf8");
+const versionMatch = cargoToml.match(
+  /^\[workspace\.package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m,
+);
+const latestVersion = versionMatch?.[1] ?? "0.0.0";
+
+export default defineConfig({
+  title: "mr boxington",
+  description: "A build cache for Rust projects",
+  lang: "en-US",
+  lastUpdated: true,
+  appearance: "force-dark",
+  cleanUrls: true,
+  sitemap: {
+    hostname: "https://mr-boxington.jdx.dev",
+  },
+  themeConfig: {
+    logo: "/logo.svg",
+    nav: [
+      { text: "Get Started", link: "/getting-started" },
+      { text: "Configuration", link: "/configuration" },
+      { text: "GitHub Actions", link: "/github-actions" },
+      { text: "CLI", link: "/cli" },
+      {
+        text: `v${latestVersion}`,
+        link: "https://github.com/jdx/mr-boxington/releases",
+      },
+    ],
+    sidebar: [
+      {
+        text: "Getting started",
+        items: [
+          { text: "Introduction", link: "/" },
+          { text: "Install and run", link: "/getting-started" },
+        ],
+      },
+      {
+        text: "Use mbx",
+        items: [
+          { text: "Configuration", link: "/configuration" },
+          { text: "GitHub Actions", link: "/github-actions" },
+          { text: "Remote cache", link: "/remote-cache" },
+          { text: "Managed targets", link: "/managed-targets" },
+        ],
+      },
+      {
+        text: "Understand mbx",
+        items: [
+          { text: "How it works", link: "/how-it-works" },
+          { text: "Cache results", link: "/cache-results" },
+          { text: "Limits", link: "/limits" },
+        ],
+      },
+      {
+        text: "Reference",
+        items: [{ text: "CLI", link: "/cli" }],
+      },
+    ],
+    outline: { level: [2, 3] },
+    socialLinks: [
+      { icon: "github", link: "https://github.com/jdx/mr-boxington" },
+      { icon: "discord", link: "https://discord.gg/UBa7pJUN7Z" },
+    ],
+    editLink: {
+      pattern: "https://github.com/jdx/mr-boxington/edit/main/docs/:path",
+      text: "Edit this page on GitHub",
+    },
+    search: { provider: "local" },
+    footer: false,
+  },
+  head: [
+    ["link", { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" }],
+    ["meta", { name: "theme-color", content: "#d69b42" }],
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:site_name", content: "mr boxington" }],
+    ["meta", { property: "og:title", content: "mr boxington" }],
+    [
+      "meta",
+      { property: "og:description", content: "A build cache for Rust projects" },
+    ],
+    [
+      "meta",
+      {
+        property: "og:image",
+        content: "https://mr-boxington.jdx.dev/logo.svg",
+      },
+    ],
+    ["meta", { name: "twitter:card", content: "summary" }],
+  ],
+});

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -1,0 +1,23 @@
+<template>
+  <footer class="EndevFooter">
+    <span>MIT License</span>
+    <span aria-hidden="true">·</span>
+    <span>Copyright © {{ year }}</span>
+    <span aria-hidden="true">·</span>
+    <a class="EndevFooterLink" href="https://jdx.dev">
+      <span aria-hidden="true" class="EndevFooterLogo">j</span>
+      <span>jdx.dev</span>
+    </a>
+  </footer>
+</template>
+
+<script setup>
+const year = new Date().getFullYear();
+</script>
+
+<style scoped>
+.EndevFooter { align-items: center; border-top: 1px solid var(--vp-c-divider); color: var(--vp-c-text-2); display: flex; flex-wrap: wrap; font-size: 14px; gap: 8px; justify-content: center; line-height: 28px; margin-top: auto; padding: 22px 24px 26px; text-align: center; }
+.EndevFooterLink { align-items: center; color: inherit; display: inline-flex; gap: 8px; text-decoration: none; }
+.EndevFooterLink:hover { color: var(--vp-c-brand-1); }
+.EndevFooterLogo { align-items: center; background: var(--vp-c-brand-soft); border: 1px solid var(--vp-c-brand-1); border-radius: 8px; color: var(--vp-c-brand-1); display: inline-flex; font-family: Georgia, serif; font-size: 18px; font-weight: 700; height: 28px; justify-content: center; width: 28px; }
+</style>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -1,0 +1,43 @@
+<template>
+  <section v-if="sponsors.length" class="EndevSponsors" aria-label="Sponsors">
+    <span class="EndevSponsorsTitle">sponsors</span>
+    <a v-for="sponsor in sponsors" :key="sponsor.url" class="EndevSponsorsLogo" :href="sponsor.url" rel="noopener noreferrer sponsored" target="_blank">
+      <img :alt="sponsor.name" :src="sponsor.logo" loading="lazy" />
+    </a>
+    <a class="EndevSponsorsCta" href="https://jdx.dev/sponsors.html">View all sponsors</a>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+
+const sponsors = ref([]);
+const footerTiers = new Set(["title", "premier", "partner"]);
+
+onMounted(async () => {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch("https://jdx.dev/sponsors.json", { signal: controller.signal });
+    if (!response.ok) return;
+    const payload = await response.json();
+    sponsors.value = (Array.isArray(payload?.sponsors) ? payload.sponsors : []).filter(
+      (sponsor) => sponsor && footerTiers.has(sponsor.tier) && typeof sponsor.name === "string" && /^https?:\/\//.test(sponsor.url) && /^https?:\/\//.test(sponsor.logo),
+    );
+  } catch {
+    sponsors.value = [];
+  } finally {
+    window.clearTimeout(timeout);
+  }
+});
+</script>
+
+<style scoped>
+.EndevSponsors { align-items: center; display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin: 0 auto; max-width: 1000px; padding: 24px; }
+.EndevSponsorsTitle { color: var(--vp-c-text-2); font-size: 13px; font-weight: 600; text-transform: uppercase; }
+.EndevSponsorsLogo { align-items: center; border: 1px solid var(--vp-c-divider); border-radius: 8px; display: inline-flex; height: 40px; justify-content: center; padding: 8px 12px; }
+.EndevSponsorsLogo:hover { border-color: var(--vp-c-brand-1); }
+.EndevSponsorsLogo img { display: block; height: 22px; max-width: 120px; object-fit: contain; width: auto; }
+.EndevSponsorsCta { color: var(--vp-c-text-2); font-size: 13px; text-decoration: none; }
+.EndevSponsorsCta:hover { color: var(--vp-c-brand-1); }
+</style>

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -1,0 +1,87 @@
+interface BannerData {
+  id: string;
+  enabled: boolean;
+  message: string;
+  link?: string;
+  linkText?: string;
+  expires?: string;
+}
+
+const dismissedKey = "jdx-banner-dismissed";
+
+function isCurrent(banner: BannerData): boolean {
+  if (!banner.enabled) return false;
+  if (!banner.expires) return true;
+  const expiration = Date.parse(banner.expires);
+  return Number.isNaN(expiration) || Date.now() < expiration;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+export function initBanner(): void {
+  if (typeof window === "undefined") return;
+
+  window.addEventListener("DOMContentLoaded", async () => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 5000);
+    try {
+      const response = await fetch("https://jdx.dev/banner.json", {
+        signal: controller.signal,
+      });
+      if (!response.ok) return;
+      const banner = (await response.json()) as BannerData;
+      if (!banner?.id || !isCurrent(banner)) return;
+      if (localStorage.getItem(dismissedKey) === banner.id) return;
+
+      const element = document.createElement("div");
+      element.className = "jdx-banner";
+      element.setAttribute("role", "region");
+      element.setAttribute("aria-label", "Site announcement");
+
+      const message = document.createElement("span");
+      message.textContent = banner.message;
+      element.appendChild(message);
+
+      if (banner.link && isHttpUrl(banner.link)) {
+        const link = document.createElement("a");
+        link.href = banner.link;
+        link.rel = "noopener";
+        link.target = "_blank";
+        link.textContent = banner.linkText || "Learn more";
+        element.appendChild(link);
+      }
+
+      const dismiss = document.createElement("button");
+      dismiss.type = "button";
+      dismiss.setAttribute("aria-label", "Dismiss announcement");
+      dismiss.textContent = "×";
+      dismiss.addEventListener("click", () => {
+        localStorage.setItem(dismissedKey, banner.id);
+        element.remove();
+        document.documentElement.style.removeProperty("--vp-layout-top-height");
+      });
+      element.appendChild(dismiss);
+      document.body.prepend(element);
+
+      const syncHeight = () => {
+        document.documentElement.style.setProperty(
+          "--vp-layout-top-height",
+          `${element.offsetHeight}px`,
+        );
+      };
+      new ResizeObserver(syncHeight).observe(element);
+      syncHeight();
+    } catch {
+      // Announcements should never prevent the documentation from loading.
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  });
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,85 @@
+:root {
+  --vp-c-brand-1: #bd7d23;
+  --vp-c-brand-2: #9f6518;
+  --vp-c-brand-3: #7e4c0d;
+  --vp-c-brand-soft: rgba(189, 125, 35, 0.16);
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(120deg, #eab864 20%, #bd7d23 68%, #6f8e93);
+  --vp-home-hero-image-background-image: radial-gradient(circle, rgba(234, 184, 100, 0.34), rgba(74, 111, 118, 0.16) 52%, transparent 72%);
+  --vp-home-hero-image-filter: blur(44px);
+}
+
+.dark {
+  --vp-c-brand-1: #e6ad54;
+  --vp-c-brand-2: #cf8f35;
+  --vp-c-brand-3: #b9761c;
+  --vp-c-brand-soft: rgba(230, 173, 84, 0.16);
+}
+
+.VPHero .name {
+  letter-spacing: -0.04em;
+}
+
+.VPHero .image-src {
+  filter: drop-shadow(0 22px 30px rgba(0, 0, 0, 0.28));
+}
+
+.VPFeature {
+  border: 1px solid var(--vp-c-divider);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.VPFeature:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+}
+
+.VPFeature .icon {
+  background: var(--vp-c-brand-soft);
+}
+
+.jdx-banner {
+  align-items: center;
+  background: var(--vp-c-brand-1);
+  color: #1c160d;
+  display: flex;
+  font-size: 0.9rem;
+  gap: 0.75rem;
+  justify-content: center;
+  line-height: 1.4;
+  min-height: 2.75rem;
+  padding: 0.5rem 3.25rem 0.5rem 2.75rem;
+  position: fixed;
+  inset: 0 0 auto;
+  text-align: center;
+  z-index: 1001;
+}
+
+.jdx-banner a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.jdx-banner button {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.25rem;
+  height: 44px;
+  position: absolute;
+  right: 0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+}
+
+@media (max-width: 640px) {
+  .jdx-banner {
+    flex-direction: column;
+    font-size: 0.8rem;
+    gap: 0.125rem;
+    padding: 0.5rem 3rem;
+  }
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,19 @@
+import DefaultTheme from "vitepress/theme";
+import type { Theme } from "vitepress";
+import { h } from "vue";
+import EndevFooter from "./EndevFooter.vue";
+import EndevSponsors from "./EndevSponsors.vue";
+import { initBanner } from "./banner";
+import "./custom.css";
+
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],
+    });
+  },
+  enhanceApp() {
+    initBanner();
+  },
+} satisfies Theme;

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -1,0 +1,1612 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      vitepress:
+        specifier: ^1.6.3
+        version: 1.6.4
+
+packages:
+
+  '@algolia/abtesting@1.23.0':
+    resolution: {integrity: sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/autocomplete-core@1.17.7':
+    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
+    peerDependencies:
+      search-insights: '>= 1 < 3'
+
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/client-abtesting@5.57.0':
+    resolution: {integrity: sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-analytics@5.57.0':
+    resolution: {integrity: sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-common@5.57.0':
+    resolution: {integrity: sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-insights@5.57.0':
+    resolution: {integrity: sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-personalization@5.57.0':
+    resolution: {integrity: sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-query-suggestions@5.57.0':
+    resolution: {integrity: sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-search@5.57.0':
+    resolution: {integrity: sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/ingestion@1.57.0':
+    resolution: {integrity: sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/monitoring@1.57.0':
+    resolution: {integrity: sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/recommend@5.57.0':
+    resolution: {integrity: sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-browser-xhr@5.57.0':
+    resolution: {integrity: sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-fetch@5.57.0':
+    resolution: {integrity: sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-node-http@5.57.0':
+    resolution: {integrity: sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@docsearch/css@3.8.2':
+    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+
+  '@docsearch/js@3.8.2':
+    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
+
+  '@docsearch/react@3.8.2':
+    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      search-insights:
+        optional: true
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@iconify-json/simple-icons@1.2.93':
+    resolution: {integrity: sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-android-arm-eabi@4.62.5':
+    resolution: {integrity: sha512-jfkGfTwhQpsiSckPF8r9bU3pn3vyd72NlWaO+TgEO6WPSDnUhXzrNYCHBMOYj0ACaUgjm6eERLF+XV9a6RstoA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.5':
+    resolution: {integrity: sha512-oGVqyQlxnrz9/ty89oHpU857VUHEl5/Xu4R2lS+aivCTrNnSsbiENzTnNaBsjxH0CNWGPhzHArOLFwo+oKXveA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.5':
+    resolution: {integrity: sha512-bW7B8xMEq8n99Q3ieEcPRGuphurdZAaFzQc9Efyyw3FL6DZO6pMy9xhdN+kBoD7Sy05xNXSr4OyPPnpkYriS/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.5':
+    resolution: {integrity: sha512-YSwBS86QeHOGlrxJ1PSOIZSkzRL/JmKeunhc+lV6M1a6En8QuVCD/T/qIA0J4Gd2Y86RIOBYrLcOUtqGh9+/1w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.5':
+    resolution: {integrity: sha512-2fST8lILgl7cKbme/1KDdPCmbXbG+gqoV3bHp19L0ypX/3akYMBVdOunPleRCwonoLnXOZ/0F+Mt/v8POFmfcQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.5':
+    resolution: {integrity: sha512-cpIxQCP9J+EVad0a6LO1kY3ZGODlk80VlI+2I96B8xMcdHZ4pLVhfQ49JFpYqjPF91FFkQWftf57YlDcTiw9yQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.5':
+    resolution: {integrity: sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.5':
+    resolution: {integrity: sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.5':
+    resolution: {integrity: sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.5':
+    resolution: {integrity: sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.5':
+    resolution: {integrity: sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.5':
+    resolution: {integrity: sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.5':
+    resolution: {integrity: sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.5':
+    resolution: {integrity: sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.5':
+    resolution: {integrity: sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.5':
+    resolution: {integrity: sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.5':
+    resolution: {integrity: sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.5':
+    resolution: {integrity: sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.5':
+    resolution: {integrity: sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.5':
+    resolution: {integrity: sha512-e7hD+sl3s+mcLQDZ8pbudBVsdG6r5yN4w3LqG2TJ8sQHDpblWj5lrJs/3m01Cvlxbt4x13zu5thLjgypgtkYzw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.5':
+    resolution: {integrity: sha512-GiyJaCf+WpMub/17aPcKk27QMl5W6f+KhdPTjlFOn5akH5Wa/DCM9Stdx5cDfmasyKB08MqpVQ1uJE2RkkpbXg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.5':
+    resolution: {integrity: sha512-+OQ8U2DdoEfXl8T4Fb18AjmEwbXMerKDKCL8yCPAYhKCEEKoul7rkbeGCBFCbAlaGaa7pmtRTpkAJM2LE/i5FA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.5':
+    resolution: {integrity: sha512-KanvAZrPKbDBFwrgiU9yEVpQoox9QPV1WZOXX7HudJQY+eSlu82CtWxDU8WtuRRvtN5EGkLczkd6Y6DTcvm9wA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.5':
+    resolution: {integrity: sha512-1aC3UEWTtRl3RK3VpDJ/Tqk1XI4SLTmXIthAq6wRWo8XiSXJNd+VprJM4/1P4+i6HIaFEFlVi9sTTziniD2tOQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.5':
+    resolution: {integrity: sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@shikijs/core@2.5.0':
+    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+
+  '@shikijs/engine-javascript@2.5.0':
+    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+
+  '@shikijs/langs@2.5.0':
+    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
+
+  '@shikijs/themes@2.5.0':
+    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+
+  '@shikijs/transformers@2.5.0':
+    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+
+  '@shikijs/types@2.5.0':
+    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.2.0':
+    resolution: {integrity: sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
+  '@vue/compiler-core@3.5.41':
+    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
+
+  '@vue/compiler-dom@3.5.41':
+    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
+
+  '@vue/compiler-sfc@3.5.41':
+    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
+
+  '@vue/compiler-ssr@3.5.41':
+    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
+
+  '@vue/devtools-api@7.7.10':
+    resolution: {integrity: sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==}
+
+  '@vue/devtools-kit@7.7.10':
+    resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
+
+  '@vue/devtools-shared@7.7.10':
+    resolution: {integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==}
+
+  '@vue/reactivity@3.5.41':
+    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
+
+  '@vue/runtime-core@3.5.41':
+    resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
+
+  '@vue/runtime-dom@3.5.41':
+    resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
+
+  '@vue/server-renderer@3.5.41':
+    resolution: {integrity: sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==}
+
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
+
+  '@vueuse/core@12.8.2':
+    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
+
+  '@vueuse/integrations@12.8.2':
+    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
+  '@vueuse/metadata@12.8.2':
+    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
+
+  '@vueuse/shared@12.8.2':
+    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
+  algoliasearch@5.57.0:
+    resolution: {integrity: sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==}
+    engines: {node: '>= 14.0.0'}
+
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  copy-anything@4.1.0:
+    resolution: {integrity: sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  focus-trap@7.8.0:
+    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mark.js@8.11.1:
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  oniguruma-to-es@3.1.1:
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup@4.62.5:
+    resolution: {integrity: sha512-/tqMfgP7GPA3PHhCmuiS4vIjrSVhHLgY++i+dhbG462euyAj7FpM4D9uq1X3BgjlqRdpcOrYhcQtfiQLNc8tqw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  search-insights@2.17.3:
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
+  shiki@2.5.0:
+    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitepress@1.6.4:
+    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
+    hasBin: true
+    peerDependencies:
+      markdown-it-mathjax3: ^4
+      postcss: ^8
+    peerDependenciesMeta:
+      markdown-it-mathjax3:
+        optional: true
+      postcss:
+        optional: true
+
+  vue@3.5.41:
+    resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@algolia/abtesting@1.23.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
+      search-insights: 2.17.3
+
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
+      '@algolia/client-search': 5.57.0
+      algoliasearch: 5.57.0
+
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)':
+    dependencies:
+      '@algolia/client-search': 5.57.0
+      algoliasearch: 5.57.0
+
+  '@algolia/client-abtesting@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/client-analytics@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/client-common@5.57.0': {}
+
+  '@algolia/client-insights@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/client-personalization@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/client-query-suggestions@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/client-search@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/ingestion@1.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/monitoring@1.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/recommend@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  '@algolia/requester-browser-xhr@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+
+  '@algolia/requester-fetch@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+
+  '@algolia/requester-node-http@5.57.0':
+    dependencies:
+      '@algolia/client-common': 5.57.0
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@docsearch/css@3.8.2': {}
+
+  '@docsearch/js@3.8.2':
+    dependencies:
+      '@docsearch/react': 3.8.2
+      preact: 10.29.8
+    transitivePeerDependencies:
+      - '@types/react'
+      - preact-render-to-string
+      - react
+      - react-dom
+      - search-insights
+
+  '@docsearch/react@3.8.2':
+    dependencies:
+      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.57.0
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@iconify-json/simple-icons@1.2.93':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.5':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.5':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.5':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.5':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.5':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.5':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.5':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.5':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.5':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.5':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.5':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.5':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.5':
+    optional: true
+
+  '@shikijs/core@2.5.0':
+    dependencies:
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 3.1.1
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/themes@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/transformers@2.5.0':
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/types@2.5.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.2.0':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
+  '@ungap/structured-clone@1.3.3': {}
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.41)':
+    dependencies:
+      vite: 5.4.21
+      vue: 3.5.41
+
+  '@vue/compiler-core@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.41
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.41':
+    dependencies:
+      '@vue/compiler-core': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-sfc@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.41
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/shared': 3.5.41
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.26
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.41':
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/devtools-api@7.7.10':
+    dependencies:
+      '@vue/devtools-kit': 7.7.10
+
+  '@vue/devtools-kit@7.7.10':
+    dependencies:
+      '@vue/devtools-shared': 7.7.10
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+
+  '@vue/devtools-shared@7.7.10':
+    dependencies:
+      rfdc: 1.4.1
+
+  '@vue/reactivity@3.5.41':
+    dependencies:
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-core@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-dom@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/runtime-core': 3.5.41
+      '@vue/shared': 3.5.41
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.41':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/shared@3.5.41': {}
+
+  '@vueuse/core@12.8.2':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2
+      vue: 3.5.41
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)':
+    dependencies:
+      '@vueuse/core': 12.8.2
+      '@vueuse/shared': 12.8.2
+      focus-trap: 7.8.0
+      vue: 3.5.41
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/shared@12.8.2':
+    dependencies:
+      vue: 3.5.41
+    transitivePeerDependencies:
+      - typescript
+
+  algoliasearch@5.57.0:
+    dependencies:
+      '@algolia/abtesting': 1.23.0
+      '@algolia/client-abtesting': 5.57.0
+      '@algolia/client-analytics': 5.57.0
+      '@algolia/client-common': 5.57.0
+      '@algolia/client-insights': 5.57.0
+      '@algolia/client-personalization': 5.57.0
+      '@algolia/client-query-suggestions': 5.57.0
+      '@algolia/client-search': 5.57.0
+      '@algolia/ingestion': 1.57.0
+      '@algolia/monitoring': 1.57.0
+      '@algolia/recommend': 5.57.0
+      '@algolia/requester-browser-xhr': 5.57.0
+      '@algolia/requester-fetch': 5.57.0
+      '@algolia/requester-node-http': 5.57.0
+
+  birpc@2.9.0: {}
+
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  copy-anything@4.1.0: {}
+
+  csstype@3.2.3: {}
+
+  dequal@2.0.3: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  emoji-regex-xs@1.0.0: {}
+
+  entities@7.0.1: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@2.0.2: {}
+
+  focus-trap@7.8.0:
+    dependencies:
+      tabbable: 6.5.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hookable@5.5.3: {}
+
+  html-void-elements@3.0.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mark.js@8.11.1: {}
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  minisearch@7.2.0: {}
+
+  mitt@3.0.1: {}
+
+  nanoid@3.3.18: {}
+
+  oniguruma-to-es@3.1.1:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  perfect-debounce@1.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  preact@10.29.8: {}
+
+  property-information@7.2.0: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rfdc@1.4.1: {}
+
+  rollup@4.62.5:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.5
+      '@rollup/rollup-android-arm64': 4.62.5
+      '@rollup/rollup-darwin-arm64': 4.62.5
+      '@rollup/rollup-darwin-x64': 4.62.5
+      '@rollup/rollup-freebsd-arm64': 4.62.5
+      '@rollup/rollup-freebsd-x64': 4.62.5
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.5
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.5
+      '@rollup/rollup-linux-arm64-gnu': 4.62.5
+      '@rollup/rollup-linux-arm64-musl': 4.62.5
+      '@rollup/rollup-linux-loong64-gnu': 4.62.5
+      '@rollup/rollup-linux-loong64-musl': 4.62.5
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.5
+      '@rollup/rollup-linux-ppc64-musl': 4.62.5
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.5
+      '@rollup/rollup-linux-riscv64-musl': 4.62.5
+      '@rollup/rollup-linux-s390x-gnu': 4.62.5
+      '@rollup/rollup-linux-x64-gnu': 4.62.5
+      '@rollup/rollup-linux-x64-musl': 4.62.5
+      '@rollup/rollup-openbsd-x64': 4.62.5
+      '@rollup/rollup-openharmony-arm64': 4.62.5
+      '@rollup/rollup-win32-arm64-msvc': 4.62.5
+      '@rollup/rollup-win32-ia32-msvc': 4.62.5
+      '@rollup/rollup-win32-x64-gnu': 4.62.5
+      '@rollup/rollup-win32-x64-msvc': 4.62.5
+      fsevents: 2.3.3
+
+  search-insights@2.17.3: {}
+
+  shiki@2.5.0:
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  speakingurl@14.0.1: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.1.0
+
+  tabbable@6.5.0: {}
+
+  trim-lines@3.0.1: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.26
+      rollup: 4.62.5
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitepress@1.6.4:
+    dependencies:
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2
+      '@iconify-json/simple-icons': 1.2.93
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.2.0
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21)(vue@3.5.41)
+      '@vue/devtools-api': 7.7.10
+      '@vue/shared': 3.5.41
+      '@vueuse/core': 12.8.2
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)
+      focus-trap: 7.8.0
+      mark.js: 8.11.1
+      minisearch: 7.2.0
+      shiki: 2.5.0
+      vite: 5.4.21
+      vue: 3.5.41
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - less
+      - lightningcss
+      - nprogress
+      - preact-render-to-string
+      - qrcode
+      - react
+      - react-dom
+      - sass
+      - sass-embedded
+      - search-insights
+      - sortablejs
+      - stylus
+      - sugarss
+      - terser
+      - typescript
+      - universal-cookie
+
+  vue@3.5.41:
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-sfc': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/server-renderer': 3.5.41
+      '@vue/shared': 3.5.41
+
+  zwitch@2.0.4: {}

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -1,0 +1,33 @@
+# Cache results
+
+The summary separates work mbx handled from work it could not safely cache.
+
+## Hit
+
+mbx derived an action key, found its result, and restored the outputs. A hit can
+come from the local store or a configured remote.
+
+## Miss
+
+mbx derived a key and looked it up, but no result existed. The compilation ran
+and its successful result was stored.
+
+## Could not look up
+
+mbx did not yet have usable dep-info or a prediction from which to derive the
+key. This is common on a genuinely cold build. The action is still stored after
+compilation, so calling it a miss would overstate the number of failed lookups.
+
+## Bypass
+
+mbx recognized that it could not model the action exactly and ran the real
+compiler without caching it. Reasons are grouped in the summary; set
+`MBX_BYPASS_LOG` to a file path for the full per-action record.
+
+## Why hit rate is not the whole story
+
+A build can report a high hit rate among attempted lookups while spending most
+of its time on actions that were not looked up or were bypassed. Read all three
+summary lines together, and compare wall-clock time when evaluating the cache.
+
+Link steps always run, so an otherwise warm binary build still has work to do.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,55 @@
+# CLI reference
+
+## `mbx build`
+
+Run Cargo with the build cache enabled.
+
+```text
+mbx build <CARGO_SUBCOMMAND> [ARGS]...
+```
+
+Examples:
+
+```sh
+mbx build build --release
+mbx build test --workspace
+mbx build clippy --all-targets -- -D warnings
+```
+
+At least one Cargo subcommand is required. All arguments after `build` are
+passed through unchanged.
+
+## `mbx cache dir`
+
+Print the action-store directory.
+
+```sh
+mbx cache dir
+```
+
+## `mbx cache stats`
+
+Summarize cached objects, action results, and their sizes.
+
+```sh
+mbx cache stats
+```
+
+## `mbx gc`
+
+Collect stale managed targets and evict cached objects until the store fits its
+budget.
+
+```text
+mbx gc [--max-size <SIZE>]
+```
+
+Without `--max-size`, the command uses `gc.max_size` / `MBX_GC_MAX_SIZE`.
+
+```sh
+mbx gc
+mbx gc --max-size 3GB
+mbx gc --max-size 20GiB
+```
+
+Eviction is safe: a missing cached object is rebuilt when it is needed again.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,23 +1,24 @@
 # CLI reference
 
-## `mbx build`
+## Cargo subcommands
 
-Run Cargo with the build cache enabled.
+Run any Cargo subcommand with the build cache enabled.
 
 ```text
-mbx build <CARGO_SUBCOMMAND> [ARGS]...
+mbx <CARGO_SUBCOMMAND> [ARGS]...
 ```
 
 Examples:
 
 ```sh
-mbx build build --release
-mbx build test --workspace
-mbx build clippy --all-targets -- -D warnings
+mbx build --release
+mbx test --workspace
+mbx clippy --all-targets -- -D warnings
 ```
 
-At least one Cargo subcommand is required. All arguments after `build` are
-passed through unchanged.
+The Cargo subcommand and all of its arguments are passed through unchanged.
+Cargo aliases and installed subcommands work too. `cache` and `gc` are reserved
+for mbx's own store-management commands.
 
 ## `mbx cache dir`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ retries = 3
 | `MBX_GC_AUTO` | `gc.auto` | `true` | Sweep after a build when due |
 | `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | Action-store budget |
 | `MBX_GC_INTERVAL` | `gc.interval` | `1h` | Minimum interval between automatic sweeps |
-| `MBX_TARGET_VIEWS` | `target.views` | `false` | Let mbx place target directories |
+| `MBX_TARGET_VIEWS` | `target.views` | `true` | Let mbx place eligible target directories |
 | `MBX_TARGET_ROOT` | `target.root` | `<cache>/targets` | Managed target root |
 | `MBX_REMOTE_URL` | `remote.url` | unset | Remote cache URL |
 | `MBX_REMOTE_NAMESPACE` | `remote.namespace` | unset | Remote namespace; required with a URL |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,79 @@
+# Configuration
+
+mbx loads environment variables over `~/.config/mbx/config.toml`, then falls
+back to defaults. Unknown TOML keys are rejected so misspelled settings do not
+silently do nothing.
+
+## Example
+
+```toml
+# ~/.config/mbx/config.toml
+cache_dir = "/var/cache/mbx"
+incremental = false
+share_out_dir = false
+
+[gc]
+auto = true
+max_size = "20GiB"
+interval = "1h"
+
+[target]
+views = true
+
+[remote]
+url = "https://cache.example.com"
+namespace = "acme/backend"
+mode = "read-write"
+
+[http]
+timeout = "30s"
+download_timeout = "10m"
+retries = 3
+```
+
+## Settings
+
+| Environment | TOML key | Default | Purpose |
+| --- | --- | --- | --- |
+| `MBX_CACHE_DIR` | `cache_dir` | platform cache directory | Cache root |
+| `MBX_STATS_REPORT` | `stats_report` | unset | Write a JSON build report |
+| `MBX_INCREMENTAL` | `incremental` | `false` | Let local workspace members compile incrementally |
+| `MBX_SHARE_OUT_DIR` | `share_out_dir` | `false` | Share eligible compilations that read `OUT_DIR` |
+| `MBX_GC_AUTO` | `gc.auto` | `true` | Sweep after a build when due |
+| `MBX_GC_MAX_SIZE` | `gc.max_size` | `20GiB` | Action-store budget |
+| `MBX_GC_INTERVAL` | `gc.interval` | `1h` | Minimum interval between automatic sweeps |
+| `MBX_TARGET_VIEWS` | `target.views` | `false` | Let mbx place target directories |
+| `MBX_TARGET_ROOT` | `target.root` | `<cache>/targets` | Managed target root |
+| `MBX_REMOTE_URL` | `remote.url` | unset | Remote cache URL |
+| `MBX_REMOTE_NAMESPACE` | `remote.namespace` | unset | Remote namespace; required with a URL |
+| `MBX_REMOTE_TOKEN` | `remote.token` | unset | Bearer token |
+| `MBX_REMOTE_TOKEN_FILE` | `remote.token_file` | unset | File containing a bearer token |
+| `MBX_REMOTE_OIDC_AUDIENCE` | `remote.oidc_audience` | unset | CI OIDC audience |
+| `MBX_REMOTE_MODE` | `remote.mode` | `read-write` | `read-write`, `read-only`, or `write-only` |
+| `MBX_HTTP_TIMEOUT` | `http.timeout` | `30s` | Connect and request timeout |
+| `MBX_HTTP_DOWNLOAD_TIMEOUT` | `http.download_timeout` | `10m` | Blob download timeout |
+| `MBX_HTTP_RETRIES` | `http.retries` | `3` | Request retries |
+
+## Diagnostic environment variables
+
+These are environment-only:
+
+| Environment | Purpose |
+| --- | --- |
+| `MBX_VERIFY` | Compile and consult the cache, then compare outputs |
+| `MBX_BYPASS_LOG` | Append the full reason for every bypassed compilation |
+
+`MBX_VERIFY=1` is deliberately slower. It qualifies correctness; it is not a
+normal build mode.
+
+## Incremental builds
+
+`MBX_INCREMENTAL=1` stops mbx from forcing `CARGO_INCREMENTAL=0` locally. This
+can help an edit/rebuild loop, but an incremental workspace artifact changes
+the inputs of crates above it and reduces reuse across worktrees. CI always
+disables it because a fresh runner has no incremental state to reuse.
+
+## Sizes and durations
+
+Sizes accept SI and IEC units. `20GB` and `20GiB` are different values. Durations
+accept values such as `30s`, `15m`, and `1h`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,73 @@
+# Get started
+
+## Install
+
+### mise
+
+```sh
+mise use -g github:jdx/mr-boxington
+```
+
+### Release archive
+
+Linux x86-64:
+
+```sh
+mkdir -p ~/.local/bin
+curl -fsSL https://github.com/jdx/mr-boxington/releases/latest/download/mbx-x86_64-unknown-linux-musl.tar.gz \
+  | tar -xzf - -C ~/.local/bin
+```
+
+Release archives are also available for Linux ARM64, Apple Silicon, Intel macOS,
+and Windows x86-64. See [GitHub Releases](https://github.com/jdx/mr-boxington/releases)
+for downloads and `SHA256SUMS`.
+
+### Cargo
+
+```sh
+cargo install mbx
+```
+
+## Run a build
+
+Put `mbx` before cargo's subcommand:
+
+```sh
+mbx build build
+mbx build test --workspace --all-features
+mbx build clippy --workspace --all-targets
+```
+
+Everything after `mbx build` is passed to cargo unchanged. Cargo still owns
+dependency resolution, feature unification, build planning, and linking.
+
+## Read the result
+
+After a build that used the cache, mbx prints a summary to stderr:
+
+```text
+cache: 139 hits, 8 misses, 147 prefetched; 312.4 MiB downloaded, 0 B uploaded, 280.1 MiB stored locally
+cache could not look up 4 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from
+cache bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
+```
+
+These are three different outcomes: a miss means mbx looked up an action and
+found nothing, “could not look up” means it had no key yet, and a bypass means
+mbx deliberately declined to cache the action. See [Cache results](/cache-results).
+
+## Inspect the store
+
+```sh
+mbx cache dir
+mbx cache stats
+mbx gc
+mbx gc --max-size 20GiB
+```
+
+Automatic collection is enabled by default with a 20 GiB budget.
+
+## Next steps
+
+- Tune local behavior in [Configuration](/configuration).
+- Warm pull requests with [GitHub Actions cache](/github-actions).
+- Learn what enters a key in [How it works](/how-it-works).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,13 +33,14 @@ cargo install mbx
 Put `mbx` before cargo's subcommand:
 
 ```sh
-mbx build build
-mbx build test --workspace --all-features
-mbx build clippy --workspace --all-targets
+mbx build
+mbx test --workspace --all-features
+mbx clippy --workspace --all-targets
 ```
 
-Everything after `mbx build` is passed to cargo unchanged. Cargo still owns
-dependency resolution, feature unification, build planning, and linking.
+The command and its arguments are passed to Cargo unchanged. Cargo still owns
+dependency resolution, feature unification, build planning, and linking. mbx
+also forwards Cargo aliases and installed subcommands.
 
 ## Read the result
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,100 @@
+# GitHub Actions
+
+The simplest GitHub-hosted setup stores mbx's local cache in GitHub Actions
+cache. A cache written by `main` can warm pull requests, including pull requests
+from forks, without giving external contributors access to a private cache host.
+
+## Build the cache on main
+
+```yaml
+name: rust-cache
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/.global-cache
+            ~/.cache/mbx
+          key: ${{ runner.os }}-${{ runner.arch }}-mbx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-mbx-
+      - uses: jdx/mise-action@v4
+        with:
+          cache: false
+          install_args: github:jdx/mr-boxington
+      - run: mbx build build --workspace --all-features
+      - run: mbx gc --max-size 3GB
+        if: always()
+```
+
+Each `main` build restores the preceding cache, adds the actions needed by the
+new commit, trims it to a repository-friendly budget, and saves an immutable
+entry for its SHA.
+
+## Restore it in pull requests
+
+Use the restore-only action so pull requests never create a cache entry:
+
+```yaml
+- uses: actions/cache/restore@v6
+  with:
+    path: |
+      ~/.cargo/registry
+      ~/.cargo/git
+      ~/.cargo/.global-cache
+      ~/.cache/mbx
+    key: ${{ runner.os }}-${{ runner.arch }}-mbx-${{ github.event.pull_request.base.sha }}
+    restore-keys: |
+      ${{ runner.os }}-${{ runner.arch }}-mbx-
+- uses: jdx/mise-action@v4
+  with:
+    cache: false
+    install_args: github:jdx/mr-boxington
+- run: mbx build test --workspace
+```
+
+The operating system, architecture, and an explicit cache generation belong in
+the key. Change the prefix when an mbx upgrade or cache-format change should
+start fresh.
+
+::: tip Pin actions in production
+The examples use major tags for readability. Pin third-party actions to full
+commit SHAs in a real workflow.
+:::
+
+## Self-hosted remote cache
+
+For trusted runners and teams, mbx can talk to a compatible remote server such
+as [`jdx/mbx-cache`](https://github.com/jdx/mbx-cache). Configure the URL,
+namespace, and OIDC audience:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  MBX_REMOTE_URL: https://cache.example.com
+  MBX_REMOTE_NAMESPACE: acme/backend
+  MBX_REMOTE_OIDC_AUDIENCE: mbx-cache
+```
+
+Only a push to a protected branch may write. Pull requests degrade to read-only,
+and tag or release builds do not use the remote cache at all. If fork authors
+must not reach the host, use GitHub Actions cache for those jobs instead.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -38,7 +38,7 @@ jobs:
         with:
           cache: false
           install_args: github:jdx/mr-boxington
-      - run: mbx build build --workspace --all-features
+      - run: mbx build --workspace --all-features
       - run: mbx gc --max-size 3GB
         if: always()
 ```
@@ -66,7 +66,7 @@ Use the restore-only action so pull requests never create a cache entry:
   with:
     cache: false
     install_args: github:jdx/mr-boxington
-- run: mbx build test --workspace
+- run: mbx test --workspace
 ```
 
 The operating system, architecture, and an explicit cache generation belong in

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,6 +1,8 @@
 # How it works
 
-`mbx build` is a cargo wrapper, not a cargo replacement.
+mbx is a Cargo wrapper, not a Cargo replacement. Run Cargo subcommands directly
+through it: `mbx build`, `mbx test`, `mbx clippy`, or any installed Cargo
+subcommand.
 
 1. mbx resolves the workspace and target roots through Cargo metadata.
 2. It starts an in-process cache agent and creates a rustc shim for the build.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,34 @@
+# How it works
+
+`mbx build` is a cargo wrapper, not a cargo replacement.
+
+1. mbx resolves the workspace and target roots through Cargo metadata.
+2. It starts an in-process cache agent and creates a rustc shim for the build.
+3. Cargo runs normally with the shim set as `RUSTC_WRAPPER`.
+4. The shim analyzes each rustc invocation and derives a content-addressed action key.
+5. A hit restores the action's outputs; a miss runs the real compiler and publishes the result.
+6. The agent exits with the build. There is no persistent daemon.
+
+## Portable keys
+
+Known workspace, target, Cargo registry, toolchain, and sysroot paths are mapped
+to stable placeholders before they enter a key. That is what lets equivalent
+worktrees share an action even though their absolute paths differ.
+
+The key also covers compiler inputs and relevant environment. If mbx cannot
+model something exactly, it bypasses the action instead of guessing.
+
+## Prediction and dep-info
+
+A rustc action key depends on the files that compilation actually reads. mbx
+learns that set from Cargo/rustc dep-info left by an earlier build and records a
+prediction for later invocations. A genuinely cold compilation may therefore
+have no key to look up yet. It still gets stored after compiling and can warm
+the next build.
+
+## Correctness first
+
+Unsupported crate types, unmodeled search paths, linking, and incremental
+compilations bypass the shared action cache. `MBX_VERIFY=1` compiles while also
+consulting the cache and compares the result, providing a deliberately expensive
+qualification mode.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,21 +17,21 @@ hero:
       link: /github-actions
 
 features:
-  - icon: "⚡"
-    title: Cache rustc actions
-    details: Restore individual compilations instead of rebuilding an entire dependency graph.
-    link: /how-it-works
+  - icon: "⚙️"
+    title: Wrap normal Cargo commands
+    details: Put mbx before build, test, or clippy. Cargo still plans the build; mbx restores the rustc work it has seen before.
+    link: /getting-started
   - icon: "🌳"
-    title: Share across worktrees
-    details: Cache keys contain no checkout-specific absolute paths, so one checkout can warm another.
+    title: Warm every worktree
+    details: Cache keys contain no checkout-specific absolute paths, so building one checkout warms its siblings automatically.
     link: /cache-results
   - icon: "☁️"
     title: Warm CI runners
     details: Use a remote cache or GitHub Actions cache while untrusted pull requests remain read-only.
     link: /github-actions
-  - icon: "📦"
-    title: Reclaim build storage
-    details: Sweep cached objects to a budget and optionally collect target directories after their checkout disappears.
+  - icon: "🧹"
+    title: Prune automatically
+    details: Keep the cache inside a size budget and reclaim managed target directories after their checkout disappears.
     link: /managed-targets
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "mr boxington"
   text: "Build it once."
-  tagline: A content-addressed build cache for Rust projects, worktrees, and CI.
+  tagline: A Cargo wrapper that shares compiled work across worktrees and CI—and prunes build storage automatically.
   image:
     src: /logo.svg
     alt: Mr Boxington, a friendly cache box

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+---
+layout: home
+
+hero:
+  name: "mr boxington"
+  text: "Build it once."
+  tagline: A content-addressed build cache for Rust projects, worktrees, and CI.
+  image:
+    src: /logo.svg
+    alt: Mr Boxington, a friendly cache box
+  actions:
+    - theme: brand
+      text: Get started
+      link: /getting-started
+    - theme: alt
+      text: GitHub Actions
+      link: /github-actions
+
+features:
+  - icon: "⚡"
+    title: Cache rustc actions
+    details: Restore individual compilations instead of rebuilding an entire dependency graph.
+    link: /how-it-works
+  - icon: "🌳"
+    title: Share across worktrees
+    details: Cache keys contain no checkout-specific absolute paths, so one checkout can warm another.
+    link: /cache-results
+  - icon: "☁️"
+    title: Warm CI runners
+    details: Use a remote cache or GitHub Actions cache while untrusted pull requests remain read-only.
+    link: /github-actions
+  - icon: "📦"
+    title: Reclaim build storage
+    details: Sweep cached objects to a budget and optionally collect target directories after their checkout disappears.
+    link: /managed-targets
+---
+
+::: warning Experimental
+mr boxington is pre-1.0. The cache format and behavior may change without notice,
+and releases are not a stability promise.
+:::

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1,0 +1,38 @@
+# Limits
+
+mr boxington favors correct uncached work over risky cache reuse.
+
+## Use `mbx build`
+
+Plain `cargo build` does not start the session agent, so it gets no mbx cache.
+Use `mbx build build`, `mbx build test`, and the same pattern for other cargo
+subcommands.
+
+## Linking is not cached
+
+Binaries and dynamic libraries always link. mbx caches supported rustc
+compilations, not the final link action.
+
+## `OUT_DIR` sharing is opt-in
+
+A generated source path can contain an absolute checkout-specific `OUT_DIR`.
+`MBX_SHARE_OUT_DIR=1` remaps the path and inspects outputs before choosing a
+shared key, but generated sources then appear in debug info under a placeholder
+path. It cannot detect a value derived from the path without embedding the path
+itself.
+
+## Incremental output reduces sharing
+
+`MBX_INCREMENTAL=1` can improve a local edit/rebuild loop, but an incremental
+artifact changes the content inputs of dependent crates. Those crates then miss
+even if another checkout built the same source. CI disables incremental builds.
+
+## Collection is approximate
+
+Object eviction prefers abandoned checkout data and then older access times.
+Filesystems using `relatime` coarsen that order; `noatime` removes it. A poor
+choice costs a recompile, not correctness.
+
+The configured size budget covers action objects and results. Prediction data,
+checkout records, temporary downloads, and managed target directories make the
+whole cache directory somewhat larger.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -2,10 +2,10 @@
 
 mr boxington favors correct uncached work over risky cache reuse.
 
-## Use `mbx build`
+## Run Cargo through mbx
 
-Plain `cargo build` does not start the session agent, so it gets no mbx cache.
-Use `mbx build build`, `mbx build test`, and the same pattern for other cargo
+Plain Cargo commands do not start the session agent, so they get no mbx cache.
+Use `mbx build`, `mbx test`, `mbx clippy`, and the same pattern for other Cargo
 subcommands.
 
 ## Linking is not cached

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -52,7 +52,8 @@ remove the directory.
 
 After acceptance, mbx temporarily moves the old directory aside. It removes
 those outputs only after the managed link and its collection record both
-succeed; if placement fails, mbx restores the original directory.
+succeed, then reports how much space the old outputs occupied. If placement
+fails, mbx restores the original directory.
 
 mbx does not offer removal for an explicitly configured target directory or a
 symlink it does not own.

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -4,10 +4,11 @@ Cargo normally writes build outputs to `<workspace>/target`. Deleting a
 worktree deletes useful outputs, while abandoning a checkout leaves gigabytes
 behind indefinitely.
 
-Enable managed targets:
+Managed targets are enabled by default. For a checkout without an existing
+`target/`, the first build is enough:
 
 ```sh
-MBX_TARGET_VIEWS=1 mbx build build
+mbx build build
 ```
 
 mbx places the target directory under its cache root and leaves a symlink at
@@ -36,10 +37,22 @@ mbx does not override an explicit target directory supplied by:
 - Cargo's `build.target-dir` configuration
 
 It also leaves an existing real `target/` directory alone. Remove that directory
-before enabling managed targets if you want mbx to replace it with a link.
+if you want the next build to replace it with a managed link.
+
+## Disable managed targets
+
+Set `MBX_TARGET_VIEWS=0`, or configure:
+
+```toml
+[target]
+views = false
+```
+
+Turning placement off does not delete a target directory mbx already manages.
+The existing `target` link continues to work, and collection can still reclaim
+the directory after its checkout disappears.
 
 ::: warning Windows
 Creating the link requires Developer Mode or a privileged process on Windows.
-If Windows cannot create it, mbx reports the problem and lets Cargo use its
-ordinary target directory.
+If Windows cannot create it, mbx lets Cargo use its ordinary target directory.
 :::

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -1,0 +1,45 @@
+# Managed target directories
+
+Cargo normally writes build outputs to `<workspace>/target`. Deleting a
+worktree deletes useful outputs, while abandoning a checkout leaves gigabytes
+behind indefinitely.
+
+Enable managed targets:
+
+```sh
+MBX_TARGET_VIEWS=1 mbx build build
+```
+
+mbx places the target directory under its cache root and leaves a symlink at
+`target`, so familiar paths continue to work:
+
+```text
+target -> ~/.cache/mbx/targets/v1/<checkout digest>
+```
+
+## Collection
+
+`mbx build` records the checkout associated with each target view. Once that
+checkout no longer exists, `mbx gc` can remove its target directory. Cached
+compilations shared with a live checkout remain protected.
+
+Managed target directories are collected when their checkout disappears; they
+are not counted against `gc.max_size`. The size budget covers cached objects
+and action results.
+
+## When mbx leaves a target alone
+
+mbx does not override an explicit target directory supplied by:
+
+- `--target-dir`
+- `CARGO_TARGET_DIR`
+- Cargo's `build.target-dir` configuration
+
+It also leaves an existing real `target/` directory alone. Remove that directory
+before enabling managed targets if you want mbx to replace it with a link.
+
+::: warning Windows
+Creating the link requires Developer Mode or a privileged process on Windows.
+If Windows cannot create it, mbx reports the problem and lets Cargo use its
+ordinary target directory.
+:::

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -15,7 +15,7 @@ mbx places the target directory under its cache root and leaves a symlink at
 `target`, so familiar paths continue to work:
 
 ```text
-target -> ~/.cache/mbx/targets/v1/<checkout digest>
+target -> <cache root>/targets/v1/<checkout digest>
 ```
 
 ## Collection
@@ -49,6 +49,10 @@ mbx can remove /path/to/project/target and replace it with a managed target that
 “Keep it” is selected by default. Declining leaves every output untouched and
 the Cargo command continues normally. Non-interactive runs never prompt or
 remove the directory.
+
+After acceptance, mbx temporarily moves the old directory aside. It removes
+those outputs only after the managed link and its collection record both
+succeed; if placement fails, mbx restores the original directory.
 
 mbx does not offer removal for an explicitly configured target directory or a
 symlink it does not own.

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -8,7 +8,7 @@ Managed targets are enabled by default. For a checkout without an existing
 `target/`, the first build is enough:
 
 ```sh
-mbx build build
+mbx build
 ```
 
 mbx places the target directory under its cache root and leaves a symlink at
@@ -20,7 +20,7 @@ target -> ~/.cache/mbx/targets/v1/<checkout digest>
 
 ## Collection
 
-`mbx build` records the checkout associated with each target view. Once that
+mbx records the checkout associated with each target view. Once that
 checkout no longer exists, `mbx gc` can remove its target directory. Cached
 compilations shared with a live checkout remain protected.
 
@@ -36,8 +36,22 @@ mbx does not override an explicit target directory supplied by:
 - `CARGO_TARGET_DIR`
 - Cargo's `build.target-dir` configuration
 
-It also leaves an existing real `target/` directory alone. Remove that directory
-if you want the next build to replace it with a managed link.
+## Existing target directories
+
+When an interactive mbx command finds an existing real `target/`, it offers to
+remove the old outputs and replace the directory with a managed link:
+
+```text
+Use a managed target directory?
+mbx can remove /path/to/project/target and replace it with a managed target that is pruned after this checkout is deleted.
+```
+
+“Keep it” is selected by default. Declining leaves every output untouched and
+the Cargo command continues normally. Non-interactive runs never prompt or
+remove the directory.
+
+mbx does not offer removal for an explicitly configured target directory or a
+symlink it does not own.
 
 ## Disable managed targets
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mr-boxington-docs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "docs:dev": "vitepress dev",
+    "docs:build": "vitepress build",
+    "docs:preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.3"
+  },
+  "pnpm": {
+    "supportedArchitectures": {
+      "os": ["linux", "darwin"],
+      "cpu": ["x64", "arm64"],
+      "libc": ["glibc"]
+    },
+    "allowBuilds": {
+      "esbuild": true
+    }
+  }
+}

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M7 18 32 6l25 12-25 13z" fill="#efc477" stroke="#5c3a16" stroke-linejoin="round" stroke-width="3"/>
+  <path d="m7 18 25 13v28L7 46z" fill="#d99a43" stroke="#5c3a16" stroke-linejoin="round" stroke-width="3"/>
+  <path d="m57 18-25 13v28l25-13z" fill="#a9641d" stroke="#5c3a16" stroke-linejoin="round" stroke-width="3"/>
+  <circle cx="20" cy="35" r="2.5" fill="#24373b"/>
+  <circle cx="32" cy="41" r="2.5" fill="#24373b"/>
+</svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -16,14 +16,15 @@
   <path d="m266 91-106 54v131l106-56z" fill="url(#side)" stroke="#5c3a16" stroke-linejoin="round" stroke-width="8"/>
   <path d="M160 145v131" fill="none" stroke="#5c3a16" stroke-width="8"/>
   <path d="m118 59 104 53v36" fill="none" stroke="#9b611c" stroke-linejoin="round" stroke-width="12"/>
-  <g fill="#24373b">
-    <circle cx="104" cy="159" r="10"/>
-    <circle cx="157" cy="185" r="10"/>
-    <path d="M115 188c11 3 19 9 24 18-14 3-25 0-32-10-3 13-12 20-26 22 0-12 5-23 17-33z"/>
+  <g transform="matrix(1 .509 0 1 54 91)" stroke="#24373b" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="34" cy="50" r="7" fill="#24373b" stroke="none"/>
+    <circle cx="72" cy="50" r="7" fill="#24373b" stroke="none"/>
+    <circle cx="72" cy="50" r="14" fill="none" stroke-width="4"/>
+    <path d="m82 60 5 20" fill="none" stroke-width="4"/>
+    <path d="M53 76c-8-12-24-12-32 1 12-1 21 4 27 12 4-4 6-8 5-13Z" fill="#24373b" stroke="none"/>
+    <path d="M53 76c8-12 24-12 32 1-12-1-21 4-27 12-4-4-6-8-5-13Z" fill="#24373b" stroke="none"/>
+    <path d="m51 108-25-13 2 27 23-8Z" fill="#34545b" stroke-width="4"/>
+    <path d="m55 108 25-13-2 27-23-8Z" fill="#34545b" stroke-width="4"/>
+    <path d="m48 104 10 1 1 14-12-2Z" fill="#e9b650" stroke-width="4"/>
   </g>
-  <g fill="#34545b" stroke="#203438" stroke-linejoin="round" stroke-width="5">
-    <path d="m105 222 29-10 25 24-31 12z"/>
-    <path d="m159 236 31-4-2 31-29-7z"/>
-  </g>
-  <path d="m140 224 19 12-8 18-21-10z" fill="#e9b650" stroke="#203438" stroke-linejoin="round" stroke-width="5"/>
 </svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" role="img" aria-labelledby="title description">
+  <title id="title">mr boxington</title>
+  <desc id="description">A friendly cardboard cache box wearing a bow tie</desc>
+  <defs>
+    <linearGradient id="box" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#efc477"/>
+      <stop offset="1" stop-color="#b97522"/>
+    </linearGradient>
+    <linearGradient id="side" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#c98932"/>
+      <stop offset="1" stop-color="#8a5215"/>
+    </linearGradient>
+  </defs>
+  <path d="M54 91 160 38l106 53-106 54z" fill="#f1c875" stroke="#5c3a16" stroke-linejoin="round" stroke-width="8"/>
+  <path d="m54 91 106 54v131L54 220z" fill="url(#box)" stroke="#5c3a16" stroke-linejoin="round" stroke-width="8"/>
+  <path d="m266 91-106 54v131l106-56z" fill="url(#side)" stroke="#5c3a16" stroke-linejoin="round" stroke-width="8"/>
+  <path d="M160 145v131" fill="none" stroke="#5c3a16" stroke-width="8"/>
+  <path d="m118 59 104 53v36" fill="none" stroke="#9b611c" stroke-linejoin="round" stroke-width="12"/>
+  <g fill="#24373b">
+    <circle cx="104" cy="159" r="10"/>
+    <circle cx="157" cy="185" r="10"/>
+    <path d="M115 188c11 3 19 9 24 18-14 3-25 0-32-10-3 13-12 20-26 22 0-12 5-23 17-33z"/>
+  </g>
+  <g fill="#34545b" stroke="#203438" stroke-linejoin="round" stroke-width="5">
+    <path d="m105 222 29-10 25 24-31 12z"/>
+    <path d="m159 236 31-4-2 31-29-7z"/>
+  </g>
+  <path d="m140 224 19 12-8 18-21-10z" fill="#e9b650" stroke="#203438" stroke-linejoin="round" stroke-width="5"/>
+</svg>

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -1,0 +1,50 @@
+# Remote cache
+
+A remote cache lets ephemeral runners and teammates restore only the rustc
+actions a build needs. The local content-addressed store remains the working
+cache; remote objects are downloaded into it and newly completed actions may be
+uploaded from trusted CI.
+
+## Configure a server
+
+```toml
+[remote]
+url = "https://cache.example.com"
+namespace = "acme/backend"
+mode = "read-write"
+```
+
+The namespace isolates one project's cache from another. It is required when a
+remote URL is set.
+
+## Authenticate
+
+Use one of:
+
+- `MBX_REMOTE_TOKEN` for a bearer token.
+- `MBX_REMOTE_TOKEN_FILE` for a file containing the token.
+- `MBX_REMOTE_OIDC_AUDIENCE` for CI-issued OIDC credentials.
+
+Avoid long-lived secrets in pull request workflows. On GitHub Actions, OIDC
+requires `id-token: write` permission.
+
+## Read and write policy
+
+Configured mode is constrained by the environment:
+
+| Context | Effective behavior |
+| --- | --- |
+| Protected branch push on GitHub Actions or GitLab CI | Configured mode |
+| Pull request, merge request, local shell, or unprotected branch | Read-only; `write-only` becomes disabled |
+| Tag or release build | Remote cache disabled |
+
+This policy prevents untrusted code from publishing objects that later builds
+would trust. The server should still authenticate and authorize requests; the
+client-side policy is defense in depth, not an access-control boundary.
+
+## Transfer behavior
+
+Remote blobs are compressed with zstd. `MBX_HTTP_DOWNLOAD_TIMEOUT` is separate
+from the normal request timeout because artifacts can be much larger than
+metadata responses. Failed requests are retried according to
+`MBX_HTTP_RETRIES`.

--- a/mise.toml
+++ b/mise.toml
@@ -22,4 +22,18 @@ run = [
 ]
 
 [tasks.ci]
-depends = ["lint", "build", "test"]
+depends = ["lint", "build", "build:docs", "test"]
+
+[tasks.docs]
+description = "Start the documentation development server"
+dir = "docs"
+run = "aube install && exec aube run docs:dev"
+
+[tasks."build:docs"]
+description = "Build the documentation website"
+dir = "docs"
+run = "aube install && exec aube run docs:build"
+
+[tools]
+aube = "latest"
+node = "24"


### PR DESCRIPTION
## Summary
- replace `clap` with `usage-rs` and expose the generated portable usage spec
- report the reclaimed size after successfully removing an existing `target/`
- make `mbx` a direct Cargo wrapper: `mbx build`, `mbx test`, `mbx clippy`, Cargo aliases, and installed subcommands are forwarded unchanged
- enable managed target directories by default for eligible checkouts, with `MBX_TARGET_VIEWS=0` / `target.views = false` as the opt-out
- use `demand` to offer interactive migration of an existing real `target/`; “Keep it” is the default and non-interactive runs never remove it
- constrain migration to the default, unrequested target path and revalidate that it is a real directory immediately before removal
- add a VitePress documentation site styled like the other jdx.dev CLI sites, including installation, configuration, cache behavior, managed targets, CI, and limitations
- include a GitHub Actions pattern where `main` builds a GHA cache that fork pull requests restore read-only
- deploy pushes to `main` through GitHub Pages at `mr-boxington.jdx.dev`

`mbx cache` and `mbx gc` remain mbx-owned commands; other subcommands are treated as Cargo commands.

## Validation
- `mise run lint-fix`
- `mise run test`
- `mise run build:docs`
- `cargo build --locked -p mbx`
- `mise x aqua:rhysd/actionlint@1.7.12 -- actionlint -shellcheck= .github/workflows/docs.yml`
- interactive PTY smoke test for accepting the existing-target migration prompt
- desktop and mobile headless-browser review

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CLI invocation is a breaking change and managed-target migration can delete an existing `target/` after a prompt. GitHub Pages deploy also grants pages write permissions.
> 
> **Overview**
> **Cargo is now invoked as `mbx <subcommand>`** instead of `mbx build <subcommand>`. Unknown commands are forwarded unchanged (`mbx test`, `mbx clippy`, aliases). `gc` and `cache` stay mbx-owned. Parsing moves from clap to `usage-rs`.
> 
> **Managed target directories are on by default** (`MBX_TARGET_VIEWS=0` to opt out). Interactive terminals can confirm replacing a real default `target/` with a managed symlink; non-interactive runs never delete it. Placement now treats Cargo config (`build.target-dir`, `--config`, includes) as an explicit request so those paths are not moved. Migration renames the old tree aside, places the view, then deletes only on success (with rollback).
> 
> README is shortened to point at a new VitePress site, with a GitHub Pages workflow that builds docs on `docs/**` changes and deploys from `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e67e35dd83c0548e3d34245abd2755af35eafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete documentation site with guides for installation, configuration, caching, CLI usage, remote caches, and GitHub Actions.
  * Added searchable documentation, responsive branding, announcements, sponsor information, and automated publishing.
  * Added automatic migration of existing default build targets to managed targets, with rollback protection and space reporting.

* **Improvements**
  * Simplified command usage: run Cargo subcommands directly through `mbx`.
  * Target views are now enabled by default.
  * Updated README and project guidance with clearer installation and workflow examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->