### PR TITLE
ci: add final status job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,21 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo build --workspace --all-targets
       - run: cargo test --workspace
+
+  final:
+    permissions: {}
+    needs:
+      - lint
+      - test
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check job results
+        if: |
+          needs.lint.result != 'success' ||
+          needs.test.result != 'success'
+        run: exit 1
+      - run: echo "All CI jobs completed successfully"


### PR DESCRIPTION
## Summary

- add a `final` CI job that depends on lint and the full test matrix
- fail the aggregate status when any required upstream job does not succeed
- skip the aggregate runner when the workflow is cancelled

## Testing

- `mise run ci`
- `mise x actionlint@1.7.7 -- actionlint -shellcheck= .github/workflows/ci.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application, auth, or data-handling impact. Risk is limited to how required checks are aggregated.
> 
> **Overview**
> Adds a `final` GitHub Actions job that waits on `lint` and the OS test matrix and fails if any required job did not succeed.
> 
> The job uses `if: ${{ !cancelled() }}` so it still reports failure after upstream jobs fail, but does not run when the workflow is cancelled (avoiding `always()` fighting `cancel-in-progress`). Empty `permissions` and a 1-minute timeout keep it cheap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4489494cfb0de1472e108d8743d4f8ef2532124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->