### PR TITLE
ci: migrate to Namespace runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - namespace-profile-endev-linux-amd64
+    - namespace-profile-endev-linux-arm64
+    - namespace-profile-endev-macos-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache: rust
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
@@ -31,27 +31,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+          - os: windows-latest
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - if: matrix.os != 'windows-latest'
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: rust
+      - if: matrix.os == 'windows-latest'
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo build --workspace --all-targets
       - run: cargo test --workspace
 
   compatibility:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # master
         with:
           toolchain: "1.91"
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
-          key: msrv
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache: rust
       - name: Check MSRV
         run: cargo check --locked --workspace --all-targets
       - name: Check without a TLS backend
@@ -62,7 +72,7 @@ jobs:
         run: cargo check --locked --workspace --all-targets --no-default-features --features rustls-native-roots
 
   supply-chain:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: EmbarkStudios/cargo-deny-action@c3bbe7e4e3f7baeee1a3dd9aec0a3b2aded580fb # v2.1.1
@@ -76,7 +86,7 @@ jobs:
       - lint
       - supply-chain
       - test
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 1
     # Run on success or upstream failure but skip when the workflow is cancelled
     # — `always()` would override `cancel-in-progress` and waste a runner.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: read
       pages: write
@@ -37,6 +37,9 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: rust
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
         if: github.ref == 'refs/heads/main'
@@ -61,7 +64,7 @@ jobs:
       pages: write
       id-token: write
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release-plz-release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     # Forks should never attempt to publish.
     if: ${{ github.repository_owner == 'jdx' }}
     permissions:
@@ -32,8 +32,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # Exchanges the OIDC token for a short-lived crates.io token. Each crate
       # needs a Trusted Publisher naming this repository and this workflow
@@ -100,7 +98,7 @@ jobs:
     name: Publish release
     needs: [release-plz-release, upload-assets]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write
     steps:
@@ -112,7 +110,7 @@ jobs:
 
   release-plz-pr:
     name: Release PR
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     if: ${{ github.repository_owner == 'jdx' }}
     permissions:
       contents: write
@@ -126,8 +124,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   build:
     name: ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     strategy:
@@ -37,18 +37,23 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
             bin: mbx
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
+            runner: namespace-profile-endev-linux-arm64
             bin: mbx
           - target: aarch64-apple-darwin
             os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
             bin: mbx
           - target: x86_64-apple-darwin
             os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
             bin: mbx
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            runner: windows-latest
             bin: mbx.exe
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -59,10 +64,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          key: ${{ matrix.target }}
 
       - name: Install the musl toolchain
         if: endsWith(matrix.target, '-musl')
@@ -114,7 +115,7 @@ jobs:
     # Needs every target: a release carrying four of five archives is worse
     # than one that arrives late, and the draft stays unpublished either way.
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

- move Linux and macOS workflow jobs to the shared Namespace runner profiles
- preserve Windows jobs on GitHub-hosted runners and keep logical OS matrix values intact
- use Namespace Rust caching for CI/docs and register custom labels with actionlint

## Test plan

- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint -color`
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise x cargo:zizmor@1.29.0 -- zizmor .github/workflows --format plain` (only pre-existing findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release and release-plz jobs lose Rust build caching and depend on Namespace runner availability; misconfigured profiles could break publishing or cross-platform test coverage despite unchanged job logic.
> 
> **Overview**
> Moves **Linux and macOS** CI, docs, release, and release-plz jobs from GitHub-hosted `ubuntu-latest` / `macos-latest` (and Linux ARM release builds from `ubuntu-24.04-arm`) onto Namespace profile runners (`namespace-profile-endev-linux-amd64`, `linux-arm64`, `macos-arm64`). **Windows** jobs stay on `windows-latest`.
> 
> Test and release build matrices now pair each logical OS with an explicit `runner` label while keeping existing `matrix.os` values for conditional steps.
> 
> On Namespace/Linux/macOS paths, **Swatinem/rust-cache** is replaced by **`namespacelabs/nscloud-cache-action`** with `cache: rust` (CI lint/compatibility/docs build; Windows CI test still uses rust-cache with `save-if` on main). **Release** and **release-plz** build jobs drop rust caching entirely rather than switching to nscloud-cache.
> 
> Adds **`.github/actionlint.yaml`** so actionlint recognizes the custom self-hosted runner labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd55b56da095886c82f6450448c26df093af2ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->