### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,20 @@
+name: zizmor
+on:
+  pull_request:
+    paths: [".github/workflows/**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          min-severity: high


### PR DESCRIPTION
Add a pinned zizmor workflow matching jdx/mise. It runs on pull requests that change GitHub Actions workflows, uses least-privilege permissions, and fails on high-severity findings.\n\nValidation:\n- zizmor --min-severity high .github/workflows\n- actionlint\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds read-only CI scanning of workflow files with no changes to application code or production runtime behavior.
> 
> **Overview**
> Adds a new **zizmor** GitHub Actions workflow that runs on pull requests when files under `.github/workflows/**` change.
> 
> The job uses **least-privilege** permissions (`permissions: {}` at workflow level, `contents: read` on the job), a **pinned** `actions/checkout` with `persist-credentials: false`, and the **pinned** `zizmorcore/zizmor-action` with `advanced-security: false` and **`min-severity: high`** so the check fails only on high-severity workflow security findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808e60dba3cec1157309a416a7a53053eb332214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->