### PR TITLE
docs: define published Rust API surface

### DIFF
--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 base64 = "0.23"
 blake3 = "1"

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -30,8 +30,11 @@ const MAX_PREFETCH_OBJECTS_PER_WAVE: usize = 100_000;
 
 /// Remote action-cache access owned by one task session.
 pub struct AgentRemoteCache {
+    /// Remote protocol client used by the agent.
     pub client: RemoteCacheClient,
+    /// Permitted remote read/write operations.
     pub mode: RemoteCacheMode,
+    /// Directory used for verified downloads before CAS ingestion.
     pub staging_dir: PathBuf,
 }
 
@@ -47,58 +50,90 @@ const MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentRequest {
+    /// Negotiate protocol and application versions.
     Hello {
+        /// Agent protocol version understood by the caller.
         protocol: u8,
+        /// Human-readable mbx client version.
         client_version: String,
     },
     /// Resolve a blob to a session-verified local CAS path.
     FindBlob {
+        /// Blob to resolve.
         digest: CacheDigest,
     },
     /// Resolve blobs to session-verified local CAS paths.
     FindBlobs {
+        /// Blobs to resolve, preserving request order in the response.
         digests: Vec<CacheDigest>,
     },
+    /// Import a file into the local content-addressed store.
     StoreBlob {
+        /// Digest the source must match.
         digest: CacheDigest,
+        /// File to verify and import.
         source: PathBuf,
     },
+    /// Look up an action-result record.
     FindActionResult {
+        /// Action digest to resolve.
         action: CacheDigest,
     },
+    /// Account for a successfully restored cache hit.
     RecordActionHit {
+        /// Action that supplied the outputs.
         action: CacheDigest,
+        /// Restoration work performed by the adapter.
         restore: RestoreStats,
     },
     /// A compilation the adapter declined to cache, grouped by reason.
     RecordBypass {
+        /// Stable, low-cardinality bypass-reason name.
         kind: String,
     },
     /// A compilation the adapter could not look up, having no key to look up
     /// with. Distinct from a bypass: these are cached once compiled.
     RecordUnconsulted,
+    /// Account for a cache hit that was rebuilt for correctness verification.
     RecordActionVerification {
+        /// Whether rebuilt and cached outputs matched.
         matched: bool,
+        /// Restoration work performed before rebuilding.
         restore: RestoreStats,
     },
+    /// Store an action-result record locally and enqueue remote publication.
     StoreActionResult {
+        /// Action-result record to store.
         result: RemoteActionResult,
     },
+    /// Find an earlier input prediction for a task and invocation.
     FindActionPrediction {
+        /// Stable task identity.
         task: String,
+        /// Digest of the compiler invocation without discovered inputs.
         invocation: CacheDigest,
     },
+    /// Record an input prediction after a successful compilation.
     RecordActionPrediction {
+        /// Stable task identity.
         task: String,
+        /// Adapter-owned prediction record.
         prediction: ActionPrediction,
     },
+    /// Find cached identity output for an executable and environment.
     FindExecutableIdentity {
+        /// Executable whose identity command would run.
         executable: PathBuf,
+        /// Environment variables affecting identity output.
         environment: BTreeMap<String, Option<String>>,
     },
+    /// Cache identity output for an executable and environment.
     StoreExecutableIdentity {
+        /// Executable whose identity command ran.
         executable: PathBuf,
+        /// Environment variables affecting identity output.
         environment: BTreeMap<String, Option<String>>,
+        /// Captured identity-command standard output.
         stdout: Vec<u8>,
     },
 }
@@ -119,39 +154,61 @@ pub struct RestoreStats {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentResponse {
+    /// Successful protocol negotiation.
     Hello {
+        /// Agent protocol version.
         protocol: u8,
+        /// Human-readable agent version.
         agent_version: String,
     },
     /// A local CAS path already verified against the requested digest.
     Blob {
+        /// Verified local path, or `None` on a cache miss.
         path: Option<PathBuf>,
     },
     /// Local CAS paths already verified against the requested digests.
     Blobs {
+        /// Verified local paths or misses, in request order.
         paths: Vec<Option<PathBuf>>,
     },
+    /// A blob was stored locally.
     Stored {
+        /// Path of the stored object in the local CAS.
         path: PathBuf,
     },
+    /// Result of an action lookup.
     ActionResult {
+        /// Validated action result, or `None` on a cache miss.
         result: Option<RemoteActionResult>,
     },
+    /// Hit statistics were updated.
     ActionHitRecorded,
+    /// Verification statistics were updated.
     ActionVerificationRecorded,
+    /// Bypass statistics were updated.
     BypassRecorded,
+    /// Unconsulted-compilation statistics were updated.
     UnconsultedRecorded,
+    /// An action result was stored.
     ActionStored {
+        /// Path of the stored local action-result record.
         path: PathBuf,
     },
+    /// Result of an input-prediction lookup.
     ActionPrediction {
+        /// Matching prediction, or `None` when none is known.
         prediction: Option<ActionPrediction>,
     },
+    /// An input prediction was recorded.
     ActionPredictionRecorded,
+    /// Result of an executable-identity lookup.
     ExecutableIdentity {
+        /// Captured output, or `None` when no identity is cached.
         stdout: Option<Vec<u8>>,
     },
+    /// The request failed without terminating the agent connection.
     Error {
+        /// Human-readable failure description.
         message: String,
     },
 }
@@ -222,9 +279,13 @@ pub struct AgentStats {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ActionPrediction {
+    /// Invocation digest used to locate this prediction.
     pub invocation: CacheDigest,
+    /// Full action digest produced when the prediction was recorded.
     pub action: CacheDigest,
+    /// Adapter name that owns and understands `payload`.
     pub adapter: String,
+    /// Adapter-defined serialized input prediction.
     pub payload: String,
 }
 

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -1,3 +1,33 @@
+//! Protocol and storage primitives for mbx build caches.
+//!
+//! This crate contains the types shared by cache clients, the task-scoped
+//! cache agent, and remote cache implementations. Protocol records are
+//! serialized with [`canonical_json`] before hashing; changing their shape is
+//! therefore a wire-format change, not merely an implementation detail.
+//!
+//! Most consumers start with [`CacheDigest`] and the local stores
+//! [`LocalCas`] and [`LocalActionCache`]. Remote clients use
+//! [`RemoteCacheClient`], while mbx's compiler shim communicates with a
+//! [`CacheAgent`] using [`AgentRequest`] and [`AgentResponse`].
+//!
+//! ```
+//! use mbx_cache_core::{CacheDigest, canonical_json};
+//! use serde::Serialize;
+//!
+//! #[derive(Serialize)]
+//! struct Key<'a> {
+//!     compiler: &'a str,
+//!     source: CacheDigest,
+//! }
+//!
+//! let source = CacheDigest::blake3(b"fn main() {}\n");
+//! let bytes = canonical_json(&Key { compiler: "rustc", source })?;
+//! let action = CacheDigest::blake3(&bytes);
+//! assert_eq!(action.algorithm, "blake3");
+//! # Ok::<(), eyre::Report>(())
+//! ```
+#![deny(missing_docs)]
+
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use eyre::{Result, bail, eyre};
 use futures_util::TryStreamExt as _;
@@ -28,15 +58,22 @@ pub use agent::{
 };
 pub use local::{LocalActionCache, LocalCas};
 
+/// Major version of the HTTP cache protocol implemented by this crate.
 pub const PROTOCOL_VERSION: u8 = 1;
 const PROTOCOL_HEADER: &str = "mbx-cache-protocol";
 const NAMESPACE_HEADER: &str = "mbx-cache-namespace";
+/// Media type for canonical [`RemoteActionResult`] JSON records.
 pub const ACTION_RESULT_MEDIA_TYPE: &str = "application/vnd.mbx.cache-action-result.v1+json";
+/// Media type for canonical [`CacheDirectory`] JSON records.
 pub const DIRECTORY_MEDIA_TYPE: &str = "application/vnd.mbx.cache-directory.v1+json";
+/// Media type for adapter-specific action metadata blobs.
 pub const CLIENT_METADATA_MEDIA_TYPE: &str = "application/vnd.mbx.cache-client-metadata.v1+json";
+/// Media type for task-to-action prediction manifests.
 pub const TASK_ACTION_MANIFEST_MEDIA_TYPE: &str =
     "application/vnd.mbx.cache-task-action-manifest.v1+json";
+/// Media type for opaque content-addressed blobs.
 pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
+/// Media type for framed batches of content-addressed blobs.
 pub const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mbx.cache-blob-pack.v1";
 const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mbx.cache-digests.v1+json";
 const BLOB_PACK_BLOBS_HEADER: &str = "mbx-cache-pack-blobs";
@@ -77,43 +114,67 @@ pub fn canonical_json(value: &impl Serialize) -> Result<Vec<u8>> {
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
+/// Operations permitted against a configured remote cache.
 pub enum RemoteCacheMode {
+    /// Permit reads from and writes to the remote cache.
     #[default]
     ReadWrite,
+    /// Permit reads but never publish new objects.
     ReadOnly,
+    /// Publish objects but never satisfy lookups from the remote cache.
     WriteOnly,
 }
 
 impl RemoteCacheMode {
+    /// Whether this mode permits remote cache reads.
     pub fn reads(self) -> bool {
         matches!(self, Self::ReadWrite | Self::ReadOnly)
     }
 
+    /// Whether this mode permits remote cache writes.
     pub fn writes(self) -> bool {
         matches!(self, Self::ReadWrite | Self::WriteOnly)
     }
 }
 
+/// Connection, authentication, and retry settings for [`RemoteCacheClient`].
 pub struct RemoteCacheConfig {
+    /// Base URL of the remote cache service.
     pub base_url: Url,
+    /// Server-side namespace used to isolate cache objects.
     pub namespace: String,
+    /// Static bearer token, if configured directly.
     pub token: Option<String>,
+    /// File containing a bearer token that may be refreshed externally.
     pub token_file: Option<PathBuf>,
+    /// Audience used when obtaining an OIDC token from the CI environment.
     pub oidc_audience: Option<String>,
+    /// Maximum time allowed to establish a connection.
     pub connect_timeout: Duration,
+    /// Maximum time without response progress for ordinary requests.
     pub read_timeout: Duration,
+    /// Overall deadline for an individual blob download attempt.
     pub download_timeout: Duration,
+    /// Number of attempts after the initial request for retryable failures.
     pub retries: i64,
 }
 
+/// Algorithm-tagged digest and byte length of a cache object.
+///
+/// Digests received from an external source should be checked with
+/// [`CacheDigest::validate`] before they are used to construct paths.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct CacheDigest {
+    /// Hash algorithm name (`blake3` or `sha256`).
     pub algorithm: String,
+    /// Lowercase hexadecimal hash value.
     pub hash: String,
+    /// Exact uncompressed object length in bytes.
     pub size: u64,
 }
 
 impl CacheDigest {
+    /// Compute a BLAKE3 digest for an in-memory object.
     pub fn blake3(bytes: &[u8]) -> Self {
         Self {
             algorithm: "blake3".into(),
@@ -132,6 +193,7 @@ impl CacheDigest {
         })
     }
 
+    /// Validate the algorithm name and hexadecimal hash representation.
     pub fn validate(&self) -> Result<()> {
         if self.algorithm != "blake3" && self.algorithm != "sha256" {
             bail!("unsupported remote cache digest algorithm");
@@ -147,6 +209,7 @@ impl CacheDigest {
         Ok(())
     }
 
+    /// Return whether `bytes` have this digest and declared length.
     pub fn matches_bytes(&self, bytes: &[u8]) -> Result<bool> {
         self.validate()?;
         if self.size != bytes.len() as u64 {
@@ -160,6 +223,7 @@ impl CacheDigest {
         Ok(self.hash == hash)
     }
 
+    /// Stream a file and return whether it has this digest and length.
     pub fn matches_file(&self, path: &Path) -> Result<bool> {
         self.validate()?;
         let (hash, size) = match self.algorithm.as_str() {
@@ -207,11 +271,15 @@ fn hash_file_sha256(path: &Path) -> Result<(String, u64)> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RemoteActionResult {
+    /// Digest of the canonical action descriptor this record satisfies.
     pub action: CacheDigest,
+    /// Optional adapter metadata blob, such as [`RustcMetadata`].
     #[serde(default)]
     pub metadata: Option<CacheDigest>,
+    /// Optional digest of the root [`CacheDirectory`] containing outputs.
     #[serde(default)]
     pub output_root: Option<CacheDigest>,
+    /// Action-result schema version.
     pub version: u8,
 }
 
@@ -219,9 +287,13 @@ pub struct RemoteActionResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheDirectory {
+    /// Child directory entries, sorted canonically by name.
     pub directories: Vec<CacheDirectoryNode>,
+    /// Child file entries, sorted canonically by name.
     pub files: Vec<CacheFileNode>,
+    /// Child symbolic-link entries, sorted canonically by name.
     pub symlinks: Vec<CacheSymlinkNode>,
+    /// Directory-object schema version.
     pub version: u8,
 }
 
@@ -229,8 +301,11 @@ pub struct CacheDirectory {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheDirectoryNode {
+    /// Digest of the child [`CacheDirectory`].
     pub digest: CacheDigest,
+    /// Platform mode bits recorded for the directory.
     pub mode: u32,
+    /// Single path-component name within the parent directory.
     pub name: String,
 }
 
@@ -238,9 +313,13 @@ pub struct CacheDirectoryNode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheFileNode {
+    /// Digest of the file contents.
     pub digest: CacheDigest,
+    /// Whether the file should be restored as executable.
     pub executable: bool,
+    /// Platform mode bits recorded for the file.
     pub mode: u32,
+    /// Single path-component name within the parent directory.
     pub name: String,
 }
 
@@ -248,8 +327,11 @@ pub struct CacheFileNode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheSymlinkNode {
+    /// Platform mode bits recorded for the symbolic link.
     pub mode: u32,
+    /// Single path-component name within the parent directory.
     pub name: String,
+    /// Link target text exactly as recorded by the producer.
     pub target: String,
 }
 
@@ -257,36 +339,56 @@ pub struct CacheSymlinkNode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RustcMetadata {
+    /// Metadata schema version.
     pub version: u8,
+    /// Adapter-defined output kind.
     pub kind: String,
+    /// Digest of captured compiler standard output.
     pub stdout: CacheDigest,
+    /// Digest of captured compiler standard error.
     pub stderr: CacheDigest,
 }
 
+/// Backing data for a blob upload.
 pub enum BlobSource {
+    /// Bytes held in memory.
     Bytes(Vec<u8>),
+    /// A temporary file whose lifetime is owned by the upload.
     File(tempfile::NamedTempFile),
+    /// A persistent file at the given path.
     Path(PathBuf),
 }
 
+/// A digest paired with the data to upload under that digest.
 pub struct BlobUpload {
+    /// Expected digest and length of the source data.
     pub digest: CacheDigest,
+    /// Data source read by [`RemoteCacheClient::put_blob`].
     pub source: BlobSource,
 }
 
+/// Task action-manifest bytes returned with their concurrency token.
 pub struct RemoteActionManifest {
+    /// Raw canonical manifest JSON.
     pub bytes: Vec<u8>,
+    /// Entity tag used for conditional manifest replacement.
     pub etag: String,
 }
 
 /// A verified set of remote CAS objects downloaded through blob-pack streams.
 pub struct RemoteBlobPack {
     _directory: tempfile::TempDir,
+    /// Verified blobs paired with paths in this pack's temporary directory.
     pub blobs: Vec<(CacheDigest, PathBuf)>,
+    /// Number of HTTP pack requests needed to retrieve the requested set.
     pub requests: u64,
+    /// Unique digests requested from the remote service.
     pub requested: Vec<CacheDigest>,
+    /// Number of verified blob frames received.
     pub blob_count: u64,
+    /// Total unframed blob payload bytes received.
     pub payload_bytes: u64,
+    /// Total bytes received including framing.
     pub framed_bytes: u64,
 }
 
@@ -423,11 +525,18 @@ struct DigestList<'a> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Result of a conditional task-manifest write.
 pub enum ManifestPutOutcome {
+    /// The manifest was stored.
     Stored,
+    /// The supplied entity-tag precondition did not match.
     PreconditionFailed,
 }
 
+/// HTTP client for the mbx remote cache protocol.
+///
+/// The client validates digests, response sizes, media types, and redirects at
+/// the protocol boundary. It is safe to share between asynchronous tasks.
 pub struct RemoteCacheClient {
     base_url: Url,
     namespace: String,
@@ -440,6 +549,7 @@ pub struct RemoteCacheClient {
 }
 
 impl RemoteCacheClient {
+    /// Construct a client and validate its URL and authentication settings.
     pub fn new(config: RemoteCacheConfig) -> Result<Self> {
         let authenticated = config
             .token
@@ -687,6 +797,7 @@ impl RemoteCacheClient {
             .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
     }
 
+    /// Fetch and validate an action-result record, returning `None` on a miss.
     pub async fn get_action_result(
         &self,
         action: &CacheDigest,
@@ -713,6 +824,7 @@ impl RemoteCacheClient {
         Ok(result)
     }
 
+    /// Canonically serialize and store an action-result record.
     pub async fn put_action_result(&self, result: &RemoteActionResult) -> Result<()> {
         let url = self.action_result_endpoint(&result.action)?;
         let body = serde_json::to_vec(result)?;
@@ -733,6 +845,7 @@ impl RemoteCacheClient {
         .await
     }
 
+    /// Fetch a task action manifest and the entity tag needed to update it.
     pub async fn get_action_manifest(
         &self,
         key: &CacheDigest,
@@ -762,6 +875,7 @@ impl RemoteCacheClient {
         .await
     }
 
+    /// Store a task action manifest, optionally requiring an entity-tag match.
     pub async fn put_action_manifest(
         &self,
         key: &CacheDigest,
@@ -796,6 +910,7 @@ impl RemoteCacheClient {
         .await
     }
 
+    /// Download a small blob into memory and verify its digest.
     pub async fn get_blob(
         &self,
         digest: &CacheDigest,
@@ -828,6 +943,7 @@ impl RemoteCacheClient {
         .await
     }
 
+    /// Download a blob to a temporary file and verify its digest.
     pub async fn get_blob_file(
         &self,
         digest: &CacheDigest,
@@ -866,6 +982,7 @@ impl RemoteCacheClient {
             .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
     }
 
+    /// Verify and upload a content-addressed blob.
     pub async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
         let url = self.blob_endpoint(&upload.digest)?;
         // A failed negotiation downgrades to identity rather than failing the

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -29,7 +29,9 @@ impl DepInfoCommand {
 /// The source and environment inputs reported by rustc's dep-info output.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RustcDepInfo {
+    /// Source paths listed in the first dep-info dependency rule.
     pub files: Vec<PathBuf>,
+    /// Environment inputs recorded by rustc `# env-dep:` lines.
     pub environment: BTreeMap<String, Option<String>>,
 }
 
@@ -127,7 +129,9 @@ impl RustcDepInfo {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveredInputs {
     working_dir: PathBuf,
+    /// Content-addressed compiler input files.
     pub inputs: Vec<ActionInput>,
+    /// Environment inputs captured from dep-info.
     pub environment: BTreeMap<String, Option<String>>,
 }
 

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -1,3 +1,33 @@
+//! Conservative parsing and action-key construction for `rustc` invocations.
+//!
+//! The adapter deliberately rejects any compiler option whose effect on the
+//! action key is unknown. Callers should treat [`BypassReason`] as a safe cache
+//! bypass, run the real compiler, and avoid publishing an action result.
+//!
+//! A typical integration parses an invocation, discovers precise inputs from
+//! rustc dep-info with [`RustcInvocation::discover_inputs`], adds them to an
+//! [`ActionContext`], and finally calls [`RustcInvocation::action`]. Path
+//! mappings make workspace-local absolute paths stable across machines.
+//!
+//! ```
+//! use mbx_cache_rustc::{PathMapping, normalize_mapped_path};
+//! use std::path::Path;
+//!
+//! let mappings = PathMapping::ordered(&[
+//!     PathMapping::new("/work/project", "workspace"),
+//! ]);
+//! assert_eq!(
+//!     normalize_mapped_path(
+//!         Path::new("src/lib.rs"),
+//!         Path::new("/work/project"),
+//!         &mappings,
+//!     )?,
+//!     "${workspace}/src/lib.rs",
+//! );
+//! # Ok::<(), mbx_cache_rustc::BypassReason>(())
+//! ```
+#![deny(missing_docs)]
+
 use mbx_cache_core::{CacheDigest, canonical_json};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -9,7 +39,9 @@ mod dep_info;
 
 pub use dep_info::{DepInfoCommand, DiscoveredInputs, RustcDepInfo};
 
+/// Schema version embedded in canonical rustc action descriptors.
 pub const ACTION_SCHEMA_VERSION: u8 = 1;
+/// Version of the rustc argument and input model used to construct keys.
 pub const ADAPTER_VERSION: u8 = 1;
 
 impl BypassReason {
@@ -57,85 +89,143 @@ const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
 
 #[derive(Debug, Clone, PartialEq, Eq, Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
+/// Reason an invocation cannot safely use the action cache.
+///
+/// A bypass is an expected conservative outcome, not necessarily a compiler
+/// error. Variants carry diagnostic context while [`BypassReason::kind`]
+/// provides a stable aggregation key.
 pub enum BypassReason {
+    /// An argument cannot be represented in the canonical UTF-8 key.
     #[error("rustc argument {index} is not valid UTF-8")]
-    NonUtf8Argument { index: usize },
+    NonUtf8Argument {
+        /// Zero-based index in the argument slice.
+        index: usize,
+    },
+    /// The invocation uses a response file, whose contents are not modeled.
     #[error("rustc response files are not supported: {0}")]
     ResponseFile(String),
+    /// A compiler flag is not modeled by this adapter version.
     #[error("rustc flag is not modeled by the cache adapter: {0}")]
     UnknownFlag(String),
+    /// A `-C` option is not modeled by this adapter version.
     #[error("rustc codegen option is not modeled by the cache adapter: {0}")]
     UnknownCodegenOption(String),
+    /// A recognized flag was not followed by its required value.
     #[error("rustc flag requires a value: {0}")]
     MissingValue(String),
+    /// The invocation queries compiler information instead of compiling.
     #[error("rustc invocation is a compiler query, not a compilation")]
     CompilerQuery,
+    /// Source would be read from standard input and cannot be rediscovered.
     #[error("rustc invocation reads source from standard input")]
     StandardInput,
+    /// No Rust source input was supplied.
     #[error("rustc invocation has no source input")]
     MissingInput,
+    /// More than one source input was supplied.
     #[error("rustc invocation has multiple source inputs")]
     MultipleInputs,
+    /// Incremental state makes the outputs unsuitable for action caching.
     #[error("incremental compilation cannot be combined with action caching")]
     Incremental,
+    /// The requested crate type is outside the supported cacheability tier.
     #[error("rustc crate type is not cacheable yet: {0}")]
     UnsupportedCrateType(String),
+    /// The requested emit kind is outside the supported cacheability tier.
     #[error("rustc output type is not cacheable yet: {0}")]
     UnsupportedEmit(String),
+    /// The invocation emits neither an rlib nor metadata artifact.
     #[error("rustc invocation does not emit an rlib or metadata artifact")]
     NoCacheableOutput,
+    /// The invocation does not emit the dep-info needed for input discovery.
     #[error("rustc invocation does not emit dependency information")]
     NoDepInfo,
+    /// Outputs cannot be represented as one cache directory.
     #[error("rustc output paths do not share one directory")]
     SplitOutputDirectories,
+    /// An output path does not name a file.
     #[error("rustc output path has no file name: {0}")]
     InvalidOutputPath(PathBuf),
+    /// `-o` leaves the name of an implicit emit ambiguous.
     #[error("rustc -o with an emit that has no explicit path is not modeled: {0}")]
     ImplicitEmitWithOutputFile(PathBuf),
+    /// Native-library lookup is not modeled as a precise input.
     #[error("native library lookup is not cacheable yet")]
     NativeLibrary,
+    /// A library search-path kind is not modeled.
     #[error("rustc search path kind is not cacheable yet: {0}")]
     UnsupportedSearchPath(String),
+    /// An extern name does not resolve to a concrete input artifact.
     #[error("rustc extern does not identify an input artifact: {0}")]
     UnresolvedExtern(String),
+    /// An absolute path has no stable placeholder mapping.
     #[error("absolute path has no stable cache mapping: {0}")]
     UnmappedAbsolutePath(PathBuf),
+    /// A path cannot be represented in a canonical UTF-8 action key.
     #[error("cache key paths must be valid UTF-8: {0}")]
     NonUtf8Path(PathBuf),
+    /// The action working directory is not absolute.
     #[error("cache action working directory must be absolute: {0}")]
     RelativeWorkingDirectory(PathBuf),
+    /// A path-mapping root is not absolute.
     #[error("cache path mapping must use an absolute root: {0}")]
     RelativePathMapping(PathBuf),
+    /// A mapping placeholder is empty or contains unsafe characters.
     #[error("cache path mapping placeholder is invalid: {0}")]
     InvalidPathPlaceholder(String),
+    /// An input referenced by compiler arguments is missing from the context.
     #[error("required compiler input was not provided: {0}")]
     MissingRequiredInput(String),
+    /// A supplied compiler-input digest is malformed.
     #[error("compiler input has an invalid digest: {0}")]
     InvalidInputDigest(String),
+    /// One normalized input path has multiple distinct digests.
     #[error("compiler input appears more than once with different content: {0}")]
     ConflictingInput(String),
+    /// rustc dep-info does not follow the supported format.
     #[error("rustc dep-info is malformed: {0}")]
     MalformedDepInfo(String),
+    /// A dep-info file could not be read as UTF-8 text.
     #[error("failed to read rustc dep-info {path}: {message}")]
-    DepInfoRead { path: PathBuf, message: String },
+    DepInfoRead {
+        /// Dep-info file path.
+        path: PathBuf,
+        /// Underlying I/O or decoding error.
+        message: String,
+    },
+    /// The requested dep-info output path is not absolute.
     #[error("rustc dep-info output path must be absolute: {0}")]
     RelativeDepInfoPath(PathBuf),
+    /// A dep-info output path contains a comma and cannot be safely rendered.
     #[error("rustc dep-info output path cannot contain a comma: {0}")]
     UnsafeDepInfoPath(PathBuf),
+    /// A discovered compiler input could not be read or was not a file.
     #[error("failed to read compiler input {path}: {message}")]
-    InputRead { path: PathBuf, message: String },
+    InputRead {
+        /// Compiler-input path.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        message: String,
+    },
+    /// Input contents changed after they were hashed.
     #[error("compiler input changed after discovery: {0}")]
     InputChanged(PathBuf),
+    /// An input's modification time overlaps the compiler execution.
     #[error("compiler input was modified during compilation: {0}")]
     InputModifiedDuringCompilation(PathBuf),
+    /// Discovered inputs and the action use different working directories.
     #[error("discovered inputs were collected from a different working directory")]
     DiscoveryWorkingDirectory,
+    /// One observed environment input has conflicting values.
     #[error("compiler environment input has conflicting values: {0}")]
     ConflictingEnvironment(String),
+    /// Canonical action serialization failed.
     #[error("failed to serialize the rustc action: {0}")]
     Serialization(String),
+    /// The stored prediction uses an unsupported version or exceeds limits.
     #[error("rustc action prediction is unsupported")]
     UnsupportedPrediction,
+    /// A normalized predicted path cannot be mapped back to the host.
     #[error("rustc action prediction contains an invalid input path: {0}")]
     InvalidPredictedInput(String),
 }
@@ -157,6 +247,10 @@ struct Emit {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Parsed, cache-safe model of one `rustc` command line.
+///
+/// Fields are intentionally private so new modeled flags can be added without
+/// exposing the adapter's internal representation.
 pub struct RustcInvocation {
     arguments: Vec<Argument>,
     source: PathBuf,
@@ -171,8 +265,11 @@ pub struct RustcInvocation {
 /// The cacheable files and dependency manifest produced by a rustc invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustcOutputs {
+    /// Common directory containing all modeled outputs.
     pub directory: PathBuf,
+    /// Cacheable rlib and/or metadata files.
     pub files: Vec<PathBuf>,
+    /// Dep-info file used for precise input discovery.
     pub dep_info: PathBuf,
 }
 
@@ -323,8 +420,11 @@ impl RustcInvocation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Mapping from a host-specific absolute root to a stable key placeholder.
 pub struct PathMapping {
+    /// Absolute host path to replace.
     pub root: PathBuf,
+    /// Placeholder name without the surrounding `${...}` syntax.
     pub placeholder: String,
 }
 
@@ -377,23 +477,35 @@ pub fn normalize_mapped_path(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Compiler properties that distinguish incompatible action outputs.
 pub struct CompilerIdentity {
+    /// Toolchain selector or installation identity.
     pub toolchain: String,
+    /// Complete verbose rustc version string.
     pub rustc_version: String,
+    /// Compiler host target triple.
     pub host: String,
 }
 
+/// One file input paired with the digest used in the action key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActionInput {
+    /// Absolute host path used to read and verify the input.
     pub path: PathBuf,
+    /// Digest of the input contents.
     pub digest: CacheDigest,
 }
 
+/// External information needed to construct a canonical rustc action.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActionContext {
+    /// Identity of the compiler that produces the outputs.
     pub compiler: CompilerIdentity,
+    /// Absolute directory in which rustc runs.
     pub working_dir: PathBuf,
+    /// Host roots replaced with stable placeholders in the key.
     pub path_mappings: Vec<PathMapping>,
+    /// Environment inputs and their observed values.
     pub environment: BTreeMap<String, Option<String>>,
     /// Environment inputs whose absolute values the compilation has been made
     /// independent of, and whose values the key therefore normalizes.
@@ -402,12 +514,16 @@ pub struct ActionContext {
     /// caller must both neutralize the value inside it (with
     /// `--remap-path-prefix`) and confirm no output carries the value anyway.
     pub portable_environment: BTreeSet<String>,
+    /// Complete set of direct and discovered file inputs.
     pub inputs: Vec<ActionInput>,
 }
 
+/// Canonical action descriptor and its content digest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustcAction {
+    /// Digest of `bytes`, used as the action-cache key.
     pub digest: CacheDigest,
+    /// Canonical serialized action descriptor.
     pub bytes: Vec<u8>,
 }
 
@@ -416,8 +532,11 @@ pub struct RustcAction {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RustcInputPrediction {
+    /// Prediction schema version.
     pub version: u8,
+    /// Normalized input paths observed during the successful invocation.
     pub inputs: Vec<String>,
+    /// Names of environment variables read by the compilation.
     pub environment: Vec<String>,
 }
 

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 bytesize = "2"
 demand = "2"

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -3,6 +3,10 @@
 //! Compilations are cached as individual rustc actions in a content-addressed
 //! store shared by every project and worktree on a machine, and optionally
 //! shared further through a remote cache.
+//!
+//! This library target exists so the executable and integration tests can
+//! share application code; it is not a stable embedding API. Applications
+//! should use `mbx-cache-core` or `mbx-cache-rustc` instead.
 
 pub mod cli;
 pub mod config;


### PR DESCRIPTION
## Summary

- document the published `mbx-cache-core` protocol, CAS, remote client, and agent API
- document the conservative rustc adapter model and every bypass contract
- enforce complete public documentation for both library crates with `#![deny(missing_docs)]`
- add tested crate-level examples and docs.rs all-feature builds
- clarify that the `mbx` library target is application-sharing code rather than the supported embedding API

## Verification

- `cargo fmt --all`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and `#![deny(missing_docs)]` only; no changes to cache protocol, security, or runtime logic.
> 
> **Overview**
> This PR **documents the supported library APIs** for `mbx-cache-core` and `mbx-cache-rustc` and makes missing public docs a **build failure** via `#![deny(missing_docs)]` on both crates.
> 
> **`mbx-cache-core`** gets a crate-level overview (protocol hashing, CAS, remote client, agent wire types) plus rustdoc on agent request/response enums, remote cache types, digests, and `RemoteCacheClient` methods. **`mbx-cache-rustc`** documents the conservative adapter model, every **`BypassReason`** variant, and key types like `RustcInvocation` and `ActionContext`. Each library crate adds a **doctest example** at the root.
> 
> **docs.rs** is configured with **`all-features = true`** on `mbx-cache-core`, `mbx-cache-rustc`, and `mbx`. The **`mbx` lib** crate docs now state it is internal sharing for the binary/tests, not a stable embed API—callers should use the cache crates instead.
> 
> No runtime or protocol behavior changes; this is documentation and doc-build policy only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae7117dc363d248036c166cef156f3205fbe72b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->