### PR TITLE
feat: complete setup lifecycle

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -303,6 +303,11 @@ fn setup_at_action(
             return Ok(ExitCode::FAILURE);
         }
         SetupAction::Update if !owns_configuration => {
+            if let Some(configured) = configured {
+                eyre::bail!(
+                    "mbx setup is not active because build.rustc-wrapper is {configured}; refusing to replace another wrapper"
+                );
+            }
             eyre::bail!("mbx setup is not installed; run `mbx setup` first");
         }
         SetupAction::Uninstall => {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -30,7 +30,7 @@ enum Commands {
     /// Run a Cargo command and explain every compilation mbx cannot cache.
     Explain(ExplainArgs),
     /// Install a persistent rustc wrapper for plain Cargo commands.
-    Setup,
+    Setup(SetupArgs),
     /// Collect stale managed targets and evict cached objects until the store fits a size budget.
     ///
     /// A missing cached object is rebuilt when it is needed again.
@@ -49,6 +49,45 @@ struct PrefetchArgs {
     /// Cargo subcommand and arguments whose previous manifest should be warmed.
     #[usage(value_name = "CARGO_ARGS", required = true)]
     cargo_args: Vec<String>,
+}
+
+#[derive(usage::Args)]
+struct SetupArgs {
+    /// Report whether plain Cargo integration is installed and current.
+    #[usage(long)]
+    status: bool,
+    /// Refresh an existing mbx wrapper without installing a missing one.
+    #[usage(long)]
+    update: bool,
+    /// Remove mbx's Cargo configuration and installed wrapper.
+    #[usage(long)]
+    uninstall: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SetupAction {
+    Install,
+    Status,
+    Update,
+    Uninstall,
+}
+
+impl SetupArgs {
+    fn action(&self) -> Result<SetupAction> {
+        let selected = self.status as u8 + self.update as u8 + self.uninstall as u8;
+        if selected > 1 {
+            eyre::bail!("--status, --update, and --uninstall are mutually exclusive");
+        }
+        Ok(if self.status {
+            SetupAction::Status
+        } else if self.update {
+            SetupAction::Update
+        } else if self.uninstall {
+            SetupAction::Uninstall
+        } else {
+            SetupAction::Install
+        })
+    }
 }
 
 #[derive(usage::Args)]
@@ -102,7 +141,7 @@ pub fn run() -> Result<ExitCode> {
     let config = Config::load()?;
     match cli.command {
         Commands::Explain(args) => crate::explain::run(&config, &args.arguments()),
-        Commands::Setup => setup().map(|()| ExitCode::SUCCESS),
+        Commands::Setup(args) => setup(args.action()?),
         Commands::Gc(args) => gc(
             &config,
             args.max_size
@@ -179,8 +218,13 @@ fn validate_prefetch_config(config: &Config, release_context: bool) -> Result<()
     Ok(())
 }
 
-fn setup() -> Result<()> {
+fn setup(action: SetupAction) -> Result<ExitCode> {
     let executable = std::env::current_exe().wrap_err("failed to locate the mbx executable")?;
+    let (install_dir, config_path) = setup_paths()?;
+    setup_at_action(&executable, &install_dir, &config_path, action)
+}
+
+fn setup_paths() -> Result<(PathBuf, PathBuf)> {
     let data = dirs::data_local_dir()
         .ok_or_else(|| eyre::eyre!("the platform data directory could not be located"))?;
     let install_dir = data.join("mbx").join("bin");
@@ -194,10 +238,21 @@ fn setup() -> Result<()> {
         } else {
             cargo_home.join("config")
         };
-    setup_at(&executable, &install_dir, &config_path)
+    Ok((install_dir, config_path))
 }
 
+#[cfg(test)]
 fn setup_at(executable: &Path, install_dir: &Path, config_path: &Path) -> Result<()> {
+    setup_at_action(executable, install_dir, config_path, SetupAction::Install)?;
+    Ok(())
+}
+
+fn setup_at_action(
+    executable: &Path,
+    install_dir: &Path,
+    config_path: &Path,
+    action: SetupAction,
+) -> Result<ExitCode> {
     let contents = match std::fs::read_to_string(config_path) {
         Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -212,23 +267,93 @@ fn setup_at(executable: &Path, install_dir: &Path, config_path: &Path) -> Result
         crate::session::RUSTC_SHIM_STEM.into()
     };
     let shim = install_dir.join(shim_name);
-    if let Some(configured) = document
+    let configured = document
         .get("build")
         .and_then(toml_edit::Item::as_table_like)
-        .and_then(|build| build.get("rustc-wrapper"))
-    {
-        if configured.as_str() == Some(shim.to_string_lossy().as_ref()) {
+        .and_then(|build| build.get("rustc-wrapper"));
+    let owns_configuration = configured
+        .and_then(toml_edit::Item::as_str)
+        .is_some_and(|configured| Path::new(configured) == shim);
+
+    match action {
+        SetupAction::Status => {
+            if !owns_configuration {
+                if let Some(configured) = configured {
+                    println!(
+                        "mbx setup is not active: build.rustc-wrapper is {}",
+                        configured
+                    );
+                } else {
+                    println!("mbx setup is not installed");
+                }
+                return Ok(ExitCode::FAILURE);
+            }
+            if !shim.is_file() {
+                println!(
+                    "mbx setup is configured but {} is missing; run `mbx setup --update`",
+                    shim.display()
+                );
+                return Ok(ExitCode::FAILURE);
+            }
+            if same_file_contents(executable, &shim)? {
+                println!("mbx setup is installed and current: {}", shim.display());
+                return Ok(ExitCode::SUCCESS);
+            }
+            println!("mbx setup is installed but outdated; run `mbx setup --update`");
+            return Ok(ExitCode::FAILURE);
+        }
+        SetupAction::Update if !owns_configuration => {
+            eyre::bail!("mbx setup is not installed; run `mbx setup` first");
+        }
+        SetupAction::Uninstall => {
+            if owns_configuration {
+                let build = document
+                    .get_mut("build")
+                    .and_then(toml_edit::Item::as_table_like_mut)
+                    .expect("the configuration was inspected above");
+                build.remove("rustc-wrapper");
+                if build.is_empty() {
+                    document.remove("build");
+                }
+                crate::util::write_atomic(config_path, document.to_string().as_bytes())?;
+            }
+            match std::fs::remove_file(&shim) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+            if owns_configuration {
+                println!(
+                    "removed mbx setup from {} and deleted {}",
+                    config_path.display(),
+                    shim.display()
+                );
+            } else {
+                println!("mbx setup was not installed");
+            }
+            return Ok(ExitCode::SUCCESS);
+        }
+        SetupAction::Install | SetupAction::Update => {}
+    }
+
+    if let Some(configured) = configured {
+        if owns_configuration {
             std::fs::create_dir_all(install_dir)?;
             crate::session::install_shim(executable, install_dir)?;
-            println!("refreshed {}; Cargo was already configured", shim.display());
-            return Ok(());
+            let verb = if action == SetupAction::Update {
+                "updated"
+            } else {
+                "refreshed"
+            };
+            println!("{verb} {}; Cargo was already configured", shim.display());
+            return Ok(ExitCode::SUCCESS);
         }
         println!(
             "left {} unchanged: build.rustc-wrapper is already {}",
             config_path.display(),
             configured
         );
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
 
     std::fs::create_dir_all(install_dir)?;
@@ -245,7 +370,17 @@ fn setup_at(executable: &Path, install_dir: &Path, config_path: &Path) -> Result
         config_path.display()
     );
     println!("plain cargo commands now use mbx's local action cache");
-    Ok(())
+    Ok(ExitCode::SUCCESS)
+}
+
+fn same_file_contents(left: &Path, right: &Path) -> Result<bool> {
+    let left_metadata = std::fs::metadata(left)?;
+    let right_metadata = std::fs::metadata(right)?;
+    if left_metadata.len() != right_metadata.len() {
+        return Ok(false);
+    }
+    Ok(mbx_cache_core::CacheDigest::blake3_file(left)?
+        == mbx_cache_core::CacheDigest::blake3_file(right)?)
 }
 
 fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -559,3 +559,94 @@ fn setup_never_displaces_an_existing_wrapper() {
     assert_eq!(std::fs::read_to_string(config).unwrap(), original);
     assert!(!install.exists());
 }
+
+#[test]
+fn setup_flags_are_mutually_exclusive() {
+    let args = SetupArgs {
+        status: true,
+        update: true,
+        uninstall: false,
+    };
+    assert!(args.action().is_err());
+    assert_eq!(
+        SetupArgs {
+            status: false,
+            update: false,
+            uninstall: true,
+        }
+        .action()
+        .unwrap(),
+        SetupAction::Uninstall
+    );
+}
+
+#[test]
+fn setup_status_detects_and_update_refreshes_a_stale_wrapper() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory.path().join("mbx");
+    std::fs::write(&executable, b"first mbx binary").unwrap();
+    let install = directory.path().join("data/bin");
+    let config = directory.path().join("cargo/config.toml");
+
+    setup_at_action(&executable, &install, &config, SetupAction::Install).unwrap();
+    assert_eq!(
+        setup_at_action(&executable, &install, &config, SetupAction::Status).unwrap(),
+        ExitCode::SUCCESS
+    );
+
+    std::fs::remove_file(&executable).unwrap();
+    std::fs::write(&executable, b"new mbx binary with another size").unwrap();
+    assert_eq!(
+        setup_at_action(&executable, &install, &config, SetupAction::Status).unwrap(),
+        ExitCode::FAILURE
+    );
+    setup_at_action(&executable, &install, &config, SetupAction::Update).unwrap();
+    let shim = install.join(if cfg!(windows) {
+        "mbx-rustc.exe"
+    } else {
+        "mbx-rustc"
+    });
+    assert!(same_file_contents(&executable, &shim).unwrap());
+}
+
+#[test]
+fn setup_uninstall_removes_only_mbx_configuration() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory.path().join("mbx");
+    std::fs::write(&executable, b"mbx binary").unwrap();
+    let install = directory.path().join("data/bin");
+    let config = directory.path().join("cargo/config.toml");
+    std::fs::create_dir_all(config.parent().unwrap()).unwrap();
+    std::fs::write(&config, "# keep me\n[net]\noffline = true\n").unwrap();
+
+    setup_at_action(&executable, &install, &config, SetupAction::Install).unwrap();
+    let shim = install.join(if cfg!(windows) {
+        "mbx-rustc.exe"
+    } else {
+        "mbx-rustc"
+    });
+    assert!(shim.is_file());
+    setup_at_action(&executable, &install, &config, SetupAction::Uninstall).unwrap();
+
+    let contents = std::fs::read_to_string(&config).unwrap();
+    assert!(contents.contains("# keep me"));
+    assert!(contents.contains("offline = true"));
+    assert!(!contents.contains("rustc-wrapper"));
+    assert!(!shim.exists());
+    setup_at_action(&executable, &install, &config, SetupAction::Uninstall).unwrap();
+}
+
+#[test]
+fn setup_update_requires_an_existing_installation() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory.path().join("mbx");
+    std::fs::write(&executable, b"mbx binary").unwrap();
+    let error = setup_at_action(
+        &executable,
+        &directory.path().join("data/bin"),
+        &directory.path().join("cargo/config.toml"),
+        SetupAction::Update,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("not installed"));
+}

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -649,4 +649,20 @@ fn setup_update_requires_an_existing_installation() {
     )
     .unwrap_err();
     assert!(error.to_string().contains("not installed"));
+
+    let config = directory.path().join("cargo/config.toml");
+    std::fs::create_dir_all(config.parent().unwrap()).unwrap();
+    std::fs::write(&config, "[build]\nrustc-wrapper = \"sccache\"\n").unwrap();
+    let error = setup_at_action(
+        &executable,
+        &directory.path().join("data/bin"),
+        &config,
+        SetupAction::Update,
+    )
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("refusing to replace another wrapper")
+    );
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,11 +32,14 @@ Run a Cargo command and explain every compilation mbx cannot cache.
 
 ## `mbx setup`
 
-- **Usage:** `mbx setup`
+- **Usage:** `mbx setup [FLAGS]`
 
 Install a persistent rustc wrapper for plain Cargo commands.
 
 ### Flags
+- **`--status`** — Report whether plain Cargo integration is installed and current.
+- **`--update`** — Refresh an existing mbx wrapper without installing a missing one.
+- **`--uninstall`** — Remove mbx's Cargo configuration and installed wrapper.
 - **`-h --help`** — Print help
 
 ## `mbx gc`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,6 +60,19 @@ Setup installs a persistent `mbx-rustc` wrapper and adds it as Cargo's global
 Rerun setup after upgrading mbx so the installed wrapper matches the new
 version.
 
+Inspect, refresh, or remove the integration explicitly with:
+
+```sh
+mbx setup --status
+mbx setup --update
+mbx setup --uninstall
+```
+
+Status exits unsuccessfully when the integration is missing, stale, or points
+at another wrapper. Update only refreshes an existing mbx installation;
+uninstall removes mbx's `rustc-wrapper` entry without disturbing the rest of
+Cargo's configuration.
+
 The persistent wrapper uses the local action store. Continue to run commands
 through `mbx` when you need a remote cache, build statistics, managed target
 directories, or automatic collection.

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -68,6 +68,50 @@ EOF
   assert_file_contains "$CARGO_HOME/config.toml" 'rustc-wrapper = "sccache"'
 }
 
+@test "setup status update and uninstall cover the full lifecycle" {
+  local wrapper
+  cat >"$CARGO_HOME/config.toml" <<'EOF'
+# keep me
+[net]
+offline = true
+EOF
+
+  run "$MBX_BIN" setup --status
+  assert_failure
+  assert_output --partial "not installed"
+
+  run "$MBX_BIN" setup
+  assert_success
+  wrapper="$(sed -n 's/.*rustc-wrapper = "\([^"]*\)".*/\1/p' "$CARGO_HOME/config.toml")"
+  [[ -n "$wrapper" ]]
+
+  run "$MBX_BIN" setup --status
+  assert_success
+  assert_output --partial "installed and current"
+
+  rm "$wrapper"
+  printf 'stale wrapper\n' >"$wrapper"
+  chmod +x "$wrapper"
+  run "$MBX_BIN" setup --status
+  assert_failure
+  assert_output --partial "outdated"
+
+  run "$MBX_BIN" setup --update
+  assert_success
+  assert_output --partial "updated"
+
+  run "$MBX_BIN" setup --uninstall
+  assert_success
+  assert_file_not_exist "$wrapper"
+  assert_file_contains "$CARGO_HOME/config.toml" "# keep me"
+  assert_file_contains "$CARGO_HOME/config.toml" "offline = true"
+  refute_file_contains "$CARGO_HOME/config.toml" "rustc-wrapper"
+
+  run "$MBX_BIN" setup --uninstall
+  assert_success
+  assert_output --partial "was not installed"
+}
+
 @test "the persistent wrapper restores a second checkout without an mbx session" {
   local first="$BATS_TEST_TMPDIR/first-checkout"
   local second="$BATS_TEST_TMPDIR/second-checkout"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -105,7 +105,8 @@ EOF
   assert_file_not_exist "$wrapper"
   assert_file_contains "$CARGO_HOME/config.toml" "# keep me"
   assert_file_contains "$CARGO_HOME/config.toml" "offline = true"
-  refute_file_contains "$CARGO_HOME/config.toml" "rustc-wrapper"
+  run grep -F "rustc-wrapper" "$CARGO_HOME/config.toml"
+  assert_failure
 
   run "$MBX_BIN" setup --uninstall
   assert_success


### PR DESCRIPTION
## Summary
- add `mbx setup --status`, `--update`, and `--uninstall` while preserving bare setup as install-or-refresh
- detect stale installed wrappers by content, repair only an existing mbx configuration with update, and return script-friendly status codes
- remove only mbx-owned Cargo configuration and wrapper files during idempotent uninstall
- preserve unrelated Cargo TOML, comments, and existing third-party wrappers

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- generated CLI documentation is current
- unit coverage exercises install/current/stale/update/uninstall/refusal paths on exact temporary targets

The Bats checkout is absent locally; CI runs the added full lifecycle test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The PR edits global Cargo `config.toml` and wrapper files on disk; mistakes could break plain `cargo` builds, though scope is limited to mbx-owned `rustc-wrapper` paths and refusal to replace other wrappers.
> 
> **Overview**
> **`mbx setup`** is now a small lifecycle command: bare **`mbx setup`** still installs or refreshes the persistent **`mbx-rustc`** shim when Cargo already points at mbx, while **`--status`**, **`--update`**, and **`--uninstall`** are mutually exclusive extras.
> 
> **`--status`** reports whether mbx owns **`build.rustc-wrapper`**, whether the shim file exists, and whether it matches the current **`mbx`** binary (BLAKE3), using exit success only when installed and current. **`--update`** refreshes the shim only for an existing mbx-owned install and errors if setup was never run or another wrapper is configured. **`--uninstall`** drops mbx’s **`rustc-wrapper`** entry (and empty **`[build]`** if needed) and removes the shim, leaving unrelated Cargo TOML and third-party wrappers untouched.
> 
> Docs and integration tests cover the full install → status → stale → update → uninstall flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fe644e970a2c76408d1fcc0a514403f097f491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->