### PR TITLE
feat: add JSON inspection output

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -656,8 +656,8 @@ fn gc(config: &Config, max_bytes: u64, json: bool) -> Result<()> {
             return Err(error);
         }
     };
-    let pruned = pruned?;
     if json {
+        let pruned = pruned?;
         print_json(&GcReport {
             version: 1,
             max_bytes,
@@ -674,18 +674,23 @@ fn gc(config: &Config, max_bytes: u64, json: bool) -> Result<()> {
             },
         })?;
     } else {
-        println!("{}", evictions(&outcome));
-        if outcome.removed_checkout_records > 0 {
-            println!(
-                "dropped {} stale checkout records",
-                outcome.removed_checkout_records
-            );
-        }
+        print_gc_store_outcome(&outcome);
+        let pruned = pruned?;
         if pruned.removed_views > 0 {
             println!("{}", target_removals(&pruned));
         }
     }
     Ok(())
+}
+
+fn print_gc_store_outcome(outcome: &store::GcOutcome) {
+    println!("{}", evictions(outcome));
+    if outcome.removed_checkout_records > 0 {
+        println!(
+            "dropped {} stale checkout records",
+            outcome.removed_checkout_records
+        );
+    }
 }
 
 /// One line describing the target directories a sweep freed.
@@ -755,8 +760,8 @@ fn prune_targets(config: &Config) {
 fn cache_stats(config: &Config, json: bool) -> Result<()> {
     let store = config.store_dir();
     let stats = store::stats(&store)?;
-    let views = target::stats(&config.target.root)?;
     if json {
+        let views = target::stats(&config.target.root)?;
         return print_json(&CacheStatsReport {
             version: 1,
             store: store.display().to_string(),
@@ -790,6 +795,7 @@ fn cache_stats(config: &Config, json: bool) -> Result<()> {
         "checkouts: {} live, {} stale",
         stats.live_checkouts, stats.stale_checkouts
     );
+    let views = target::stats(&config.target.root)?;
     println!(
         "target directories: {} ({})",
         views.views,

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -28,7 +28,7 @@ struct Cli {
 #[derive(usage::Subcommands)]
 enum Commands {
     /// Check the local installation, cache, toolchain, and remote connection.
-    Doctor,
+    Doctor(JsonArgs),
     /// Run a Cargo command and explain every compilation mbx cannot cache.
     Explain(ExplainArgs),
     /// Install a persistent rustc wrapper for plain Cargo commands.
@@ -98,6 +98,16 @@ struct GcArgs {
     /// configured budget.
     #[usage(long, value_name = "SIZE")]
     max_size: Option<ByteSize>,
+    /// Print a stable machine-readable report.
+    #[usage(long)]
+    json: bool,
+}
+
+#[derive(usage::Args)]
+struct JsonArgs {
+    /// Print a stable machine-readable report.
+    #[usage(long)]
+    json: bool,
 }
 
 #[derive(usage::Args)]
@@ -128,9 +138,9 @@ struct CacheArgs {
 #[derive(usage::Subcommands)]
 enum CacheCommands {
     /// Print the store directory.
-    Dir,
+    Dir(JsonArgs),
     /// Summarize what the store holds.
-    Stats,
+    Stats(JsonArgs),
 }
 
 /// Parse the command line and run it.
@@ -140,26 +150,36 @@ pub fn run() -> Result<ExitCode> {
     if let Commands::Prefetch(args) = &mut cli.command {
         args.cargo_args = original_prefetch_arguments(&original)?;
     }
-    if matches!(&cli.command, Commands::Doctor) {
-        return crate::doctor::run_loaded(Config::load());
+    if let Commands::Doctor(args) = &cli.command {
+        return crate::doctor::run_loaded(Config::load(), args.json);
     }
     let config = Config::load()?;
     match cli.command {
-        Commands::Doctor => unreachable!("doctor was handled before configuration loading"),
+        Commands::Doctor(_) => unreachable!("doctor was handled before configuration loading"),
         Commands::Explain(args) => crate::explain::run(&config, &args.arguments()),
         Commands::Setup(args) => setup(args.action()?),
         Commands::Gc(args) => gc(
             &config,
             args.max_size
                 .map_or(config.gc.max_bytes, |requested| requested.as_u64()),
+            args.json,
         )
         .map(|()| ExitCode::SUCCESS),
         Commands::Cache(args) => match args.command {
-            CacheCommands::Dir => {
-                println!("{}", config.store_dir().display());
+            CacheCommands::Dir(args) => {
+                if args.json {
+                    print_json(&CacheDirReport {
+                        version: 1,
+                        store: config.store_dir().display().to_string(),
+                    })?;
+                } else {
+                    println!("{}", config.store_dir().display());
+                }
                 Ok(ExitCode::SUCCESS)
             }
-            CacheCommands::Stats => cache_stats(&config).map(|()| ExitCode::SUCCESS),
+            CacheCommands::Stats(args) => {
+                cache_stats(&config, args.json).map(|()| ExitCode::SUCCESS)
+            }
         },
         Commands::Prefetch(args) => prefetch(&config, &args.cargo_args),
         Commands::Cargo(arguments) => cargo(&config, &arguments),
@@ -615,7 +635,7 @@ fn exit_code(status: std::process::ExitStatus) -> ExitCode {
     }
 }
 
-fn gc(config: &Config, max_bytes: u64) -> Result<()> {
+fn gc(config: &Config, max_bytes: u64, json: bool) -> Result<()> {
     let store = config.store_dir();
     let outcome = store::gc(&store, max_bytes);
     // Independent collections: a broken action store must not prevent the
@@ -625,7 +645,7 @@ fn gc(config: &Config, max_bytes: u64) -> Result<()> {
         Ok(outcome) => outcome,
         Err(error) => {
             match pruned {
-                Ok(pruned) if pruned.removed_views > 0 => {
+                Ok(pruned) if !json && pruned.removed_views > 0 => {
                     println!("{}", target_removals(&pruned));
                 }
                 Ok(_) => {}
@@ -636,16 +656,34 @@ fn gc(config: &Config, max_bytes: u64) -> Result<()> {
             return Err(error);
         }
     };
-    println!("{}", evictions(&outcome));
-    if outcome.removed_checkout_records > 0 {
-        println!(
-            "dropped {} stale checkout records",
-            outcome.removed_checkout_records
-        );
-    }
     let pruned = pruned?;
-    if pruned.removed_views > 0 {
-        println!("{}", target_removals(&pruned));
+    if json {
+        print_json(&GcReport {
+            version: 1,
+            max_bytes,
+            action_store: GcActionStoreReport {
+                removed_objects: outcome.removed_objects,
+                removed_action_results: outcome.removed_action_results,
+                removed_checkout_records: outcome.removed_checkout_records,
+                removed_bytes: outcome.removed_bytes,
+                remaining_bytes: outcome.remaining_bytes,
+            },
+            targets: GcTargetReport {
+                removed_directories: pruned.removed_views,
+                removed_bytes: pruned.removed_bytes,
+            },
+        })?;
+    } else {
+        println!("{}", evictions(&outcome));
+        if outcome.removed_checkout_records > 0 {
+            println!(
+                "dropped {} stale checkout records",
+                outcome.removed_checkout_records
+            );
+        }
+        if pruned.removed_views > 0 {
+            println!("{}", target_removals(&pruned));
+        }
     }
     Ok(())
 }
@@ -714,9 +752,25 @@ fn prune_targets(config: &Config) {
     }
 }
 
-fn cache_stats(config: &Config) -> Result<()> {
+fn cache_stats(config: &Config, json: bool) -> Result<()> {
     let store = config.store_dir();
     let stats = store::stats(&store)?;
+    let views = target::stats(&config.target.root)?;
+    if json {
+        return print_json(&CacheStatsReport {
+            version: 1,
+            store: store.display().to_string(),
+            objects: stats.objects,
+            object_bytes: stats.object_bytes,
+            action_results: stats.action_results,
+            action_result_bytes: stats.action_result_bytes,
+            total_bytes: stats.total_bytes(),
+            live_checkouts: stats.live_checkouts,
+            stale_checkouts: stats.stale_checkouts,
+            target_directories: views.views,
+            target_bytes: views.bytes,
+        });
+    }
     println!("store: {}", store.display());
     println!(
         "objects: {} ({})",
@@ -736,12 +790,60 @@ fn cache_stats(config: &Config) -> Result<()> {
         "checkouts: {} live, {} stale",
         stats.live_checkouts, stats.stale_checkouts
     );
-    let views = target::stats(&config.target.root)?;
     println!(
         "target directories: {} ({})",
         views.views,
         ByteSize::b(views.bytes).display().iec()
     );
+    Ok(())
+}
+
+#[derive(serde::Serialize)]
+struct CacheDirReport {
+    version: u8,
+    store: String,
+}
+
+#[derive(serde::Serialize)]
+struct CacheStatsReport {
+    version: u8,
+    store: String,
+    objects: u64,
+    object_bytes: u64,
+    action_results: u64,
+    action_result_bytes: u64,
+    total_bytes: u64,
+    live_checkouts: u64,
+    stale_checkouts: u64,
+    target_directories: u64,
+    target_bytes: u64,
+}
+
+#[derive(serde::Serialize)]
+struct GcReport {
+    version: u8,
+    max_bytes: u64,
+    action_store: GcActionStoreReport,
+    targets: GcTargetReport,
+}
+
+#[derive(serde::Serialize)]
+struct GcActionStoreReport {
+    removed_objects: u64,
+    removed_action_results: u64,
+    removed_checkout_records: u64,
+    removed_bytes: u64,
+    remaining_bytes: u64,
+}
+
+#[derive(serde::Serialize)]
+struct GcTargetReport {
+    removed_directories: u64,
+    removed_bytes: u64,
+}
+
+fn print_json(value: &impl serde::Serialize) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
 }
 

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -76,13 +76,13 @@ fn render(checks: &[Check], json: bool) -> Result<ExitCode> {
             "{}",
             serde_json::to_string_pretty(&DoctorReport {
                 version: 1,
-                checks: &checks,
+                checks,
                 failures,
                 warnings,
             })?
         );
     } else {
-        for check in &checks {
+        for check in checks {
             let marker = match check.severity {
                 Severity::Pass => "ok",
                 Severity::Warn => "warn",

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -8,14 +8,15 @@ use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 enum Severity {
     Pass,
     Warn,
     Fail,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize)]
 struct Check {
     severity: Severity,
     name: &'static str,
@@ -50,10 +51,18 @@ impl Check {
 
 /// Run all diagnostics and fail only when mbx cannot operate as configured.
 pub fn run(config: &Config) -> Result<ExitCode> {
+    run_formatted(config, false)
+}
+
+pub(crate) fn run_formatted(config: &Config, json: bool) -> Result<ExitCode> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
     let checks = runtime.block_on(check(config));
+    render(&checks, json)
+}
+
+fn render(checks: &[Check], json: bool) -> Result<ExitCode> {
     let failures = checks
         .iter()
         .filter(|check| check.severity == Severity::Fail)
@@ -62,15 +71,27 @@ pub fn run(config: &Config) -> Result<ExitCode> {
         .iter()
         .filter(|check| check.severity == Severity::Warn)
         .count();
-    for check in &checks {
-        let marker = match check.severity {
-            Severity::Pass => "ok",
-            Severity::Warn => "warn",
-            Severity::Fail => "FAIL",
-        };
-        println!("{marker:>4}  {:<12} {}", check.name, check.detail);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&DoctorReport {
+                version: 1,
+                checks: &checks,
+                failures,
+                warnings,
+            })?
+        );
+    } else {
+        for check in &checks {
+            let marker = match check.severity {
+                Severity::Pass => "ok",
+                Severity::Warn => "warn",
+                Severity::Fail => "FAIL",
+            };
+            println!("{marker:>4}  {:<12} {}", check.name, check.detail);
+        }
+        println!("\n{failures} failures, {warnings} warnings");
     }
-    println!("\n{failures} failures, {warnings} warnings");
     Ok(if failures == 0 {
         ExitCode::SUCCESS
     } else {
@@ -78,15 +99,19 @@ pub fn run(config: &Config) -> Result<ExitCode> {
     })
 }
 
-pub(crate) fn run_loaded(config: Result<Config>) -> Result<ExitCode> {
+pub(crate) fn run_loaded(config: Result<Config>, json: bool) -> Result<ExitCode> {
     match config {
-        Ok(config) => run(&config),
-        Err(error) => {
-            println!("FAIL  {:<12} {error:#}", "config");
-            println!("\n1 failures, 0 warnings");
-            Ok(ExitCode::FAILURE)
-        }
+        Ok(config) => run_formatted(&config, json),
+        Err(error) => render(&[Check::fail("config", format!("{error:#}"))], json),
     }
+}
+
+#[derive(serde::Serialize)]
+struct DoctorReport<'a> {
+    version: u8,
+    checks: &'a [Check],
+    failures: usize,
+    warnings: usize,
 }
 
 async fn check(config: &Config) -> Vec<Check> {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,11 +19,12 @@ Examples:
 
 ## `mbx doctor`
 
-- **Usage:** `mbx doctor`
+- **Usage:** `mbx doctor [--json]`
 
 Check the local installation, cache, toolchain, and remote connection.
 
 ### Flags
+- **`--json`** — Print a stable machine-readable report.
 - **`-h --help`** — Print help
 
 ## `mbx explain`
@@ -53,7 +54,7 @@ Install a persistent rustc wrapper for plain Cargo commands.
 
 ## `mbx gc`
 
-- **Usage:** `mbx gc [--max-size <SIZE>]`
+- **Usage:** `mbx gc [--max-size <SIZE>] [--json]`
 
 Collect stale managed targets and evict cached objects until the store fits a size budget.
 
@@ -61,6 +62,7 @@ A missing cached object is rebuilt when it is needed again.
 
 ### Flags
 - **`--max-size <SIZE>`** — Size the store may occupy afterwards, for example 20GiB. Defaults to the configured budget.
+- **`--json`** — Print a stable machine-readable report.
 - **`-h --help`** — Print help
 
 ## `mbx cache`
@@ -74,20 +76,22 @@ Inspect the local store.
 
 ## `mbx cache dir`
 
-- **Usage:** `mbx cache dir`
+- **Usage:** `mbx cache dir [--json]`
 
 Print the store directory.
 
 ### Flags
+- **`--json`** — Print a stable machine-readable report.
 - **`-h --help`** — Print help
 
 ## `mbx cache stats`
 
-- **Usage:** `mbx cache stats`
+- **Usage:** `mbx cache stats [--json]`
 
 Summarize what the store holds.
 
 ### Flags
+- **`--json`** — Print a stable machine-readable report.
 - **`-h --help`** — Print help
 
 ## `mbx prefetch`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,6 +113,16 @@ mbx gc --max-size 20GiB
 
 Automatic collection is enabled by default with a 20 GiB budget.
 
+Every inspection command also supports stable, versioned JSON for scripts and
+CI integrations:
+
+```sh
+mbx doctor --json
+mbx cache dir --json
+mbx cache stats --json
+mbx gc --json
+```
+
 ## Next steps
 
 - Tune local behavior in [Configuration](/configuration).

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -49,6 +49,28 @@ setup() {
   assert_output --partial "compiler-query"
 }
 
+@test "inspection commands offer versioned JSON" {
+  run "$MBX_BIN" cache dir --json
+  assert_success
+  assert_output --partial '"version": 1'
+  assert_output --partial '"store"'
+
+  run "$MBX_BIN" cache stats --json
+  assert_success
+  assert_output --partial '"objects": 0'
+  assert_output --partial '"target_directories": 0'
+
+  run "$MBX_BIN" gc --json
+  assert_success
+  assert_output --partial '"action_store"'
+  assert_output --partial '"targets"'
+
+  run "$MBX_BIN" doctor --json
+  assert_success
+  assert_output --partial '"checks"'
+  assert_output --partial '"failures": 0'
+}
+
 @test "cargo new is forwarded" {
   run "$MBX_BIN" new --vcs none new-project
 


### PR DESCRIPTION
## Summary
- add stable versioned JSON to `mbx doctor`, `mbx gc`, `mbx cache dir`, and `mbx cache stats`
- retain existing human-readable output and exit-status behavior by default
- document the machine-readable interface and cover all four commands end to end

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- exercised all four `--json` commands locally
- generated CLI documentation is current

## Dependency
This PR is narrowly stacked on #57 because it adds JSON to the new doctor command. It will be retargeted to `main` after #57 merges. The Bats checkout is absent locally; CI runs the added end-to-end coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional output formatting on read-only inspection and gc reporting; no change to default behavior or core build/cache paths.
> 
> **Overview**
> Adds a **`--json`** flag to **`mbx doctor`**, **`mbx gc`**, **`mbx cache dir`**, and **`mbx cache stats`** so scripts and CI can consume **stable, versioned** (`version: 1`) pretty-printed JSON instead of human text.
> 
> Each command emits a dedicated report shape (e.g. doctor **`checks`** with lowercase severities, gc **`action_store`** / **`targets`**, cache stats including target directory totals). **Default text output and exit codes are unchanged** when `--json` is not passed; gc JSON still reports target prune results even when the human path would only print target lines on partial failure.
> 
> CLI parsing uses shared **`JsonArgs`** for doctor and cache subcommands; **`doctor`** routing passes the flag through **`run_loaded`** / **`render`**, including config load failures as JSON checks. Docs and a Bats test cover all four commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28f0733b3d46de45f189514750f2686c532c8304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->