### PR TITLE
feat: add installation doctor

### DIFF
--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -268,6 +268,23 @@ async fn falls_back_when_blob_packs_are_not_advertised() {
 }
 
 #[tokio::test]
+async fn connection_check_requires_a_capabilities_endpoint() {
+    let mut server = mockito::Server::new_async().await;
+    let capabilities = server
+        .mock("GET", "/v1/capabilities")
+        .with_status(404)
+        .expect(1)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let error = client.check_connection().await.unwrap_err();
+
+    assert!(error.to_string().contains("404"));
+    capabilities.assert_async().await;
+}
+
+#[tokio::test]
 async fn disables_blob_packs_when_the_advertised_endpoint_is_unavailable() {
     let mut server = mockito::Server::new_async().await;
     let capabilities = server

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -351,7 +351,7 @@ impl RemoteCacheClient {
     /// that need to distinguish a valid client configuration from a reachable,
     /// compatible remote cache.
     pub async fn check_connection(&self) -> Result<()> {
-        self.negotiated_capabilities().await?;
+        self.fetch_capabilities(false).await?;
         Ok(())
     }
 
@@ -422,66 +422,67 @@ impl RemoteCacheClient {
 
     async fn negotiated_capabilities(&self) -> Result<NegotiatedCapabilities> {
         self.capabilities
-            .get_or_try_init(|| async {
-                let url = self.capabilities_endpoint()?;
-                let response = self
-                    .request(reqwest::Method::GET, url, "application/json")
-                    .await?
-                    .send()
-                    .await?;
-                if matches!(
-                    response.status(),
-                    StatusCode::NOT_FOUND
-                        | StatusCode::METHOD_NOT_ALLOWED
-                        | StatusCode::NOT_IMPLEMENTED
-                ) {
-                    return Ok(NegotiatedCapabilities::default());
-                }
-                let bytes =
-                    read_bounded_json(response.error_for_status()?, "capabilities").await?;
-                let capabilities: RemoteCacheCapabilities = serde_json::from_slice(&bytes)?;
-                if capabilities.protocol.major != PROTOCOL_VERSION {
-                    bail!(
-                        "remote cache capability protocol {} is incompatible with client protocol {PROTOCOL_VERSION}",
-                        capabilities.protocol.major
-                    );
-                }
-                // Compression is negotiated, never assumed: a body sent with a
-                // coding the server did not offer would be stored corrupt or
-                // rejected, so absence of the advertisement means identity.
-                let zstd_uploads = capabilities
-                    .compressors
-                    .iter()
-                    .any(|compressor| compressor == "zstd");
-                let blob_packs = if capabilities.features.blob_packs {
-                    let max_items = usize::try_from(capabilities.limits.max_batch_items)
-                        .ok()
-                        .filter(|limit| *limit > 0)
-                        .ok_or_else(|| {
-                            eyre!(
-                                "remote cache blob packs require a positive max_batch_items limit"
-                            )
-                        })?;
-                    if capabilities.limits.max_pack_bytes == 0 {
-                        bail!("remote cache blob packs require a positive max_pack_bytes limit");
-                    }
-                    Some(BlobPackLimits {
-                        max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
-                        max_bytes: capabilities
-                            .limits
-                            .max_pack_bytes
-                            .min(MAX_STAGED_BLOB_PACK_BYTES),
-                    })
-                } else {
-                    None
-                };
-                Ok(NegotiatedCapabilities {
-                    blob_packs,
-                    zstd_uploads,
-                })
-            })
+            .get_or_try_init(|| self.fetch_capabilities(true))
             .await
             .copied()
+    }
+
+    async fn fetch_capabilities(&self, allow_missing: bool) -> Result<NegotiatedCapabilities> {
+        let url = self.capabilities_endpoint()?;
+        let response = self
+            .request(reqwest::Method::GET, url, "application/json")
+            .await?
+            .send()
+            .await?;
+        if allow_missing
+            && matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            )
+        {
+            return Ok(NegotiatedCapabilities::default());
+        }
+        let bytes = read_bounded_json(response.error_for_status()?, "capabilities").await?;
+        let capabilities: RemoteCacheCapabilities = serde_json::from_slice(&bytes)?;
+        if capabilities.protocol.major != PROTOCOL_VERSION {
+            bail!(
+                "remote cache capability protocol {} is incompatible with client protocol {PROTOCOL_VERSION}",
+                capabilities.protocol.major
+            );
+        }
+        // Compression is negotiated, never assumed: a body sent with a
+        // coding the server did not offer would be stored corrupt or
+        // rejected, so absence of the advertisement means identity.
+        let zstd_uploads = capabilities
+            .compressors
+            .iter()
+            .any(|compressor| compressor == "zstd");
+        let blob_packs = if capabilities.features.blob_packs {
+            let max_items = usize::try_from(capabilities.limits.max_batch_items)
+                .ok()
+                .filter(|limit| *limit > 0)
+                .ok_or_else(|| {
+                    eyre!("remote cache blob packs require a positive max_batch_items limit")
+                })?;
+            if capabilities.limits.max_pack_bytes == 0 {
+                bail!("remote cache blob packs require a positive max_pack_bytes limit");
+            }
+            Some(BlobPackLimits {
+                max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
+                max_bytes: capabilities
+                    .limits
+                    .max_pack_bytes
+                    .min(MAX_STAGED_BLOB_PACK_BYTES),
+            })
+        } else {
+            None
+        };
+        Ok(NegotiatedCapabilities {
+            blob_packs,
+            zstd_uploads,
+        })
     }
 
     /// Download verified CAS objects using the server's negotiated blob-pack extension.

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -345,6 +345,16 @@ impl RemoteCacheClient {
         })
     }
 
+    /// Connect to the server, authenticate, and negotiate protocol capabilities.
+    ///
+    /// This performs no cache reads or writes. It is intended for diagnostics
+    /// that need to distinguish a valid client configuration from a reachable,
+    /// compatible remote cache.
+    pub async fn check_connection(&self) -> Result<()> {
+        self.negotiated_capabilities().await?;
+        Ok(())
+    }
+
     fn action_result_endpoint(&self, action: &CacheDigest) -> Result<Url> {
         action.validate()?;
         if action.algorithm != "blake3" {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -27,6 +27,8 @@ struct Cli {
 
 #[derive(usage::Subcommands)]
 enum Commands {
+    /// Check the local installation, cache, toolchain, and remote connection.
+    Doctor,
     /// Run a Cargo command and explain every compilation mbx cannot cache.
     Explain(ExplainArgs),
     /// Install a persistent rustc wrapper for plain Cargo commands.
@@ -140,6 +142,7 @@ pub fn run() -> Result<ExitCode> {
     }
     let config = Config::load()?;
     match cli.command {
+        Commands::Doctor => crate::doctor::run(&config),
         Commands::Explain(args) => crate::explain::run(&config, &args.arguments()),
         Commands::Setup(args) => setup(args.action()?),
         Commands::Gc(args) => gc(

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -140,9 +140,12 @@ pub fn run() -> Result<ExitCode> {
     if let Commands::Prefetch(args) = &mut cli.command {
         args.cargo_args = original_prefetch_arguments(&original)?;
     }
+    if matches!(&cli.command, Commands::Doctor) {
+        return crate::doctor::run_loaded(Config::load());
+    }
     let config = Config::load()?;
     match cli.command {
-        Commands::Doctor => crate::doctor::run(&config),
+        Commands::Doctor => unreachable!("doctor was handled before configuration loading"),
         Commands::Explain(args) => crate::explain::run(&config, &args.arguments()),
         Commands::Setup(args) => setup(args.action()?),
         Commands::Gc(args) => gc(

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -441,6 +441,7 @@ fn cli_exposes_its_usage_spec() {
     assert!(spec.contains("external_subcommand #true"));
     assert!(spec.contains("cmd setup"));
     assert!(spec.contains("cmd explain"));
+    assert!(spec.contains("cmd doctor"));
     assert!(spec.contains("cmd gc"));
     assert!(spec.contains("cmd cache"));
     assert!(spec.contains("config {"));

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -1,0 +1,317 @@
+//! Installation and connectivity diagnostics.
+
+use crate::config::Config;
+use crate::policy;
+use eyre::{Context, Result};
+use mbx_cache_core::{RemoteCacheClient, RemoteCacheConfig};
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Severity {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Check {
+    severity: Severity,
+    name: &'static str,
+    detail: String,
+}
+
+impl Check {
+    fn pass(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Pass,
+            name,
+            detail: detail.into(),
+        }
+    }
+
+    fn warn(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Warn,
+            name,
+            detail: detail.into(),
+        }
+    }
+
+    fn fail(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Fail,
+            name,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Run all diagnostics and fail only when mbx cannot operate as configured.
+pub fn run(config: &Config) -> Result<ExitCode> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let checks = runtime.block_on(check(config));
+    let failures = checks
+        .iter()
+        .filter(|check| check.severity == Severity::Fail)
+        .count();
+    let warnings = checks
+        .iter()
+        .filter(|check| check.severity == Severity::Warn)
+        .count();
+    for check in &checks {
+        let marker = match check.severity {
+            Severity::Pass => "ok",
+            Severity::Warn => "warn",
+            Severity::Fail => "FAIL",
+        };
+        println!("{marker:>4}  {:<12} {}", check.name, check.detail);
+    }
+    println!("\n{failures} failures, {warnings} warnings");
+    Ok(if failures == 0 {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    })
+}
+
+async fn check(config: &Config) -> Vec<Check> {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+    let mut checks = vec![
+        command_check("cargo", &cargo),
+        command_check("rustc", &rustc),
+    ];
+    checks.push(cache_check(&config.cache_dir));
+    checks.push(Check::pass(
+        "config",
+        format!(
+            "{} budget, automatic gc {}, managed targets {} at {}",
+            bytesize::ByteSize::b(config.gc.max_bytes).display().iec(),
+            enabled(config.gc.auto),
+            enabled(config.target.views),
+            config.target.root.display(),
+        ),
+    ));
+    checks.push(reflink_check(&config.cache_dir));
+    checks.push(setup_check());
+    checks.extend(remote_checks(config).await);
+    checks
+}
+
+fn enabled(value: bool) -> &'static str {
+    if value { "enabled" } else { "disabled" }
+}
+
+fn command_check(name: &'static str, command: &OsStr) -> Check {
+    match Command::new(command).arg("--version").output() {
+        Ok(output) if output.status.success() => Check::pass(
+            name,
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ),
+        Ok(output) => Check::fail(name, format!("--version exited with {}", output.status)),
+        Err(error) => Check::fail(
+            name,
+            format!("could not execute {}: {error}", command.to_string_lossy()),
+        ),
+    }
+}
+
+fn cache_check(cache_dir: &Path) -> Check {
+    if let Err(error) = std::fs::create_dir_all(cache_dir) {
+        return Check::fail("cache", format!("{}: {error}", cache_dir.display()));
+    }
+    match tempfile::NamedTempFile::new_in(cache_dir) {
+        Ok(_) => Check::pass("cache", format!("{} is writable", cache_dir.display())),
+        Err(error) => Check::fail(
+            "cache",
+            format!("{} is not writable: {error}", cache_dir.display()),
+        ),
+    }
+}
+
+fn reflink_check(cache_dir: &Path) -> Check {
+    let Ok(directory) = tempfile::tempdir_in(cache_dir) else {
+        return Check::warn("reflink", "not tested because the cache is not writable");
+    };
+    let source = directory.path().join("source");
+    let destination = directory.path().join("destination");
+    if let Err(error) = std::fs::write(&source, b"mbx reflink probe") {
+        return Check::warn("reflink", format!("probe could not be written: {error}"));
+    }
+    match reflink_copy::reflink(&source, &destination) {
+        Ok(()) => Check::pass("reflink", "supported by the cache filesystem"),
+        Err(error) => Check::warn(
+            "reflink",
+            format!("unavailable ({error}); restored outputs will be copied"),
+        ),
+    }
+}
+
+fn setup_check() -> Check {
+    let Some((config_path, expected_shim)) = setup_paths() else {
+        return Check::warn("setup", "platform Cargo paths could not be determined");
+    };
+    let contents = match std::fs::read_to_string(&config_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Check::warn("setup", "plain cargo integration is not installed");
+        }
+        Err(error) => {
+            return Check::warn(
+                "setup",
+                format!("{} could not be read: {error}", config_path.display()),
+            );
+        }
+    };
+    let document = match contents.parse::<toml_edit::DocumentMut>() {
+        Ok(document) => document,
+        Err(error) => {
+            return Check::warn(
+                "setup",
+                format!("{} is invalid TOML: {error}", config_path.display()),
+            );
+        }
+    };
+    let wrapper = document
+        .get("build")
+        .and_then(toml_edit::Item::as_table_like)
+        .and_then(|build| build.get("rustc-wrapper"))
+        .and_then(toml_edit::Item::as_str);
+    match wrapper {
+        Some(wrapper) if Path::new(wrapper) == expected_shim && expected_shim.is_file() => {
+            Check::pass("setup", format!("{} is installed", expected_shim.display()))
+        }
+        Some(wrapper) if Path::new(wrapper) == expected_shim => Check::warn(
+            "setup",
+            format!("configured wrapper is missing: {}", expected_shim.display()),
+        ),
+        Some(wrapper) => Check::warn("setup", format!("Cargo uses another wrapper: {wrapper}")),
+        None => Check::warn("setup", "plain cargo integration is not installed"),
+    }
+}
+
+fn setup_paths() -> Option<(PathBuf, PathBuf)> {
+    let data = dirs::data_local_dir()?;
+    let cargo_home = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cargo")))?;
+    let config = if cargo_home.join("config.toml").exists() || !cargo_home.join("config").exists() {
+        cargo_home.join("config.toml")
+    } else {
+        cargo_home.join("config")
+    };
+    let shim = data.join("mbx").join("bin").join(if cfg!(windows) {
+        format!("{}.exe", crate::session::RUSTC_SHIM_STEM)
+    } else {
+        crate::session::RUSTC_SHIM_STEM.into()
+    });
+    Some((config, shim))
+}
+
+async fn remote_checks(config: &Config) -> Vec<Check> {
+    let Some(base_url) = &config.remote.url else {
+        return vec![Check::pass(
+            "remote",
+            "not configured; using the local cache",
+        )];
+    };
+    let Some(namespace) = config
+        .remote
+        .namespace
+        .as_deref()
+        .map(str::trim)
+        .filter(|namespace| !namespace.is_empty())
+    else {
+        return vec![Check::fail(
+            "remote",
+            "remote.namespace is required when remote.url is set",
+        )];
+    };
+    let effective = if policy::release_context() {
+        "disabled in this release context".to_string()
+    } else {
+        policy::effective_remote_cache_mode(config.remote.mode).map_or_else(
+            || "disabled by CI policy".to_string(),
+            |mode| mode.to_string(),
+        )
+    };
+    let policy = Check::pass(
+        "policy",
+        format!("configured {}, effective {effective}", config.remote.mode),
+    );
+    let parsed = match base_url.parse() {
+        Ok(url) => url,
+        Err(error) => {
+            return vec![
+                policy,
+                Check::fail("remote", format!("invalid URL {base_url:?}: {error}")),
+            ];
+        }
+    };
+    let client = match RemoteCacheClient::new(RemoteCacheConfig {
+        base_url: parsed,
+        namespace: namespace.to_string(),
+        token: config.remote.token.clone(),
+        token_file: config.remote.token_file.clone(),
+        oidc_audience: config.remote.oidc_audience.clone(),
+        connect_timeout: config.http.timeout,
+        read_timeout: config.http.timeout,
+        download_timeout: config.http.download_timeout,
+        retries: config.http.retries,
+    }) {
+        Ok(client) => client,
+        Err(error) => return vec![policy, Check::fail("remote", format!("{error:#}"))],
+    };
+    let remote = match client
+        .check_connection()
+        .await
+        .wrap_err("connection check failed")
+    {
+        Ok(()) => Check::pass("remote", format!("{base_url} ({namespace}) is compatible")),
+        Err(error) => Check::fail("remote", format!("{error:#}")),
+    };
+    vec![policy, remote]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writable_cache_passes_and_leaves_no_probe() {
+        let directory = tempfile::tempdir().unwrap();
+        assert_eq!(cache_check(directory.path()).severity, Severity::Pass);
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn missing_remote_namespace_fails() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = Config {
+            cache_dir: directory.path().to_path_buf(),
+            stats_report: None,
+            verify: false,
+            incremental: false,
+            share_out_dir: false,
+            remote: Default::default(),
+            http: Default::default(),
+            gc: Default::default(),
+            target: crate::config::TargetSettings {
+                views: true,
+                root: directory.path().join("targets"),
+            },
+        };
+        config.remote.url = Some("https://cache.example".into());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let checks = runtime.block_on(remote_checks(&config));
+        assert_eq!(checks[0].severity, Severity::Fail);
+        assert!(checks[0].detail.contains("namespace"));
+    }
+}

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -246,12 +246,6 @@ async fn remote_checks(config: &Config) -> Vec<Check> {
         "policy",
         format!("configured {}, effective {effective}", config.remote.mode),
     );
-    if effective_mode.is_none() {
-        return vec![
-            policy,
-            Check::pass("remote", "probe skipped because remote caching is disabled"),
-        ];
-    }
     let Some(namespace) = config
         .remote
         .namespace
@@ -290,6 +284,12 @@ async fn remote_checks(config: &Config) -> Vec<Check> {
         Ok(client) => client,
         Err(error) => return vec![policy, Check::fail("remote", format!("{error:#}"))],
     };
+    if effective_mode.is_none() {
+        return vec![
+            policy,
+            Check::pass("remote", "probe skipped because remote caching is disabled"),
+        ];
+    }
     let remote = match client
         .check_connection()
         .await
@@ -330,6 +330,7 @@ mod tests {
             },
         };
         config.remote.url = Some("https://cache.example".into());
+        config.remote.mode = mbx_cache_core::RemoteCacheMode::WriteOnly;
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -224,28 +224,44 @@ fn setup_paths() -> Option<(PathBuf, PathBuf)> {
 }
 
 async fn remote_checks(config: &Config) -> Vec<Check> {
+    let release_context = policy::release_context();
+    let effective_mode = if release_context {
+        None
+    } else {
+        policy::effective_remote_cache_mode(config.remote.mode)
+    };
+    remote_checks_with_policy(config, release_context, effective_mode).await
+}
+
+async fn remote_checks_with_policy(
+    config: &Config,
+    release_context: bool,
+    effective_mode: Option<mbx_cache_core::RemoteCacheMode>,
+) -> Vec<Check> {
     let Some(base_url) = &config.remote.url else {
         return vec![Check::pass(
             "remote",
             "not configured; using the local cache",
         )];
     };
-    let (effective, effective_mode) = if policy::release_context() {
-        ("disabled in this release context".to_string(), None)
+    let effective = if release_context {
+        "disabled in this release context".to_string()
     } else {
-        let mode = policy::effective_remote_cache_mode(config.remote.mode);
-        (
-            mode.map_or_else(
-                || "disabled by CI policy".to_string(),
-                |mode| mode.to_string(),
-            ),
-            mode,
+        effective_mode.map_or_else(
+            || "disabled by cache write policy".to_string(),
+            |mode| mode.to_string(),
         )
     };
     let policy = Check::pass(
         "policy",
         format!("configured {}, effective {effective}", config.remote.mode),
     );
+    if effective_mode.is_none() {
+        return vec![
+            policy,
+            Check::pass("remote", "probe skipped because remote caching is disabled"),
+        ];
+    }
     let Some(namespace) = config
         .remote
         .namespace
@@ -284,12 +300,6 @@ async fn remote_checks(config: &Config) -> Vec<Check> {
         Ok(client) => client,
         Err(error) => return vec![policy, Check::fail("remote", format!("{error:#}"))],
     };
-    if effective_mode.is_none() {
-        return vec![
-            policy,
-            Check::pass("remote", "probe skipped because remote caching is disabled"),
-        ];
-    }
     let remote = match client
         .check_connection()
         .await
@@ -330,16 +340,55 @@ mod tests {
             },
         };
         config.remote.url = Some("https://cache.example".into());
-        config.remote.mode = mbx_cache_core::RemoteCacheMode::WriteOnly;
+        config.remote.mode = mbx_cache_core::RemoteCacheMode::ReadWrite;
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
-        let checks = runtime.block_on(remote_checks(&config));
+        let checks = runtime.block_on(remote_checks_with_policy(
+            &config,
+            false,
+            Some(mbx_cache_core::RemoteCacheMode::ReadOnly),
+        ));
         let failure = checks
             .iter()
             .find(|check| check.severity == Severity::Fail)
             .expect("the missing namespace should fail");
         assert!(failure.detail.contains("namespace"));
+    }
+
+    #[test]
+    fn disabled_remote_does_not_require_a_namespace_or_client() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = Config {
+            cache_dir: directory.path().to_path_buf(),
+            stats_report: None,
+            verify: false,
+            incremental: false,
+            share_out_dir: false,
+            remote: Default::default(),
+            http: Default::default(),
+            gc: Default::default(),
+            target: crate::config::TargetSettings {
+                views: true,
+                root: directory.path().join("targets"),
+            },
+        };
+        config.remote.url = Some("not a URL".into());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let checks = runtime.block_on(remote_checks_with_policy(&config, false, None));
+
+        assert!(checks.iter().all(|check| check.severity == Severity::Pass));
+        assert!(checks.iter().any(|check| {
+            check.name == "policy" && check.detail.contains("disabled by cache write policy")
+        }));
+        assert!(
+            checks
+                .iter()
+                .any(|check| { check.name == "remote" && check.detail.contains("probe skipped") })
+        );
     }
 }

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -78,6 +78,17 @@ pub fn run(config: &Config) -> Result<ExitCode> {
     })
 }
 
+pub(crate) fn run_loaded(config: Result<Config>) -> Result<ExitCode> {
+    match config {
+        Ok(config) => run(&config),
+        Err(error) => {
+            println!("FAIL  {:<12} {error:#}", "config");
+            println!("\n1 failures, 0 warnings");
+            Ok(ExitCode::FAILURE)
+        }
+    }
+}
+
 async fn check(config: &Config) -> Vec<Check> {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
     let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
@@ -219,6 +230,28 @@ async fn remote_checks(config: &Config) -> Vec<Check> {
             "not configured; using the local cache",
         )];
     };
+    let (effective, effective_mode) = if policy::release_context() {
+        ("disabled in this release context".to_string(), None)
+    } else {
+        let mode = policy::effective_remote_cache_mode(config.remote.mode);
+        (
+            mode.map_or_else(
+                || "disabled by CI policy".to_string(),
+                |mode| mode.to_string(),
+            ),
+            mode,
+        )
+    };
+    let policy = Check::pass(
+        "policy",
+        format!("configured {}, effective {effective}", config.remote.mode),
+    );
+    if effective_mode.is_none() {
+        return vec![
+            policy,
+            Check::pass("remote", "probe skipped because remote caching is disabled"),
+        ];
+    }
     let Some(namespace) = config
         .remote
         .namespace
@@ -226,23 +259,14 @@ async fn remote_checks(config: &Config) -> Vec<Check> {
         .map(str::trim)
         .filter(|namespace| !namespace.is_empty())
     else {
-        return vec![Check::fail(
-            "remote",
-            "remote.namespace is required when remote.url is set",
-        )];
+        return vec![
+            policy,
+            Check::fail(
+                "remote",
+                "remote.namespace is required when remote.url is set",
+            ),
+        ];
     };
-    let effective = if policy::release_context() {
-        "disabled in this release context".to_string()
-    } else {
-        policy::effective_remote_cache_mode(config.remote.mode).map_or_else(
-            || "disabled by CI policy".to_string(),
-            |mode| mode.to_string(),
-        )
-    };
-    let policy = Check::pass(
-        "policy",
-        format!("configured {}, effective {effective}", config.remote.mode),
-    );
     let parsed = match base_url.parse() {
         Ok(url) => url,
         Err(error) => {
@@ -311,7 +335,10 @@ mod tests {
             .build()
             .unwrap();
         let checks = runtime.block_on(remote_checks(&config));
-        assert_eq!(checks[0].severity, Severity::Fail);
-        assert!(checks[0].detail.contains("namespace"));
+        let failure = checks
+            .iter()
+            .find(|check| check.severity == Severity::Fail)
+            .expect("the missing namespace should fail");
+        assert!(failure.detail.contains("namespace"));
     }
 }

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod cli;
 pub mod config;
+pub mod doctor;
 pub mod explain;
 pub mod policy;
 pub mod session;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,15 @@ Examples:
 - **`-h --help`** — Print help
 - **`-V --version`** — Print version
 
+## `mbx doctor`
+
+- **Usage:** `mbx doctor`
+
+Check the local installation, cache, toolchain, and remote connection.
+
+### Flags
+- **`-h --help`** — Print help
+
 ## `mbx explain`
 
 - **Usage:** `mbx explain <CARGO_COMMAND> [CARGO_ARGS]…`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,6 +77,17 @@ The persistent wrapper uses the local action store. Continue to run commands
 through `mbx` when you need a remote cache, build statistics, managed target
 directories, or automatic collection.
 
+## Diagnose the installation
+
+```sh
+mbx doctor
+```
+
+Doctor checks the Cargo and rustc executables, cache write access, filesystem
+reflink support, plain Cargo wrapper installation, effective remote policy,
+and remote protocol connectivity. Warnings describe optional features or
+fallbacks; failures make the command exit unsuccessfully.
+
 ## Read the result
 
 After a build that used the cache, mbx prints a summary to stderr:

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -18,6 +18,17 @@ setup() {
   assert_success
   assert_output --partial "cache"
   assert_output --partial "gc"
+  assert_output --partial "doctor"
+}
+
+@test "doctor validates an isolated local installation" {
+  run "$MBX_BIN" doctor
+
+  assert_success
+  assert_output --partial "cargo"
+  assert_output --partial "cache"
+  assert_output --partial "remote"
+  assert_output --partial "0 failures"
 }
 
 @test "an isolated store starts empty" {


### PR DESCRIPTION
## Summary
- add `mbx doctor` for toolchain, cache, configuration, reflink, and setup diagnostics
- negotiate remote capabilities to verify connectivity, authentication, and protocol compatibility without reading or writing cache data
- document the command and cover it with unit and CLI tests

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- generated CLI documentation is current

`mise run test:bats` could not execute locally because the Bats checkout is absent; the new Bats case is included for CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive diagnostics and a refactored capabilities path; existing cache negotiation behavior is unchanged when `allow_missing` is true.
> 
> **Overview**
> Adds **`mbx doctor`**, a read-only diagnostic command that prints pass/warn/fail lines for Cargo/rustc, cache writability, config summary, reflink support, plain-Cargo wrapper setup, effective remote policy, and (when remote is enabled) live connectivity.
> 
> In **`mbx-cache-core`**, capability negotiation is extracted into **`fetch_capabilities(allow_missing)`**. Normal cache use still treats a missing capabilities endpoint as defaults (`allow_missing=true`); the new public **`check_connection()`** uses **`allow_missing=false`** so doctor can fail on 404/incompatible protocol without reading or writing cache objects.
> 
> The CLI wires **`doctor`** early via **`run_loaded`** so config parse errors surface as a failed check. Docs and **unit/Bats** tests cover the command and the stricter connection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096aaced4d608053767a462d6ba1fe3415ccff8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `doctor` diagnostics for installation, cache, configuration, and remote connectivity.
  - Added `explain` for inspecting cache decisions and compiler queries.
  - Added `prefetch` to warm the cache for supported Cargo workflows.
  - Expanded `setup` with status, update, and uninstall actions.
  - Added remote connection validation without modifying cached data.

- **Documentation**
  - Documented the new commands and setup options.
  - Added getting-started guidance for diagnosing installations.

- **Bug Fixes**
  - Improved handling and reporting of unavailable remote capability endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->