### PR TITLE
feat: explain cache bypasses

### DIFF
--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(cli)* run a Cargo command with actionable cache-bypass diagnostics using `mbx explain`
+
 ### Changed
 
 - *(cache)* restore verified outputs with observable copy-on-write materialization

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -27,6 +27,8 @@ struct Cli {
 
 #[derive(usage::Subcommands)]
 enum Commands {
+    /// Run a Cargo command and explain every compilation mbx cannot cache.
+    Explain(ExplainArgs),
     /// Install a persistent rustc wrapper for plain Cargo commands.
     Setup,
     /// Collect stale managed targets and evict cached objects until the store fits a size budget.
@@ -48,6 +50,25 @@ struct GcArgs {
 }
 
 #[derive(usage::Args)]
+#[usage(unknown_flags = "value")]
+struct ExplainArgs {
+    /// Cargo subcommand to run under diagnostics.
+    #[usage(value_name = "CARGO_COMMAND")]
+    cargo_command: String,
+    /// Arguments to pass to the Cargo subcommand.
+    #[usage(double_dash = "preserve", value_name = "CARGO_ARGS")]
+    cargo_args: Vec<String>,
+}
+
+impl ExplainArgs {
+    fn arguments(self) -> Vec<String> {
+        std::iter::once(self.cargo_command)
+            .chain(self.cargo_args)
+            .collect()
+    }
+}
+
+#[derive(usage::Args)]
 struct CacheArgs {
     #[usage(subcommand)]
     command: CacheCommands,
@@ -66,6 +87,7 @@ pub fn run() -> Result<ExitCode> {
     let cli = Cli::parse();
     let config = Config::load()?;
     match cli.command {
+        Commands::Explain(args) => crate::explain::run(&config, &args.arguments()),
         Commands::Setup => setup().map(|()| ExitCode::SUCCESS),
         Commands::Gc(args) => gc(
             &config,
@@ -154,6 +176,14 @@ fn setup_at(executable: &Path, install_dir: &Path, config_path: &Path) -> Result
 }
 
 fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {
+    cargo_with_bypass_log(config, arguments, None)
+}
+
+pub(crate) fn cargo_with_bypass_log(
+    config: &Config,
+    arguments: &[String],
+    bypass_log: Option<&Path>,
+) -> Result<ExitCode> {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     // Release builds publish artifacts that must not depend on a cache, and a
     // tag build has no later build to share with anyway.
@@ -223,6 +253,12 @@ fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     let status = runtime.block_on(async {
         let session = CacheSession::start(session_dir.path(), config).await?;
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
+        if let Some(path) = bypass_log {
+            environment.insert(
+                crate::session::BYPASS_LOG_ENV.into(),
+                path.display().to_string(),
+            );
+        }
         if let Some(directory) = &placed {
             environment.insert(
                 CARGO_TARGET_DIR_ENV.into(),

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -254,6 +254,11 @@ pub(crate) fn cargo_with_bypass_log(
         let session = CacheSession::start(session_dir.path(), config).await?;
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
         if let Some(path) = bypass_log {
+            let path = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                working_dir.join(path)
+            };
             environment.insert(
                 crate::session::BYPASS_LOG_ENV.into(),
                 path.display().to_string(),

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -373,10 +373,33 @@ fn mbx_commands_still_take_precedence() {
 }
 
 #[test]
+fn explain_forwards_cargo_flags_and_the_rustc_separator() {
+    let argv = [
+        "mbx",
+        "explain",
+        "clippy",
+        "--workspace",
+        "--",
+        "-D",
+        "warnings",
+    ]
+    .map(std::ffi::OsStr::new);
+    let cli = Cli::try_parse_from(&argv).unwrap();
+    let Commands::Explain(arguments) = cli.command else {
+        panic!("explain should be reserved by mbx");
+    };
+    assert_eq!(
+        arguments.arguments(),
+        ["clippy", "--workspace", "--", "-D", "warnings"]
+    );
+}
+
+#[test]
 fn cli_exposes_its_usage_spec() {
     let spec = Cli::to_kdl();
     assert!(spec.contains("external_subcommand #true"));
     assert!(spec.contains("cmd setup"));
+    assert!(spec.contains("cmd explain"));
     assert!(spec.contains("cmd gc"));
     assert!(spec.contains("cmd cache"));
     assert!(spec.contains("config {"));

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -1,0 +1,150 @@
+//! Actionable explanations for conservative cache bypasses.
+
+use crate::config::Config;
+use eyre::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::ExitCode;
+
+/// Run Cargo with a private bypass trace and explain its contents afterwards.
+pub fn run(config: &Config, arguments: &[String]) -> Result<ExitCode> {
+    let directory = tempfile::Builder::new().prefix("mbx-explain-").tempdir()?;
+    let log = directory.path().join("bypasses.tsv");
+    let status = crate::cli::cargo_with_bypass_log(config, arguments, Some(&log))?;
+    let records = read_records(&log)?;
+    display(&records);
+    Ok(status)
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Records(BTreeMap<String, BTreeMap<String, u64>>);
+
+impl Records {
+    fn add(&mut self, kind: &str, detail: &str) {
+        *self
+            .0
+            .entry(kind.to_string())
+            .or_default()
+            .entry(detail.to_string())
+            .or_default() += 1;
+    }
+
+    fn total(&self) -> u64 {
+        self.0.values().flat_map(BTreeMap::values).copied().sum()
+    }
+}
+
+fn read_records(path: &Path) -> Result<Records> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Records::default()),
+        Err(error) => {
+            return Err(error).wrap_err_with(|| format!("failed to read {}", path.display()));
+        }
+    };
+    parse_records(&contents)
+}
+
+fn parse_records(contents: &str) -> Result<Records> {
+    let mut records = Records::default();
+    for (index, line) in contents.lines().enumerate() {
+        let (kind, detail) = line
+            .split_once('\t')
+            .ok_or_else(|| eyre::eyre!("invalid bypass record on line {}", index + 1))?;
+        if kind.is_empty() || detail.is_empty() {
+            eyre::bail!("invalid bypass record on line {}", index + 1);
+        }
+        records.add(kind, detail);
+    }
+    Ok(records)
+}
+
+fn display(records: &Records) {
+    if records.0.is_empty() {
+        crate::session::note("\ncache explanation: no compilations bypassed the cache");
+        return;
+    }
+    crate::session::note(&format!(
+        "\ncache explanation: {} compilations bypassed the cache",
+        records.total()
+    ));
+    for (kind, details) in &records.0 {
+        let count: u64 = details.values().sum();
+        crate::session::note(&format!("\n{kind} ({count})"));
+        crate::session::note(guidance(kind));
+        for (detail, occurrences) in details {
+            let suffix = if *occurrences > 1 {
+                format!(" ({occurrences} times)")
+            } else {
+                String::new()
+            };
+            crate::session::note(&format!("  - {detail}{suffix}"));
+        }
+    }
+}
+
+fn guidance(kind: &str) -> &'static str {
+    match kind {
+        "compiler-query" => {
+            "Expected: Cargo asks rustc for toolchain information; there is no compilation to cache."
+        }
+        "standard-input" => {
+            "Expected for Cargo probes: source supplied on standard input cannot be rediscovered later."
+        }
+        "incremental" => {
+            "Disable incremental compilation (`MBX_INCREMENTAL=0`) to make this action cacheable."
+        }
+        "response-file" => {
+            "The invocation uses an `@response-file`; mbx does not model response-file contents yet."
+        }
+        "unsupported-crate-type" => {
+            "This artifact type is outside mbx's current cacheability tier. Native binaries and dynamic libraries still link normally."
+        }
+        "unsupported-search-path" | "native-library" => {
+            "A native dependency or search path is not a precise compiler input, so mbx cannot safely reuse this action."
+        }
+        "unknown-flag" | "unknown-codegen-option" => {
+            "The toolchain passed an option this mbx adapter does not model. Check for a newer mbx release before reporting it."
+        }
+        "unmapped-absolute-path" => {
+            "The invocation references an absolute path outside the workspace, target, Cargo, toolchain, and home mappings. Move it under a mapped root or keep this action uncached."
+        }
+        "no-dep-info" | "malformed-dep-info" => {
+            "mbx needs valid rustc dep-info to discover every input. Inspect the detail below for the rejected output."
+        }
+        "input-read" | "input-changed" | "input-modified-during-compilation" => {
+            "An input was unavailable or changed while rustc ran. Stabilize generated inputs before retrying."
+        }
+        "other" => {
+            "The cache adapter failed outside a recognized conservative bypass. The detail below should be included in a bug report."
+        }
+        _ => {
+            "This action cannot be represented safely by the current cache model. The exact reason is shown below."
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn groups_repeated_details_by_stable_kind() {
+        let records = parse_records(
+            "unsupported-crate-type\trustc crate type is not cacheable yet: bin\n\
+             unsupported-crate-type\trustc crate type is not cacheable yet: bin\n\
+             compiler-query\trustc invocation is a compiler query, not a compilation\n",
+        )
+        .unwrap();
+
+        assert_eq!(records.total(), 3);
+        assert_eq!(records.0["unsupported-crate-type"].values().sum::<u64>(), 2);
+        assert!(guidance("incremental").contains("MBX_INCREMENTAL=0"));
+    }
+
+    #[test]
+    fn rejects_partial_records_instead_of_guessing() {
+        let error = parse_records("missing a tab\n").unwrap_err();
+        assert!(error.to_string().contains("line 1"));
+    }
+}

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod cli;
 pub mod config;
+pub mod explain;
 pub mod policy;
 pub mod session;
 pub mod store;

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -24,6 +24,15 @@ mbx recognized that it could not model the action exactly and ran the real
 compiler without caching it. Reasons are grouped in the summary; set
 `MBX_BYPASS_LOG` to a file path for the full per-action record.
 
+Run a Cargo command through `mbx explain` to collect those records temporarily,
+group identical causes, and print guidance for every bypass category:
+
+```sh
+mbx explain build --workspace
+```
+
+The command preserves Cargo's exit status after printing the explanation.
+
 ## Why hit rate is not the whole story
 
 A build can report a high hit rate among attempted lookups while spending most

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,19 @@ Examples:
 - **`-h --help`** — Print help
 - **`-V --version`** — Print version
 
+## `mbx explain`
+
+- **Usage:** `mbx explain <CARGO_COMMAND> [CARGO_ARGS]…`
+
+Run a Cargo command and explain every compilation mbx cannot cache.
+
+### Arguments
+- **`<CARGO_COMMAND>`** — Cargo subcommand to run under diagnostics.
+- **`[CARGO_ARGS]…`** — Arguments to pass to the Cargo subcommand.
+
+### Flags
+- **`-h --help`** — Print help
+
 ## `mbx setup`
 
 - **Usage:** `mbx setup`

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -27,6 +27,17 @@ setup() {
   assert_output --partial "0 B"
 }
 
+@test "explain reports why compilations bypass the cache" {
+  cargo init --lib --vcs none explained-project
+  cd explained-project
+
+  run "$MBX_BIN" explain check
+
+  assert_success
+  assert_output --partial "cache explanation:"
+  assert_output --partial "compiler-query"
+}
+
 @test "cargo new is forwarded" {
   run "$MBX_BIN" new --vcs none new-project
 


### PR DESCRIPTION
## Summary
- add `mbx explain <cargo command> ...` with byte-for-byte Cargo argument forwarding, including the rustc `--` separator
- capture bypass records privately, group repeated exact causes, and print category-specific remediation
- preserve Cargo exit status and document the workflow

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- exercised `mbx explain check -p mbx-cache-rustc` locally
- generated CLI documentation is current

The Bats checkout is absent in this worktree, so the added end-to-end case is left to CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957c3031353a99a5a52e6e7e8507fa03f5bdaf15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->