### PR TITLE
perf(cache): avoid rereading reflinked outputs

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -113,6 +113,14 @@ pub struct RestoreStats {
     pub output_files: u64,
     /// Declared size of compiler output files restored.
     pub output_bytes: u64,
+    /// Number of restored output files that share data blocks with the CAS.
+    pub reflinked_output_files: u64,
+    /// Declared size of restored outputs that share data blocks with the CAS.
+    pub reflinked_output_bytes: u64,
+    /// Number of restored output files that required a byte-for-byte copy.
+    pub copied_output_files: u64,
+    /// Declared size of restored outputs that required a byte-for-byte copy.
+    pub copied_output_bytes: u64,
 }
 
 /// A response returned by the task-scoped cache agent.
@@ -215,6 +223,14 @@ pub struct AgentStats {
     pub restored_output_files: u64,
     /// Declared size of compiler output files restored from action hits.
     pub restored_output_bytes: u64,
+    /// Number of restored output files materialized with filesystem reflinks.
+    pub reflinked_output_files: u64,
+    /// Declared size of outputs materialized with filesystem reflinks.
+    pub reflinked_output_bytes: u64,
+    /// Number of restored output files materialized by copying their bytes.
+    pub copied_output_files: u64,
+    /// Declared size of outputs materialized by copying their bytes.
+    pub copied_output_bytes: u64,
 }
 
 /// Adapter-owned data needed to reconstruct an action before fresh dependency
@@ -255,6 +271,10 @@ struct AtomicAgentStats {
     bypasses: Mutex<BTreeMap<String, u64>>,
     restored_output_files: AtomicU64,
     restored_output_bytes: AtomicU64,
+    reflinked_output_files: AtomicU64,
+    reflinked_output_bytes: AtomicU64,
+    copied_output_files: AtomicU64,
+    copied_output_bytes: AtomicU64,
 }
 
 struct AtomicDurationTimer<'a> {
@@ -740,6 +760,10 @@ impl CacheAgent {
                 .load(Ordering::Relaxed),
             restored_output_files: self.stats.restored_output_files.load(Ordering::Relaxed),
             restored_output_bytes: self.stats.restored_output_bytes.load(Ordering::Relaxed),
+            reflinked_output_files: self.stats.reflinked_output_files.load(Ordering::Relaxed),
+            reflinked_output_bytes: self.stats.reflinked_output_bytes.load(Ordering::Relaxed),
+            copied_output_files: self.stats.copied_output_files.load(Ordering::Relaxed),
+            copied_output_bytes: self.stats.copied_output_bytes.load(Ordering::Relaxed),
         }
     }
 
@@ -1656,6 +1680,16 @@ impl CacheAgent {
         self.record_materialization(restore);
         atomic_saturating_add(&self.stats.restored_output_files, restore.output_files);
         atomic_saturating_add(&self.stats.restored_output_bytes, restore.output_bytes);
+        atomic_saturating_add(
+            &self.stats.reflinked_output_files,
+            restore.reflinked_output_files,
+        );
+        atomic_saturating_add(
+            &self.stats.reflinked_output_bytes,
+            restore.reflinked_output_bytes,
+        );
+        atomic_saturating_add(&self.stats.copied_output_files, restore.copied_output_files);
+        atomic_saturating_add(&self.stats.copied_output_bytes, restore.copied_output_bytes);
     }
 
     fn record_materialization(&self, restore: RestoreStats) {
@@ -2215,6 +2249,10 @@ mod tests {
                         duration_ns: 7,
                         output_files: 2,
                         output_bytes: 11,
+                        reflinked_output_files: 1,
+                        reflinked_output_bytes: 7,
+                        copied_output_files: 1,
+                        copied_output_bytes: 4,
                     },
                 })
                 .await,
@@ -2228,6 +2266,10 @@ mod tests {
                 materialization_duration_ns: 7,
                 restored_output_files: 2,
                 restored_output_bytes: 11,
+                reflinked_output_files: 1,
+                reflinked_output_bytes: 7,
+                copied_output_files: 1,
+                copied_output_bytes: 4,
                 ..AgentStats::default()
             }
         );
@@ -2273,6 +2315,7 @@ mod tests {
                         duration_ns: 7,
                         output_files: 2,
                         output_bytes: 11,
+                        ..RestoreStats::default()
                     },
                 })
                 .await,

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(cache)* restore verified outputs with observable copy-on-write materialization
+
 ## [0.3.0](https://github.com/jdx/mr-boxington/compare/v0.2.0...v0.3.0) - 2026-08-23
 
 ### Added

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -35,6 +35,12 @@ struct StagedOutputs {
     files: Vec<(tempfile::TempPath, PathBuf)>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Materialization {
+    Reflink,
+    Copy,
+}
+
 pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
     let working_dir = std::env::current_dir()?;
     let portable = Portable::detect(&working_dir);
@@ -458,8 +464,27 @@ fn restore_result(
     std::fs::create_dir_all(&outputs.directory)?;
     let staging = tempfile::tempdir_in(&outputs.directory)?;
     let mut staged = Vec::with_capacity(files.len());
+    let mut restore = RestoreStats {
+        output_files: restored_output_files,
+        output_bytes: restored_output_bytes,
+        ..RestoreStats::default()
+    };
     for (index, ((node, destination), source)) in files.into_iter().zip(&blobs[2..]).enumerate() {
-        let temporary = stage_cached_output(staging.path(), index, source, &node)?;
+        let (temporary, materialization) =
+            stage_verified_cached_output(staging.path(), index, source, &node)?;
+        match materialization {
+            Materialization::Reflink => {
+                restore.reflinked_output_files = restore.reflinked_output_files.saturating_add(1);
+                restore.reflinked_output_bytes = restore
+                    .reflinked_output_bytes
+                    .saturating_add(node.digest.size);
+            }
+            Materialization::Copy => {
+                restore.copied_output_files = restore.copied_output_files.saturating_add(1);
+                restore.copied_output_bytes =
+                    restore.copied_output_bytes.saturating_add(node.digest.size);
+            }
+        }
         staged.push((temporary, destination));
     }
     let staged = StagedOutputs {
@@ -470,15 +495,11 @@ fn restore_result(
     discovered.verify()?;
     verify_environment(&discovered.environment)?;
     finalize_restored_outputs(staged, restore_outputs)?;
-    let restore = RestoreStats {
-        duration_ns: materialization_started
-            .elapsed()
-            .as_nanos()
-            .try_into()
-            .unwrap_or(u64::MAX),
-        output_files: restored_output_files,
-        output_bytes: restored_output_bytes,
-    };
+    restore.duration_ns = materialization_started
+        .elapsed()
+        .as_nanos()
+        .try_into()
+        .unwrap_or(u64::MAX);
     if restore_outputs {
         record_action_hit(&action.digest, restore);
     }
@@ -497,29 +518,43 @@ fn finalize_restored_outputs(staged: StagedOutputs, restore_outputs: bool) -> Re
     Ok(())
 }
 
-fn stage_cached_output(
+fn stage_verified_cached_output(
     directory: &Path,
     index: usize,
     source: &Path,
     node: &CacheFileNode,
-) -> Result<tempfile::TempPath> {
+) -> Result<(tempfile::TempPath, Materialization)> {
     let temporary = directory.join(format!("output-{index}"));
-    reflink_copy::reflink_or_copy(source, &temporary)
+    let copied_bytes = reflink_copy::reflink_or_copy(source, &temporary)
         .wrap_err_with(|| format!("failed to materialize cached rustc output {}", node.name))?;
+    let materialization = match copied_bytes {
+        None => Materialization::Reflink,
+        Some(written) if written == node.digest.size => Materialization::Copy,
+        Some(_) => bail!(
+            "materialized cached rustc output has the wrong size: {}",
+            node.name
+        ),
+    };
     let temporary = tempfile::TempPath::try_from_path(temporary)?;
     make_owner_writable(&temporary)?;
     // Deliberately not fsynced. These are build artifacts in a target
     // directory, and cargo does not sync its own outputs either, so syncing
     // here buys no durability the build relies on -- it only costs one fsync
     // per restored file, which on a large workspace is most of the restore.
-    if !node.digest.matches_file(&temporary)? {
+    // `source` is a session-verified CAS path returned by `FindBlobs`. Hashing
+    // the result again would read every output a second time and, for a
+    // reflink, eagerly fault the shared data blocks that cloning was intended
+    // to leave deferred. A reflink is a CoW snapshot and the copy fallback
+    // reports the number of bytes it wrote, so checking the staged length is
+    // sufficient after the agent's content verification.
+    if std::fs::metadata(&temporary)?.len() != node.digest.size {
         bail!(
-            "cached rustc output failed digest verification: {}",
+            "materialized cached rustc output has the wrong size: {}",
             node.name
         );
     }
     apply_file_mode(&temporary, node.mode)?;
-    Ok(temporary)
+    Ok((temporary, materialization))
 }
 
 fn cached_matches(cached: &CachedCompilation, output: &Output) -> bool {
@@ -1376,7 +1411,7 @@ mod tests {
         let staging = tempfile::tempdir_in(root.path()).unwrap();
         let node = test_file("artifact.rlib");
 
-        let output = stage_cached_output(staging.path(), 0, &source, &node).unwrap();
+        let (output, _) = stage_verified_cached_output(staging.path(), 0, &source, &node).unwrap();
         std::fs::write(&output, b"modified").unwrap();
 
         assert_eq!(std::fs::read(source).unwrap(), b"artifact");
@@ -1384,14 +1419,14 @@ mod tests {
     }
 
     #[test]
-    fn rejects_same_size_corrupt_cached_outputs() {
+    fn rejects_cached_outputs_with_the_wrong_size() {
         let root = tempfile::tempdir().unwrap();
         let source = root.path().join("cas-blob");
-        std::fs::write(&source, b"corrupt!").unwrap();
+        std::fs::write(&source, b"short").unwrap();
         let staging = tempfile::tempdir_in(root.path()).unwrap();
         let node = test_file("artifact.rlib");
 
-        assert!(stage_cached_output(staging.path(), 0, &source, &node).is_err());
+        assert!(stage_verified_cached_output(staging.path(), 0, &source, &node).is_err());
     }
 
     #[test]
@@ -1405,7 +1440,7 @@ mod tests {
         let staging = tempfile::tempdir_in(root.path()).unwrap();
         let node = test_file("artifact.rlib");
 
-        let output = stage_cached_output(staging.path(), 0, &source, &node).unwrap();
+        let (output, _) = stage_verified_cached_output(staging.path(), 0, &source, &node).unwrap();
 
         assert_eq!(std::fs::read(output).unwrap(), b"artifact");
         assert!(std::fs::metadata(&source).unwrap().permissions().readonly());
@@ -1450,28 +1485,31 @@ mod tests {
             name: "artifact.rlib".into(),
         };
 
-        let started = std::time::Instant::now();
-        for _ in 0..iterations {
-            let mut temporary = tempfile::NamedTempFile::new_in(root.path()).unwrap();
-            let mut input = std::fs::File::open(&source).unwrap();
-            std::io::copy(&mut input, temporary.as_file_mut()).unwrap();
-            temporary.flush().unwrap();
-            temporary.as_file().sync_all().unwrap();
-            assert!(digest.matches_file(temporary.path()).unwrap());
-            apply_file_mode(temporary.path(), node.mode).unwrap();
-        }
-        let copied = started.elapsed();
-
         let staging = tempfile::tempdir_in(root.path()).unwrap();
         let started = std::time::Instant::now();
         for _ in 0..iterations {
-            stage_cached_output(staging.path(), 0, &source, &node).unwrap();
+            let temporary = staging.path().join("legacy-output");
+            reflink_copy::reflink_or_copy(&source, &temporary).unwrap();
+            let temporary = tempfile::TempPath::try_from_path(temporary).unwrap();
+            make_owner_writable(&temporary).unwrap();
+            assert!(digest.matches_file(&temporary).unwrap());
+            apply_file_mode(&temporary, node.mode).unwrap();
+        }
+        let legacy = started.elapsed();
+
+        let staging = tempfile::tempdir_in(root.path()).unwrap();
+        let started = std::time::Instant::now();
+        let mut method = None;
+        for _ in 0..iterations {
+            let (_, observed) =
+                stage_verified_cached_output(staging.path(), 0, &source, &node).unwrap();
+            method = Some(observed);
         }
         let materialized = started.elapsed();
 
         println!(
-            "materialized {iterations} x {size_mib} MiB: copied={copied:.2?}, reflink_or_copy={materialized:.2?}, speedup={:.2}x",
-            copied.as_secs_f64() / materialized.as_secs_f64()
+            "materialized {iterations} x {size_mib} MiB with {method:?}: legacy_reverify={legacy:.2?}, verified_cas={materialized:.2?}, speedup={:.2}x",
+            legacy.as_secs_f64() / materialized.as_secs_f64()
         );
     }
 }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -303,6 +303,10 @@ struct StatsReport {
     stored_bytes: u64,
     restored_output_files: u64,
     restored_output_bytes: u64,
+    reflinked_output_files: u64,
+    reflinked_output_bytes: u64,
+    copied_output_files: u64,
+    copied_output_bytes: u64,
     remote_manifest_lookups: u64,
     remote_action_lookups: u64,
     remote_blob_requests: u64,
@@ -336,6 +340,10 @@ impl From<&AgentStats> for StatsReport {
             stored_bytes: stats.stored_bytes,
             restored_output_files: stats.restored_output_files,
             restored_output_bytes: stats.restored_output_bytes,
+            reflinked_output_files: stats.reflinked_output_files,
+            reflinked_output_bytes: stats.reflinked_output_bytes,
+            copied_output_files: stats.copied_output_files,
+            copied_output_bytes: stats.copied_output_bytes,
             remote_manifest_lookups: stats.remote_manifest_lookups,
             remote_action_lookups: stats.remote_action_lookups,
             remote_blob_requests: stats.remote_blob_requests,
@@ -414,6 +422,15 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         format_nanos(stats.local_cas_write_duration_ns),
         format_nanos(stats.materialization_duration_ns),
     ));
+    if stats.restored_output_files > 0 {
+        note(&format!(
+            "cache materialization: {} outputs ({}) reflinked, {} outputs ({}) copied",
+            stats.reflinked_output_files,
+            ByteSize::b(stats.reflinked_output_bytes).display().iec(),
+            stats.copied_output_files,
+            ByteSize::b(stats.copied_output_bytes).display().iec(),
+        ));
+    }
     if stats.verifications > 0 {
         note(&format!(
             "cache qualification: {} verified, {} diverged",
@@ -1180,6 +1197,10 @@ mod tests {
             downloaded_bytes: 1024,
             restored_output_files: 7,
             restored_output_bytes: 2048,
+            reflinked_output_files: 5,
+            reflinked_output_bytes: 1536,
+            copied_output_files: 2,
+            copied_output_bytes: 512,
             remote_blob_requests: 4,
             remote_blob_pack_requests: 2,
             remote_blob_pack_blobs: 100,
@@ -1200,6 +1221,10 @@ mod tests {
         assert_eq!(report["downloaded_bytes"], 1024);
         assert_eq!(report["restored_output_files"], 7);
         assert_eq!(report["restored_output_bytes"], 2048);
+        assert_eq!(report["reflinked_output_files"], 5);
+        assert_eq!(report["reflinked_output_bytes"], 1536);
+        assert_eq!(report["copied_output_files"], 2);
+        assert_eq!(report["copied_output_bytes"], 512);
         assert_eq!(report["remote_blob_requests"], 4);
         assert_eq!(report["remote_blob_pack_requests"], 2);
         assert_eq!(report["remote_blob_pack_blobs"], 100);

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -28,6 +28,28 @@ prediction for later invocations. A genuinely cold compilation may therefore
 have no key to look up yet. It still gets stored after compiling and can warm
 the next build.
 
+## Copy-on-write output restoration
+
+The cache agent verifies each local CAS blob against its digest before returning
+it to the rustc wrapper. The wrapper first tries to reflink that verified blob
+into a staging directory beside Cargo's destination, applies the expected file
+mode, and atomically renames it into place. A reflink is an ordinary file that
+shares its data blocks with the CAS until either copy is written, so Cargo sees
+the complete output immediately without the wrapper re-reading or allocating
+all of its data after verification. Writes to a restored output cannot change
+the CAS object.
+
+Reflinks require support from the filesystem and generally require the cache
+and target directory to be on the same filesystem. When cloning is unavailable,
+mbx transparently copies the bytes instead. The session summary reports the
+file count and logical size handled by each path; `MBX_STATS_REPORT` includes
+the same values as `reflinked_output_files`, `reflinked_output_bytes`,
+`copied_output_files`, and `copied_output_bytes`.
+
+This is filesystem copy-on-write, not a placeholder or userspace on-demand
+filesystem. Restored paths retain normal file semantics on every supported
+platform, including when mbx has to use the copy fallback.
+
 ## Correctness first
 
 Unsupported crate types, unmodeled search paths, linking, and incremental


### PR DESCRIPTION
## Summary

- trust the cache agent's immediately preceding digest verification when staging a verified CAS output, removing the wrapper's redundant full-file hash
- preserve atomic Cargo-visible files and CAS independence with filesystem CoW, with a transparent byte-copy fallback when reflinks are unavailable
- report reflinked versus copied file counts and logical bytes in the session summary and `MBX_STATS_REPORT`
- document the exact CoW behavior and its portability boundary
- update the ignored local benchmark to compare the old post-clone re-verification path with the new verified-CAS path

## Correctness

The cache agent still verifies every local CAS blob against its declared digest before returning its path. Staging verifies the resulting length and the copy fallback's reported byte count, applies the cached mode, and atomically persists all outputs. A test mutates the restored output and confirms the CAS blob remains unchanged.

This does not use placeholders or claim FUSE-style read-fault laziness: reflinks are complete ordinary files whose physical blocks are shared copy-on-write. Unsupported/cross-filesystem cases copy normally.

## Measurement

On this checkout's reflink-capable filesystem:

```
MBX_BENCH_MIB=128 MBX_BENCH_ITERATIONS=4 cargo test -p mbx --locked \
  rustc::tests::benchmark_cached_output_materialization -- --ignored --nocapture

materialized 4 x 128 MiB with Some(Reflink): \
  legacy_reverify=372.05ms, verified_cas=37.65ms, speedup=9.88x
```

## Validation

- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how restored compiler outputs are validated during materialization; correctness still depends on agent CAS verification plus size checks, but digest re-check on staging is removed for verified paths.
> 
> **Overview**
> Speeds up cache hits by **staging verified CAS blobs with filesystem reflinks** (copy-on-write) instead of always re-hashing restored rustc outputs after clone.
> 
> The rustc wrapper now uses `stage_verified_cached_output`, which trusts the agent’s prior digest verification on `FindBlobs` paths and only checks staged **file length** (and the copy fallback’s reported byte count). That avoids a second full read on reflinks, which would fault shared blocks and erase the CoW win. Reflink vs byte copy is classified via `reflink_or_copy` and rolled into **`RestoreStats` / `AgentStats`** (`reflinked_*` and `copied_*` fields), surfaced in the session summary and `MBX_STATS_REPORT`.
> 
> Docs and the changelog describe CoW restoration and the cross-filesystem copy fallback; tests and the ignored benchmark compare legacy post-clone re-verification with the verified-CAS path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfad3fc0a60ba3612781e61eb3fc36b101458aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->