### PR TITLE
feat: cache plain cargo commands after setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
+ "toml_edit",
  "usage-config",
  "usage-rs",
  "which",
@@ -2242,6 +2243,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +2804,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/PLAN.md
+++ b/PLAN.md
@@ -88,9 +88,10 @@ Two modes:
 - **Session mode** (under an mbx-wrapped Cargo command): talks to the agent over the socket;
   gets prefetch, batched uploads, and staged blob packs. This is the only mode
   today.
-- **Standalone mode** (no `MBX_SOCKET`): would read and write the local store
-  directly, making `build.rustc-wrapper` useful for plain `cargo build`. Blocked
-  on cross-process prefetch manifests — see future work.
+- **Standalone mode** (no `MBX_SOCKET`): reads and writes the local store
+  directly for plain Cargo commands. Prediction manifests are sharded by
+  invocation digest and committed immediately, so independent rustc wrapper
+  processes share them without a daemon.
 
 On any unsupported invocation, error, or bypass condition the shim execs the
 real rustc transparently. Correctness beats hit rate everywhere.
@@ -174,7 +175,6 @@ Protocol version stays 1; nothing in the wild speaks the old names.
   `build.rustc-wrapper` in `~/.cargo/config.toml`. If that key already names
   another wrapper, such as sccache, setup reports it and changes nothing:
   silently displacing a wrapper the user chose is worse than doing nothing.
-  Depends on standalone shim mode, so it lands with it.
 - `mbx-rustc` (argv0) — the shim; not invoked by humans.
 
 ## Configuration
@@ -288,15 +288,6 @@ env vars, and wire constants to match `mbx-cache-core` exactly.
   one member cold-misses its whole dependent subtree. Measure on a multi-member
   workspace — mise is one crate, so nearly all of its 65% is dependencies and
   the trade-off will not show there.
-- **Standalone shim mode**, so `build.rustc-wrapper` helps plain `cargo build`
-  and `mbx setup` becomes worth having. This needs cross-process prefetch
-  manifests first: `begin_task` derives its run id from the process id, so each
-  of the many rustc processes cargo spawns would get its own manifest and see
-  none of the others' predictions. Without prediction the shim can only use a
-  dep-info file left by an earlier build, which is exactly the case a cold
-  target directory does not have — so the feature is not worth shipping until
-  runs can be shared. Either make the run id deterministic per identity, or
-  persist predictions as they are recorded instead of at commit.
 - **Default `MBX_SHARE_OUT_DIR` on**, once a verify-mode run over a real
   workspace has qualified it. Blocked on the verify-mode gap below rather than
   on the feature itself.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ supported compilations it has seen before.
 mbx build                  # cargo build, with caching
 mbx test --all-features    # cargo test --all-features, with caching
 mbx clippy --workspace     # cargo clippy --workspace, with caching
+mbx setup                  # cache future plain cargo commands locally
 ```
 
 ## Why mbx?
@@ -109,6 +110,19 @@ to disable managed placement and the prompt.
 
 [Learn about managed targets →](https://mr-boxington.jdx.dev/managed-targets)
 
+## Plain Cargo commands
+
+Run `mbx setup` once to install a persistent rustc wrapper and configure it in
+Cargo's global configuration. Afterwards, ordinary `cargo build`, `cargo test`,
+and other Cargo commands use the local action store without a daemon. Setup
+leaves the configuration untouched when `build.rustc-wrapper` already names
+another tool, such as sccache.
+
+The persistent wrapper deliberately stays local-only: use `mbx <subcommand>`
+when a build needs remote prefetch, session statistics, managed targets, or
+automatic collection. Rerun `mbx setup` after upgrading mbx to refresh the
+installed wrapper binary.
+
 ## Worktree and CI warming
 
 An equivalent rustc action keys the same across checkout paths. One worktree's
@@ -130,9 +144,8 @@ An `mbx` Cargo command starts an in-process cache agent, points Cargo at a rustc
 derives an action key, restores cached outputs when possible, or runs the real
 compiler and publishes a successful result.
 
-Anything mbx cannot model exactly bypasses the cache. Linking is not cached,
-incremental compilation is off by default, and plain `cargo build` does not use
-mbx. Correctness comes before hit rate.
+Anything mbx cannot model exactly bypasses the cache. Linking is not cached and
+incremental compilations bypass the cache. Correctness comes before hit rate.
 
 [Read the architecture and limits →](https://mr-boxington.jdx.dev/how-it-works)
 

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -443,6 +443,7 @@ struct TaskActionState {
     manifest: String,
     baseline_loaded: bool,
     predictions: BTreeMap<CacheDigest, ActionPrediction>,
+    pending_predictions: BTreeMap<CacheDigest, ActionPrediction>,
     remote_etag: Option<String>,
 }
 
@@ -548,6 +549,7 @@ impl CacheAgent {
                     .into_iter()
                     .map(|prediction| (prediction.invocation.clone(), prediction))
                     .collect(),
+                pending_predictions: BTreeMap::new(),
                 remote_etag,
             }
         } else {
@@ -621,7 +623,11 @@ impl CacheAgent {
                         .collect::<BTreeMap<_, _>>()
                 })
                 .unwrap_or_default();
-            predictions.extend(state.predictions);
+            // Only publish predictions recorded by this run. `predictions`
+            // also contains the baseline loaded by `begin_task`; extending
+            // with that snapshot would overwrite newer entries committed by
+            // another agent process after this run began.
+            predictions.extend(state.pending_predictions);
             let manifest = TaskActionManifest {
                 version: TASK_ACTION_MANIFEST_VERSION,
                 task: task.clone(),
@@ -1807,6 +1813,9 @@ impl CacheAgent {
         }
         state
             .predictions
+            .insert(prediction.invocation.clone(), prediction.clone());
+        state
+            .pending_predictions
             .insert(prediction.invocation.clone(), prediction);
         Ok(AgentResponse::ActionPredictionRecorded)
     }

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -47,7 +47,7 @@ pub const AGENT_PROTOCOL_VERSION: u8 = 1;
 const MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
 
 /// A request accepted by the task-scoped cache agent.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentRequest {
     /// Negotiate protocol and application versions.
@@ -159,7 +159,7 @@ pub struct RestoreStats {
 }
 
 /// A response returned by the task-scoped cache agent.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentResponse {
     /// Successful protocol negotiation.
@@ -826,6 +826,23 @@ impl CacheAgent {
             copied_output_files: self.stats.copied_output_files.load(Ordering::Relaxed),
             copied_output_bytes: self.stats.copied_output_bytes.load(Ordering::Relaxed),
         }
+    }
+
+    /// Handle requests without a transport connection.
+    ///
+    /// Persistent wrappers use this entry point when Cargo invokes mbx outside
+    /// an orchestrated session. It intentionally has the same response
+    /// semantics as [`Self::handle_connection`], while leaving framing and the
+    /// version handshake to callers that actually cross a process boundary.
+    pub async fn handle_requests(
+        &self,
+        requests: impl IntoIterator<Item = AgentRequest>,
+    ) -> Vec<AgentResponse> {
+        let mut responses = Vec::new();
+        for request in requests {
+            responses.push(self.respond(request).await);
+        }
+        responses
     }
 
     fn write_lock(&self, digest: &CacheDigest) -> Arc<tokio::sync::Mutex<()>> {

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -424,6 +424,97 @@ async fn publishes_only_successfully_committed_task_action_manifests() {
 }
 
 #[tokio::test]
+async fn concurrent_task_commits_do_not_republish_stale_baselines() {
+    let directory = tempfile::tempdir().unwrap();
+    let cache = directory.path().join("cache");
+    let task = "d".repeat(64);
+    let first_invocation = CacheDigest::blake3(b"first invocation");
+    let old = ActionPrediction {
+        invocation: first_invocation.clone(),
+        action: CacheDigest::blake3(b"old action"),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+
+    let seed = CacheAgent::new(&cache, "test-version");
+    let seed_run = seed.begin_task(&task).await.unwrap();
+    assert!(matches!(
+        seed.respond(AgentRequest::RecordActionPrediction {
+            task: seed_run.clone(),
+            prediction: old,
+        })
+        .await,
+        AgentResponse::ActionPredictionRecorded
+    ));
+    seed.commit_task(&seed_run).await.unwrap();
+
+    // Both agents load the old value before either publishes. The second
+    // commit must merge only its new entry, not its stale baseline.
+    let first = CacheAgent::new(&cache, "test-version");
+    let second = CacheAgent::new(&cache, "test-version");
+    let first_run = first.begin_task(&task).await.unwrap();
+    let second_run = second.begin_task(&task).await.unwrap();
+    let updated = ActionPrediction {
+        invocation: first_invocation.clone(),
+        action: CacheDigest::blake3(b"updated action"),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    assert!(matches!(
+        first
+            .respond(AgentRequest::RecordActionPrediction {
+                task: first_run.clone(),
+                prediction: updated.clone(),
+            })
+            .await,
+        AgentResponse::ActionPredictionRecorded
+    ));
+    first.commit_task(&first_run).await.unwrap();
+
+    let second_prediction = ActionPrediction {
+        invocation: CacheDigest::blake3(b"second invocation"),
+        action: CacheDigest::blake3(b"second action"),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    assert!(matches!(
+        second
+            .respond(AgentRequest::RecordActionPrediction {
+                task: second_run.clone(),
+                prediction: second_prediction.clone(),
+            })
+            .await,
+        AgentResponse::ActionPredictionRecorded
+    ));
+    second.commit_task(&second_run).await.unwrap();
+
+    let reader = CacheAgent::new(&cache, "test-version");
+    let reader_run = reader.begin_task(&task).await.unwrap();
+    assert!(matches!(
+        reader
+            .respond(AgentRequest::FindActionPrediction {
+                task: reader_run.clone(),
+                invocation: first_invocation,
+            })
+            .await,
+        AgentResponse::ActionPrediction {
+            prediction: Some(prediction)
+        } if prediction == updated
+    ));
+    assert!(matches!(
+        reader
+            .respond(AgentRequest::FindActionPrediction {
+                task: reader_run,
+                invocation: second_prediction.invocation.clone(),
+            })
+            .await,
+        AgentResponse::ActionPrediction {
+            prediction: Some(prediction)
+        } if prediction == second_prediction
+    ));
+}
+
+#[tokio::test]
 async fn round_trips_task_actions_between_fresh_local_caches() {
     let directory = tempfile::tempdir().unwrap();
     let mut server = mockito::Server::new_async().await;

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -260,6 +260,7 @@ pub struct RustcInvocation {
     out_dir: Option<PathBuf>,
     explicit_output: Option<PathBuf>,
     emits: Vec<Emit>,
+    target: Option<String>,
 }
 
 /// The cacheable files and dependency manifest produced by a rustc invocation.
@@ -287,6 +288,11 @@ impl RustcInvocation {
     /// Return the source input passed to rustc.
     pub fn source(&self) -> &Path {
         &self.source
+    }
+
+    /// Return the explicitly selected compilation target, if any.
+    pub fn target(&self) -> Option<&str> {
+        self.target.as_deref()
     }
 
     /// Resolve the rlib/rmeta files produced by this invocation.
@@ -627,6 +633,7 @@ struct Parser<'a> {
     extra_filename: String,
     out_dir: Option<PathBuf>,
     explicit_output: Option<PathBuf>,
+    target: Option<String>,
 }
 
 impl<'a> Parser<'a> {
@@ -644,6 +651,7 @@ impl<'a> Parser<'a> {
             extra_filename: String::new(),
             out_dir: None,
             explicit_output: None,
+            target: None,
         }
     }
 
@@ -685,6 +693,7 @@ impl<'a> Parser<'a> {
             out_dir: self.out_dir,
             explicit_output: self.explicit_output,
             emits: self.emits,
+            target: self.target,
         })
     }
 
@@ -742,6 +751,7 @@ impl<'a> Parser<'a> {
             }
             "target" => {
                 let value = self.take_value(&rendered_flag, inline)?;
+                self.target = Some(value.clone());
                 if value.ends_with(".json") || value.contains(['/', '\\']) {
                     let path = PathBuf::from(value);
                     self.required_inputs.push(path.clone());

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 toml = "0.9"
+toml_edit = "0.23"
 usage = { package = "usage-rs", version = "6", features = ["config"] }
 usage-config = { version = "6", features = ["toml"] }
 which = "8"

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -16,7 +16,7 @@ use std::process::{Command, ExitCode};
     version,
     config = crate::config::RawConfig,
     about = "A build cache for Rust projects",
-    long_about = "Run any Cargo subcommand with the build cache enabled. The subcommand and all of its arguments are passed through unchanged, including Cargo aliases and installed subcommands. `cache` and `gc` are reserved for mbx's own store-management commands.\n\nExamples:\n  mbx build --release\n  mbx test --workspace\n  mbx clippy --all-targets -- -D warnings",
+    long_about = "Run any Cargo subcommand with the build cache enabled. The subcommand and all of its arguments are passed through unchanged, including Cargo aliases and installed subcommands. `cache`, `gc`, and `setup` are reserved for mbx's own commands.\n\nExamples:\n  mbx build --release\n  mbx test --workspace\n  mbx clippy --all-targets -- -D warnings\n  mbx setup",
     unknown_flags = "error"
 )]
 struct Cli {
@@ -26,6 +26,8 @@ struct Cli {
 
 #[derive(usage::Subcommands)]
 enum Commands {
+    /// Install a persistent rustc wrapper for plain Cargo commands.
+    Setup,
     /// Collect stale managed targets and evict cached objects until the store fits a size budget.
     ///
     /// A missing cached object is rebuilt when it is needed again.
@@ -63,6 +65,7 @@ pub fn run() -> Result<ExitCode> {
     let cli = Cli::parse();
     let config = Config::load()?;
     match cli.command {
+        Commands::Setup => setup().map(|()| ExitCode::SUCCESS),
         Commands::Gc(args) => gc(
             &config,
             args.max_size
@@ -78,6 +81,75 @@ pub fn run() -> Result<ExitCode> {
         },
         Commands::Cargo(arguments) => cargo(&config, &arguments),
     }
+}
+
+fn setup() -> Result<()> {
+    let executable = std::env::current_exe().wrap_err("failed to locate the mbx executable")?;
+    let data = dirs::data_local_dir()
+        .ok_or_else(|| eyre::eyre!("the platform data directory could not be located"))?;
+    let install_dir = data.join("mbx").join("bin");
+    let cargo_home = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cargo")))
+        .ok_or_else(|| eyre::eyre!("Cargo's configuration directory could not be located"))?;
+    let config_path =
+        if cargo_home.join("config.toml").exists() || !cargo_home.join("config").exists() {
+            cargo_home.join("config.toml")
+        } else {
+            cargo_home.join("config")
+        };
+    setup_at(&executable, &install_dir, &config_path)
+}
+
+fn setup_at(executable: &Path, install_dir: &Path, config_path: &Path) -> Result<()> {
+    let contents = match std::fs::read_to_string(config_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error.into()),
+    };
+    let mut document = contents
+        .parse::<toml_edit::DocumentMut>()
+        .wrap_err_with(|| format!("failed to parse {}", config_path.display()))?;
+    let shim_name = if cfg!(windows) {
+        format!("{}.exe", crate::session::RUSTC_SHIM_STEM)
+    } else {
+        crate::session::RUSTC_SHIM_STEM.into()
+    };
+    let shim = install_dir.join(shim_name);
+    if let Some(configured) = document
+        .get("build")
+        .and_then(toml_edit::Item::as_table_like)
+        .and_then(|build| build.get("rustc-wrapper"))
+    {
+        if configured.as_str() == Some(shim.to_string_lossy().as_ref()) {
+            std::fs::create_dir_all(install_dir)?;
+            crate::session::install_shim(executable, install_dir)?;
+            println!("refreshed {}; Cargo was already configured", shim.display());
+            return Ok(());
+        }
+        println!(
+            "left {} unchanged: build.rustc-wrapper is already {}",
+            config_path.display(),
+            configured
+        );
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(install_dir)?;
+    let shim = crate::session::install_shim(executable, install_dir)?;
+    document["build"]["rustc-wrapper"] = toml_edit::value(shim.to_string_lossy().into_owned());
+    let parent = config_path
+        .parent()
+        .ok_or_else(|| eyre::eyre!("Cargo configuration path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    crate::util::write_atomic(config_path, document.to_string().as_bytes())?;
+    println!(
+        "installed {} and configured {}",
+        shim.display(),
+        config_path.display()
+    );
+    println!("plain cargo commands now use mbx's local action cache");
+    Ok(())
 }
 
 fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -2,6 +2,7 @@
 
 use crate::config::Config;
 use crate::session::CacheSession;
+use crate::util::workspace_root;
 use crate::{policy, store, target};
 use bytesize::ByteSize;
 use eyre::{Context, Result};
@@ -481,25 +482,6 @@ fn cache_stats(config: &Config) -> Result<()> {
         ByteSize::b(views.bytes).display().iec()
     );
     Ok(())
-}
-
-/// Find the workspace root above `start`.
-///
-/// The outermost directory holding a `Cargo.lock` is preferred, since that is
-/// the one cargo resolves against; a directory holding only a `Cargo.toml`
-/// stands in when there is no lockfile yet.
-fn workspace_root(start: &Path) -> PathBuf {
-    let mut lockfile = None;
-    let mut manifest = None;
-    for directory in start.ancestors() {
-        if directory.join("Cargo.lock").is_file() {
-            lockfile = Some(directory.to_path_buf());
-        }
-        if directory.join("Cargo.toml").is_file() {
-            manifest = Some(directory.to_path_buf());
-        }
-    }
-    lockfile.or(manifest).unwrap_or_else(|| start.to_path_buf())
 }
 
 /// Settings the shim maps out of its cache keys.

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -363,6 +363,7 @@ fn mbx_commands_still_take_precedence() {
 fn cli_exposes_its_usage_spec() {
     let spec = Cli::to_kdl();
     assert!(spec.contains("external_subcommand #true"));
+    assert!(spec.contains("cmd setup"));
     assert!(spec.contains("cmd gc"));
     assert!(spec.contains("cmd cache"));
     assert!(spec.contains("config {"));
@@ -432,4 +433,43 @@ fn declining_the_target_prompt_preserves_outputs() {
 
     assert!(!accepted);
     assert!(target_dir.join("artifact").is_file());
+}
+
+#[test]
+fn setup_preserves_cargo_configuration_and_installs_the_wrapper() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory
+        .path()
+        .join(if cfg!(windows) { "mbx.exe" } else { "mbx" });
+    std::fs::write(&executable, b"mbx binary").unwrap();
+    let install = directory.path().join("data/bin");
+    let config = directory.path().join("cargo/config.toml");
+    std::fs::create_dir_all(config.parent().unwrap()).unwrap();
+    std::fs::write(&config, "# keep me\n[net]\noffline = true\n").unwrap();
+
+    setup_at(&executable, &install, &config).unwrap();
+
+    let written = std::fs::read_to_string(&config).unwrap();
+    assert!(written.contains("# keep me"));
+    let document = written.parse::<toml_edit::DocumentMut>().unwrap();
+    assert_eq!(document["net"]["offline"].as_bool(), Some(true));
+    let wrapper = document["build"]["rustc-wrapper"].as_str().unwrap();
+    assert!(Path::new(wrapper).is_file());
+}
+
+#[test]
+fn setup_never_displaces_an_existing_wrapper() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory.path().join("mbx");
+    std::fs::write(&executable, b"mbx binary").unwrap();
+    let install = directory.path().join("data/bin");
+    let config = directory.path().join("cargo/config.toml");
+    std::fs::create_dir_all(config.parent().unwrap()).unwrap();
+    let original = "[build]\nrustc-wrapper = \"sccache\"\n";
+    std::fs::write(&config, original).unwrap();
+
+    setup_at(&executable, &install, &config).unwrap();
+
+    assert_eq!(std::fs::read_to_string(config).unwrap(), original);
+    assert!(!install.exists());
 }

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -455,6 +455,15 @@ fn setup_preserves_cargo_configuration_and_installs_the_wrapper() {
     assert_eq!(document["net"]["offline"].as_bool(), Some(true));
     let wrapper = document["build"]["rustc-wrapper"].as_str().unwrap();
     assert!(Path::new(wrapper).is_file());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        assert_ne!(
+            std::fs::metadata(wrapper).unwrap().permissions().mode() & 0o100,
+            0
+        );
+    }
 }
 
 #[test]

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -48,7 +48,11 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     // learn its output directory and use that as the stable target mapping.
     let initial_invocation = RustcInvocation::parse(arguments)?;
     let initial_outputs = initial_invocation.outputs(&working_dir)?;
-    let portable = Portable::detect(&working_dir, Some(&initial_outputs.directory));
+    let portable = Portable::detect(
+        &working_dir,
+        Some(&initial_outputs.directory),
+        initial_invocation.target(),
+    );
     let arguments = portable.applied_to(arguments);
     let invocation = RustcInvocation::parse(&arguments)?;
     let outputs = invocation.outputs(&working_dir)?;
@@ -856,9 +860,9 @@ struct Portable {
 }
 
 impl Portable {
-    fn detect(working_dir: &Path, target_output: Option<&Path>) -> Self {
+    fn detect(working_dir: &Path, target_output: Option<&Path>, target: Option<&str>) -> Self {
         let mut portable = Self {
-            mappings: PathMapping::ordered(&path_mappings(working_dir, target_output)),
+            mappings: PathMapping::ordered(&path_mappings(working_dir, target_output, target)),
             arguments: Vec::new(),
             names: BTreeSet::new(),
             values: Vec::new(),
@@ -946,7 +950,11 @@ fn contains(haystack: &[u8], needle: &[u8]) -> bool {
     false
 }
 
-fn path_mappings(working_dir: &Path, target_output: Option<&Path>) -> Vec<PathMapping> {
+fn path_mappings(
+    working_dir: &Path,
+    target_output: Option<&Path>,
+    target: Option<&str>,
+) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     let mut roots = BTreeSet::new();
     // The target directory comes first, and before the workspace that usually
@@ -963,7 +971,7 @@ fn path_mappings(working_dir: &Path, target_output: Option<&Path>) -> Vec<PathMa
     if let Some(root) = configured_target.or_else(|| {
         target_output
             .filter(|root| root.is_absolute())
-            .map(standalone_target_root)
+            .map(|output| standalone_target_root(output, target))
     }) {
         add_mapping(&mut mappings, &mut roots, root, "target");
     }
@@ -998,11 +1006,17 @@ fn path_mappings(working_dir: &Path, target_output: Option<&Path>) -> Vec<PathMa
 /// Cargo normally writes compilations to `<target>/<profile>/deps` (or the
 /// same shape below a target-triple directory). Mapping the profile parent,
 /// rather than only `deps`, also covers generated inputs below `build/`.
-fn standalone_target_root(output: &Path) -> PathBuf {
+fn standalone_target_root(output: &Path, target: Option<&str>) -> PathBuf {
     if output.file_name() == Some(OsStr::new("deps"))
-        && let Some(root) = output.parent().and_then(Path::parent)
+        && let Some(profile_root) = output.parent().and_then(Path::parent)
     {
-        return root.to_path_buf();
+        let target_component = target.and_then(|target| Path::new(target).file_stem());
+        if target_component.is_some_and(|target| profile_root.file_name() == Some(target))
+            && let Some(root) = profile_root.parent()
+        {
+            return root.to_path_buf();
+        }
+        return profile_root.to_path_buf();
     }
     output.to_path_buf()
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -968,6 +968,11 @@ fn path_mappings_with_env(
 ) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     let mut roots = BTreeSet::new();
+    let home_roots = ["HOME", "USERPROFILE"]
+        .into_iter()
+        .filter_map(|name| environment(name).map(PathBuf::from))
+        .filter(|root| root.is_absolute())
+        .collect::<Vec<_>>();
     // The target directory comes first, and before the workspace that usually
     // contains it: output paths are the ones that differ between checkouts, and
     // mapping them explicitly also keeps keys stable when the target directory
@@ -997,6 +1002,16 @@ fn path_mappings_with_env(
             add_mapping(&mut mappings, &mut roots, root, placeholder);
         }
     }
+    if let Some(home) = home_roots.first() {
+        for (directory, placeholder) in [(".cargo", "cargo_home"), (".rustup", "rustup_home")] {
+            if !mappings
+                .iter()
+                .any(|mapping| mapping.placeholder == placeholder)
+            {
+                add_mapping(&mut mappings, &mut roots, home.join(directory), placeholder);
+            }
+        }
+    }
     // Without a session, recover Cargo's workspace root from the outermost
     // lockfile so member crates use the same placeholder as session mode.
     if !mappings
@@ -1015,12 +1030,8 @@ fn path_mappings_with_env(
     // checkout-specific prefix must be `${workspace}` so equivalent worktrees
     // agree on their source paths. Cargo and rustup roots come first because a
     // registry compilation uses one of those as its working directory.
-    for name in ["HOME", "USERPROFILE"] {
-        if let Some(root) = environment(name).map(PathBuf::from)
-            && root.is_absolute()
-        {
-            add_mapping(&mut mappings, &mut roots, root, "home");
-        }
+    for root in home_roots {
+        add_mapping(&mut mappings, &mut roots, root, "home");
     }
     mappings
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -43,7 +43,12 @@ enum Materialization {
 
 pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
     let working_dir = std::env::current_dir()?;
-    let portable = Portable::detect(&working_dir);
+    // The orchestrated session supplies the target root. A persistent wrapper
+    // has no parent session, so first parse just enough of the invocation to
+    // learn its output directory and use that as the stable target mapping.
+    let initial_invocation = RustcInvocation::parse(arguments)?;
+    let initial_outputs = initial_invocation.outputs(&working_dir)?;
+    let portable = Portable::detect(&working_dir, Some(&initial_outputs.directory));
     let arguments = portable.applied_to(arguments);
     let invocation = RustcInvocation::parse(&arguments)?;
     let outputs = invocation.outputs(&working_dir)?;
@@ -163,10 +168,9 @@ fn restore_predicted_result(
     portable: &Portable,
     restore_outputs: bool,
 ) -> Result<Option<CachedCompilation>> {
-    let task = std::env::var(session::BUILD_ENV)
-        .wrap_err_with(|| format!("{} is not set", session::BUILD_ENV))?;
     let mut context = base_action_context(rustc, working_dir, portable)?;
     let invocation_digest = invocation.invocation_digest(&context)?;
+    let task = prediction_task(&invocation_digest);
     let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
         task,
         invocation: invocation_digest.clone(),
@@ -357,8 +361,7 @@ fn record_prediction(
 
 fn record_prediction_value(invocation: CacheDigest, action: CacheDigest, payload: String) {
     let result = (|| {
-        let task = std::env::var(session::BUILD_ENV)
-            .wrap_err_with(|| format!("{} is not set", session::BUILD_ENV))?;
+        let task = prediction_task(&invocation);
         let responses = session::request_agent(&[AgentRequest::RecordActionPrediction {
             task,
             prediction: ActionPrediction {
@@ -377,6 +380,18 @@ fn record_prediction_value(invocation: CacheDigest, action: CacheDigest, payload
     if let Err(error) = result {
         eprintln!("mbx warning: action prediction was not recorded: {error:#}");
     }
+}
+
+/// Select the session run, or a bounded persistent-manifest shard when this
+/// shim was installed directly in Cargo configuration.
+fn prediction_task(invocation: &CacheDigest) -> String {
+    std::env::var(session::BUILD_ENV).unwrap_or_else(|_| {
+        // A global manifest would eventually hit the prediction count limit.
+        // Sharding by the invocation digest keeps related reads and writes
+        // together while bounding each manifest independently.
+        let shard = invocation.hash.get(..2).unwrap_or(&invocation.hash);
+        CacheDigest::blake3(format!("standalone-predictions-v1\0{shard}").as_bytes()).hash
+    })
 }
 
 fn verify_environment(environment: &BTreeMap<String, Option<String>>) -> Result<()> {
@@ -841,9 +856,9 @@ struct Portable {
 }
 
 impl Portable {
-    fn detect(working_dir: &Path) -> Self {
+    fn detect(working_dir: &Path, target_output: Option<&Path>) -> Self {
         let mut portable = Self {
-            mappings: PathMapping::ordered(&path_mappings(working_dir)),
+            mappings: PathMapping::ordered(&path_mappings(working_dir, target_output)),
             arguments: Vec::new(),
             names: BTreeSet::new(),
             values: Vec::new(),
@@ -931,7 +946,7 @@ fn contains(haystack: &[u8], needle: &[u8]) -> bool {
     false
 }
 
-fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
+fn path_mappings(working_dir: &Path, target_output: Option<&Path>) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     let mut roots = BTreeSet::new();
     // The target directory comes first, and before the workspace that usually
@@ -942,8 +957,17 @@ fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
     // Cargo compiles a dependency with its working directory inside the
     // registry, not in the workspace, so neither root can be inferred from the
     // working directory -- the session passes both in.
+    let configured_target = std::env::var_os(session::TARGET_DIR_ENV)
+        .map(PathBuf::from)
+        .filter(|root| root.is_absolute());
+    if let Some(root) = configured_target.or_else(|| {
+        target_output
+            .filter(|root| root.is_absolute())
+            .map(standalone_target_root)
+    }) {
+        add_mapping(&mut mappings, &mut roots, root, "target");
+    }
     for (name, placeholder) in [
-        (session::TARGET_DIR_ENV, "target"),
         (session::WORKSPACE_ROOT_ENV, "workspace"),
         ("CARGO_HOME", "cargo_home"),
         ("RUSTUP_HOME", "rustup_home"),
@@ -967,6 +991,20 @@ fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
         );
     }
     mappings
+}
+
+/// Infer the profile subtree shared by rustc outputs and build-script output.
+///
+/// Cargo normally writes compilations to `<target>/<profile>/deps` (or the
+/// same shape below a target-triple directory). Mapping the profile parent,
+/// rather than only `deps`, also covers generated inputs below `build/`.
+fn standalone_target_root(output: &Path) -> PathBuf {
+    if output.file_name() == Some(OsStr::new("deps"))
+        && let Some(root) = output.parent().and_then(Path::parent)
+    {
+        return root.to_path_buf();
+    }
+    output.to_path_buf()
 }
 
 fn add_mapping(
@@ -999,9 +1037,13 @@ fn replay_bytes(stdout_bytes: &[u8], stderr_bytes: &[u8]) -> Result<()> {
 }
 
 fn staging_directory() -> Result<tempfile::TempDir> {
-    let root = std::env::var_os(session::STAGING_ENV)
-        .map(PathBuf::from)
-        .ok_or_else(|| eyre::eyre!("{} is not set", session::STAGING_ENV))?;
+    let root = match std::env::var_os(session::STAGING_ENV).filter(|root| !root.is_empty()) {
+        Some(root) => PathBuf::from(root),
+        None => crate::config::Config::load()?
+            .store_dir()
+            .join("standalone-staging"),
+    };
+    std::fs::create_dir_all(&root)?;
     Ok(tempfile::tempdir_in(root)?)
 }
 

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -955,6 +955,17 @@ fn path_mappings(
     target_output: Option<&Path>,
     target: Option<&str>,
 ) -> Vec<PathMapping> {
+    path_mappings_with_env(working_dir, target_output, target, |name| {
+        std::env::var_os(name)
+    })
+}
+
+fn path_mappings_with_env(
+    working_dir: &Path,
+    target_output: Option<&Path>,
+    target: Option<&str>,
+    environment: impl Fn(&str) -> Option<OsString>,
+) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     let mut roots = BTreeSet::new();
     // The target directory comes first, and before the workspace that usually
@@ -965,7 +976,7 @@ fn path_mappings(
     // Cargo compiles a dependency with its working directory inside the
     // registry, not in the workspace, so neither root can be inferred from the
     // working directory -- the session passes both in.
-    let configured_target = std::env::var_os(session::TARGET_DIR_ENV)
+    let configured_target = environment(session::TARGET_DIR_ENV)
         .map(PathBuf::from)
         .filter(|root| root.is_absolute());
     if let Some(root) = configured_target.or_else(|| {
@@ -979,10 +990,8 @@ fn path_mappings(
         (session::WORKSPACE_ROOT_ENV, "workspace"),
         ("CARGO_HOME", "cargo_home"),
         ("RUSTUP_HOME", "rustup_home"),
-        ("HOME", "home"),
-        ("USERPROFILE", "home"),
     ] {
-        if let Some(root) = std::env::var_os(name).map(PathBuf::from)
+        if let Some(root) = environment(name).map(PathBuf::from)
             && root.is_absolute()
         {
             add_mapping(&mut mappings, &mut roots, root, placeholder);
@@ -990,13 +999,28 @@ fn path_mappings(
     }
     // Without a session there is no workspace root to trust, so fall back to
     // the working directory rather than bypassing every action.
-    if !roots.iter().any(|root| working_dir.starts_with(root)) {
+    if !mappings
+        .iter()
+        .any(|mapping| mapping.placeholder == "workspace")
+        && !roots.iter().any(|root| working_dir.starts_with(root))
+    {
         add_mapping(
             &mut mappings,
             &mut roots,
             working_dir.to_path_buf(),
             "workspace",
         );
+    }
+    // Home is deliberately last. Most real checkouts live under it, but a
+    // checkout-specific prefix must be `${workspace}` so equivalent worktrees
+    // agree on their source paths. Cargo and rustup roots come first because a
+    // registry compilation uses one of those as its working directory.
+    for name in ["HOME", "USERPROFILE"] {
+        if let Some(root) = environment(name).map(PathBuf::from)
+            && root.is_absolute()
+        {
+            add_mapping(&mut mappings, &mut roots, root, "home");
+        }
     }
     mappings
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1,4 +1,4 @@
-use crate::session;
+use crate::{session, util::workspace_root};
 use eyre::{Context, Result, bail};
 use mbx_cache_core::{
     ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode,
@@ -997,8 +997,8 @@ fn path_mappings_with_env(
             add_mapping(&mut mappings, &mut roots, root, placeholder);
         }
     }
-    // Without a session there is no workspace root to trust, so fall back to
-    // the working directory rather than bypassing every action.
+    // Without a session, recover Cargo's workspace root from the outermost
+    // lockfile so member crates use the same placeholder as session mode.
     if !mappings
         .iter()
         .any(|mapping| mapping.placeholder == "workspace")
@@ -1007,7 +1007,7 @@ fn path_mappings_with_env(
         add_mapping(
             &mut mappings,
             &mut roots,
-            working_dir.to_path_buf(),
+            workspace_root(working_dir),
             "workspace",
         );
     }

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -175,6 +175,33 @@ fn standalone_workspace_mapping_uses_the_outer_workspace_for_members() {
 }
 
 #[test]
+fn standalone_registry_mapping_uses_the_default_cargo_home() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = directory.path().join("home");
+    let dependency = home.join(".cargo/registry/src/index/widget-1.0.0");
+    std::fs::create_dir_all(&dependency).unwrap();
+    std::fs::write(
+        dependency.join("Cargo.toml"),
+        "[package]\nname = \"widget\"\n",
+    )
+    .unwrap();
+
+    let mappings = path_mappings_with_env(&dependency, None, None, |name| match name {
+        "HOME" => Some(home.as_os_str().to_owned()),
+        _ => None,
+    });
+
+    assert!(mappings.iter().any(|mapping| {
+        mapping.placeholder == "cargo_home" && mapping.root == home.join(".cargo")
+    }));
+    assert!(
+        !mappings
+            .iter()
+            .any(|mapping| mapping.placeholder == "workspace")
+    );
+}
+
+#[test]
 fn standalone_target_mapping_covers_the_profile_tree() {
     assert_eq!(
         standalone_target_root(Path::new("/tmp/target/debug/deps"), None),

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -135,6 +135,18 @@ fn mappings_do_not_duplicate_home_placeholders() {
 }
 
 #[test]
+fn standalone_target_mapping_covers_the_profile_tree() {
+    assert_eq!(
+        standalone_target_root(Path::new("/tmp/target/debug/deps")),
+        Path::new("/tmp/target")
+    );
+    assert_eq!(
+        standalone_target_root(Path::new("/tmp/target/triple/release/deps")),
+        Path::new("/tmp/target/triple")
+    );
+}
+
+#[test]
 fn validates_exact_rustc_output_set() {
     let root = tempfile::tempdir().unwrap();
     let outputs = test_outputs(root.path());

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -126,7 +126,7 @@ fn parses_verbose_rustc_identity() {
 #[test]
 fn mappings_do_not_duplicate_home_placeholders() {
     let directory = tempfile::tempdir().unwrap();
-    let mappings = path_mappings(directory.path());
+    let mappings = path_mappings(directory.path(), None, None);
     let placeholders = mappings
         .iter()
         .map(|mapping| &mapping.placeholder)
@@ -137,12 +137,22 @@ fn mappings_do_not_duplicate_home_placeholders() {
 #[test]
 fn standalone_target_mapping_covers_the_profile_tree() {
     assert_eq!(
-        standalone_target_root(Path::new("/tmp/target/debug/deps")),
+        standalone_target_root(Path::new("/tmp/target/debug/deps"), None),
         Path::new("/tmp/target")
     );
     assert_eq!(
-        standalone_target_root(Path::new("/tmp/target/triple/release/deps")),
-        Path::new("/tmp/target/triple")
+        standalone_target_root(
+            Path::new("/tmp/target/x86_64-unknown-linux-gnu/release/deps"),
+            Some("x86_64-unknown-linux-gnu"),
+        ),
+        Path::new("/tmp/target")
+    );
+    assert_eq!(
+        standalone_target_root(
+            Path::new("/tmp/target/custom/release/deps"),
+            Some("/tmp/targets/custom.json"),
+        ),
+        Path::new("/tmp/target")
     );
 }
 

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -144,9 +144,11 @@ fn standalone_workspace_mapping_wins_beneath_home() {
         _ => None,
     });
 
-    assert!(mappings.iter().any(|mapping| {
-        mapping.placeholder == "workspace" && mapping.root == workspace
-    }));
+    assert!(
+        mappings
+            .iter()
+            .any(|mapping| { mapping.placeholder == "workspace" && mapping.root == workspace })
+    );
     assert!(
         mappings
             .iter()

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -157,6 +157,24 @@ fn standalone_workspace_mapping_wins_beneath_home() {
 }
 
 #[test]
+fn standalone_workspace_mapping_uses_the_outer_workspace_for_members() {
+    let directory = tempfile::tempdir().unwrap();
+    let workspace = directory.path().join("workspace");
+    let member = workspace.join("crates/widget");
+    std::fs::create_dir_all(&member).unwrap();
+    std::fs::write(workspace.join("Cargo.lock"), "").unwrap();
+    std::fs::write(member.join("Cargo.toml"), "[package]\nname = \"widget\"\n").unwrap();
+
+    let mappings = path_mappings_with_env(&member, None, None, |_| None);
+
+    assert!(
+        mappings
+            .iter()
+            .any(|mapping| { mapping.placeholder == "workspace" && mapping.root == workspace })
+    );
+}
+
+#[test]
 fn standalone_target_mapping_covers_the_profile_tree() {
     assert_eq!(
         standalone_target_root(Path::new("/tmp/target/debug/deps"), None),

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -135,6 +135,25 @@ fn mappings_do_not_duplicate_home_placeholders() {
 }
 
 #[test]
+fn standalone_workspace_mapping_wins_beneath_home() {
+    let home = Path::new("/tmp/example-home");
+    let workspace = home.join("src/project");
+    let mappings = path_mappings_with_env(&workspace, None, None, |name| match name {
+        "HOME" => Some(home.as_os_str().to_owned()),
+        _ => None,
+    });
+
+    assert!(mappings.iter().any(|mapping| {
+        mapping.placeholder == "workspace" && mapping.root == workspace
+    }));
+    assert!(
+        mappings
+            .iter()
+            .any(|mapping| mapping.placeholder == "home" && mapping.root == home)
+    );
+}
+
+#[test]
 fn standalone_target_mapping_covers_the_profile_tree() {
     assert_eq!(
         standalone_target_root(Path::new("/tmp/target/debug/deps"), None),

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -136,7 +136,8 @@ fn mappings_do_not_duplicate_home_placeholders() {
 
 #[test]
 fn standalone_workspace_mapping_wins_beneath_home() {
-    let home = Path::new("/tmp/example-home");
+    let directory = tempfile::tempdir().unwrap();
+    let home = directory.path().join("home");
     let workspace = home.join("src/project");
     let mappings = path_mappings_with_env(&workspace, None, None, |name| match name {
         "HOME" => Some(home.as_os_str().to_owned()),

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -485,6 +485,17 @@ pub fn install_shim(executable: &Path, directory: &Path) -> Result<PathBuf> {
             format!("failed to install the rustc shim by hard link ({link_error}) or copy")
         })?;
     }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // Some filesystems do not retain executable permissions when the
+        // cross-device fallback copies the running binary. Cargo must be able
+        // to invoke the installed wrapper directly.
+        let mut permissions = std::fs::metadata(&shim)?.permissions();
+        permissions.set_mode(permissions.mode() | 0o100);
+        std::fs::set_permissions(&shim, permissions)?;
+    }
     Ok(shim)
 }
 

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -11,6 +11,7 @@ use mbx_cache_core::{
     CacheDigest, RemoteCacheClient, RemoteCacheConfig, canonical_json,
 };
 use serde::Serialize;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
@@ -899,9 +900,100 @@ fn append_line(path: &OsString, line: &str) -> std::io::Result<()> {
 }
 
 pub(crate) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
-    let socket =
-        std::env::var_os(SOCKET_ENV).ok_or_else(|| eyre::eyre!("{SOCKET_ENV} is not set"))?;
-    request_agent_at(&socket, requests)
+    match std::env::var_os(SOCKET_ENV).filter(|socket| !socket.is_empty()) {
+        Some(socket) => request_agent_at(&socket, requests),
+        None => request_standalone_agent(requests),
+    }
+}
+
+/// Serve a persistent Cargo wrapper directly from the local store.
+///
+/// There is deliberately no remote access here: the short-lived process has
+/// no trusted session policy or opportunity to batch transfers. Prediction
+/// manifests are still persisted after every successful record so the many
+/// wrapper processes in one Cargo build, and later builds, share what they
+/// learn without a daemon.
+fn request_standalone_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
+    thread_local! {
+        static STANDALONE_AGENT: RefCell<Option<StandaloneAgent>> = const { RefCell::new(None) };
+    }
+
+    STANDALONE_AGENT.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.is_none() {
+            let config = Config::load()?;
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            *slot = Some(StandaloneAgent {
+                agent: CacheAgent::new(config.store_dir(), VERSION),
+                runtime,
+                runs: BTreeMap::new(),
+            });
+        }
+        let standalone = slot.as_mut().expect("standalone agent was initialized");
+        let StandaloneAgent {
+            agent,
+            runtime,
+            runs,
+        } = standalone;
+        runtime.block_on(async {
+            let mut responses = Vec::with_capacity(requests.len());
+            for request in requests.iter().cloned() {
+                let (request, run_to_commit) = match request {
+                    AgentRequest::FindActionPrediction { task, invocation } => {
+                        let run = match runs.get(&task) {
+                            Some(run) => run.clone(),
+                            None => {
+                                let run = agent.begin_task(&task).await?;
+                                runs.insert(task.clone(), run.clone());
+                                run
+                            }
+                        };
+                        (
+                            AgentRequest::FindActionPrediction {
+                                task: run,
+                                invocation,
+                            },
+                            None,
+                        )
+                    }
+                    AgentRequest::RecordActionPrediction { task, prediction } => {
+                        let run = match runs.remove(&task) {
+                            Some(run) => run,
+                            None => agent.begin_task(&task).await?,
+                        };
+                        (
+                            AgentRequest::RecordActionPrediction {
+                                task: run.clone(),
+                                prediction,
+                            },
+                            Some(run),
+                        )
+                    }
+                    request => (request, None),
+                };
+                let response = agent
+                    .handle_requests(std::iter::once(request))
+                    .await
+                    .into_iter()
+                    .next()
+                    .expect("one request returns one response");
+                let succeeded = !matches!(response, AgentResponse::Error { .. });
+                responses.push(response);
+                if succeeded && let Some(run) = run_to_commit {
+                    agent.commit_task(&run).await?;
+                }
+            }
+            Ok(responses)
+        })
+    })
+}
+
+struct StandaloneAgent {
+    agent: CacheAgent,
+    runtime: tokio::runtime::Runtime,
+    runs: BTreeMap<String, String>,
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -3,6 +3,25 @@ use std::io::Write as _;
 use std::path::Path;
 use std::time::Duration;
 
+/// Find the workspace root above `start`.
+///
+/// The outermost directory holding a `Cargo.lock` is preferred, since that is
+/// the one Cargo resolves against; a directory holding only a `Cargo.toml`
+/// stands in when there is no lockfile yet.
+pub fn workspace_root(start: &Path) -> std::path::PathBuf {
+    let mut lockfile = None;
+    let mut manifest = None;
+    for directory in start.ancestors() {
+        if directory.join("Cargo.lock").is_file() {
+            lockfile = Some(directory.to_path_buf());
+        }
+        if directory.join("Cargo.toml").is_file() {
+            manifest = Some(directory.to_path_buf());
+        }
+    }
+    lockfile.or(manifest).unwrap_or_else(|| start.to_path_buf())
+}
+
 /// Write `contents` to `path` so readers never observe a partial file.
 pub fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
     let parent = path

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -172,15 +172,6 @@ fn count(stats: &serde_json::Value, field: &str) -> u64 {
         .unwrap_or_else(|| panic!("{field} should be a number"))
 }
 
-#[cfg(unix)]
-fn compilation_count(path: &Path) -> usize {
-    std::fs::read_to_string(path)
-        .unwrap_or_default()
-        .lines()
-        .filter(|line| *line == "compile")
-        .count()
-}
-
 /// Remove the outputs behind a target link so the next build must restore.
 fn wipe_target(project: &Path) {
     let target = project.join("target");
@@ -215,61 +206,6 @@ fn incremental_is_opt_in_and_reaches_cargo() {
     assert!(
         incremental_sessions(project.path()) > 0,
         "cargo should have compiled the member incrementally: {stats}"
-    );
-}
-
-#[cfg(unix)]
-#[test]
-fn a_persistent_wrapper_restores_without_an_mbx_session() {
-    use std::os::unix::fs::PermissionsExt as _;
-
-    let directory = tempfile::tempdir().unwrap();
-    let first = directory.path().join("first-checkout");
-    let second = directory.path().join("second-checkout");
-    write_project(&first);
-    write_project(&second);
-    let wrappers = directory.path().join("bin");
-    std::fs::create_dir_all(&wrappers).unwrap();
-    let shim = mbx::session::install_shim(Path::new(env!("CARGO_BIN_EXE_mbx")), &wrappers)
-        .expect("the persistent shim should install");
-    let compiler = directory.path().join("counting-rustc");
-    let log = directory.path().join("rustc.log");
-    std::fs::write(
-        &compiler,
-        "#!/bin/sh\ncrate_name=0\nfor arg in \"$@\"; do\n  if [ \"$crate_name\" = 1 ]; then\n    if [ \"$arg\" = fixture ]; then\n      printf 'compile\\n' >> \"$MBX_TEST_RUSTC_LOG\"\n    fi\n    break\n  fi\n  if [ \"$arg\" = \"--crate-name\" ]; then\n    crate_name=1\n  fi\ndone\nexec \"$MBX_TEST_REAL_RUSTC\" \"$@\"\n",
-    )
-    .unwrap();
-    std::fs::set_permissions(&compiler, std::fs::Permissions::from_mode(0o755)).unwrap();
-    let cache = directory.path().join("cache");
-    let wrapper_config = format!(
-        "build.rustc-wrapper={:?}",
-        shim.to_string_lossy().into_owned()
-    );
-    let real_rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
-
-    for (project, target) in [(&first, "first-target"), (&second, "second-target")] {
-        let output = Command::new(cargo())
-            .current_dir(project)
-            .args(["build", "--offline", "--config", &wrapper_config])
-            .env("CARGO_TARGET_DIR", directory.path().join(target))
-            .env("CARGO_INCREMENTAL", "0")
-            .env("RUSTC", &compiler)
-            .env("MBX_CACHE_DIR", &cache)
-            .env("MBX_TEST_RUSTC_LOG", &log)
-            .env("MBX_TEST_REAL_RUSTC", &real_rustc)
-            .output()
-            .expect("cargo should run through the persistent wrapper");
-        assert!(
-            output.status.success(),
-            "build failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    assert_eq!(
-        compilation_count(&log),
-        1,
-        "the second target directory should restore the compilation"
     );
 }
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -172,6 +172,15 @@ fn count(stats: &serde_json::Value, field: &str) -> u64 {
         .unwrap_or_else(|| panic!("{field} should be a number"))
 }
 
+#[cfg(unix)]
+fn compilation_count(path: &Path) -> usize {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| *line == "compile")
+        .count()
+}
+
 /// Remove the outputs behind a target link so the next build must restore.
 fn wipe_target(project: &Path) {
     let target = project.join("target");
@@ -206,6 +215,61 @@ fn incremental_is_opt_in_and_reaches_cargo() {
     assert!(
         incremental_sessions(project.path()) > 0,
         "cargo should have compiled the member incrementally: {stats}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_persistent_wrapper_restores_without_an_mbx_session() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let directory = tempfile::tempdir().unwrap();
+    let first = directory.path().join("first-checkout");
+    let second = directory.path().join("second-checkout");
+    write_project(&first);
+    write_project(&second);
+    let wrappers = directory.path().join("bin");
+    std::fs::create_dir_all(&wrappers).unwrap();
+    let shim = mbx::session::install_shim(Path::new(env!("CARGO_BIN_EXE_mbx")), &wrappers)
+        .expect("the persistent shim should install");
+    let compiler = directory.path().join("counting-rustc");
+    let log = directory.path().join("rustc.log");
+    std::fs::write(
+        &compiler,
+        "#!/bin/sh\ncrate_name=0\nfor arg in \"$@\"; do\n  if [ \"$crate_name\" = 1 ]; then\n    if [ \"$arg\" = fixture ]; then\n      printf 'compile\\n' >> \"$MBX_TEST_RUSTC_LOG\"\n    fi\n    break\n  fi\n  if [ \"$arg\" = \"--crate-name\" ]; then\n    crate_name=1\n  fi\ndone\nexec \"$MBX_TEST_REAL_RUSTC\" \"$@\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&compiler, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let cache = directory.path().join("cache");
+    let wrapper_config = format!(
+        "build.rustc-wrapper={:?}",
+        shim.to_string_lossy().into_owned()
+    );
+    let real_rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+
+    for (project, target) in [(&first, "first-target"), (&second, "second-target")] {
+        let output = Command::new(cargo())
+            .current_dir(project)
+            .args(["build", "--offline", "--config", &wrapper_config])
+            .env("CARGO_TARGET_DIR", directory.path().join(target))
+            .env("CARGO_INCREMENTAL", "0")
+            .env("RUSTC", &compiler)
+            .env("MBX_CACHE_DIR", &cache)
+            .env("MBX_TEST_RUSTC_LOG", &log)
+            .env("MBX_TEST_REAL_RUSTC", &real_rustc)
+            .output()
+            .expect("cargo should run through the persistent wrapper");
+        assert!(
+            output.status.success(),
+            "build failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    assert_eq!(
+        compilation_count(&log),
+        1,
+        "the second target directory should restore the compilation"
     );
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,12 +2,13 @@
 # `mbx`
 - **Version:** 0.3.0
 
-Run any Cargo subcommand with the build cache enabled. The subcommand and all of its arguments are passed through unchanged, including Cargo aliases and installed subcommands. `cache` and `gc` are reserved for mbx's own store-management commands.
+Run any Cargo subcommand with the build cache enabled. The subcommand and all of its arguments are passed through unchanged, including Cargo aliases and installed subcommands. `cache`, `gc`, and `setup` are reserved for mbx's own commands.
 
 Examples:
   mbx build --release
   mbx test --workspace
   mbx clippy --all-targets -- -D warnings
+  mbx setup
 
 
 - **Usage:** `mbx <SUBCOMMAND>`
@@ -15,6 +16,15 @@ Examples:
 ## Flags
 - **`-h --help`** — Print help
 - **`-V --version`** — Print version
+
+## `mbx setup`
+
+- **Usage:** `mbx setup`
+
+Install a persistent rustc wrapper for plain Cargo commands.
+
+### Flags
+- **`-h --help`** — Print help
 
 ## `mbx gc`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,6 +49,21 @@ The command and its arguments are passed to Cargo unchanged. Cargo still owns
 dependency resolution, feature unification, build planning, and linking. mbx
 also forwards Cargo aliases and installed subcommands.
 
+## Enable plain Cargo commands
+
+```sh
+mbx setup
+```
+
+Setup installs a persistent `mbx-rustc` wrapper and adds it as Cargo's global
+`build.rustc-wrapper`. It never replaces a wrapper that is already configured.
+Rerun setup after upgrading mbx so the installed wrapper matches the new
+version.
+
+The persistent wrapper uses the local action store. Continue to run commands
+through `mbx` when you need a remote cache, build statistics, managed target
+directories, or automatic collection.
+
 ## Read the result
 
 After a build that used the cache, mbx prints a summary to stderr:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -11,6 +11,12 @@ subcommand.
 5. A hit restores the action's outputs; a miss runs the real compiler and publishes the result.
 6. The agent exits with the build. There is no persistent daemon.
 
+`mbx setup` also supports plain Cargo commands. Its persistent rustc wrapper
+opens the same local CAS directly and commits prediction shards after every
+successful compilation. This lets Cargo's parallel wrapper processes and later
+builds share predictions without a daemon. Remote transfers remain in session
+mode, where the agent can enforce policy and batch them efficiently.
+
 ## Portable keys
 
 Known workspace, target, Cargo registry, toolchain, and sysroot paths are mapped

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -2,11 +2,14 @@
 
 mr boxington favors correct uncached work over risky cache reuse.
 
-## Run Cargo through mbx
+## Plain Cargo has local-only caching
 
-Plain Cargo commands do not start the session agent, so they get no mbx cache.
-Use `mbx build`, `mbx test`, `mbx clippy`, and the same pattern for other Cargo
-subcommands.
+After `mbx setup`, plain Cargo commands use the local action store. They do not
+start a session agent, so remote transfers, build statistics, managed targets,
+and automatic collection still require `mbx build`, `mbx test`, or the same
+pattern for another Cargo subcommand. Cargo's normal incremental workspace
+compilations continue to bypass the action cache; dependencies, which Cargo
+normally builds non-incrementally, remain cacheable.
 
 ## Linking is not cached
 

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+setup() {
+  local rustup_home="${RUSTUP_HOME:-}"
+  if command -v rustup >/dev/null 2>&1; then
+    rustup_home="$(rustup show home)"
+  fi
+
+  load "test_helper/common_setup"
+  _common_setup
+
+  if [[ -n "$rustup_home" ]]; then
+    export RUSTUP_HOME="$rustup_home"
+  fi
+  export CARGO_HOME="$BATS_TEST_TMPDIR/cargo-home"
+  export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/mbx-cache"
+  mkdir -p "$CARGO_HOME"
+}
+
+write_project() {
+  local project="$1"
+  mkdir -p "$project/src"
+  cat >"$project/Cargo.toml" <<'EOF'
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"
+EOF
+  cat >"$project/src/lib.rs" <<'EOF'
+pub fn double(value: u32) -> u32 {
+    value * 2
+}
+EOF
+  cargo generate-lockfile --offline --manifest-path "$project/Cargo.toml"
+}
+
+@test "setup installs and configures the persistent wrapper" {
+  mkdir -p "$CARGO_HOME"
+  cat >"$CARGO_HOME/config.toml" <<'EOF'
+# keep me
+[net]
+offline = true
+EOF
+
+  run "$MBX_BIN" setup
+
+  assert_success
+  assert_output --partial "and configured $CARGO_HOME/config.toml"
+  assert_file_contains "$CARGO_HOME/config.toml" "# keep me"
+  assert_file_contains "$CARGO_HOME/config.toml" "offline = true"
+  assert_file_contains "$CARGO_HOME/config.toml" "rustc-wrapper"
+  assert_file_executable "$XDG_DATA_HOME/mbx/bin/mbx-rustc"
+}
+
+@test "setup leaves an existing rustc wrapper unchanged" {
+  cat >"$CARGO_HOME/config.toml" <<'EOF'
+[build]
+rustc-wrapper = "sccache"
+EOF
+
+  run "$MBX_BIN" setup
+
+  assert_success
+  assert_output --partial "left $CARGO_HOME/config.toml unchanged"
+  assert_file_contains "$CARGO_HOME/config.toml" 'rustc-wrapper = "sccache"'
+  assert_file_not_exists "$XDG_DATA_HOME/mbx/bin/mbx-rustc"
+}
+
+@test "the persistent wrapper restores a second checkout without an mbx session" {
+  local first="$BATS_TEST_TMPDIR/first-checkout"
+  local second="$BATS_TEST_TMPDIR/second-checkout"
+  local compiler="$BATS_TEST_TMPDIR/counting-rustc"
+  local rustc_log="$BATS_TEST_TMPDIR/rustc.log"
+  local real_rustc
+  real_rustc="$(command -v rustc)"
+
+  write_project "$first"
+  write_project "$second"
+  cat >"$compiler" <<'EOF'
+#!/bin/sh
+crate_name=0
+for arg in "$@"; do
+  if [ "$crate_name" = 1 ]; then
+    if [ "$arg" = fixture ]; then
+      printf 'compile\n' >>"$MBX_TEST_RUSTC_LOG"
+    fi
+    break
+  fi
+  if [ "$arg" = "--crate-name" ]; then
+    crate_name=1
+  fi
+done
+exec "$MBX_TEST_REAL_RUSTC" "$@"
+EOF
+  chmod +x "$compiler"
+
+  run "$MBX_BIN" setup
+  assert_success
+
+  run env \
+    CARGO_INCREMENTAL=0 \
+    CARGO_TARGET_DIR="$BATS_TEST_TMPDIR/first-target" \
+    MBX_TEST_REAL_RUSTC="$real_rustc" \
+    MBX_TEST_RUSTC_LOG="$rustc_log" \
+    RUSTC="$compiler" \
+    cargo build --offline --manifest-path "$first/Cargo.toml"
+  assert_success
+
+  run env \
+    CARGO_INCREMENTAL=0 \
+    CARGO_TARGET_DIR="$BATS_TEST_TMPDIR/second-target" \
+    MBX_TEST_REAL_RUSTC="$real_rustc" \
+    MBX_TEST_RUSTC_LOG="$rustc_log" \
+    RUSTC="$compiler" \
+    cargo build --offline --manifest-path "$second/Cargo.toml"
+  assert_success
+
+  run grep -c '^compile$' "$rustc_log"
+  assert_success
+  assert_output "1"
+}

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -35,6 +35,7 @@ EOF
 }
 
 @test "setup installs and configures the persistent wrapper" {
+  local wrapper
   mkdir -p "$CARGO_HOME"
   cat >"$CARGO_HOME/config.toml" <<'EOF'
 # keep me
@@ -49,7 +50,9 @@ EOF
   assert_file_contains "$CARGO_HOME/config.toml" "# keep me"
   assert_file_contains "$CARGO_HOME/config.toml" "offline = true"
   assert_file_contains "$CARGO_HOME/config.toml" "rustc-wrapper"
-  assert_file_executable "$XDG_DATA_HOME/mbx/bin/mbx-rustc"
+  wrapper="$(sed -n 's/.*rustc-wrapper = "\([^"]*\)".*/\1/p' "$CARGO_HOME/config.toml")"
+  [[ -n "$wrapper" ]]
+  assert_file_executable "$wrapper"
 }
 
 @test "setup leaves an existing rustc wrapper unchanged" {
@@ -63,7 +66,6 @@ EOF
   assert_success
   assert_output --partial "left $CARGO_HOME/config.toml unchanged"
   assert_file_contains "$CARGO_HOME/config.toml" 'rustc-wrapper = "sccache"'
-  assert_file_not_exists "$XDG_DATA_HOME/mbx/bin/mbx-rustc"
 }
 
 @test "the persistent wrapper restores a second checkout without an mbx session" {


### PR DESCRIPTION
## Summary

- add `mbx setup`, preserving any existing Cargo rustc wrapper
- serve persistent wrapper requests directly from the local CAS without a daemon
- persist sharded action predictions across Cargo wrapper processes
- infer stable workspace and target mappings outside an orchestrated session
- cover setup and cross-checkout restore behavior in the shared Bats harness from #46
- document the local-only standalone behavior and its limits

## Correctness and safety

- standalone mode never contacts a remote cache because it has no session policy or batching boundary
- setup reports an existing wrapper and makes no changes
- incremental workspace compilations continue to bypass; normal non-incremental dependency compilations remain cacheable
- concurrent prediction commits merge only the current run, preventing stale baseline overwrites
- a Bats end-to-end test proves the second of two separate checkout paths restores without invoking rustc

## Stack

- based on #49, which stacks CI final-status and documentation integration over the Bats foundation in #46

## Validation

- `test/bats/bin/bats test`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache key path mapping and prediction persistence across processes; mistakes could cause wrong restores or manifest corruption, though concurrent-commit tests and conservative wrapper bypass mitigate this.
> 
> **Overview**
> Adds **`mbx setup`**, which installs a persistent **`mbx-rustc`** shim and sets Cargo’s global **`build.rustc-wrapper`** (via **`toml_edit`**, atomic writes). If another wrapper is already configured, setup reports it and leaves config unchanged; rerunning refreshes the shim when mbx is already wired.
> 
> **Standalone shim mode** (no **`MBX_SOCKET`**) serves cache agent requests in-process from the local CAS—**local-only**, no remote session. Action predictions use **sharded manifest tasks** (invocation-digest shards when **`MBX_BUILD`** is absent) and **commit after each successful record** so parallel Cargo wrapper processes share predictions without a daemon.
> 
> **Correctness fixes for shared manifests:** task commits merge only **`pending_predictions`** from the current run so concurrent agents don’t republish stale baselines. The rustc shim **infers workspace/target path mappings** outside a session (outer **`Cargo.lock`**, profile tree from output paths, **`--target`** parsing) so cross-checkout keys stay aligned with session mode.
> 
> Docs and Bats cover setup behavior and a second-checkout restore without an mbx session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d245ed275d6342fd1dbdaa2cb7da31936f316245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->