### PR TITLE
chore: wrap project cargo commands with mbx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,13 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
-      - run: cargo fmt --all --check
-      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+      - name: Bootstrap mbx
+        run: |
+          cargo build --package mbx --target-dir target/mbx-bootstrap-build
+          mkdir -p target/mbx-bootstrap
+          cp target/mbx-bootstrap-build/debug/mbx target/mbx-bootstrap/mbx
+      - run: ./target/mbx-bootstrap/mbx fmt --all --check
+      - run: ./target/mbx-bootstrap/mbx clippy --workspace --all-features --all-targets -- -D warnings
 
   test:
     strategy:
@@ -68,11 +73,26 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: rustup target add wasm32-unknown-unknown
-      - run: cargo build --workspace --all-targets
-      - run: cargo test --workspace
-      - name: Run behavioral tests
+      - name: Bootstrap mbx
+        shell: bash
+        run: |
+          cargo build --package mbx --target-dir target/mbx-bootstrap-build
+          mkdir -p target/mbx-bootstrap
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp target/mbx-bootstrap-build/debug/mbx.exe target/mbx-bootstrap/mbx.exe
+          else
+            cp target/mbx-bootstrap-build/debug/mbx target/mbx-bootstrap/mbx
+          fi
+      - run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} build --workspace --all-targets
+      - run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} test --workspace
+      - name: Run Bats behavioral tests
         if: runner.os != 'Windows'
+        env:
+          MBX_BIN: ${{ github.workspace }}/target/mbx-bootstrap/mbx
         run: test/bats/bin/bats test
+      - name: Windows end-to-end tests
+        if: runner.os == 'Windows'
+        run: pwsh e2e-win/run.ps1
 
   compatibility:
     runs-on: namespace-profile-endev-linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Bootstrap mbx
+        shell: bash
+        run: |
+          cargo build --package mbx --target-dir target/mbx-bootstrap-build
+          mkdir -p target/mbx-bootstrap
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp target/mbx-bootstrap-build/debug/mbx.exe target/mbx-bootstrap/mbx.exe
+          else
+            cp target/mbx-bootstrap-build/debug/mbx target/mbx-bootstrap/mbx
+          fi
+
       - name: Install the musl toolchain
         if: endsWith(matrix.target, '-musl')
         run: |
@@ -78,9 +89,12 @@ jobs:
         # `musl-gcc`. Naming it for both musl targets is harmless elsewhere,
         # since nothing else consults these variables.
         env:
+          # workflow_call preserves the caller's branch context, so tell mbx
+          # explicitly that this artifact build must bypass its cache.
+          MBX_RELEASE: 1
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
-        run: cargo build --release --locked --package mbx --target ${{ matrix.target }}
+        run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} build --release --locked --package mbx --target ${{ matrix.target }}
 
       - name: Check the binary runs
         # Every target but this one is native to its runner.

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -343,13 +343,26 @@ fn a_command_line_config_include_may_set_the_target_dir() {
 }
 
 #[test]
-fn cargo_subcommands_are_forwarded_directly() {
-    let argv = ["mbx", "clippy", "--workspace"].map(std::ffi::OsStr::new);
-    let cli = Cli::try_parse_from(&argv).unwrap();
-    let Commands::Cargo(arguments) = cli.command else {
-        panic!("clippy should be treated as a cargo subcommand");
-    };
-    assert_eq!(arguments, ["clippy", "--workspace"]);
+fn all_non_reserved_subcommands_are_forwarded_directly() {
+    for argv in [
+        ["mbx", "new", "--vcs", "none"],
+        ["mbx", "init", "--lib", "fixture"],
+        ["mbx", "command-added-later", "--future-flag", "value"],
+    ] {
+        let argv = argv.map(std::ffi::OsStr::new);
+        let cli = Cli::try_parse_from(&argv).unwrap();
+        let Commands::Cargo(arguments) = cli.command else {
+            panic!(
+                "{} should be treated as a cargo subcommand",
+                argv[1].to_string_lossy()
+            );
+        };
+        let expected = argv[1..]
+            .iter()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(arguments, expected);
+    }
 }
 
 #[test]

--- a/crates/mbx/src/policy.rs
+++ b/crates/mbx/src/policy.rs
@@ -62,9 +62,10 @@ fn trusted_cache_writer(get_env: &impl Fn(&str) -> Option<String>) -> bool {
 }
 
 fn release_context_with(get_env: impl Fn(&str) -> Option<String>) -> bool {
-    (env_truthy(get_env("GITHUB_ACTIONS"))
-        && (get_env("GITHUB_REF_TYPE").as_deref() == Some("tag")
-            || get_env("GITHUB_EVENT_NAME").as_deref() == Some("release")))
+    env_truthy(get_env("MBX_RELEASE"))
+        || (env_truthy(get_env("GITHUB_ACTIONS"))
+            && (get_env("GITHUB_REF_TYPE").as_deref() == Some("tag")
+                || get_env("GITHUB_EVENT_NAME").as_deref() == Some("release")))
         || (env_truthy(get_env("GITLAB_CI")) && get_env("CI_COMMIT_TAG").is_some())
 }
 
@@ -149,6 +150,7 @@ mod tests {
 
     #[test]
     fn tags_and_releases_are_release_contexts() {
+        assert!(release_context_with(env(&[("MBX_RELEASE", "1")])));
         assert!(release_context_with(env(&[
             ("GITHUB_ACTIONS", "1"),
             ("GITHUB_REF_TYPE", "tag"),

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -422,6 +422,44 @@ fn an_empty_store_reports_nothing() {
 }
 
 #[test]
+fn forwards_non_build_cargo_subcommands() {
+    let root = tempfile::tempdir().unwrap();
+    let store = tempfile::tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(root.path())
+        .args(["new", "--vcs", "none", "new-project"])
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_GC_AUTO", "0")
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("mbx new should run");
+    assert!(
+        output.status.success(),
+        "mbx new failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(root.path().join("new-project/Cargo.toml").is_file());
+
+    let initialized = root.path().join("initialized-project");
+    std::fs::create_dir(&initialized).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(&initialized)
+        .args(["init", "--vcs", "none"])
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_GC_AUTO", "0")
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("mbx init should run");
+    assert!(
+        output.status.success(),
+        "mbx init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(initialized.join("Cargo.toml").is_file());
+}
+
+#[test]
 fn a_build_records_the_checkout_it_ran_in() {
     let store = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();

--- a/e2e-win/CargoDispatch.Tests.ps1
+++ b/e2e-win/CargoDispatch.Tests.ps1
@@ -1,0 +1,70 @@
+Describe 'Cargo command dispatch' {
+    BeforeEach {
+        $script:OriginalDir = Get-Location
+        $script:OriginalCacheDir = [Environment]::GetEnvironmentVariable('MBX_CACHE_DIR', 'Process')
+        $script:OriginalGcAuto = [Environment]::GetEnvironmentVariable('MBX_GC_AUTO', 'Process')
+        $script:OriginalTargetDir = [Environment]::GetEnvironmentVariable('CARGO_TARGET_DIR', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        Set-Location $script:TestRoot
+        $env:MBX_CACHE_DIR = Join-Path $script:TestRoot 'cache'
+        $env:MBX_GC_AUTO = '0'
+        Remove-Item Env:CARGO_TARGET_DIR -ErrorAction Ignore
+    }
+
+    AfterEach {
+        Set-Location $script:OriginalDir
+        foreach ($item in @(
+            @{ Name = 'MBX_CACHE_DIR'; Value = $script:OriginalCacheDir },
+            @{ Name = 'MBX_GC_AUTO'; Value = $script:OriginalGcAuto },
+            @{ Name = 'CARGO_TARGET_DIR'; Value = $script:OriginalTargetDir }
+        )) {
+            if ($null -eq $item.Value) {
+                Remove-Item "Env:$($item.Name)" -ErrorAction Ignore
+            } else {
+                [Environment]::SetEnvironmentVariable($item.Name, $item.Value, 'Process')
+            }
+        }
+    }
+
+    It 'forwards cargo new' {
+        $output = & mbx new --vcs none new-project 2>&1 | Out-String
+        $status = $LASTEXITCODE
+
+        $status | Should -Be 0 -Because $output
+        Test-Path -LiteralPath 'new-project\Cargo.toml' | Should -BeTrue
+    }
+
+    It 'forwards cargo init' {
+        New-Item -ItemType Directory -Path initialized-project | Out-Null
+        Set-Location initialized-project
+
+        $output = & mbx init --vcs none 2>&1 | Out-String
+        $status = $LASTEXITCODE
+
+        $status | Should -Be 0 -Because $output
+        Test-Path -LiteralPath 'Cargo.toml' | Should -BeTrue
+    }
+
+    It 'forwards cargo aliases that mbx does not know' {
+        New-Item -ItemType Directory -Path .cargo | Out-Null
+        @"
+[alias]
+mbx-probe = "new --vcs none"
+"@ | Set-Content -Encoding utf8 .cargo\config.toml
+
+        $output = & mbx mbx-probe alias-project 2>&1 | Out-String
+        $status = $LASTEXITCODE
+
+        $status | Should -Be 0 -Because $output
+        Test-Path -LiteralPath 'alias-project\Cargo.toml' | Should -BeTrue
+    }
+
+    It 'lets cargo reject an unknown command' {
+        $output = & mbx command-added-after-mbx --future-flag value 2>&1 | Out-String
+        $status = $LASTEXITCODE
+
+        $status | Should -Not -Be 0
+        $output | Should -Match 'no such command: .*command-added-after-mbx'
+    }
+}

--- a/e2e-win/run.ps1
+++ b/e2e-win/run.ps1
@@ -1,0 +1,16 @@
+param(
+    [string]$TestName
+)
+
+$config = New-PesterConfiguration
+$config.Run.Path = $PSScriptRoot
+$config.Run.Exit = $true
+$config.TestResult.Enabled = $true
+
+if ($TestName) {
+    $config.Filter.FullName = $TestName
+}
+
+$env:PATH = "$PSScriptRoot\..\target\mbx-bootstrap;$env:PATH"
+
+Invoke-Pester -Configuration $config

--- a/mise.toml
+++ b/mise.toml
@@ -1,37 +1,72 @@
 [env]
-_.path = ["test/bats/bin", "{{ env.CARGO_TARGET_DIR | default(value='target') }}/debug"]
+_.path = ["test/bats/bin"]
+
+[tasks.bootstrap]
+hide = true
+run = [
+  "cargo build --package mbx --target-dir target/mbx-bootstrap-build",
+  "mkdir -p target/mbx-bootstrap",
+  "cp target/mbx-bootstrap-build/debug/mbx target/mbx-bootstrap/mbx",
+]
+run_windows = [
+  "cargo build --package mbx --target-dir target/mbx-bootstrap-build",
+  "New-Item -ItemType Directory -Force target/mbx-bootstrap | Out-Null",
+  "Copy-Item -Force target/mbx-bootstrap-build/debug/mbx.exe target/mbx-bootstrap/mbx.exe",
+]
 
 [tasks.build]
 alias = "b"
-run = "cargo build --workspace --all-targets"
+depends = ["bootstrap"]
+run = "./target/mbx-bootstrap/mbx build --workspace --all-targets"
+run_windows = "./target/mbx-bootstrap/mbx.exe build --workspace --all-targets"
 
 [tasks.test]
 alias = "t"
-description = "Run cargo and Bats tests"
-depends = ["test:cargo", "test:bats"]
+description = "Run Rust and behavioral tests"
+depends = ["test:cargo", "test:e2e"]
 
 [tasks."test:cargo"]
 description = "Run Rust tests"
-run = "cargo test --workspace"
+depends = ["bootstrap"]
+run = "./target/mbx-bootstrap/mbx test --workspace"
+run_windows = "./target/mbx-bootstrap/mbx.exe test --workspace"
+
+[tasks."test:e2e"]
+description = "Run platform behavioral tests"
+depends = ["build"]
+run = "MBX_BIN=$PWD/target/mbx-bootstrap/mbx bats test"
+run_windows = "pwsh e2e-win/run.ps1"
 
 [tasks."test:bats"]
 description = "Run behavioral tests"
 depends = ["build"]
-run = "bats test"
+run = "MBX_BIN=$PWD/target/mbx-bootstrap/mbx bats test"
 
 [tasks.format]
-run = "cargo fmt --all"
+depends = ["bootstrap"]
+run = "./target/mbx-bootstrap/mbx fmt --all"
+run_windows = "./target/mbx-bootstrap/mbx.exe fmt --all"
 
 [tasks.lint]
+depends = ["bootstrap"]
 run = [
-  "cargo fmt --all --check",
-  "cargo clippy --workspace --all-features --all-targets -- -D warnings",
+  "./target/mbx-bootstrap/mbx fmt --all --check",
+  "./target/mbx-bootstrap/mbx clippy --workspace --all-features --all-targets -- -D warnings",
+]
+run_windows = [
+  "./target/mbx-bootstrap/mbx.exe fmt --all --check",
+  "./target/mbx-bootstrap/mbx.exe clippy --workspace --all-features --all-targets -- -D warnings",
 ]
 
 [tasks.lint-fix]
+depends = ["bootstrap"]
 run = [
-  "cargo fmt --all",
-  "cargo clippy --workspace --all-features --all-targets --fix --allow-dirty --allow-staged -- -D warnings",
+  "./target/mbx-bootstrap/mbx fmt --all",
+  "./target/mbx-bootstrap/mbx clippy --workspace --all-features --all-targets --fix --allow-dirty --allow-staged -- -D warnings",
+]
+run_windows = [
+  "./target/mbx-bootstrap/mbx.exe fmt --all",
+  "./target/mbx-bootstrap/mbx.exe clippy --workspace --all-features --all-targets --fix --allow-dirty --allow-staged -- -D warnings",
 ]
 
 [tasks.ci]
@@ -51,7 +86,9 @@ run = "aube install && exec aube run docs:build"
 
 [tasks."render:docs"]
 description = "Generate reference documentation from the usage spec"
-run = "cargo run --quiet -p mbx -- __usage_spec__ | usage generate markdown --file - --replace-pre-with-code-fences --out-file docs/cli.md"
+depends = ["bootstrap"]
+run = "./target/mbx-bootstrap/mbx __usage_spec__ | usage generate markdown --file - --replace-pre-with-code-fences --out-file docs/cli.md"
+run_windows = "./target/mbx-bootstrap/mbx.exe __usage_spec__ | usage generate markdown --file - --replace-pre-with-code-fences --out-file docs/cli.md"
 
 [tasks."check:docs"]
 description = "Check that generated documentation is current"

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -26,3 +26,37 @@ setup() {
   assert_success
   assert_output --partial "0 B"
 }
+
+@test "cargo new is forwarded" {
+  run "$MBX_BIN" new --vcs none new-project
+
+  assert_success
+  assert_file_exist "new-project/Cargo.toml"
+}
+
+@test "cargo init is forwarded" {
+  mkdir initialized-project
+  cd initialized-project
+
+  run "$MBX_BIN" init --vcs none
+
+  assert_success
+  assert_file_exist "Cargo.toml"
+}
+
+@test "Cargo aliases unknown to mbx are forwarded" {
+  mkdir .cargo
+  printf '[alias]\nmbx-probe = "new --vcs none"\n' >.cargo/config.toml
+
+  run "$MBX_BIN" mbx-probe alias-project
+
+  assert_success
+  assert_file_exist "alias-project/Cargo.toml"
+}
+
+@test "Cargo rejects commands unknown to both tools" {
+  run "$MBX_BIN" command-added-after-mbx --future-flag value
+
+  assert_failure
+  assert_output --regexp 'no such command: .*command-added-after-mbx'
+}

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -22,6 +22,9 @@ _common_setup() {
     return 1
   fi
 
+  # Keep the installed toolchain reachable after HOME is isolated below.
+  export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+  export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
   export HOME="$BATS_TEST_TMPDIR/home"
   export XDG_CACHE_HOME="$BATS_TEST_TMPDIR/cache"
   export XDG_CONFIG_HOME="$BATS_TEST_TMPDIR/config"


### PR DESCRIPTION
## Summary

- stack on #46’s Bats harness and add Cargo-dispatch coverage for `new`, `init`, Cargo aliases, and unknown future commands
- add an equivalent native Windows Pester suite
- bootstrap `mbx` once from the current checkout, copy it outside Cargo’s output path, then use that binary for repository build, test, format, clippy, docs generation, and release commands
- preserve rustup/Cargo toolchain homes while Bats isolates the fixture home
- explicitly mark release artifact builds so `mbx` bypasses its cache

`cache` and `gc` remain mbx commands; everything else dispatches to Cargo.

## Stack

- base: #46
- this PR: Cargo forwarding coverage, dogfooding, release-context fix, and Windows Pester coverage

## Verification

- `mise run ci`
- `mise run test:e2e`
- `actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/release.yml`
- Windows CI: `pwsh e2e-win/run.ps1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all CI and release binaries are produced (bootstrap + cache policy via `MBX_RELEASE`); misconfiguration could affect artifact correctness or caching, but scope is mostly tooling and test harnesses.
> 
> **Overview**
> **Dogfoods `mbx` across local dev and CI** by bootstrapping a checkout-built binary into `target/mbx-bootstrap`, then routing workspace **build**, **test**, **fmt**, **clippy**, and docs generation through it instead of plain `cargo`. **Mise** tasks mirror the same bootstrap + `mbx` invocation pattern (including Windows `.exe` paths).
> 
> **CI/release workflow updates**: lint and test jobs bootstrap `mbx` before running checks; non-Windows behavioral tests set `MBX_BIN` to the bootstrap binary; **Windows** runs a new **Pester** suite via `e2e-win/run.ps1`. Release artifact builds set **`MBX_RELEASE=1`** so release policy treats the job as a release context (cache bypass) when `workflow_call` does not look like a tag/release, and the release **build** step uses the bootstrapped `mbx`.
> 
> **Cargo dispatch coverage** expands beyond build-style commands: unit tests assert any non-reserved subcommand (`new`, `init`, unknown future commands) forwards to Cargo while `cache`/`gc` stay native; integration **Bats** and **Pester** tests cover `new`, `init`, Cargo aliases, and unknown-command errors. Bats setup now keeps **`CARGO_HOME` / `RUSTUP_HOME`** on the real toolchain when isolating `HOME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c38282df577bf6e7bb43f8b41654ff2ea0ddfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->