### PR TITLE
chore: establish compatibility and security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,40 @@ jobs:
       - run: cargo build --workspace --all-targets
       - run: cargo test --workspace
 
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          key: msrv
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Check MSRV
+        run: cargo check --locked --workspace --all-targets
+      - name: Check without a TLS backend
+        run: cargo check --locked --workspace --all-targets --no-default-features
+      - name: Check native TLS
+        run: cargo check --locked --workspace --all-targets --no-default-features --features native-tls
+      - name: Check rustls with native roots
+        run: cargo check --locked --workspace --all-targets --no-default-features --features rustls-native-roots
+
+  supply-chain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: EmbarkStudios/cargo-deny-action@c3bbe7e4e3f7baeee1a3dd9aec0a3b2aded580fb # v2.1.1
+        with:
+          command: check
+
   final:
     permissions: {}
     needs:
+      - compatibility
       - lint
+      - supply-chain
       - test
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -55,6 +85,8 @@ jobs:
       - name: Check job results
         if: |
           needs.lint.result != 'success' ||
+          needs.compatibility.result != 'success' ||
+          needs.supply-chain.result != 'success' ||
           needs.test.result != 'success'
         run: exit 1
       - run: echo "All CI jobs completed successfully"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["crates/mbx", "crates/mbx-cache-core", "crates/mbx-cache-rustc"]
 [workspace.package]
 version = "0.3.0"
 edition = "2024"
+rust-version = "1.91"
 license = "MIT"
 homepage = "https://github.com/jdx/mr-boxington"
 repository = "https://github.com/jdx/mr-boxington"

--- a/README.md
+++ b/README.md
@@ -64,8 +64,12 @@ Or install the latest Linux x86-64 release archive:
 
 ```sh
 mkdir -p ~/.local/bin
-curl -fsSL https://github.com/jdx/mr-boxington/releases/latest/download/mbx-x86_64-unknown-linux-musl.tar.gz \
-  | tar -xzf - -C ~/.local/bin
+archive=mbx-x86_64-unknown-linux-musl.tar.gz
+release=https://github.com/jdx/mr-boxington/releases/latest/download
+curl -fsSLO "$release/$archive"
+curl -fsSLO "$release/SHA256SUMS"
+grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
+tar -xzf "$archive" -C ~/.local/bin
 ```
 
 Release archives also cover Linux ARM64, Apple Silicon, Intel macOS, and

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ cargo install mbx
 Or install the latest Linux x86-64 release archive:
 
 ```sh
+(
+set -e
 mkdir -p ~/.local/bin
 archive=mbx-x86_64-unknown-linux-musl.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
@@ -70,6 +72,7 @@ curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
 grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
+)
 ```
 
 Release archives also cover Linux ARM64, Apple Silicon, Intel macOS, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are made on the latest released version and on the `main`
+branch. Please upgrade to the newest release before reporting an issue that may
+already have been fixed.
+
+## Report a vulnerability
+
+Please use [GitHub's private vulnerability reporting][report] rather than a
+public issue. Include the affected mbx version, operating system, reproduction
+steps, impact, and any relevant cache or remote-server configuration. Remove
+bearer tokens, OIDC credentials, and private source paths from logs and
+attachments.
+
+You should receive an acknowledgement within seven days. We will coordinate
+validation, remediation, and disclosure with you. Please do not publish the
+report before a fix or mitigation is available.
+
+[report]: https://github.com/jdx/mr-boxington/security/advisories/new
+
+## Trust model
+
+mbx restores compiler outputs and some of those outputs may later be linked or
+executed. Treat anyone who can write to a cache as having the same trust as
+someone who can contribute build artifacts:
+
+- Grant remote-cache write access only to trusted CI and maintainers. Pull
+  requests, merge requests, local shells, and unprotected branches are forced
+  read-only by the client, but the server must still enforce authentication and
+  authorization.
+- A remote namespace prevents accidental key collisions; it is not an access
+  control boundary. Use HTTPS, narrowly scoped credentials, and separate
+  server-side authorization where projects have different trust domains.
+- Remote cache storage and transport are treated as untrusted. mbx validates
+  content digests, result metadata, and materialization paths before accepting
+  data. A digest match proves integrity relative to the action record, not that
+  the writer was trustworthy.
+- The local cache is trusted at the level of the operating-system user who owns
+  it. Do not share a writable local cache between mutually untrusted users.
+- `MBX_VERIFY=1` recompiles while consulting the cache and compares results. It
+  is useful when qualifying a server or investigating suspected cache
+  corruption, but it does not replace access control.
+
+Bearer tokens can be supplied directly or through a token file; OIDC is
+recommended for CI where available. Avoid long-lived credentials in pull
+request workflows, restrict token-file permissions, and never commit tokens to
+the repository.
+
+## In scope
+
+Reports are especially valuable for cache poisoning, action-key confusion,
+digest-validation bypasses, path traversal or unsafe materialization, credential
+disclosure, privilege-boundary violations, and parsing vulnerabilities in data
+received from a remote cache. Incorrect cache hits that silently alter build
+outputs are also considered security-relevant.
+
+Denial of service that requires control of the same local user account, and
+vulnerabilities in an unsupported version that do not reproduce on the latest
+release, are generally out of scope.

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "mbx-cache-core"
 version.workspace = true
 description = "Action cache protocol, CAS, authentication, and transport primitives for mbx"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -3,6 +3,7 @@ name = "mbx-cache-rustc"
 version.workspace = true
 description = "Conservative rustc action analysis and key construction for mbx"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -3,6 +3,7 @@ name = "mbx"
 version.workspace = true
 description = "A build cache for Rust projects"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,24 @@
+[advisories]
+yanked = "deny"
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+  "Apache-2.0",
+  "BSD-3-Clause",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "Unicode-3.0",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,8 @@ mise use -g github:jdx/mr-boxington
 Linux x86-64:
 
 ```sh
+(
+set -e
 mkdir -p ~/.local/bin
 archive=mbx-x86_64-unknown-linux-musl.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
@@ -20,6 +22,7 @@ curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
 grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
+)
 ```
 
 Release archives are also available for Linux ARM64, Apple Silicon, Intel macOS,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,8 +14,12 @@ Linux x86-64:
 
 ```sh
 mkdir -p ~/.local/bin
-curl -fsSL https://github.com/jdx/mr-boxington/releases/latest/download/mbx-x86_64-unknown-linux-musl.tar.gz \
-  | tar -xzf - -C ~/.local/bin
+archive=mbx-x86_64-unknown-linux-musl.tar.gz
+release=https://github.com/jdx/mr-boxington/releases/latest/download
+curl -fsSLO "$release/$archive"
+curl -fsSLO "$release/SHA256SUMS"
+grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
+tar -xzf "$archive" -C ~/.local/bin
 ```
 
 Release archives are also available for Linux ARM64, Apple Silicon, Intel macOS,


### PR DESCRIPTION
## Summary

- declare Rust 1.91 as the workspace MSRV (the current `usage-rs` and `usage-config` 6.3 dependency line requires it)
- add one focused compatibility job covering the MSRV, no-default-features, native TLS, and rustls/native-roots builds
- enforce advisory, license, source, yanked-crate, and wildcard-dependency policy with a commit-pinned cargo-deny action
- document mbx's remote/local cache, credential, and artifact trust model and private vulnerability reporting path
- verify release archive checksums before extraction in both install guides
- add grouped weekly Dependabot updates for Cargo and GitHub Actions; no existing config or bot PR history was present

## Verification

- `cargo +1.91.0 check --locked --workspace --all-targets`
- `cargo +1.91.0 check --locked --workspace --all-targets --no-default-features`
- `cargo +1.91.0 check --locked --workspace --all-targets --no-default-features --features native-tls`
- `cargo +1.91.0 check --locked --workspace --all-targets --no-default-features --features rustls-native-roots`
- `cargo +1.91.0 test --locked --workspace`
- `cargo fmt --all --check`
- `cargo-deny 0.20.2 check`
- `actionlint 1.7.12 .github/workflows/ci.yml`
- checksum instructions verified against the latest published Linux x86-64 archive

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI, dependency policy, and documentation only; no application runtime logic is modified in the diff.
> 
> **Overview**
> This PR formalizes **Rust 1.91** as the workspace MSRV in `Cargo.toml` and wires CI to enforce it, plus **TLS/feature-matrix** checks (`no-default-features`, `native-tls`, `rustls-native-roots`).
> 
> **Supply chain and maintenance:** adds `deny.toml` and a **`supply-chain`** job using `cargo-deny`, plus weekly grouped **Dependabot** for Cargo and GitHub Actions.
> 
> **Security and install trust:** new **`SECURITY.md`** documents private reporting, cache/credential trust boundaries, and in-scope issues. **README** and **getting-started** install snippets now download `SHA256SUMS` and verify the archive before extraction.
> 
> The **`final`** CI job now requires **`compatibility`** and **`supply-chain`** to succeed alongside lint and test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f002a7da51926a741a58bb59f4a6d7ecdf17bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->