### PR TITLE
fix(docs): align favicon eyes

### DIFF
--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -2,6 +2,6 @@
   <path d="M7 18 32 6l25 12-25 13z" fill="#efc477" stroke="#5c3a16" stroke-linejoin="round" stroke-width="3"/>
   <path d="m7 18 25 13v28L7 46z" fill="#d99a43" stroke="#5c3a16" stroke-linejoin="round" stroke-width="3"/>
   <path d="m57 18-25 13v28l25-13z" fill="#a9641d" stroke="#5c3a16" stroke-linejoin="round" stroke-width="3"/>
-  <circle cx="20" cy="35" r="2.5" fill="#24373b"/>
-  <circle cx="32" cy="41" r="2.5" fill="#24373b"/>
+  <circle cx="15.5" cy="33" r="2" fill="#24373b"/>
+  <circle cx="24.5" cy="37.5" r="2" fill="#24373b"/>
 </svg>


### PR DESCRIPTION
## Summary\n- align the favicon eyes with the projected front face used by the full logo\n- reduce the eye size slightly so they remain distinct at favicon scale\n\n## Test\n- 
  vitepress v1.6.4

build complete in 1.64s.\n\n*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic SVG tweak only; no functional, security, or data-handling impact.
> 
> **Overview**
> Tweaks the docs favicon so the two “eyes” sit on the cube’s front face and are slightly smaller, matching the full logo at favicon scale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac1d2fcc6b9260c2ed9d0c691211768d260ab08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->