### PR TITLE
feat(docs): bold UI refresh for the docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -77,6 +77,18 @@ export default defineConfig({
   head: [
     ["link", { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" }],
     ["link", { rel: "alternate icon", href: "/favicon.png", type: "image/png" }],
+    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+    [
+      "link",
+      { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" },
+    ],
+    [
+      "link",
+      {
+        rel: "stylesheet",
+        href: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;600&display=swap",
+      },
+    ],
     ["meta", { name: "theme-color", content: "#d69b42" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:site_name", content: "mr boxington" }],

--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -50,25 +50,25 @@
 
 .window {
   background: #100c07;
-  border: 1px solid rgba(230, 173, 84, 0.22);
+  border: 1px solid rgb(var(--mbx-amber-rgb) / 0.22);
   border-radius: 14px;
   box-shadow:
     0 30px 70px -30px rgba(0, 0, 0, 0.75),
-    0 20px 60px -30px rgba(230, 173, 84, 0.2);
+    0 20px 60px -30px rgb(var(--mbx-amber-rgb) / 0.2);
   overflow: hidden;
 }
 
 .titlebar {
   align-items: center;
-  background: rgba(230, 173, 84, 0.07);
-  border-bottom: 1px solid rgba(230, 173, 84, 0.14);
+  background: rgb(var(--mbx-amber-rgb) / 0.07);
+  border-bottom: 1px solid rgb(var(--mbx-amber-rgb) / 0.14);
   display: flex;
   gap: 8px;
   padding: 10px 14px;
 }
 
 .dot {
-  background: rgba(230, 173, 84, 0.35);
+  background: rgb(var(--mbx-amber-rgb) / 0.35);
   border-radius: 50%;
   height: 11px;
   width: 11px;
@@ -112,7 +112,7 @@
 }
 
 .path {
-  color: #7fa6ad;
+  color: var(--mbx-teal-light);
 }
 
 .prompt {
@@ -120,12 +120,12 @@
 }
 
 .cmd {
-  color: #f5ead6;
+  color: var(--mbx-paper);
   font-weight: 600;
 }
 
 .verb {
-  color: #86c07e;
+  color: var(--mbx-cargo-green);
   font-weight: 600;
 }
 
@@ -134,12 +134,12 @@
 }
 
 .time {
-  color: #f5ead6;
+  color: var(--mbx-paper);
   font-weight: 600;
 }
 
 .time.fast {
-  background: rgba(230, 173, 84, 0.18);
+  background: rgb(var(--mbx-amber-rgb) / 0.18);
   border-radius: 4px;
   color: var(--vp-c-brand-1);
   padding: 1px 5px;

--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -1,0 +1,191 @@
+<template>
+  <section class="MbxDemo" aria-label="mbx across two checkouts">
+    <div class="window">
+      <div class="titlebar">
+        <span aria-hidden="true" class="dot"></span>
+        <span aria-hidden="true" class="dot"></span>
+        <span aria-hidden="true" class="dot"></span>
+        <span class="label">two checkouts · one cache</span>
+      </div>
+      <div
+        aria-label="Terminal transcript: the first checkout compiles every crate in 3 minutes 41 seconds; a fresh worktree finishes in 4.9 seconds with 191 cache hits"
+        class="screen"
+        role="img"
+      >
+        <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
+        <div class="line"><span class="verb">   Compiling</span> libc v0.2.174</div>
+        <div class="line"><span class="verb">   Compiling</span> serde v1.0.219</div>
+        <div class="line dim">            … 193 more crates …</div>
+        <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time">3m 41s</span></div>
+        <div aria-hidden="true" class="line gap"></div>
+        <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">git worktree add ../review &amp;&amp; cd ../review</span></div>
+        <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
+        <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time fast">4.9s</span></div>
+        <div class="line cache">cache: 191 hits, 3 misses, 187 prefetched; 0 B downloaded, 0 B uploaded, 412.6 MiB stored locally</div>
+        <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
+      </div>
+    </div>
+    <p class="caption">The second checkout never compiles what the first already did — locally or in CI.</p>
+  </section>
+</template>
+
+<style scoped>
+.MbxDemo {
+  margin: 0 auto;
+  max-width: 852px;
+  padding: 16px 24px 8px;
+}
+
+@media (min-width: 640px) {
+  .MbxDemo {
+    padding: 24px 48px 8px;
+  }
+}
+
+@media (min-width: 960px) {
+  .MbxDemo {
+    padding: 32px 64px 8px;
+  }
+}
+
+.window {
+  background: #100c07;
+  border: 1px solid rgba(230, 173, 84, 0.22);
+  border-radius: 14px;
+  box-shadow:
+    0 30px 70px -30px rgba(0, 0, 0, 0.75),
+    0 20px 60px -30px rgba(230, 173, 84, 0.2);
+  overflow: hidden;
+}
+
+.titlebar {
+  align-items: center;
+  background: rgba(230, 173, 84, 0.07);
+  border-bottom: 1px solid rgba(230, 173, 84, 0.14);
+  display: flex;
+  gap: 8px;
+  padding: 10px 14px;
+}
+
+.dot {
+  background: rgba(230, 173, 84, 0.35);
+  border-radius: 50%;
+  height: 11px;
+  width: 11px;
+}
+
+.label {
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  margin-left: auto;
+}
+
+.screen {
+  font-family: var(--vp-font-family-mono);
+  font-size: 13px;
+  line-height: 1.75;
+  overflow-x: auto;
+  padding: 18px 20px;
+}
+
+.line {
+  animation: mbx-line-in 0.35s ease both;
+  white-space: pre;
+}
+
+.line:nth-child(1) { animation-delay: 0.15s; }
+.line:nth-child(2) { animation-delay: 0.45s; }
+.line:nth-child(3) { animation-delay: 0.6s; }
+.line:nth-child(4) { animation-delay: 0.75s; }
+.line:nth-child(5) { animation-delay: 1.15s; }
+.line:nth-child(6) { animation-delay: 1.15s; }
+.line:nth-child(7) { animation-delay: 1.45s; }
+.line:nth-child(8) { animation-delay: 1.85s; }
+.line:nth-child(9) { animation-delay: 2.15s; }
+.line:nth-child(10) { animation-delay: 2.35s; }
+.line:nth-child(11) { animation-delay: 2.6s; }
+
+.gap {
+  height: 0.9em;
+}
+
+.path {
+  color: #7fa6ad;
+}
+
+.prompt {
+  color: var(--vp-c-brand-1);
+}
+
+.cmd {
+  color: #f5ead6;
+  font-weight: 600;
+}
+
+.verb {
+  color: #86c07e;
+  font-weight: 600;
+}
+
+.dim {
+  color: var(--vp-c-text-3);
+}
+
+.time {
+  color: #f5ead6;
+  font-weight: 600;
+}
+
+.time.fast {
+  background: rgba(230, 173, 84, 0.18);
+  border-radius: 4px;
+  color: var(--vp-c-brand-1);
+  padding: 1px 5px;
+}
+
+.cache {
+  color: var(--vp-c-brand-1);
+}
+
+.cursor {
+  animation: mbx-line-in 0.35s ease 2.6s both, mbx-blink 1.1s steps(1) 2.95s infinite;
+  background: var(--vp-c-brand-1);
+  display: inline-block;
+  height: 1.1em;
+  vertical-align: text-bottom;
+  width: 0.55em;
+}
+
+.caption {
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  margin-top: 14px;
+  text-align: center;
+}
+
+@keyframes mbx-line-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes mbx-blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .line,
+  .cursor {
+    animation: none;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -2,35 +2,59 @@
 
 :root {
   --mbx-display: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
-  --mbx-amber: #e6ad54;
-  --mbx-amber-strong: #f2c479;
-  --mbx-teal: #6f8e93;
+
+  /*
+   * The two hues that carry alpha variants are stored as channel triples, so
+   * every translucent use composes from one value: rgb(var(--mbx-amber-rgb) / 0.16).
+   * The rest are opaque one-offs and stay plain hex.
+   */
+  --mbx-amber-rgb: 230 173 84;
+  --mbx-teal-rgb: 111 142 147;
+  --mbx-amber-shade-rgb: 189 125 35;
+
+  --mbx-amber: rgb(var(--mbx-amber-rgb));
+  --mbx-amber-bright: #f2c479;
+  --mbx-amber-deep: #cf8f35;
+  --mbx-amber-shade: rgb(var(--mbx-amber-shade-rgb));
+  --mbx-teal-light: #7fa6ad;
   --mbx-ink: #1c160d;
+  --mbx-paper: #f5ead6;
+  --mbx-cargo-green: #86c07e;
 
   --vp-font-family-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
-  --vp-c-brand-1: #bd7d23;
+  --vp-c-brand-1: var(--mbx-amber-shade);
   --vp-c-brand-2: #9f6518;
   --vp-c-brand-3: #7e4c0d;
-  --vp-c-brand-soft: rgba(189, 125, 35, 0.16);
+  --vp-c-brand-soft: rgb(var(--mbx-amber-shade-rgb) / 0.16);
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(120deg, #f4cd88 15%, #e6ad54 55%, #7fa6ad);
-  --vp-home-hero-image-background-image: radial-gradient(circle, rgba(234, 184, 100, 0.4), rgba(74, 111, 118, 0.18) 52%, transparent 72%);
+  --vp-home-hero-name-background: linear-gradient(
+    120deg,
+    var(--mbx-amber-bright) 15%,
+    var(--mbx-amber) 55%,
+    var(--mbx-teal-light)
+  );
+  --vp-home-hero-image-background-image: radial-gradient(
+    circle,
+    rgb(var(--mbx-amber-rgb) / 0.4),
+    rgb(var(--mbx-teal-rgb) / 0.18) 52%,
+    transparent 72%
+  );
   --vp-home-hero-image-filter: blur(48px);
 }
 
 .dark {
-  --vp-c-brand-1: #e6ad54;
-  --vp-c-brand-2: #cf8f35;
+  --vp-c-brand-1: var(--mbx-amber);
+  --vp-c-brand-2: var(--mbx-amber-deep);
   --vp-c-brand-3: #b9761c;
-  --vp-c-brand-soft: rgba(230, 173, 84, 0.16);
+  --vp-c-brand-soft: rgb(var(--mbx-amber-rgb) / 0.16);
 
   /* warm the neutral greys toward cardboard */
   --vp-c-bg: #161209;
   --vp-c-bg-alt: #100d07;
   --vp-c-bg-elv: #1e1810;
   --vp-c-bg-soft: #1e1810;
-  --vp-c-divider: rgba(230, 173, 84, 0.15);
+  --vp-c-divider: rgb(var(--mbx-amber-rgb) / 0.15);
   --vp-c-gutter: #0c0a05;
   --vp-code-block-bg: #100d07;
   --vp-c-text-1: #f1e9da;
@@ -39,7 +63,7 @@
 }
 
 ::selection {
-  background: rgba(230, 173, 84, 0.35);
+  background: rgb(var(--mbx-amber-rgb) / 0.35);
 }
 
 ::-webkit-scrollbar {
@@ -52,14 +76,14 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(230, 173, 84, 0.22);
+  background: rgb(var(--mbx-amber-rgb) / 0.22);
   border: 2px solid transparent;
   background-clip: padding-box;
   border-radius: 6px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(230, 173, 84, 0.38);
+  background: rgb(var(--mbx-amber-rgb) / 0.38);
   background-clip: padding-box;
 }
 
@@ -86,8 +110,8 @@ body::after {
 
 .VPHome {
   background:
-    radial-gradient(64rem 36rem at 85% -8%, rgba(230, 173, 84, 0.12), transparent 60%),
-    radial-gradient(52rem 32rem at 0% 18%, rgba(111, 142, 147, 0.12), transparent 60%);
+    radial-gradient(64rem 36rem at 85% -8%, rgb(var(--mbx-amber-rgb) / 0.12), transparent 60%),
+    radial-gradient(52rem 32rem at 0% 18%, rgb(var(--mbx-teal-rgb) / 0.12), transparent 60%);
 }
 
 .VPHero .name,
@@ -105,8 +129,8 @@ body::after {
 .VPHero .name .clip::after {
   background: repeating-linear-gradient(
     -45deg,
-    rgba(230, 173, 84, 0.18) 0 12px,
-    rgba(230, 173, 84, 0.09) 12px 24px
+    rgb(var(--mbx-amber-rgb) / 0.18) 0 12px,
+    rgb(var(--mbx-amber-rgb) / 0.09) 12px 24px
   );
   border-radius: 3px;
   bottom: 0.04em;
@@ -152,17 +176,17 @@ body::after {
 }
 
 .VPButton.brand {
-  background: linear-gradient(135deg, #f2c479, #cf8f35);
+  background: linear-gradient(135deg, var(--mbx-amber-bright), var(--mbx-amber-deep));
   border-color: transparent;
-  box-shadow: 0 10px 28px -10px rgba(230, 173, 84, 0.55);
+  box-shadow: 0 10px 28px -10px rgb(var(--mbx-amber-rgb) / 0.55);
   color: var(--mbx-ink);
   font-weight: 700;
   transition: box-shadow 0.25s ease, filter 0.25s ease, transform 0.25s ease;
 }
 
 .VPButton.brand:hover {
-  background: linear-gradient(135deg, #f2c479, #cf8f35);
-  box-shadow: 0 14px 34px -10px rgba(230, 173, 84, 0.7);
+  background: linear-gradient(135deg, var(--mbx-amber-bright), var(--mbx-amber-deep));
+  box-shadow: 0 14px 34px -10px rgb(var(--mbx-amber-rgb) / 0.7);
   color: var(--mbx-ink);
   filter: brightness(1.08);
   transform: translateY(-1px);
@@ -179,23 +203,23 @@ body::after {
 }
 
 .VPFeature {
-  background: linear-gradient(180deg, rgba(230, 173, 84, 0.06), rgba(230, 173, 84, 0) 45%), var(--vp-c-bg-soft);
+  background: linear-gradient(180deg, rgb(var(--mbx-amber-rgb) / 0.06), rgb(var(--mbx-amber-rgb) / 0) 45%), var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
   border-radius: 14px;
   transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
 .VPFeature:hover {
-  border-color: rgba(230, 173, 84, 0.55);
+  border-color: rgb(var(--mbx-amber-rgb) / 0.55);
   box-shadow:
-    0 18px 40px -18px rgba(230, 173, 84, 0.3),
+    0 18px 40px -18px rgb(var(--mbx-amber-rgb) / 0.3),
     0 12px 32px -12px rgba(0, 0, 0, 0.5);
   transform: translateY(-4px);
 }
 
 .VPFeature .icon {
-  background: linear-gradient(160deg, rgba(230, 173, 84, 0.22), rgba(111, 142, 147, 0.16));
-  border: 1px solid rgba(230, 173, 84, 0.25);
+  background: linear-gradient(160deg, rgb(var(--mbx-amber-rgb) / 0.22), rgb(var(--mbx-teal-rgb) / 0.16));
+  border: 1px solid rgb(var(--mbx-amber-rgb) / 0.25);
   border-radius: 10px;
   font-size: 26px;
   height: 52px;
@@ -263,7 +287,7 @@ body::after {
 .jdx-banner {
   align-items: center;
   background: var(--vp-c-brand-1);
-  color: #1c160d;
+  color: var(--mbx-ink);
   display: flex;
   font-size: 0.9rem;
   gap: 0.75rem;

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,12 +1,22 @@
+/* mr boxington — warm cardboard-dark theme */
+
 :root {
+  --mbx-display: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  --mbx-amber: #e6ad54;
+  --mbx-amber-strong: #f2c479;
+  --mbx-teal: #6f8e93;
+  --mbx-ink: #1c160d;
+
+  --vp-font-family-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
   --vp-c-brand-1: #bd7d23;
   --vp-c-brand-2: #9f6518;
   --vp-c-brand-3: #7e4c0d;
   --vp-c-brand-soft: rgba(189, 125, 35, 0.16);
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(120deg, #eab864 20%, #bd7d23 68%, #6f8e93);
-  --vp-home-hero-image-background-image: radial-gradient(circle, rgba(234, 184, 100, 0.34), rgba(74, 111, 118, 0.16) 52%, transparent 72%);
-  --vp-home-hero-image-filter: blur(44px);
+  --vp-home-hero-name-background: linear-gradient(120deg, #f4cd88 15%, #e6ad54 55%, #7fa6ad);
+  --vp-home-hero-image-background-image: radial-gradient(circle, rgba(234, 184, 100, 0.4), rgba(74, 111, 118, 0.18) 52%, transparent 72%);
+  --vp-home-hero-image-filter: blur(48px);
 }
 
 .dark {
@@ -14,29 +24,241 @@
   --vp-c-brand-2: #cf8f35;
   --vp-c-brand-3: #b9761c;
   --vp-c-brand-soft: rgba(230, 173, 84, 0.16);
+
+  /* warm the neutral greys toward cardboard */
+  --vp-c-bg: #161209;
+  --vp-c-bg-alt: #100d07;
+  --vp-c-bg-elv: #1e1810;
+  --vp-c-bg-soft: #1e1810;
+  --vp-c-divider: rgba(230, 173, 84, 0.15);
+  --vp-c-gutter: #0c0a05;
+  --vp-code-block-bg: #100d07;
+  --vp-c-text-1: #f1e9da;
+  --vp-c-text-2: #b3a891;
+  --vp-c-text-3: #837a66;
 }
 
-.VPHero .name {
-  letter-spacing: -0.04em;
+::selection {
+  background: rgba(230, 173, 84, 0.35);
+}
+
+::-webkit-scrollbar {
+  height: 10px;
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(230, 173, 84, 0.22);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  border-radius: 6px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(230, 173, 84, 0.38);
+  background-clip: padding-box;
+}
+
+/* subtle paper grain over everything */
+body::after {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  content: "";
+  inset: 0;
+  opacity: 0.035;
+  pointer-events: none;
+  position: fixed;
+  z-index: 999;
+}
+
+/* ---------- navbar ---------- */
+
+.VPNavBarTitle .title {
+  font-family: var(--mbx-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* ---------- home ---------- */
+
+.VPHome {
+  background:
+    radial-gradient(64rem 36rem at 85% -8%, rgba(230, 173, 84, 0.12), transparent 60%),
+    radial-gradient(52rem 32rem at 0% 18%, rgba(111, 142, 147, 0.12), transparent 60%);
+}
+
+.VPHero .name,
+.VPHero .text {
+  font-family: var(--mbx-display);
+  letter-spacing: -0.03em;
+}
+
+.VPHero .name .clip {
+  position: relative;
+  z-index: 0;
+}
+
+/* a strip of packing tape behind the name */
+.VPHero .name .clip::after {
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(230, 173, 84, 0.18) 0 12px,
+    rgba(230, 173, 84, 0.09) 12px 24px
+  );
+  border-radius: 3px;
+  bottom: 0.04em;
+  content: "";
+  height: 0.42em;
+  left: -0.25em;
+  position: absolute;
+  right: -0.25em;
+  transform: rotate(-1.2deg);
+  z-index: -1;
+}
+
+.VPHero .tagline {
+  max-width: 34rem;
+}
+
+@media (min-width: 960px) {
+  .VPHero .name {
+    font-size: 64px;
+    line-height: 72px;
+  }
 }
 
 .VPHero .image-src {
-  filter: drop-shadow(0 22px 30px rgba(0, 0, 0, 0.28));
+  animation: mbx-float 7s ease-in-out infinite;
+  filter: drop-shadow(0 26px 38px rgba(0, 0, 0, 0.38));
+}
+
+@keyframes mbx-float {
+  0%,
+  100% {
+    transform: translate(-50%, -50%);
+  }
+  50% {
+    transform: translate(-50%, calc(-50% - 12px));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .VPHero .image-src {
+    animation: none;
+  }
+}
+
+.VPButton.brand {
+  background: linear-gradient(135deg, #f2c479, #cf8f35);
+  border-color: transparent;
+  box-shadow: 0 10px 28px -10px rgba(230, 173, 84, 0.55);
+  color: var(--mbx-ink);
+  font-weight: 700;
+  transition: box-shadow 0.25s ease, filter 0.25s ease, transform 0.25s ease;
+}
+
+.VPButton.brand:hover {
+  background: linear-gradient(135deg, #f2c479, #cf8f35);
+  box-shadow: 0 14px 34px -10px rgba(230, 173, 84, 0.7);
+  color: var(--mbx-ink);
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+
+.VPButton.alt {
+  border: 1px solid var(--vp-c-divider);
+  transition: border-color 0.25s ease, transform 0.25s ease;
+}
+
+.VPButton.alt:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-1px);
 }
 
 .VPFeature {
+  background: linear-gradient(180deg, rgba(230, 173, 84, 0.06), rgba(230, 173, 84, 0) 45%), var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  border-radius: 14px;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
 .VPFeature:hover {
-  border-color: var(--vp-c-brand-1);
-  transform: translateY(-2px);
+  border-color: rgba(230, 173, 84, 0.55);
+  box-shadow:
+    0 18px 40px -18px rgba(230, 173, 84, 0.3),
+    0 12px 32px -12px rgba(0, 0, 0, 0.5);
+  transform: translateY(-4px);
 }
 
 .VPFeature .icon {
-  background: var(--vp-c-brand-soft);
+  background: linear-gradient(160deg, rgba(230, 173, 84, 0.22), rgba(111, 142, 147, 0.16));
+  border: 1px solid rgba(230, 173, 84, 0.25);
+  border-radius: 10px;
+  font-size: 26px;
+  height: 52px;
+  width: 52px;
 }
+
+.VPFeature .title {
+  font-family: var(--mbx-display);
+  font-size: 17px;
+  letter-spacing: -0.01em;
+}
+
+/* ---------- doc pages ---------- */
+
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3 {
+  font-family: var(--mbx-display);
+  letter-spacing: -0.02em;
+}
+
+.vp-doc h2 {
+  border-top: none;
+  margin: 56px 0 20px;
+  padding-top: 0;
+}
+
+.vp-doc h2::before {
+  background: linear-gradient(90deg, var(--mbx-amber), transparent);
+  border-radius: 2px;
+  content: "";
+  display: block;
+  height: 3px;
+  margin-bottom: 0.8rem;
+  width: 2.25rem;
+}
+
+.vp-doc div[class*="language-"] {
+  border: 1px solid var(--vp-c-divider);
+}
+
+.vp-doc [class*="language-"] > span.lang {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+
+.vp-doc .custom-block {
+  border-radius: 12px;
+}
+
+.vp-doc .custom-block.tip {
+  border-left: 3px solid var(--vp-c-tip-1);
+}
+
+.vp-doc .custom-block.warning {
+  border-left: 3px solid var(--vp-c-warning-1);
+}
+
+.vp-doc .custom-block.danger {
+  border-left: 3px solid var(--vp-c-danger-1);
+}
+
+/* ---------- announcement banner ---------- */
 
 .jdx-banner {
   align-items: center;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import type { Theme } from "vitepress";
 import { h } from "vue";
 import EndevFooter from "./EndevFooter.vue";
 import EndevSponsors from "./EndevSponsors.vue";
+import HomeTerminal from "./HomeTerminal.vue";
 import { initBanner } from "./banner";
 import "./custom.css";
 
@@ -10,6 +11,7 @@ export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
+      "home-hero-after": () => h(HomeTerminal),
       "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],
     });
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@ hero:
       text: Get started
       link: /getting-started
     - theme: alt
+      text: How it works
+      link: /how-it-works
+    - theme: alt
       text: GitHub Actions
       link: /github-actions
 


### PR DESCRIPTION
## What

A visual overhaul of the VitePress docs site — same structure and content, much more personality.

### Site-wide
- **Warm cardboard-dark palette**: backgrounds, dividers, and text greys shifted toward the box's amber/brown, plus a subtle paper-grain overlay and radial amber/teal glows on the homepage.
- **Typography**: Space Grotesk for headings, hero, and the nav title; JetBrains Mono for code (loaded from Google Fonts with preconnect).
- Themed scrollbar and text selection.

### Homepage
- A strip of "packing tape" behind the hero name, echoing the tape motif on the redesigned logo from #31. Gently floating logo (disabled under `prefers-reduced-motion`) and a gradient brand button with an amber glow.
- Added a *How it works* action button alongside Get started and GitHub Actions.
- **New animated terminal demo** under the hero: a cold `mbx build` (3m 41s) followed by `git worktree add` and a warm build (4.9s) with the real `cache: N hits…` summary-line format from the getting-started page. Lines fade in staggered; static under reduced motion; full transcript available to screen readers via `aria-label`.
- Feature cards with gradient icon tiles and hover lift + amber glow.

### Doc pages
- Amber tick markers on `h2` instead of the divider rule, bordered code blocks with an amber language label, left-accented custom blocks.

## Notes

This branch originally also reworded the hero text and tagline; #36 has since landed that copy change on `main`, so the copy here is now entirely main's and this PR is purely presentational. The only `index.md` change left is the added *How it works* button.

## Verification

`aube run docs:build` passes on the rebased branch; the built homepage HTML contains the terminal demo markup, the font links, and the favicon/OG tags from #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS, Vue, and VitePress config; no changes to the Rust tool or runtime behavior beyond third-party font loading.
> 
> **Overview**
> **Visual overhaul** of the VitePress docs site: a warm cardboard-dark palette, shared `--mbx-*` color tokens, Space Grotesk + JetBrains Mono (via new `head` links in `config.mts`), paper-grain overlay, themed scrollbars/selection, and richer hero/feature/doc-page styling in `custom.css`.
> 
> The homepage gains a **How it works** CTA in `index.md` and a new **`HomeTerminal.vue`** demo mounted through the `home-hero-after` slot in `theme/index.ts`—a staged `mbx build` vs worktree rebuild story with staggered animation and `prefers-reduced-motion` / screen-reader-friendly labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f081b0bd671ce4deffd5c77ccd6d68373bde8334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->