### PR TITLE
ci: gate documentation through final status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - name: Build documentation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mise run check:docs
+          mise run build:docs
+
   lint:
     runs-on: namespace-profile-endev-linux-amd64
     steps:
@@ -103,6 +118,7 @@ jobs:
     permissions: {}
     needs:
       - compatibility
+      - docs
       - lint
       - supply-chain
       - public-api
@@ -115,6 +131,7 @@ jobs:
     steps:
       - name: Check job results
         if: |
+          needs.docs.result != 'success' ||
           needs.lint.result != 'success' ||
           needs.compatibility.result != 'success' ||
           needs.supply-chain.result != 'success' ||

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,21 +10,13 @@ on:
       - "crates/mbx/**"
       - "mise.toml"
       - ".github/workflows/docs.yml"
-  pull_request:
-    paths:
-      - "docs/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/mbx/**"
-      - "mise.toml"
-      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions: {}
 
 concurrency:
   group: pages-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- run documentation validation and builds inside `ci.yml`
- require the docs job from the branch-protection `final` status
- keep `docs.yml` focused on main-branch/manual GitHub Pages deployment
- stack this directly above the Bats CI foundation

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/docs.yml`
- `mise run check:docs`
- `mise run build:docs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no runtime or application code; main risk is CI misconfiguration blocking merges or duplicate/missing doc checks.
> 
> **Overview**
> **Documentation checks now run on every CI workflow** (push/PR) via a new `docs` job in `ci.yml` that runs `mise run check:docs` and `mise run build:docs` on `ubuntu-latest` with `mise-action`. The aggregate **`final` job** depends on `docs` and fails the required status if docs does not succeed.
> 
> **`docs.yml` is narrowed to publishing only**: the `pull_request` path-filtered trigger is removed, and Pages concurrency **`cancel-in-progress` is always `false`** (no longer tied to PR events). PRs still get doc validation through `ci.yml`; main/manual runs still build and deploy GitHub Pages from `docs.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ed359396ab7b94cfa2e0b4f373c4c7cc3cb23f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->