### PR TITLE
feat: cache compiler-linked wasm outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: rustup target add wasm32-unknown-unknown
       - run: cargo build --workspace --all-targets
       - run: cargo test --workspace
       - name: Run behavioral tests

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ An `mbx` Cargo command starts an in-process cache agent, points Cargo at a rustc
 derives an action key, restores cached outputs when possible, or runs the real
 compiler and publishes a successful result.
 
-Anything mbx cannot model exactly bypasses the cache. Linking is not cached and
-incremental compilations bypass the cache. Correctness comes before hit rate.
+Anything mbx cannot model exactly bypasses the cache. Native linking is not
+cached; the intentionally narrow exception is `wasm32-unknown-unknown`, whose
+default linker ships inside the Rust toolchain. Incremental compilations bypass
+the cache. Correctness comes before hit rate.
 
 [Read the architecture and limits →](https://mr-boxington.jdx.dev/how-it-works)
 

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -152,9 +152,6 @@ pub enum BypassReason {
     /// Native-library lookup is not modeled as a precise input.
     #[error("native library lookup is not cacheable yet")]
     NativeLibrary,
-    /// A linker-affecting compiler configuration is not modeled.
-    #[error("rustc linker configuration is not cacheable yet: {0}")]
-    UnsupportedLinkerConfiguration(String),
     /// A library search-path kind is not modeled.
     #[error("rustc search path kind is not cacheable yet: {0}")]
     UnsupportedSearchPath(String),
@@ -280,8 +277,6 @@ pub struct RustcOutputs {
     pub directory: PathBuf,
     /// Cacheable library, metadata, and/or compiler-linked wasm files.
     pub files: Vec<PathBuf>,
-    /// Outputs that must retain executable permissions when restored.
-    pub executable_files: BTreeSet<PathBuf>,
     /// Dep-info file used for precise input discovery.
     pub dep_info: PathBuf,
 }
@@ -343,7 +338,6 @@ impl RustcInvocation {
             return Err(BypassReason::ImplicitEmitWithOutputFile(output.clone()));
         }
         let mut files = BTreeSet::new();
-        let mut executable_files = BTreeSet::new();
         let mut dep_info = None;
         for emit in &self.emits {
             if emit.kind == "dep-info" {
@@ -365,12 +359,12 @@ impl RustcInvocation {
                 dep_info = Some(path);
                 continue;
             }
-            let (prefix, extension, executable) = match emit.kind.as_str() {
+            let (prefix, extension) = match emit.kind.as_str() {
                 "link" => match self.link_output {
-                    LinkOutput::Library => ("lib", "rlib", false),
-                    LinkOutput::WasmExecutable => ("", "wasm", true),
+                    LinkOutput::Library => ("lib", "rlib"),
+                    LinkOutput::WasmExecutable => ("", "wasm"),
                 },
-                "metadata" => ("lib", "rmeta", false),
+                "metadata" => ("lib", "rmeta"),
                 _ => continue,
             };
             let path = if let Some(path) = &emit.path {
@@ -387,9 +381,6 @@ impl RustcInvocation {
             if path.parent() != Some(output_directory.as_path()) {
                 return Err(BypassReason::SplitOutputDirectories);
             }
-            if executable {
-                executable_files.insert(path.clone());
-            }
             files.insert(path);
         }
         let dep_info = dep_info.ok_or(BypassReason::NoDepInfo)?;
@@ -399,7 +390,6 @@ impl RustcInvocation {
         Ok(RustcOutputs {
             directory: output_directory,
             files: files.into_iter().collect(),
-            executable_files,
             dep_info,
         })
     }
@@ -449,7 +439,10 @@ impl RustcOutputs {
     /// Whether `path` is a linked program whose executable permission is part
     /// of the declared output contract.
     pub fn is_executable(&self, path: &Path) -> bool {
-        self.executable_files.contains(path)
+        self.files.iter().any(|output| output == path)
+            && path
+                .extension()
+                .is_some_and(|extension| extension == "wasm")
     }
 }
 
@@ -1026,7 +1019,7 @@ impl<'a> Parser<'a> {
             if self.parsed.iter().any(|argument| {
                 matches!(argument, Argument::Plain(value) if value == "--codegen=link-self-contained" || value.starts_with("--codegen=link-self-contained="))
             }) {
-                return Err(BypassReason::UnsupportedLinkerConfiguration(
+                return Err(BypassReason::UnknownCodegenOption(
                     "link-self-contained".into(),
                 ));
             }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -957,10 +957,8 @@ impl<'a> Parser<'a> {
         {
             LinkOutput::Library
         } else if self.target.as_deref() == Some("wasm32-unknown-unknown")
-            && self
-                .crate_types
-                .iter()
-                .all(|crate_type| crate_type == "bin")
+            && ((self.test && self.crate_types.is_empty())
+                || self.crate_types.as_slice() == ["bin"])
         {
             if self.parsed.iter().any(|argument| {
                 matches!(argument, Argument::Plain(value) if value == "--codegen=link-self-contained" || value.starts_with("--codegen=link-self-contained="))

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -134,8 +134,8 @@ pub enum BypassReason {
     /// The requested emit kind is outside the supported cacheability tier.
     #[error("rustc output type is not cacheable yet: {0}")]
     UnsupportedEmit(String),
-    /// The invocation emits neither an rlib nor metadata artifact.
-    #[error("rustc invocation does not emit an rlib or metadata artifact")]
+    /// The invocation emits no artifact in the supported cacheability tier.
+    #[error("rustc invocation does not emit a cacheable artifact")]
     NoCacheableOutput,
     /// The invocation does not emit the dep-info needed for input discovery.
     #[error("rustc invocation does not emit dependency information")]
@@ -152,6 +152,9 @@ pub enum BypassReason {
     /// Native-library lookup is not modeled as a precise input.
     #[error("native library lookup is not cacheable yet")]
     NativeLibrary,
+    /// A linker-affecting compiler configuration is not modeled.
+    #[error("rustc linker configuration is not cacheable yet: {0}")]
+    UnsupportedLinkerConfiguration(String),
     /// A library search-path kind is not modeled.
     #[error("rustc search path kind is not cacheable yet: {0}")]
     UnsupportedSearchPath(String),
@@ -261,6 +264,13 @@ pub struct RustcInvocation {
     explicit_output: Option<PathBuf>,
     emits: Vec<Emit>,
     target: Option<String>,
+    link_output: LinkOutput,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinkOutput {
+    Library,
+    WasmExecutable,
 }
 
 /// The cacheable files and dependency manifest produced by a rustc invocation.
@@ -268,8 +278,10 @@ pub struct RustcInvocation {
 pub struct RustcOutputs {
     /// Common directory containing all modeled outputs.
     pub directory: PathBuf,
-    /// Cacheable rlib and/or metadata files.
+    /// Cacheable library, metadata, and/or compiler-linked wasm files.
     pub files: Vec<PathBuf>,
+    /// Outputs that must retain executable permissions when restored.
+    pub executable_files: BTreeSet<PathBuf>,
     /// Dep-info file used for precise input discovery.
     pub dep_info: PathBuf,
 }
@@ -280,7 +292,7 @@ impl RustcInvocation {
     ///
     /// Any flag whose cache semantics are not modeled returns a bypass reason
     /// instead of guessing. A successful parse only admits the initial
-    /// rlib/rmeta cacheability tier.
+    /// rlib/rmeta tier plus compiler-linked `wasm32-unknown-unknown` binaries.
     pub fn parse(arguments: &[OsString]) -> Result<Self, BypassReason> {
         Parser::new(arguments).parse()
     }
@@ -295,7 +307,7 @@ impl RustcInvocation {
         self.target.as_deref()
     }
 
-    /// Resolve the rlib/rmeta files produced by this invocation.
+    /// Resolve the files produced by this invocation.
     ///
     /// The initial cache tier requires one output directory so its artifact can
     /// be represented by one protocol directory and restored atomically later.
@@ -331,6 +343,7 @@ impl RustcInvocation {
             return Err(BypassReason::ImplicitEmitWithOutputFile(output.clone()));
         }
         let mut files = BTreeSet::new();
+        let mut executable_files = BTreeSet::new();
         let mut dep_info = None;
         for emit in &self.emits {
             if emit.kind == "dep-info" {
@@ -352,16 +365,19 @@ impl RustcInvocation {
                 dep_info = Some(path);
                 continue;
             }
-            let extension = match emit.kind.as_str() {
-                "link" => "rlib",
-                "metadata" => "rmeta",
+            let (prefix, extension, executable) = match emit.kind.as_str() {
+                "link" => match self.link_output {
+                    LinkOutput::Library => ("lib", "rlib", false),
+                    LinkOutput::WasmExecutable => ("", "wasm", true),
+                },
+                "metadata" => ("lib", "rmeta", false),
                 _ => continue,
             };
             let path = if let Some(path) = &emit.path {
                 absolute_path(path, working_dir)
             } else {
                 output_directory.join(format!(
-                    "lib{}{}.{}",
+                    "{prefix}{}{}.{}",
                     self.crate_name, self.extra_filename, extension
                 ))
             };
@@ -370,6 +386,9 @@ impl RustcInvocation {
             }
             if path.parent() != Some(output_directory.as_path()) {
                 return Err(BypassReason::SplitOutputDirectories);
+            }
+            if executable {
+                executable_files.insert(path.clone());
             }
             files.insert(path);
         }
@@ -380,6 +399,7 @@ impl RustcInvocation {
         Ok(RustcOutputs {
             directory: output_directory,
             files: files.into_iter().collect(),
+            executable_files,
             dep_info,
         })
     }
@@ -422,6 +442,14 @@ impl RustcInvocation {
             inputs,
             environment: discovered.environment.keys().cloned().collect(),
         })
+    }
+}
+
+impl RustcOutputs {
+    /// Whether `path` is a linked program whose executable permission is part
+    /// of the declared output contract.
+    pub fn is_executable(&self, path: &Path) -> bool {
+        self.executable_files.contains(path)
     }
 }
 
@@ -672,7 +700,7 @@ impl<'a> Parser<'a> {
         }
 
         let source = self.source.clone().ok_or(BypassReason::MissingInput)?;
-        self.classify()?;
+        let link_output = self.classify()?;
         let crate_name = self.crate_name.clone().map_or_else(
             || {
                 source
@@ -694,6 +722,7 @@ impl<'a> Parser<'a> {
             explicit_output: self.explicit_output,
             emits: self.emits,
             target: self.target,
+            link_output,
         })
     }
 
@@ -753,6 +782,7 @@ impl<'a> Parser<'a> {
                 let value = self.take_value(&rendered_flag, inline)?;
                 self.target = Some(value.clone());
                 if value.ends_with(".json") || value.contains(['/', '\\']) {
+                    self.target = None;
                     let path = PathBuf::from(value);
                     self.required_inputs.push(path.clone());
                     self.parsed.push(Argument::Path {
@@ -760,6 +790,7 @@ impl<'a> Parser<'a> {
                         path,
                     });
                 } else {
+                    self.target = Some(value.clone());
                     self.parsed
                         .push(Argument::Plain(format!("{rendered_flag}={value}")));
                 }
@@ -916,20 +947,43 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn classify(&self) -> Result<(), BypassReason> {
-        if self.crate_types.is_empty() {
-            return Err(BypassReason::UnsupportedCrateType("bin".into()));
-        }
-        if let Some(crate_type) = self
-            .crate_types
-            .iter()
-            .find(|crate_type| !matches!(crate_type.as_str(), "lib" | "rlib"))
+    fn classify(&self) -> Result<LinkOutput, BypassReason> {
+        let link_output = if !self.test
+            && !self.crate_types.is_empty()
+            && self
+                .crate_types
+                .iter()
+                .all(|crate_type| matches!(crate_type.as_str(), "lib" | "rlib"))
         {
-            return Err(BypassReason::UnsupportedCrateType(crate_type.clone()));
-        }
-        if self.test {
+            LinkOutput::Library
+        } else if self.target.as_deref() == Some("wasm32-unknown-unknown")
+            && self
+                .crate_types
+                .iter()
+                .all(|crate_type| crate_type == "bin")
+        {
+            if self.parsed.iter().any(|argument| {
+                matches!(argument, Argument::Plain(value) if value == "--codegen=link-self-contained" || value.starts_with("--codegen=link-self-contained="))
+            }) {
+                return Err(BypassReason::UnsupportedLinkerConfiguration(
+                    "link-self-contained".into(),
+                ));
+            }
+            // This target's built-in linker is rust-lld from the Rust
+            // toolchain. Unlike a native link, it has no implicit host CRT or
+            // system-library inputs outside the compiler identity.
+            LinkOutput::WasmExecutable
+        } else if self.test {
             return Err(BypassReason::UnsupportedCrateType("test".into()));
-        }
+        } else {
+            return Err(BypassReason::UnsupportedCrateType(
+                self.crate_types
+                    .iter()
+                    .find(|crate_type| !matches!(crate_type.as_str(), "lib" | "rlib"))
+                    .cloned()
+                    .unwrap_or_else(|| "bin".into()),
+            ));
+        };
         if let Some(name) = self.parsed.iter().find_map(|argument| match argument {
             Argument::Extern { name, path: None } if name != "proc_macro" => Some(name),
             _ => None,
@@ -950,7 +1004,7 @@ impl<'a> Parser<'a> {
         {
             return Err(BypassReason::NoCacheableOutput);
         }
-        Ok(())
+        Ok(link_output)
     }
 }
 

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -838,7 +838,6 @@ impl<'a> Parser<'a> {
                 let value = self.take_value(&rendered_flag, inline)?;
                 self.target = Some(value.clone());
                 if value.ends_with(".json") || value.contains(['/', '\\']) {
-                    self.target = None;
                     let path = PathBuf::from(value);
                     self.required_inputs.push(path.clone());
                     self.parsed.push(Argument::Path {

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -491,14 +491,33 @@ pub fn normalize_mapped_path(
     working_dir: &Path,
     mappings: &[PathMapping],
 ) -> Result<String, BypassReason> {
+    let mappings = mappings
+        .iter()
+        .map(|mapping| PathMapping {
+            root: resolve_mapping_root(&mapping.root),
+            placeholder: mapping.placeholder.clone(),
+        })
+        .collect::<Vec<_>>();
+    normalize_resolved_mapped_path(path, working_dir, &mappings)
+}
+
+fn normalize_resolved_mapped_path(
+    path: &Path,
+    working_dir: &Path,
+    mappings: &[PathMapping],
+) -> Result<String, BypassReason> {
     let absolute = if path.is_absolute() {
         normalize_components(path)
     } else {
         normalize_components(&working_dir.join(path))
     };
+    let resolved = if absolute.is_absolute() {
+        resolve_path_aliases(&absolute)
+    } else {
+        absolute.clone()
+    };
     for mapping in mappings {
-        let root = normalize_components(&mapping.root);
-        if let Ok(relative) = absolute.strip_prefix(&root) {
+        if let Ok(relative) = resolved.strip_prefix(&mapping.root) {
             let suffix = slash_path(relative)?;
             return Ok(if suffix.is_empty() {
                 format!("${{{}}}", mapping.placeholder)
@@ -508,6 +527,50 @@ pub fn normalize_mapped_path(
         }
     }
     Err(BypassReason::UnmappedAbsolutePath(absolute))
+}
+
+/// Resolve aliases in the existing prefix while preserving a not-yet-created
+/// output suffix. Cargo and rustc may spell the same macOS temporary directory
+/// as `/var/...` and `/private/var/...`; comparing only lexical paths makes a
+/// target mapping miss even though both names identify the same directory.
+#[cfg(unix)]
+fn resolve_path_aliases(path: &Path) -> PathBuf {
+    let mut existing = path;
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::canonicalize(existing) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return normalize_components(&resolved);
+            }
+            Err(_) => {
+                let Some(name) = existing.file_name() else {
+                    return path.to_path_buf();
+                };
+                missing.push(name.to_os_string());
+                let Some(parent) = existing.parent() else {
+                    return path.to_path_buf();
+                };
+                existing = parent;
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn resolve_path_aliases(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+fn resolve_mapping_root(root: &Path) -> PathBuf {
+    let root = normalize_components(root);
+    if root.is_absolute() {
+        resolve_path_aliases(&root)
+    } else {
+        root
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1030,9 +1093,17 @@ struct ActionBuilder<'a> {
 impl<'a> ActionBuilder<'a> {
     fn new(invocation: &'a RustcInvocation, mut context: ActionContext) -> Self {
         context.path_mappings = PathMapping::ordered(&context.path_mappings);
+        let mappings = context
+            .path_mappings
+            .iter()
+            .map(|mapping| PathMapping {
+                root: resolve_mapping_root(&mapping.root),
+                placeholder: mapping.placeholder.clone(),
+            })
+            .collect();
         Self {
             invocation,
-            mappings: context.path_mappings.clone(),
+            mappings,
             context,
         }
     }
@@ -1197,7 +1268,7 @@ impl<'a> ActionBuilder<'a> {
     }
 
     fn normalize_path(&self, path: &Path) -> Result<String, BypassReason> {
-        normalize_mapped_path(path, &self.context.working_dir, &self.mappings)
+        normalize_resolved_mapped_path(path, &self.context.working_dir, &self.mappings)
     }
 }
 

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -158,7 +158,6 @@ fn resolves_cargo_library_outputs() {
                 working_dir.join("target/debug/deps/libwidget-abc123.rlib"),
                 working_dir.join("target/debug/deps/libwidget-abc123.rmeta"),
             ],
-            executable_files: BTreeSet::new(),
             dep_info: working_dir.join("target/debug/deps/widget-abc123.d"),
         }
     );
@@ -184,8 +183,7 @@ fn resolves_a_compiler_linked_wasm_binary() {
         invocation.outputs(&working_dir).unwrap(),
         RustcOutputs {
             directory: working_dir.join("target/wasm32-unknown-unknown/debug/deps"),
-            files: vec![executable.clone()],
-            executable_files: BTreeSet::from([executable]),
+            files: vec![executable],
             dep_info: working_dir.join("target/wasm32-unknown-unknown/debug/deps/widget-abc123.d"),
         }
     );
@@ -229,7 +227,7 @@ fn custom_wasm_linker_modes_still_bypass() {
     ]);
     assert_eq!(
         RustcInvocation::parse(&arguments),
-        Err(BypassReason::UnsupportedLinkerConfiguration(
+        Err(BypassReason::UnknownCodegenOption(
             "link-self-contained".into()
         ))
     );
@@ -305,7 +303,6 @@ fn resolves_an_output_file_when_every_emit_names_its_path() {
                 working_dir.join("target/widget.rlib"),
                 working_dir.join("target/widget.rmeta"),
             ],
-            executable_files: BTreeSet::new(),
             dep_info: working_dir.join("target/widget.d"),
         }
     );

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -139,8 +139,83 @@ fn resolves_cargo_library_outputs() {
                 working_dir.join("target/debug/deps/libwidget-abc123.rlib"),
                 working_dir.join("target/debug/deps/libwidget-abc123.rmeta"),
             ],
+            executable_files: BTreeSet::new(),
             dep_info: working_dir.join("target/debug/deps/widget-abc123.d"),
         }
+    );
+}
+
+#[test]
+fn resolves_a_compiler_linked_wasm_binary() {
+    let working_dir = absolute(&["workspace"]);
+    let invocation = RustcInvocation::parse(&args(&[
+        "--crate-name=widget",
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--out-dir=target/wasm32-unknown-unknown/debug/deps",
+        "--target=wasm32-unknown-unknown",
+        "-Cextra-filename=-abc123",
+        "src/main.rs",
+    ]))
+    .unwrap();
+    let executable =
+        working_dir.join("target/wasm32-unknown-unknown/debug/deps/widget-abc123.wasm");
+
+    assert_eq!(
+        invocation.outputs(&working_dir).unwrap(),
+        RustcOutputs {
+            directory: working_dir.join("target/wasm32-unknown-unknown/debug/deps"),
+            files: vec![executable.clone()],
+            executable_files: BTreeSet::from([executable]),
+            dep_info: working_dir
+                .join("target/wasm32-unknown-unknown/debug/deps/widget-abc123.d"),
+        }
+    );
+}
+
+#[test]
+fn accepts_wasm_tests_but_not_native_tests() {
+    let wasm = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "--target=wasm32-unknown-unknown",
+        "src/lib.rs",
+    ]);
+    assert!(RustcInvocation::parse(&wasm).is_ok());
+
+    let native = args(&["--test", "--emit=dep-info,link", "src/lib.rs"]);
+    assert_eq!(
+        RustcInvocation::parse(&native),
+        Err(BypassReason::UnsupportedCrateType("test".into()))
+    );
+}
+
+#[test]
+fn custom_wasm_linker_modes_still_bypass() {
+    let arguments = args(&[
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--target=wasm32-unknown-unknown",
+        "-Clink-self-contained=no",
+        "src/main.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse(&arguments),
+        Err(BypassReason::UnsupportedLinkerConfiguration(
+            "link-self-contained".into()
+        ))
+    );
+
+    let arguments = args(&[
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--target=wasm32-unknown-unknown",
+        "-Clinker=/tmp/custom-linker",
+        "src/main.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse(&arguments),
+        Err(BypassReason::UnknownCodegenOption("linker".into()))
     );
 }
 
@@ -202,6 +277,7 @@ fn resolves_an_output_file_when_every_emit_names_its_path() {
                 working_dir.join("target/widget.rlib"),
                 working_dir.join("target/widget.rmeta"),
             ],
+            executable_files: BTreeSet::new(),
             dep_info: working_dir.join("target/widget.d"),
         }
     );

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -183,6 +183,16 @@ fn accepts_wasm_tests_but_not_native_tests() {
     ]);
     assert!(RustcInvocation::parse(&wasm).is_ok());
 
+    let implicit_binary = args(&[
+        "--emit=dep-info,link",
+        "--target=wasm32-unknown-unknown",
+        "src/main.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse(&implicit_binary),
+        Err(BypassReason::UnsupportedCrateType("bin".into()))
+    );
+
     let native = args(&["--test", "--emit=dep-info,link", "src/lib.rs"]);
     assert_eq!(
         RustcInvocation::parse(&native),

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -23,6 +23,25 @@ fn bypass_kinds_are_stable_and_field_independent() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn path_mappings_resolve_symlinked_roots_for_missing_outputs() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let physical = directory.path().join("physical");
+    let alias = directory.path().join("alias");
+    std::fs::create_dir(&physical).unwrap();
+    symlink(&physical, &alias).unwrap();
+
+    let mappings = vec![PathMapping::new(alias, "target")];
+    let output = physical.join("debug/deps/not-created.wasm");
+    assert_eq!(
+        normalize_mapped_path(&output, directory.path(), &mappings).unwrap(),
+        "${target}/debug/deps/not-created.wasm"
+    );
+}
+
 use super::*;
 
 fn args(values: &[&str]) -> Vec<OsString> {

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -652,6 +652,7 @@ fn custom_targets_are_required_inputs() {
         "src/lib.rs",
     ]))
     .unwrap();
+    assert_eq!(invocation.target(), Some("targets/custom.json"));
     let error = invocation
         .action(context(&[("src/lib.rs", "source")]))
         .unwrap_err();

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -186,8 +186,7 @@ fn resolves_a_compiler_linked_wasm_binary() {
             directory: working_dir.join("target/wasm32-unknown-unknown/debug/deps"),
             files: vec![executable.clone()],
             executable_files: BTreeSet::from([executable]),
-            dep_info: working_dir
-                .join("target/wasm32-unknown-unknown/debug/deps/widget-abc123.d"),
+            dep_info: working_dir.join("target/wasm32-unknown-unknown/debug/deps/widget-abc123.d"),
         }
     );
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -27,6 +27,7 @@ struct CachedCompilation {
 struct CachedOutput {
     path: PathBuf,
     digest: CacheDigest,
+    executable: bool,
     mode: u32,
 }
 
@@ -143,10 +144,8 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             )?;
             discovered.verify_not_modified_since(compilation_started)?;
             discovered.verify()?;
-            let mut cacheable_outputs = outputs.files.clone();
-            cacheable_outputs.push(outputs.dep_info.clone());
             let action = candidates.publishable(&portable, &outputs.files)?;
-            publish_result(&action.digest, &action.bytes, &cacheable_outputs, &output)?;
+            publish_result(&action.digest, &action.bytes, &outputs, &output)?;
             record_prediction(
                 rustc,
                 &invocation,
@@ -465,6 +464,7 @@ fn restore_result(
         .map(|(node, destination)| CachedOutput {
             path: destination.clone(),
             digest: node.digest.clone(),
+            executable: node.executable,
             mode: node.mode,
         })
         .collect();
@@ -572,7 +572,7 @@ fn stage_verified_cached_output(
             node.name
         );
     }
-    apply_file_mode(&temporary, node.mode)?;
+    apply_file_mode(&temporary, node.mode, node.executable)?;
     Ok((temporary, materialization))
 }
 
@@ -583,6 +583,7 @@ fn cached_matches(cached: &CachedCompilation, output: &Output) -> bool {
         && cached.outputs.iter().all(|expected| {
             std::fs::metadata(&expected.path).is_ok_and(|metadata| {
                 file_mode(&metadata) == expected.mode
+                    && executable_mode_matches(&metadata, expected.executable)
                     && expected
                         .digest
                         .matches_file(&expected.path)
@@ -725,7 +726,10 @@ fn validated_outputs(
             if path.parent() != Some(outputs.directory.as_path()) {
                 bail!("expected rustc output escapes its output directory");
             }
-            Ok((name.to_string(), path.clone()))
+            Ok((
+                name.to_string(),
+                (path.clone(), outputs.is_executable(path)),
+            ))
         })
         .collect::<Result<BTreeMap<_, _>>>()?;
     if directory.files.len() != expected.len() {
@@ -733,10 +737,10 @@ fn validated_outputs(
     }
     let mut files = Vec::with_capacity(directory.files.len());
     for node in directory.files {
-        validate_file_mode(&node)?;
-        let destination = expected
+        let (destination, executable) = expected
             .remove(&node.name)
             .ok_or_else(|| eyre::eyre!("cached rustc output is unexpected: {}", node.name))?;
+        validate_file_mode(&node, executable)?;
         files.push((node, destination));
     }
     if !expected.is_empty() {
@@ -1112,10 +1116,10 @@ fn resolve_executable(executable: &OsStr) -> Result<PathBuf> {
 fn publish_result(
     action: &CacheDigest,
     action_bytes: &[u8],
-    outputs: &[PathBuf],
+    outputs: &RustcOutputs,
     output: &Output,
 ) -> Result<()> {
-    if outputs.is_empty() {
+    if outputs.files.is_empty() {
         bail!("rustc produced no cacheable outputs");
     }
     let staging = staging_directory()?;
@@ -1124,8 +1128,12 @@ fn publish_result(
     let stderr = staged_bytes(staging.path(), "stderr", &output.stderr)?;
     blobs.extend([stdout.clone(), stderr.clone()]);
 
-    let mut files = Vec::with_capacity(outputs.len());
-    for path in outputs {
+    let output_paths = outputs
+        .files
+        .iter()
+        .chain(std::iter::once(&outputs.dep_info));
+    let mut files = Vec::with_capacity(outputs.files.len() + 1);
+    for path in output_paths {
         let metadata = std::fs::metadata(path)
             .wrap_err_with(|| format!("failed to inspect rustc output {}", path.display()))?;
         if !metadata.is_file() {
@@ -1135,7 +1143,7 @@ fn publish_result(
         blobs.push((digest.clone(), path.clone()));
         files.push(CacheFileNode {
             digest,
-            executable: false,
+            executable: outputs.is_executable(path),
             mode: file_mode(&metadata),
             name: path
                 .file_name()
@@ -1206,8 +1214,8 @@ fn file_mode(_metadata: &std::fs::Metadata) -> u32 {
 }
 
 #[cfg(unix)]
-fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
-    if node.executable
+fn validate_file_mode(node: &CacheFileNode, executable: bool) -> Result<()> {
+    if node.executable != executable
         || node.mode & !0o777 != 0
         || node.mode & 0o111 != 0
         || node.mode & 0o022 != 0
@@ -1218,23 +1226,38 @@ fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
-    if node.executable || node.mode != 0 {
+fn validate_file_mode(node: &CacheFileNode, executable: bool) -> Result<()> {
+    if node.executable != executable || node.mode != 0 {
         bail!("cached rustc output has an unsafe file mode: {}", node.name);
     }
     Ok(())
 }
 
 #[cfg(unix)]
-fn apply_file_mode(temporary: &Path, mode: u32) -> Result<()> {
+fn apply_file_mode(temporary: &Path, mode: u32, executable: bool) -> Result<()> {
     use std::os::unix::fs::PermissionsExt as _;
-    std::fs::set_permissions(temporary, std::fs::Permissions::from_mode(mode))?;
+    let executable_mode = if executable { 0o111 } else { 0 };
+    std::fs::set_permissions(
+        temporary,
+        std::fs::Permissions::from_mode(mode | executable_mode),
+    )?;
     Ok(())
 }
 
 #[cfg(windows)]
-fn apply_file_mode(_temporary: &Path, _mode: u32) -> Result<()> {
+fn apply_file_mode(_temporary: &Path, _mode: u32, _executable: bool) -> Result<()> {
     Ok(())
+}
+
+#[cfg(unix)]
+fn executable_mode_matches(metadata: &std::fs::Metadata, executable: bool) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    (metadata.permissions().mode() & 0o111 != 0) == executable
+}
+
+#[cfg(windows)]
+fn executable_mode_matches(_metadata: &std::fs::Metadata, _executable: bool) -> bool {
+    true
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -80,7 +80,6 @@ fn test_outputs(root: &Path) -> RustcOutputs {
     let directory = root.join("out");
     RustcOutputs {
         files: vec![directory.join("libdemo.rlib")],
-        executable_files: BTreeSet::new(),
         dep_info: directory.join("demo.d"),
         directory,
     }
@@ -259,11 +258,11 @@ fn rejects_executable_rustc_outputs() {
 }
 
 #[test]
-fn accepts_only_declared_executable_rustc_outputs() {
+fn accepts_wasm_executable_rustc_outputs() {
     let root = tempfile::tempdir().unwrap();
     let mut outputs = test_outputs(root.path());
-    outputs.executable_files.insert(outputs.files[0].clone());
-    let mut file = test_file("libdemo.rlib");
+    outputs.files = vec![outputs.directory.join("demo.wasm")];
+    let mut file = test_file("demo.wasm");
     file.executable = true;
 
     assert!(validated_outputs(test_output_directory(file), &outputs).is_ok());

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -284,7 +284,7 @@ fn restores_declared_executable_permissions() {
         name: "fixture.wasm".into(),
     };
 
-    let staged = stage_cached_output(root.path(), 0, &source, &node).unwrap();
+    let (staged, _) = stage_verified_cached_output(root.path(), 0, &source, &node).unwrap();
     assert_eq!(
         std::fs::metadata(staged).unwrap().permissions().mode() & 0o777,
         0o755

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -80,6 +80,7 @@ fn test_outputs(root: &Path) -> RustcOutputs {
     let directory = root.join("out");
     RustcOutputs {
         files: vec![directory.join("libdemo.rlib")],
+        executable_files: BTreeSet::new(),
         dep_info: directory.join("demo.d"),
         directory,
     }
@@ -258,6 +259,39 @@ fn rejects_executable_rustc_outputs() {
 }
 
 #[test]
+fn accepts_only_declared_executable_rustc_outputs() {
+    let root = tempfile::tempdir().unwrap();
+    let mut outputs = test_outputs(root.path());
+    outputs.executable_files.insert(outputs.files[0].clone());
+    let mut file = test_file("libdemo.rlib");
+    file.executable = true;
+
+    assert!(validated_outputs(test_output_directory(file), &outputs).is_ok());
+}
+
+#[cfg(unix)]
+#[test]
+fn restores_declared_executable_permissions() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    std::fs::write(&source, b"wasm").unwrap();
+    let node = CacheFileNode {
+        digest: CacheDigest::blake3(b"wasm"),
+        executable: true,
+        mode: 0o644,
+        name: "fixture.wasm".into(),
+    };
+
+    let staged = stage_cached_output(root.path(), 0, &source, &node).unwrap();
+    assert_eq!(
+        std::fs::metadata(staged).unwrap().permissions().mode() & 0o777,
+        0o755
+    );
+}
+
+#[test]
 fn rejects_group_or_world_writable_rustc_outputs() {
     let root = tempfile::tempdir().unwrap();
     let outputs = test_outputs(root.path());
@@ -398,7 +432,7 @@ fn benchmark_cached_output_materialization() {
         let temporary = tempfile::TempPath::try_from_path(temporary).unwrap();
         make_owner_writable(&temporary).unwrap();
         assert!(digest.matches_file(&temporary).unwrap());
-        apply_file_mode(&temporary, node.mode).unwrap();
+        apply_file_mode(&temporary, node.mode, node.executable).unwrap();
     }
     let legacy = started.elapsed();
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -10,22 +10,6 @@ fn write_project(directory: &Path) {
     write_named_project(directory, "fixture");
 }
 
-fn write_wasm_binary_project(directory: &Path) {
-    std::fs::create_dir_all(directory.join("src")).unwrap();
-    std::fs::write(
-        directory.join("Cargo.toml"),
-        "[package]\nname = \"wasm-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-    )
-    .unwrap();
-    std::fs::write(directory.join("src/main.rs"), "fn main() {}\n").unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success(), "the fixture should resolve offline");
-}
-
 /// Write the fixture under `name`.
 ///
 /// The name reaches the lockfile, and the lockfile is what the build identity
@@ -140,26 +124,6 @@ fn build_with(
         serde_json::from_slice(&stats).expect("the report should be JSON"),
         String::from_utf8_lossy(&output.stderr).into_owned(),
     )
-}
-
-fn build_wasm(project: &Path, target_dir: &Path, store: &Path, report: &Path) -> serde_json::Value {
-    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
-        .current_dir(project)
-        .args(["build", "--offline", "--target", "wasm32-unknown-unknown"])
-        .env("CARGO_TARGET_DIR", target_dir)
-        .env("MBX_CACHE_DIR", store)
-        .env("MBX_STATS_REPORT", report)
-        .env_remove("MBX_INCREMENTAL")
-        .env_remove("CARGO_INCREMENTAL")
-        .env_remove("CI")
-        .output()
-        .expect("mbx should run");
-    assert!(
-        output.status.success(),
-        "wasm build failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    serde_json::from_slice(&std::fs::read(report).unwrap()).unwrap()
 }
 
 /// Run `mbx` against `store` and return its stdout.
@@ -334,47 +298,6 @@ fn a_second_checkout_starts_warm() {
     assert!(
         count(&warm, "hits") > 0,
         "a checkout at another path should reuse the first build: {warm}"
-    );
-}
-
-#[test]
-fn a_wasm_link_output_restores_into_a_distinct_target_directory() {
-    let store = tempfile::tempdir().unwrap();
-    let project = tempfile::tempdir().unwrap();
-    let first_target = tempfile::tempdir().unwrap();
-    let second_target = tempfile::tempdir().unwrap();
-    let reports = tempfile::tempdir().unwrap();
-    write_wasm_binary_project(project.path());
-
-    let cold = build_wasm(
-        project.path(),
-        first_target.path(),
-        store.path(),
-        &reports.path().join("wasm-cold.json"),
-    );
-    assert_eq!(count(&cold, "hits"), 0, "a cold wasm link cannot hit");
-    let first = first_target
-        .path()
-        .join("wasm32-unknown-unknown/debug/wasm-fixture.wasm");
-    let expected = std::fs::read(&first).expect("rustc should link the wasm binary");
-
-    let warm = build_wasm(
-        project.path(),
-        second_target.path(),
-        store.path(),
-        &reports.path().join("wasm-warm.json"),
-    );
-    assert_eq!(
-        count(&warm, "hits"),
-        1,
-        "the linked wasm output should be restored: {warm}"
-    );
-    let restored = second_target
-        .path()
-        .join("wasm32-unknown-unknown/debug/wasm-fixture.wasm");
-    assert_eq!(
-        std::fs::read(restored).expect("the wasm link output should exist"),
-        expected
     );
 }
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -10,6 +10,22 @@ fn write_project(directory: &Path) {
     write_named_project(directory, "fixture");
 }
 
+fn write_wasm_binary_project(directory: &Path) {
+    std::fs::create_dir_all(directory.join("src")).unwrap();
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        "[package]\nname = \"wasm-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(directory.join("src/main.rs"), "fn main() {}\n").unwrap();
+    let status = Command::new(cargo())
+        .current_dir(directory)
+        .args(["generate-lockfile", "--offline"])
+        .status()
+        .expect("cargo should run");
+    assert!(status.success(), "the fixture should resolve offline");
+}
+
 /// Write the fixture under `name`.
 ///
 /// The name reaches the lockfile, and the lockfile is what the build identity
@@ -124,6 +140,26 @@ fn build_with(
         serde_json::from_slice(&stats).expect("the report should be JSON"),
         String::from_utf8_lossy(&output.stderr).into_owned(),
     )
+}
+
+fn build_wasm(project: &Path, target_dir: &Path, store: &Path, report: &Path) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project)
+        .args(["build", "--offline", "--target", "wasm32-unknown-unknown"])
+        .env("CARGO_TARGET_DIR", target_dir)
+        .env("MBX_CACHE_DIR", store)
+        .env("MBX_STATS_REPORT", report)
+        .env_remove("MBX_INCREMENTAL")
+        .env_remove("CARGO_INCREMENTAL")
+        .env_remove("CI")
+        .output()
+        .expect("mbx should run");
+    assert!(
+        output.status.success(),
+        "wasm build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&std::fs::read(report).unwrap()).unwrap()
 }
 
 /// Run `mbx` against `store` and return its stdout.
@@ -298,6 +334,47 @@ fn a_second_checkout_starts_warm() {
     assert!(
         count(&warm, "hits") > 0,
         "a checkout at another path should reuse the first build: {warm}"
+    );
+}
+
+#[test]
+fn a_wasm_link_output_restores_into_a_distinct_target_directory() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let first_target = tempfile::tempdir().unwrap();
+    let second_target = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_wasm_binary_project(project.path());
+
+    let cold = build_wasm(
+        project.path(),
+        first_target.path(),
+        store.path(),
+        &reports.path().join("wasm-cold.json"),
+    );
+    assert_eq!(count(&cold, "hits"), 0, "a cold wasm link cannot hit");
+    let first = first_target
+        .path()
+        .join("wasm32-unknown-unknown/debug/wasm-fixture.wasm");
+    let expected = std::fs::read(&first).expect("rustc should link the wasm binary");
+
+    let warm = build_wasm(
+        project.path(),
+        second_target.path(),
+        store.path(),
+        &reports.path().join("wasm-warm.json"),
+    );
+    assert_eq!(
+        count(&warm, "hits"),
+        1,
+        "the linked wasm output should be restored: {warm}"
+    );
+    let restored = second_target
+        .path()
+        .join("wasm32-unknown-unknown/debug/wasm-fixture.wasm");
+    assert_eq!(
+        std::fs::read(restored).expect("the wasm link output should exist"),
+        expected
     );
 }
 

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -30,4 +30,6 @@ A build can report a high hit rate among attempted lookups while spending most
 of its time on actions that were not looked up or were bypassed. Read all three
 summary lines together, and compare wall-clock time when evaluating the cache.
 
-Link steps always run, so an otherwise warm binary build still has work to do.
+Native link steps always run, so an otherwise warm native binary build still
+has work to do. Default-linked `wasm32-unknown-unknown` binaries and tests are
+the exception and may be restored as hits.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -58,7 +58,9 @@ platform, including when mbx has to use the copy fallback.
 
 ## Correctness first
 
-Unsupported crate types, unmodeled search paths, linking, and incremental
-compilations bypass the shared action cache. `MBX_VERIFY=1` compiles while also
-consulting the cache and compares the result, providing a deliberately expensive
-qualification mode.
+Unsupported crate types, unmodeled search paths, native linking, and
+incremental compilations bypass the shared action cache. The only linked
+programs admitted today are `wasm32-unknown-unknown` binaries and tests using
+the compiler-bundled default linker. `MBX_VERIFY=1` compiles while also
+consulting the cache and compares the result, providing a deliberately
+expensive qualification mode.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -11,10 +11,17 @@ pattern for another Cargo subcommand. Cargo's normal incremental workspace
 compilations continue to bypass the action cache; dependencies, which Cargo
 normally builds non-incrementally, remain cacheable.
 
-## Linking is not cached
+## Native linking is not cached
 
-Binaries and dynamic libraries always link. mbx caches supported rustc
-compilations, not the final link action.
+Native binaries and dynamic libraries always link. Their results can depend on
+an external linker, startup objects, and system libraries that rustc dep-info
+does not enumerate, so mbx bypasses them.
+
+The narrow exception is a binary or test for `wasm32-unknown-unknown` using its
+default compiler-bundled linker. mbx caches that link because all explicit
+artifacts are modeled inputs and the linker is covered by the Rust toolchain
+identity. Native targets, custom target specifications, native libraries,
+custom linkers, and custom `link-self-contained` modes remain uncached.
 
 ## `OUT_DIR` sharing is opt-in
 

--- a/test/wasm_link_cache.bats
+++ b/test/wasm_link_cache.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "test_helper/common_setup"
+  local developer_home="$HOME"
+  export RUSTUP_HOME="${RUSTUP_HOME:-$developer_home/.rustup}"
+  export CARGO_HOME="${CARGO_HOME:-$developer_home/.cargo}"
+  _common_setup
+
+  unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI
+  export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store"
+
+  export PROJECT="$BATS_TEST_TMPDIR/project"
+  mkdir -p "$PROJECT/src"
+  cat >"$PROJECT/Cargo.toml" <<'EOF'
+[package]
+name = "wasm-fixture"
+version = "0.1.0"
+edition = "2021"
+EOF
+  echo 'fn main() {}' >"$PROJECT/src/main.rs"
+
+  run cargo generate-lockfile --offline --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+}
+
+@test "a linked wasm binary restores into a distinct target directory" {
+  local first_target="$BATS_TEST_TMPDIR/first-target"
+  local second_target="$BATS_TEST_TMPDIR/second-target"
+  local cold_report="$BATS_TEST_TMPDIR/cold.json"
+  local warm_report="$BATS_TEST_TMPDIR/warm.json"
+  local relative_output="wasm32-unknown-unknown/debug/wasm-fixture.wasm"
+
+  run env \
+    CARGO_TARGET_DIR="$first_target" \
+    MBX_STATS_REPORT="$cold_report" \
+    "$MBX_BIN" build --offline --target wasm32-unknown-unknown \
+    --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  assert_file_exists "$first_target/$relative_output"
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*0' "$cold_report"
+  assert_success
+
+  run env \
+    CARGO_TARGET_DIR="$second_target" \
+    MBX_STATS_REPORT="$warm_report" \
+    "$MBX_BIN" build --offline --target wasm32-unknown-unknown \
+    --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  assert_file_exists "$second_target/$relative_output"
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*1' "$warm_report"
+  assert_success
+
+  run cmp "$first_target/$relative_output" "$second_target/$relative_output"
+  assert_success
+}


### PR DESCRIPTION
## Summary

- cache `wasm32-unknown-unknown` binary and test link outputs produced by rustc's toolchain-bundled default linker
- preserve and validate executable output permissions during publication and restore
- keep native links, custom targets, native libraries, custom linkers, and custom `link-self-contained` modes on conservative bypass paths
- install the wasm target in CI and cover restoration into a distinct empty Cargo target directory
- document the exact link-cache boundary and remaining bypasses

## Safety boundary

Native linking remains uncached because rustc dep-info does not enumerate host linkers, CRTs, or system libraries. This PR admits only the built-in `wasm32-unknown-unknown` target with the default compiler-contained linker. Existing parser rules still reject native library flags, non-dependency search paths, unmodeled codegen/link flags, response files, and custom target JSON.

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `mise run test:bats` (real Cargo: cold wasm link, then one cache hit restoring identical `.wasm` bytes into a distinct empty target directory)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the cache correctness boundary into linked artifacts and executable permissions; scope is limited to default-linked `wasm32-unknown-unknown`, with explicit bypasses for custom link modes.
> 
> **Overview**
> Extends the rustc cache beyond **rlib/rmeta** to **linked `wasm32-unknown-unknown` binaries and tests** when Cargo uses the toolchain’s default linker. Native `bin` links and native tests still bypass; custom `-Clinker`, `-Clink-self-contained`, and implicit wasm bins without `--crate-type=bin` remain on bypass paths.
> 
> The cache adapter models **`.wasm` link outputs** (paths, dep-info, action keys) and treats them as **executable artifacts** on publish, restore, and shadow verification. **Unix path normalization** resolves symlinked mapping roots (e.g. macOS `/var` vs `/private/var`) so target placeholders still match outputs that do not exist yet.
> 
> CI installs the wasm target; a **bats** scenario builds cold then restores identical `.wasm` bytes into a second empty `CARGO_TARGET_DIR`. Docs/README clarify that **native linking stays uncached** while default-linked wasm is the narrow exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1190354c05c5d8eae78ffc2968224e3996b5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->