### PR TITLE
feat(docs): show GitHub star count

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
         if: github.ref == 'refs/heads/main'
       - name: Build with VitePress
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           mise run check:docs
           mise run build:docs

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -1,0 +1,44 @@
+const fallbackStars = 0;
+
+function formatStars(stars: number) {
+  if (stars < 1000) return String(stars);
+  return `${(stars / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+}
+
+export default {
+  async load() {
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    const shouldUpdate = token || process.env.UPDATE_GITHUB_STARS === "1";
+    let stars = fallbackStars;
+
+    if (shouldUpdate) {
+      try {
+        const headers: Record<string, string> = {
+          "User-Agent": "mr-boxington-docs",
+          Accept: "application/vnd.github+json",
+        };
+        if (token) headers.Authorization = `Bearer ${token}`;
+
+        const response = await fetch(
+          "https://api.github.com/repos/jdx/mr-boxington",
+          {
+            headers,
+            signal: AbortSignal.timeout(10000),
+          },
+        );
+        if (response.ok) {
+          const data = (await response.json()) as { stargazers_count?: number };
+          if (typeof data.stargazers_count === "number") {
+            stars = data.stargazers_count;
+          }
+        }
+      } catch {
+        // Keep docs builds working offline or when GitHub rate limits the request.
+      }
+    }
+
+    return {
+      stars: stars > 0 ? formatStars(stars) : "",
+    };
+  },
+};

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -284,6 +284,10 @@ body::after {
 
 /* ---------- announcement banner ---------- */
 
+.VPSocialLinks {
+  align-items: center !important;
+}
+
 .VPSocialLinks a[href*="github.com/jdx/mr-boxington"] {
   display: inline-flex !important;
   flex-direction: column;

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -284,6 +284,47 @@ body::after {
 
 /* ---------- announcement banner ---------- */
 
+.VPSocialLinks a[href*="github.com/jdx/mr-boxington"] {
+  display: inline-flex !important;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  position: relative;
+  padding-bottom: 12px !important;
+  margin-bottom: -12px !important;
+}
+
+.VPSocialLinks a[href*="github.com/jdx/mr-boxington"] svg {
+  display: block !important;
+  width: 20px;
+  height: 20px;
+  margin-top: 2px;
+}
+
+.VPSocialLinks .star-count {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.VPSocialLinks .star-count .star-glyph {
+  font-family: -apple-system, "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+  margin-right: 0.2em;
+}
+
+.VPSocialLinks a[href*="github.com/jdx/mr-boxington"]:hover .star-count {
+  color: var(--vp-c-brand-1);
+}
+
 .jdx-banner {
   align-items: center;
   background: var(--vp-c-brand-1);
@@ -322,6 +363,10 @@ body::after {
 }
 
 @media (max-width: 640px) {
+  .VPSocialLinks .star-count {
+    display: none;
+  }
+
   .jdx-banner {
     flex-direction: column;
     font-size: 0.8rem;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
-import { h } from "vue";
+import { h, onMounted, onUnmounted } from "vue";
+import { data as starsData } from "../stars.data";
 import EndevFooter from "./EndevFooter.vue";
 import EndevSponsors from "./EndevSponsors.vue";
 import HomeTerminal from "./HomeTerminal.vue";
@@ -17,5 +18,47 @@ export default {
   },
   enhanceApp() {
     initBanner();
+  },
+  setup() {
+    let observer: MutationObserver | undefined;
+    onMounted(() => {
+      const addStarCount = () => {
+        if (!starsData.stars) return false;
+
+        const githubLinks = document.querySelectorAll(
+          '.VPSocialLinks a[href*="github.com/jdx/mr-boxington"]',
+        );
+        githubLinks.forEach((githubLink) => {
+          if (!githubLink.querySelector(".star-count")) {
+            const starBadge = document.createElement("span");
+            starBadge.className = "star-count";
+            starBadge.title = "GitHub Stars";
+            const glyph = document.createElement("span");
+            glyph.className = "star-glyph";
+            glyph.textContent = "★";
+            glyph.setAttribute("aria-hidden", "true");
+            starBadge.append(glyph, starsData.stars);
+            githubLink.appendChild(starBadge);
+          }
+        });
+        return (
+          githubLinks.length > 0 &&
+          Array.from(githubLinks).every((link) =>
+            link.querySelector(".star-count"),
+          )
+        );
+      };
+
+      if (addStarCount()) return;
+
+      observer = new MutationObserver(() => {
+        if (addStarCount()) observer?.disconnect();
+      });
+      observer.observe(document.querySelector(".VPNav") || document.body, {
+        childList: true,
+        subtree: true,
+      });
+    });
+    onUnmounted(() => observer?.disconnect());
   },
 } satisfies Theme;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -49,10 +49,9 @@ export default {
         );
       };
 
-      if (addStarCount()) return;
-
+      addStarCount();
       observer = new MutationObserver(() => {
-        if (addStarCount()) observer?.disconnect();
+        addStarCount();
       });
       observer.observe(document.querySelector(".VPNav") || document.body, {
         childList: true,


### PR DESCRIPTION
## Summary

- fetch and format the repository star count at docs build time
- display the count below the GitHub social icon using the same responsive treatment as other jdx projects
- authenticate the docs workflow API request and gracefully omit the count when GitHub is unavailable

## Testing

- `mise run build:docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only UI and an optional build-time GitHub API call with silent fallback; CI uses the standard `github.token` with no new secrets.
> 
> **Overview**
> Adds a **GitHub star count** under the docs nav GitHub social link, loaded at **VitePress build time** and kept in sync during client navigation.
> 
> A new `stars.data.ts` loader calls the GitHub API for `jdx/mr-boxington` when `GITHUB_TOKEN`/`GH_TOKEN` or `UPDATE_GITHUB_STARS=1` is set, formats large counts (e.g. `1.2k`), and returns an empty string on failure so offline or rate-limited builds still succeed. The **docs workflow** now sets `GITHUB_TOKEN: ${{ github.token }}` on the VitePress build step so CI gets a higher rate limit.
> 
> The theme **`setup()`** injects a star badge into matching `.VPSocialLinks` anchors via a `MutationObserver` on the nav. **`custom.css`** stacks the icon and count, adds hover styling, and hides the count below 640px width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a5fbf6adb9046fc049c31cbccf07e8b23480d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub links in the documentation now display the repository’s star count beneath the icon.
  * Star counts use compact formatting for larger values and update consistently during navigation.
* **Style**
  * Added branded hover styling and improved vertical alignment for social links.
  * Star counts are hidden on smaller screens for a cleaner mobile layout.
* **Bug Fixes**
  * Star-count display remains resilient when GitHub data is unavailable or rate-limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->