### PR TITLE
feat: add managed target retention policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,7 @@ dependencies = [
  "env_logger",
  "eyre",
  "filetime",
+ "fslock",
  "log",
  "mbx-cache-core",
  "mbx-cache-rustc",

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ or collect it explicitly with:
 mbx cache stats
 mbx gc
 mbx gc --max-size 3GB
+mbx gc --dry-run
 ```
 
 For a checkout without an existing `target/`, managed target directories are

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -17,6 +17,7 @@ demand = "2"
 env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"
+fslock = "0.2"
 log = "0.4"
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.5.0", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.4.0", default-features = false }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -667,9 +667,6 @@ fn gc(
     // The collector below remains the authority for store errors. Estimating
     // a combined budget must not prevent independent target collection when
     // the action store is damaged.
-    let target_bytes = target::stats(&config.target.root)
-        .map(|stats| stats.bytes)
-        .unwrap_or_default();
     let target_budget = target_budget(retention, max_bytes);
     let pruned = target::collect(
         &config.target.root,
@@ -677,9 +674,13 @@ fn gc(
         retention.target_max_age,
         dry_run,
     );
-    let projected_target_bytes = pruned
-        .as_ref()
-        .map_or(target_bytes, |outcome| outcome.remaining_bytes);
+    let projected_target_bytes = match &pruned {
+        Ok(outcome) => outcome.remaining_bytes,
+        Err(_) if retention.max_total_bytes.is_some() => target::stats(&config.target.root)
+            .map(|stats| stats.bytes)
+            .unwrap_or_default(),
+        Err(_) => 0,
+    };
     let store_budget = retention.max_total_bytes.map_or(max_bytes, |total| {
         max_bytes.min(total.saturating_sub(projected_target_bytes))
     });
@@ -783,13 +784,15 @@ fn sweep_store(config: &Config, retention: &RetentionSettings) {
     match store::claim_sweep(&config.store_dir(), config.gc.interval) {
         Ok(false) => {}
         Ok(true) => {
-            prune_targets(config, retention, config.gc.max_bytes);
-            let target_bytes = target::stats(&config.target.root)
-                .map(|stats| stats.bytes)
-                .unwrap_or_default();
+            let collected_target_bytes = prune_targets(config, retention, config.gc.max_bytes);
             let store_budget = retention
                 .max_total_bytes
                 .map_or(config.gc.max_bytes, |total| {
+                    let target_bytes = collected_target_bytes.unwrap_or_else(|| {
+                        target::stats(&config.target.root)
+                            .map(|stats| stats.bytes)
+                            .unwrap_or_default()
+                    });
                     config.gc.max_bytes.min(total.saturating_sub(target_bytes))
                 });
             let outcome = match store::gc(&config.store_dir(), store_budget) {
@@ -805,13 +808,17 @@ fn sweep_store(config: &Config, retention: &RetentionSettings) {
         }
         Err(error) => {
             log::warn!("the store was not swept: {error}");
-            prune_targets(config, retention, config.gc.max_bytes);
+            let _ = prune_targets(config, retention, config.gc.max_bytes);
         }
     }
 }
 
 /// Collect target views as the other half of a due automatic sweep.
-fn prune_targets(config: &Config, retention: &RetentionSettings, store_reserve: u64) {
+fn prune_targets(
+    config: &Config,
+    retention: &RetentionSettings,
+    store_reserve: u64,
+) -> Option<u64> {
     // A target directory whose checkout is gone is the largest thing
     // collection ever frees, and walking for it on every build would be the
     // slowest, so callers keep this inside the store sweep's throttle.
@@ -822,11 +829,16 @@ fn prune_targets(config: &Config, retention: &RetentionSettings, store_reserve: 
         retention.target_max_age,
         false,
     ) {
-        Ok(pruned) if pruned.removed_views > 0 => {
-            crate::session::note(&format!("gc: {}", target_removals(&pruned, false)));
+        Ok(pruned) => {
+            if pruned.removed_views > 0 {
+                crate::session::note(&format!("gc: {}", target_removals(&pruned, false)));
+            }
+            Some(pruned.remaining_bytes)
         }
-        Ok(_) => {}
-        Err(error) => log::warn!("target directories were not collected: {error}"),
+        Err(error) => {
+            log::warn!("target directories were not collected: {error}");
+            None
+        }
     }
 }
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -667,22 +667,10 @@ fn gc(
     // The collector below remains the authority for store errors. Estimating
     // a combined budget must not prevent independent target collection when
     // the action store is damaged.
-    let store_bytes = store::stats(&store)
-        .map(|stats| stats.total_bytes())
-        .unwrap_or(max_bytes);
     let target_bytes = target::stats(&config.target.root)
         .map(|stats| stats.bytes)
         .unwrap_or_default();
-    let target_budget = retention
-        .max_total_bytes
-        .map_or(retention.target_max_bytes, |total| {
-            let budget = total.saturating_sub(store_bytes.min(max_bytes));
-            Some(
-                retention
-                    .target_max_bytes
-                    .map_or(budget, |target| target.min(budget)),
-            )
-        });
+    let target_budget = target_budget(retention, max_bytes);
     let pruned = target::collect(
         &config.target.root,
         target_budget,
@@ -792,47 +780,42 @@ fn sweep_store(config: &Config, retention: &RetentionSettings) {
     if !config.gc.auto {
         return;
     }
-    let target_bytes = target::stats(&config.target.root)
-        .map(|stats| stats.bytes)
-        .unwrap_or_default();
-    let store_budget = retention
-        .max_total_bytes
-        .map_or(config.gc.max_bytes, |total| {
-            config.gc.max_bytes.min(total.saturating_sub(target_bytes))
-        });
-    match store::sweep_if_due(&config.store_dir(), store_budget, config.gc.interval) {
-        Ok(Some(outcome)) => {
+    match store::claim_sweep(&config.store_dir(), config.gc.interval) {
+        Ok(false) => {}
+        Ok(true) => {
+            prune_targets(config, retention, config.gc.max_bytes);
+            let target_bytes = target::stats(&config.target.root)
+                .map(|stats| stats.bytes)
+                .unwrap_or_default();
+            let store_budget = retention
+                .max_total_bytes
+                .map_or(config.gc.max_bytes, |total| {
+                    config.gc.max_bytes.min(total.saturating_sub(target_bytes))
+                });
+            let outcome = match store::gc(&config.store_dir(), store_budget) {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    log::warn!("the store was not swept: {error}");
+                    return;
+                }
+            };
             if outcome.removed_bytes > 0 {
                 crate::session::note(&format!("gc: {}", evictions(&outcome)));
             }
-            prune_targets(config, retention);
         }
-        Ok(None) => {}
         Err(error) => {
             log::warn!("the store was not swept: {error}");
-            // `sweep_if_due` stamps before collecting. If collection fails,
-            // target views are still due now and will otherwise wait through
-            // the full interval before getting another chance.
-            prune_targets(config, retention);
+            prune_targets(config, retention, config.gc.max_bytes);
         }
     }
 }
 
 /// Collect target views as the other half of a due automatic sweep.
-fn prune_targets(config: &Config, retention: &RetentionSettings) {
+fn prune_targets(config: &Config, retention: &RetentionSettings, store_reserve: u64) {
     // A target directory whose checkout is gone is the largest thing
     // collection ever frees, and walking for it on every build would be the
     // slowest, so callers keep this inside the store sweep's throttle.
-    let target_budget = retention.max_total_bytes.and_then(|total| {
-        store::stats(&config.store_dir())
-            .ok()
-            .map(|stats| total.saturating_sub(stats.total_bytes()))
-    });
-    let target_budget = match (retention.target_max_bytes, target_budget) {
-        (Some(configured), Some(total)) => Some(configured.min(total)),
-        (configured, None) => configured,
-        (None, total) => total,
-    };
+    let target_budget = target_budget(retention, store_reserve);
     match target::collect(
         &config.target.root,
         target_budget,
@@ -845,6 +828,19 @@ fn prune_targets(config: &Config, retention: &RetentionSettings) {
         Ok(_) => {}
         Err(error) => log::warn!("target directories were not collected: {error}"),
     }
+}
+
+fn target_budget(retention: &RetentionSettings, store_reserve: u64) -> Option<u64> {
+    retention
+        .max_total_bytes
+        .map_or(retention.target_max_bytes, |total| {
+            let combined = total.saturating_sub(store_reserve);
+            Some(
+                retention
+                    .target_max_bytes
+                    .map_or(combined, |target| target.min(combined)),
+            )
+        })
 }
 
 fn cache_stats(config: &Config, json: bool) -> Result<()> {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -670,7 +670,9 @@ fn gc(
     let store_bytes = store::stats(&store)
         .map(|stats| stats.total_bytes())
         .unwrap_or(max_bytes);
-    let target_bytes = target::stats(&config.target.root)?.bytes;
+    let target_bytes = target::stats(&config.target.root)
+        .map(|stats| stats.bytes)
+        .unwrap_or_default();
     let target_budget = retention
         .max_total_bytes
         .map_or(retention.target_max_bytes, |total| {
@@ -790,7 +792,15 @@ fn sweep_store(config: &Config, retention: &RetentionSettings) {
     if !config.gc.auto {
         return;
     }
-    match store::sweep_if_due(&config.store_dir(), config.gc.max_bytes, config.gc.interval) {
+    let target_bytes = target::stats(&config.target.root)
+        .map(|stats| stats.bytes)
+        .unwrap_or_default();
+    let store_budget = retention
+        .max_total_bytes
+        .map_or(config.gc.max_bytes, |total| {
+            config.gc.max_bytes.min(total.saturating_sub(target_bytes))
+        });
+    match store::sweep_if_due(&config.store_dir(), store_budget, config.gc.interval) {
         Ok(Some(outcome)) => {
             if outcome.removed_bytes > 0 {
                 crate::session::note(&format!("gc: {}", evictions(&outcome)));

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -735,7 +735,7 @@ fn gc(
 
 fn print_gc_store_outcome(outcome: &store::GcOutcome, dry_run: bool) {
     let prefix = if dry_run { "would have " } else { "" };
-    println!("{prefix}{}", evictions(&outcome));
+    println!("{prefix}{}", evictions(outcome));
     if outcome.removed_checkout_records > 0 {
         println!(
             "{prefix}dropped {} stale checkout records",

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -1,6 +1,6 @@
 //! The mbx command line.
 
-use crate::config::Config;
+use crate::config::{Config, RetentionSettings};
 use crate::session::CacheSession;
 use crate::util::workspace_root;
 use crate::{policy, store, target};
@@ -156,10 +156,12 @@ pub fn run() -> Result<ExitCode> {
     if let Commands::Doctor(args) = &cli.command {
         return crate::doctor::run_loaded(Config::load(), args.json);
     }
-    let config = Config::load()?;
+    let (config, retention) = Config::load_with_retention()?;
     match cli.command {
         Commands::Doctor(_) => unreachable!("doctor was handled before configuration loading"),
-        Commands::Explain(args) => crate::explain::run(&config, &args.arguments()),
+        Commands::Explain(args) => {
+            crate::explain::run_with_retention(&config, &retention, &args.arguments())
+        }
         Commands::Setup(args) => setup(args.action()?),
         Commands::Gc(args) => gc(
             &config,
@@ -167,6 +169,7 @@ pub fn run() -> Result<ExitCode> {
                 .map_or(config.gc.max_bytes, |requested| requested.as_u64()),
             args.dry_run,
             args.json,
+            &retention,
         )
         .map(|()| ExitCode::SUCCESS),
         Commands::Cache(args) => match args.command {
@@ -186,7 +189,7 @@ pub fn run() -> Result<ExitCode> {
             }
         },
         Commands::Prefetch(args) => prefetch(&config, &args.cargo_args),
-        Commands::Cargo(arguments) => cargo(&config, &arguments),
+        Commands::Cargo(arguments) => cargo(&config, &retention, &arguments),
     }
 }
 
@@ -418,12 +421,26 @@ fn same_file_contents(left: &Path, right: &Path) -> Result<bool> {
         == mbx_cache_core::CacheDigest::blake3_file(right)?)
 }
 
-fn cargo(config: &Config, arguments: &[String]) -> Result<ExitCode> {
-    cargo_with_bypass_log(config, arguments, None)
+fn cargo(config: &Config, retention: &RetentionSettings, arguments: &[String]) -> Result<ExitCode> {
+    cargo_with_retention_and_bypass_log(config, retention, arguments, None)
 }
 
 pub(crate) fn cargo_with_bypass_log(
     config: &Config,
+    arguments: &[String],
+    bypass_log: Option<&Path>,
+) -> Result<ExitCode> {
+    cargo_with_retention_and_bypass_log(
+        config,
+        &RetentionSettings::default(),
+        arguments,
+        bypass_log,
+    )
+}
+
+pub(crate) fn cargo_with_retention_and_bypass_log(
+    config: &Config,
+    retention: &RetentionSettings,
     arguments: &[String],
     bypass_log: Option<&Path>,
 ) -> Result<ExitCode> {
@@ -544,7 +561,7 @@ pub(crate) fn cargo_with_bypass_log(
     // Outside the runtime, so a walk of the whole store cannot occupy a worker
     // thread, and after cargo has exited, so it adds nothing to the build the
     // user is waiting on.
-    sweep_store(config);
+    sweep_store(config, retention);
     status
 }
 
@@ -639,7 +656,13 @@ fn exit_code(status: std::process::ExitStatus) -> ExitCode {
     }
 }
 
-fn gc(config: &Config, max_bytes: u64, dry_run: bool, json: bool) -> Result<()> {
+fn gc(
+    config: &Config,
+    max_bytes: u64,
+    dry_run: bool,
+    json: bool,
+    retention: &RetentionSettings,
+) -> Result<()> {
     let store = config.store_dir();
     // The collector below remains the authority for store errors. Estimating
     // a combined budget must not prevent independent target collection when
@@ -648,28 +671,26 @@ fn gc(config: &Config, max_bytes: u64, dry_run: bool, json: bool) -> Result<()> 
         .map(|stats| stats.total_bytes())
         .unwrap_or(max_bytes);
     let target_bytes = target::stats(&config.target.root)?.bytes;
-    let target_budget = config
-        .gc
+    let target_budget = retention
         .max_total_bytes
-        .map_or(config.target.max_bytes, |total| {
+        .map_or(retention.target_max_bytes, |total| {
             let budget = total.saturating_sub(store_bytes.min(max_bytes));
             Some(
-                config
-                    .target
-                    .max_bytes
+                retention
+                    .target_max_bytes
                     .map_or(budget, |target| target.min(budget)),
             )
         });
     let pruned = target::collect(
         &config.target.root,
         target_budget,
-        config.target.max_age,
+        retention.target_max_age,
         dry_run,
     );
     let projected_target_bytes = pruned
         .as_ref()
         .map_or(target_bytes, |outcome| outcome.remaining_bytes);
-    let store_budget = config.gc.max_total_bytes.map_or(max_bytes, |total| {
+    let store_budget = retention.max_total_bytes.map_or(max_bytes, |total| {
         max_bytes.min(total.saturating_sub(projected_target_bytes))
     });
     let outcome = if dry_run {
@@ -734,7 +755,7 @@ fn print_gc_store_outcome(outcome: &store::GcOutcome, dry_run: bool) {
 }
 
 /// One line describing the target directories a sweep freed.
-fn target_removals(outcome: &target::PruneOutcome, dry_run: bool) -> String {
+fn target_removals(outcome: &target::CollectionOutcome, dry_run: bool) -> String {
     let verb = if dry_run { "would free" } else { "freed" };
     format!(
         "{verb} {} target directories ({}, {} abandoned and {} live); {} remain",
@@ -765,7 +786,7 @@ fn evictions(outcome: &store::GcOutcome) -> String {
 /// Reported like the cache summary beside it: a sweep that evicted nothing says
 /// nothing. A sweep that fails is logged and forgotten -- the build is already
 /// over, and its exit status is the build's answer, not the collector's.
-fn sweep_store(config: &Config) {
+fn sweep_store(config: &Config, retention: &RetentionSettings) {
     if !config.gc.auto {
         return;
     }
@@ -774,7 +795,7 @@ fn sweep_store(config: &Config) {
             if outcome.removed_bytes > 0 {
                 crate::session::note(&format!("gc: {}", evictions(&outcome)));
             }
-            prune_targets(config);
+            prune_targets(config, retention);
         }
         Ok(None) => {}
         Err(error) => {
@@ -782,22 +803,22 @@ fn sweep_store(config: &Config) {
             // `sweep_if_due` stamps before collecting. If collection fails,
             // target views are still due now and will otherwise wait through
             // the full interval before getting another chance.
-            prune_targets(config);
+            prune_targets(config, retention);
         }
     }
 }
 
 /// Collect target views as the other half of a due automatic sweep.
-fn prune_targets(config: &Config) {
+fn prune_targets(config: &Config, retention: &RetentionSettings) {
     // A target directory whose checkout is gone is the largest thing
     // collection ever frees, and walking for it on every build would be the
     // slowest, so callers keep this inside the store sweep's throttle.
-    let target_budget = config.gc.max_total_bytes.and_then(|total| {
+    let target_budget = retention.max_total_bytes.and_then(|total| {
         store::stats(&config.store_dir())
             .ok()
             .map(|stats| total.saturating_sub(stats.total_bytes()))
     });
-    let target_budget = match (config.target.max_bytes, target_budget) {
+    let target_budget = match (retention.target_max_bytes, target_budget) {
         (Some(configured), Some(total)) => Some(configured.min(total)),
         (configured, None) => configured,
         (None, total) => total,
@@ -805,7 +826,7 @@ fn prune_targets(config: &Config) {
     match target::collect(
         &config.target.root,
         target_budget,
-        config.target.max_age,
+        retention.target_max_age,
         false,
     ) {
         Ok(pruned) if pruned.removed_views > 0 => {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -101,6 +101,9 @@ struct GcArgs {
     /// Print a stable machine-readable report.
     #[usage(long)]
     json: bool,
+    /// Show what collection would remove without changing any files.
+    #[usage(long)]
+    dry_run: bool,
 }
 
 #[derive(usage::Args)]
@@ -162,6 +165,7 @@ pub fn run() -> Result<ExitCode> {
             &config,
             args.max_size
                 .map_or(config.gc.max_bytes, |requested| requested.as_u64()),
+            args.dry_run,
             args.json,
         )
         .map(|()| ExitCode::SUCCESS),
@@ -635,18 +639,52 @@ fn exit_code(status: std::process::ExitStatus) -> ExitCode {
     }
 }
 
-fn gc(config: &Config, max_bytes: u64, json: bool) -> Result<()> {
+fn gc(config: &Config, max_bytes: u64, dry_run: bool, json: bool) -> Result<()> {
     let store = config.store_dir();
-    let outcome = store::gc(&store, max_bytes);
+    // The collector below remains the authority for store errors. Estimating
+    // a combined budget must not prevent independent target collection when
+    // the action store is damaged.
+    let store_bytes = store::stats(&store)
+        .map(|stats| stats.total_bytes())
+        .unwrap_or(max_bytes);
+    let target_bytes = target::stats(&config.target.root)?.bytes;
+    let target_budget = config
+        .gc
+        .max_total_bytes
+        .map_or(config.target.max_bytes, |total| {
+            let budget = total.saturating_sub(store_bytes.min(max_bytes));
+            Some(
+                config
+                    .target
+                    .max_bytes
+                    .map_or(budget, |target| target.min(budget)),
+            )
+        });
+    let pruned = target::collect(
+        &config.target.root,
+        target_budget,
+        config.target.max_age,
+        dry_run,
+    );
+    let projected_target_bytes = pruned
+        .as_ref()
+        .map_or(target_bytes, |outcome| outcome.remaining_bytes);
+    let store_budget = config.gc.max_total_bytes.map_or(max_bytes, |total| {
+        max_bytes.min(total.saturating_sub(projected_target_bytes))
+    });
+    let outcome = if dry_run {
+        store::gc_dry_run(&store, store_budget)
+    } else {
+        store::gc(&store, store_budget)
+    };
     // Independent collections: a broken action store must not prevent the
     // command from freeing the usually much larger target directories.
-    let pruned = target::prune(&config.target.root);
     let outcome = match outcome {
         Ok(outcome) => outcome,
         Err(error) => {
             match pruned {
                 Ok(pruned) if !json && pruned.removed_views > 0 => {
-                    println!("{}", target_removals(&pruned));
+                    println!("{}", target_removals(&pruned, dry_run));
                 }
                 Ok(_) => {}
                 Err(prune_error) => {
@@ -661,6 +699,7 @@ fn gc(config: &Config, max_bytes: u64, json: bool) -> Result<()> {
         print_json(&GcReport {
             version: 1,
             max_bytes,
+            dry_run,
             action_store: GcActionStoreReport {
                 removed_objects: outcome.removed_objects,
                 removed_action_results: outcome.removed_action_results,
@@ -674,31 +713,36 @@ fn gc(config: &Config, max_bytes: u64, json: bool) -> Result<()> {
             },
         })?;
     } else {
-        print_gc_store_outcome(&outcome);
+        print_gc_store_outcome(&outcome, dry_run);
         let pruned = pruned?;
         if pruned.removed_views > 0 {
-            println!("{}", target_removals(&pruned));
+            println!("{}", target_removals(&pruned, dry_run));
         }
     }
     Ok(())
 }
 
-fn print_gc_store_outcome(outcome: &store::GcOutcome) {
-    println!("{}", evictions(outcome));
+fn print_gc_store_outcome(outcome: &store::GcOutcome, dry_run: bool) {
+    let prefix = if dry_run { "would have " } else { "" };
+    println!("{prefix}{}", evictions(&outcome));
     if outcome.removed_checkout_records > 0 {
         println!(
-            "dropped {} stale checkout records",
+            "{prefix}dropped {} stale checkout records",
             outcome.removed_checkout_records
         );
     }
 }
 
 /// One line describing the target directories a sweep freed.
-fn target_removals(outcome: &target::PruneOutcome) -> String {
+fn target_removals(outcome: &target::PruneOutcome, dry_run: bool) -> String {
+    let verb = if dry_run { "would free" } else { "freed" };
     format!(
-        "freed {} target directories of checkouts that are gone ({})",
+        "{verb} {} target directories ({}, {} abandoned and {} live); {} remain",
         outcome.removed_views,
         ByteSize::b(outcome.removed_bytes).display().iec(),
+        outcome.removed_stale_views,
+        outcome.removed_live_views,
+        ByteSize::b(outcome.remaining_bytes).display().iec(),
     )
 }
 
@@ -748,9 +792,24 @@ fn prune_targets(config: &Config) {
     // A target directory whose checkout is gone is the largest thing
     // collection ever frees, and walking for it on every build would be the
     // slowest, so callers keep this inside the store sweep's throttle.
-    match target::prune(&config.target.root) {
+    let target_budget = config.gc.max_total_bytes.and_then(|total| {
+        store::stats(&config.store_dir())
+            .ok()
+            .map(|stats| total.saturating_sub(stats.total_bytes()))
+    });
+    let target_budget = match (config.target.max_bytes, target_budget) {
+        (Some(configured), Some(total)) => Some(configured.min(total)),
+        (configured, None) => configured,
+        (None, total) => total,
+    };
+    match target::collect(
+        &config.target.root,
+        target_budget,
+        config.target.max_age,
+        false,
+    ) {
         Ok(pruned) if pruned.removed_views > 0 => {
-            crate::session::note(&format!("gc: {}", target_removals(&pruned)));
+            crate::session::note(&format!("gc: {}", target_removals(&pruned, false)));
         }
         Ok(_) => {}
         Err(error) => log::warn!("target directories were not collected: {error}"),
@@ -829,6 +888,7 @@ struct CacheStatsReport {
 struct GcReport {
     version: u8,
     max_bytes: u64,
+    dry_run: bool,
     action_store: GcActionStoreReport,
     targets: GcTargetReport,
 }

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -469,6 +469,8 @@ fn managed_target_config(root: &Path) -> Config {
         target: crate::config::TargetSettings {
             views: true,
             root: root.join("targets"),
+            max_bytes: None,
+            max_age: None,
         },
     }
 }

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -469,8 +469,6 @@ fn managed_target_config(root: &Path) -> Config {
         target: crate::config::TargetSettings {
             views: true,
             root: root.join("targets"),
-            max_bytes: None,
-            max_age: None,
         },
     }
 }

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -1,6 +1,18 @@
 use super::*;
 
 #[test]
+fn combined_budget_reserves_the_full_action_store_allowance() {
+    let retention = RetentionSettings {
+        target_max_bytes: Some(80),
+        target_max_age: None,
+        max_total_bytes: Some(100),
+    };
+
+    assert_eq!(target_budget(&retention, 70), Some(30));
+    assert_eq!(target_budget(&retention, 120), Some(0));
+}
+
+#[test]
 fn prefers_the_outermost_lockfile_as_the_workspace_root() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path();

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -171,8 +171,6 @@ pub struct HttpSettings {
 pub struct TargetSettings {
     pub views: bool,
     pub root: PathBuf,
-    pub max_bytes: Option<u64>,
-    pub max_age: Option<Duration>,
 }
 
 /// How the store is kept inside its budget.
@@ -180,8 +178,14 @@ pub struct TargetSettings {
 pub struct GcSettings {
     pub auto: bool,
     pub max_bytes: u64,
-    pub max_total_bytes: Option<u64>,
     pub interval: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RetentionSettings {
+    pub target_max_bytes: Option<u64>,
+    pub target_max_age: Option<Duration>,
+    pub max_total_bytes: Option<u64>,
 }
 
 impl Default for GcSettings {
@@ -189,7 +193,6 @@ impl Default for GcSettings {
         Self {
             auto: true,
             max_bytes: DEFAULT_GC_MAX_SIZE,
-            max_total_bytes: None,
             interval: DEFAULT_GC_INTERVAL,
         }
     }
@@ -208,12 +211,19 @@ impl Default for HttpSettings {
 impl Config {
     /// Load configuration for this machine.
     pub fn load() -> Result<Self> {
-        let env = EnvLayer::from_process();
-        let file = config_file_path().map(|path| FileLayer::at(path, FileScope::Global));
-        Self::from_layers(&env, file.as_ref())
+        Self::load_with_retention().map(|(config, _)| config)
     }
 
-    fn from_layers(env: &EnvLayer, file: Option<&FileLayer>) -> Result<Self> {
+    pub(crate) fn load_with_retention() -> Result<(Self, RetentionSettings)> {
+        let env = EnvLayer::from_process();
+        let file = config_file_path().map(|path| FileLayer::at(path, FileScope::Global));
+        Self::from_layers_with_retention(&env, file.as_ref())
+    }
+
+    fn from_layers_with_retention(
+        env: &EnvLayer,
+        file: Option<&FileLayer>,
+    ) -> Result<(Self, RetentionSettings)> {
         let mut layers = Layers::new().then(env);
         if let Some(file) = file {
             layers = layers.then(file);
@@ -232,10 +242,33 @@ impl Config {
             bail!("invalid configuration:\n{problems}");
         }
         let raw = RawConfig::read(&resolved)?;
-        Self::from_raw(raw)
+        Self::from_raw_with_retention(raw)
     }
 
-    fn from_raw(raw: RawConfig) -> Result<Self> {
+    fn from_raw_with_retention(raw: RawConfig) -> Result<(Self, RetentionSettings)> {
+        let retention = RetentionSettings {
+            target_max_bytes: raw
+                .target
+                .max_size
+                .as_deref()
+                .map(parse_byte_size)
+                .transpose()
+                .wrap_err("invalid target.max_size")?,
+            target_max_age: raw
+                .target
+                .max_age
+                .as_deref()
+                .map(parse_duration)
+                .transpose()
+                .wrap_err("invalid target.max_age")?,
+            max_total_bytes: raw
+                .gc
+                .max_total_size
+                .as_deref()
+                .map(parse_byte_size)
+                .transpose()
+                .wrap_err("invalid gc.max_total_size")?,
+        };
         let cache_dir = raw.cache_dir.or_else(default_cache_dir).ok_or_else(|| {
             eyre::eyre!("could not determine a cache directory; set MBX_CACHE_DIR")
         })?;
@@ -249,13 +282,6 @@ impl Config {
         let gc = GcSettings {
             auto: raw.gc.auto,
             max_bytes: parse_byte_size(&raw.gc.max_size).wrap_err("invalid gc.max_size")?,
-            max_total_bytes: raw
-                .gc
-                .max_total_size
-                .as_deref()
-                .map(parse_byte_size)
-                .transpose()
-                .wrap_err("invalid gc.max_total_size")?,
             interval: parse_duration(&raw.gc.interval).wrap_err("invalid gc.interval")?,
         };
         let target = TargetSettings {
@@ -265,22 +291,8 @@ impl Config {
                 Some(root) => cache_dir.join(root),
                 None => cache_dir.join("targets"),
             },
-            max_bytes: raw
-                .target
-                .max_size
-                .as_deref()
-                .map(parse_byte_size)
-                .transpose()
-                .wrap_err("invalid target.max_size")?,
-            max_age: raw
-                .target
-                .max_age
-                .as_deref()
-                .map(parse_duration)
-                .transpose()
-                .wrap_err("invalid target.max_age")?,
         };
-        Ok(Self {
+        let config = Self {
             cache_dir,
             gc,
             target,
@@ -297,7 +309,8 @@ impl Config {
                 mode,
             },
             http,
-        })
+        };
+        Ok((config, retention))
     }
 
     /// Apply the deliberately small, safe policy surface from `.mbx.toml` at
@@ -379,6 +392,13 @@ mod tests {
     use super::*;
 
     fn configured(file: Option<&str>, values: &[(&str, &str)]) -> Result<Config> {
+        configured_with_retention(file, values).map(|(config, _)| config)
+    }
+
+    fn configured_with_retention(
+        file: Option<&str>,
+        values: &[(&str, &str)],
+    ) -> Result<(Config, RetentionSettings)> {
         let env = EnvLayer::new(
             values
                 .iter()
@@ -390,7 +410,7 @@ mod tests {
             std::fs::write(&path, contents).unwrap();
             FileLayer::at(path, FileScope::Global)
         });
-        Config::from_layers(&env, file.as_ref())
+        Config::from_layers_with_retention(&env, file.as_ref())
     }
 
     #[test]
@@ -452,20 +472,17 @@ mod tests {
         assert!(config.store_dir().ends_with("actions"));
         assert!(config.gc.auto, "collection runs until it is turned off");
         assert_eq!(config.gc.max_bytes, DEFAULT_GC_MAX_SIZE);
-        assert_eq!(config.gc.max_total_bytes, None);
         assert_eq!(config.gc.interval, DEFAULT_GC_INTERVAL);
         assert!(
             config.target.views,
             "eligible target directories are managed"
         );
         assert_eq!(config.target.root, config.cache_dir.join("targets"));
-        assert_eq!(config.target.max_bytes, None);
-        assert_eq!(config.target.max_age, None);
     }
 
     #[test]
     fn reads_target_and_whole_cache_retention_limits() {
-        let config = configured(
+        let (_, retention) = configured_with_retention(
             None,
             &[
                 ("MBX_TARGET_MAX_SIZE", "8GiB"),
@@ -475,12 +492,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.target.max_bytes, Some(8 * 1024 * 1024 * 1024));
+        assert_eq!(retention.target_max_bytes, Some(8 * 1024 * 1024 * 1024));
         assert_eq!(
-            config.target.max_age,
+            retention.target_max_age,
             Some(Duration::from_secs(14 * 86_400))
         );
-        assert_eq!(config.gc.max_total_bytes, Some(12 * 1024 * 1024 * 1024));
+        assert_eq!(retention.max_total_bytes, Some(12 * 1024 * 1024 * 1024));
     }
 
     #[test]

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -90,6 +90,12 @@ struct RawTarget {
     /// Managed target root.
     #[usage(env = "MBX_TARGET_ROOT", default_note = "<cache_dir>/targets")]
     root: Option<PathBuf>,
+    /// Managed-target budget. Live views are collected oldest-first when set.
+    #[usage(env = "MBX_TARGET_MAX_SIZE")]
+    max_size: Option<String>,
+    /// Collect live managed targets that have not been used this long.
+    #[usage(env = "MBX_TARGET_MAX_AGE", ty = "duration")]
+    max_age: Option<String>,
 }
 
 #[derive(Debug, usage::Config)]
@@ -101,6 +107,9 @@ struct RawGc {
     /// Action-store budget.
     #[usage(env = "MBX_GC_MAX_SIZE", default = "20GiB")]
     max_size: String,
+    /// Combined action-store and managed-target budget.
+    #[usage(env = "MBX_GC_MAX_TOTAL_SIZE")]
+    max_total_size: Option<String>,
     /// Minimum interval between automatic sweeps.
     #[usage(env = "MBX_GC_INTERVAL", default = "1h", ty = "duration")]
     interval: String,
@@ -162,6 +171,8 @@ pub struct HttpSettings {
 pub struct TargetSettings {
     pub views: bool,
     pub root: PathBuf,
+    pub max_bytes: Option<u64>,
+    pub max_age: Option<Duration>,
 }
 
 /// How the store is kept inside its budget.
@@ -169,6 +180,7 @@ pub struct TargetSettings {
 pub struct GcSettings {
     pub auto: bool,
     pub max_bytes: u64,
+    pub max_total_bytes: Option<u64>,
     pub interval: Duration,
 }
 
@@ -177,6 +189,7 @@ impl Default for GcSettings {
         Self {
             auto: true,
             max_bytes: DEFAULT_GC_MAX_SIZE,
+            max_total_bytes: None,
             interval: DEFAULT_GC_INTERVAL,
         }
     }
@@ -236,6 +249,13 @@ impl Config {
         let gc = GcSettings {
             auto: raw.gc.auto,
             max_bytes: parse_byte_size(&raw.gc.max_size).wrap_err("invalid gc.max_size")?,
+            max_total_bytes: raw
+                .gc
+                .max_total_size
+                .as_deref()
+                .map(parse_byte_size)
+                .transpose()
+                .wrap_err("invalid gc.max_total_size")?,
             interval: parse_duration(&raw.gc.interval).wrap_err("invalid gc.interval")?,
         };
         let target = TargetSettings {
@@ -245,6 +265,20 @@ impl Config {
                 Some(root) => cache_dir.join(root),
                 None => cache_dir.join("targets"),
             },
+            max_bytes: raw
+                .target
+                .max_size
+                .as_deref()
+                .map(parse_byte_size)
+                .transpose()
+                .wrap_err("invalid target.max_size")?,
+            max_age: raw
+                .target
+                .max_age
+                .as_deref()
+                .map(parse_duration)
+                .transpose()
+                .wrap_err("invalid target.max_age")?,
         };
         Ok(Self {
             cache_dir,
@@ -418,12 +452,35 @@ mod tests {
         assert!(config.store_dir().ends_with("actions"));
         assert!(config.gc.auto, "collection runs until it is turned off");
         assert_eq!(config.gc.max_bytes, DEFAULT_GC_MAX_SIZE);
+        assert_eq!(config.gc.max_total_bytes, None);
         assert_eq!(config.gc.interval, DEFAULT_GC_INTERVAL);
         assert!(
             config.target.views,
             "eligible target directories are managed"
         );
         assert_eq!(config.target.root, config.cache_dir.join("targets"));
+        assert_eq!(config.target.max_bytes, None);
+        assert_eq!(config.target.max_age, None);
+    }
+
+    #[test]
+    fn reads_target_and_whole_cache_retention_limits() {
+        let config = configured(
+            None,
+            &[
+                ("MBX_TARGET_MAX_SIZE", "8GiB"),
+                ("MBX_TARGET_MAX_AGE", "14d"),
+                ("MBX_GC_MAX_TOTAL_SIZE", "12GiB"),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(config.target.max_bytes, Some(8 * 1024 * 1024 * 1024));
+        assert_eq!(
+            config.target.max_age,
+            Some(Duration::from_secs(14 * 86_400))
+        );
+        assert_eq!(config.gc.max_total_bytes, Some(12 * 1024 * 1024 * 1024));
     }
 
     #[test]
@@ -457,7 +514,10 @@ mod tests {
         assert!(configured(None, &[("MBX_HTTP_TIMEOUT", "later")]).is_err());
         assert!(configured(None, &[("MBX_HTTP_RETRIES", "many")]).is_err());
         assert!(configured(None, &[("MBX_GC_MAX_SIZE", "lots")]).is_err());
+        assert!(configured(None, &[("MBX_GC_MAX_TOTAL_SIZE", "lots")]).is_err());
         assert!(configured(None, &[("MBX_GC_INTERVAL", "later")]).is_err());
+        assert!(configured(None, &[("MBX_TARGET_MAX_SIZE", "lots")]).is_err());
+        assert!(configured(None, &[("MBX_TARGET_MAX_AGE", "later")]).is_err());
         // A budget that cannot be read must not be guessed at, and neither must
         // a switch: silently collecting to the wrong number, or not at all, is
         // worse than saying so.

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -21,17 +21,13 @@ pub(crate) fn run_with_retention(
 ) -> Result<ExitCode> {
     let directory = tempfile::Builder::new().prefix("mbx-explain-").tempdir()?;
     let log = directory.path().join("bypasses.tsv");
-    let status = crate::cli::cargo_with_retention_and_bypass_log(
-        config,
-        retention,
-        arguments,
-        Some(&log),
-    )?;
+    let status =
+        crate::cli::cargo_with_retention_and_bypass_log(config, retention, arguments, Some(&log))?;
     finish(&log, status)
 }
 
 fn finish(log: &Path, status: ExitCode) -> Result<ExitCode> {
-    let records = read_records(&log)?;
+    let records = read_records(log)?;
     display(&records);
     Ok(status)
 }

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -8,7 +8,10 @@ use std::process::ExitCode;
 
 /// Run Cargo with a private bypass trace and explain its contents afterwards.
 pub fn run(config: &Config, arguments: &[String]) -> Result<ExitCode> {
-    run_with_retention(config, &RetentionSettings::default(), arguments)
+    let directory = tempfile::Builder::new().prefix("mbx-explain-").tempdir()?;
+    let log = directory.path().join("bypasses.tsv");
+    let status = crate::cli::cargo_with_bypass_log(config, arguments, Some(&log))?;
+    finish(&log, status)
 }
 
 pub(crate) fn run_with_retention(
@@ -24,6 +27,10 @@ pub(crate) fn run_with_retention(
         arguments,
         Some(&log),
     )?;
+    finish(&log, status)
+}
+
+fn finish(log: &Path, status: ExitCode) -> Result<ExitCode> {
     let records = read_records(&log)?;
     display(&records);
     Ok(status)

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -1,6 +1,6 @@
 //! Actionable explanations for conservative cache bypasses.
 
-use crate::config::Config;
+use crate::config::{Config, RetentionSettings};
 use eyre::{Context, Result};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -8,9 +8,22 @@ use std::process::ExitCode;
 
 /// Run Cargo with a private bypass trace and explain its contents afterwards.
 pub fn run(config: &Config, arguments: &[String]) -> Result<ExitCode> {
+    run_with_retention(config, &RetentionSettings::default(), arguments)
+}
+
+pub(crate) fn run_with_retention(
+    config: &Config,
+    retention: &RetentionSettings,
+    arguments: &[String],
+) -> Result<ExitCode> {
     let directory = tempfile::Builder::new().prefix("mbx-explain-").tempdir()?;
     let log = directory.path().join("bypasses.tsv");
-    let status = crate::cli::cargo_with_bypass_log(config, arguments, Some(&log))?;
+    let status = crate::cli::cargo_with_retention_and_bypass_log(
+        config,
+        retention,
+        arguments,
+        Some(&log),
+    )?;
     let records = read_records(&log)?;
     display(&records);
     Ok(status)

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -13,6 +13,8 @@ fn test_config(cache_dir: &Path) -> Config {
         target: crate::config::TargetSettings {
             views: false,
             root: cache_dir.join("targets"),
+            max_bytes: None,
+            max_age: None,
         },
     }
 }

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -13,8 +13,6 @@ fn test_config(cache_dir: &Path) -> Config {
         target: crate::config::TargetSettings {
             views: false,
             root: cache_dir.join("targets"),
-            max_bytes: None,
-            max_age: None,
         },
     }
 }

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -145,6 +145,15 @@ fn checkout_record_path(store: &Path, identity: &str, workspace_root: &Path) -> 
 /// the mount records one, so the ordering is an approximation either way.
 /// Evicting a live object costs a recompile, never correctness.
 pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
+    gc_with_mode(store, max_bytes, false)
+}
+
+/// Describe the collection `gc` would perform without changing the store.
+pub fn gc_dry_run(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
+    gc_with_mode(store, max_bytes, true)
+}
+
+fn gc_with_mode(store: &Path, max_bytes: u64, dry_run: bool) -> Result<GcOutcome> {
     let mut objects = walk_files(&store.join(CAS_DIR))?;
     let results = walk_files(&store.join(ACTION_RESULTS_DIR))?;
     let mut live_bytes = objects
@@ -159,16 +168,17 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
     // last sweep stops protecting its artifacts during this one.
     let checkouts = scan_checkouts(store)?;
     for path in &checkouts.stale_records {
-        if matches!(remove(path)?, Removal::Removed) {
+        if dry_run || matches!(remove(path)?, Removal::Removed) {
             outcome.removed_checkout_records += 1;
         }
         // The identity directory is left behind empty otherwise. It may hold
         // other checkouts, in which case this fails and that is the answer.
-        if let Some(parent) = path.parent() {
+        if !dry_run && let Some(parent) = path.parent() {
             let _ = std::fs::remove_dir(parent);
         }
     }
 
+    let mut virtually_removed = HashSet::new();
     if live_bytes > max_bytes {
         // Reachability costs a read per action result and per output tree, so
         // it is computed only when something is actually about to be evicted.
@@ -178,7 +188,14 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
         // each class goes oldest-first. A store with no records at all roots
         // nothing and this is exactly the LRU it was before.
         objects.sort_by_cached_key(|entry| (rooted.contains(&entry.path), entry.used));
-        let evicted = evict_objects(&objects, &rooted, live_bytes, max_bytes, remove)?;
+        let evicted = evict_objects(&objects, &rooted, live_bytes, max_bytes, |path| {
+            if dry_run {
+                virtually_removed.insert(path.to_path_buf());
+                Ok(Removal::Removed)
+            } else {
+                remove(path)
+            }
+        })?;
         live_bytes = evicted.remaining_bytes;
         outcome.removed_objects += evicted.removed_objects;
         outcome.removed_bytes += evicted.removed_bytes;
@@ -190,8 +207,12 @@ pub fn gc(store: &Path, max_bytes: u64) -> Result<GcOutcome> {
     // store that is over budget on results alone still needs the sweep.
     let cas = LocalCas::new(store);
     for entry in &results {
-        if action_result_is_dangling(&cas, &entry.path)? {
-            match remove(&entry.path)? {
+        if action_result_is_dangling(&cas, &entry.path, &virtually_removed)? {
+            match if dry_run {
+                Removal::Removed
+            } else {
+                remove(&entry.path)?
+            } {
                 Removal::Removed => {
                     live_bytes = live_bytes.saturating_sub(entry.size);
                     outcome.removed_action_results += 1;
@@ -499,7 +520,11 @@ fn evict_objects(
 ///
 /// Only the top-level objects are checked; a result whose output tree lost a
 /// nested object still restores as a miss, which is safe.
-fn action_result_is_dangling(cas: &LocalCas, path: &Path) -> Result<bool> {
+fn action_result_is_dangling(
+    cas: &LocalCas,
+    path: &Path,
+    virtually_removed: &HashSet<PathBuf>,
+) -> Result<bool> {
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
@@ -521,7 +546,7 @@ fn action_result_is_dangling(cas: &LocalCas, path: &Path) -> Result<bool> {
     {
         match cas.path_for(digest) {
             Ok(path) => {
-                if !path.exists() {
+                if virtually_removed.contains(&path) || !path.exists() {
                     return Ok(true);
                 }
             }

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -234,16 +234,24 @@ fn gc_with_mode(store: &Path, max_bytes: u64, dry_run: bool) -> Result<GcOutcome
 /// together should cost one sweep between them, and a sweep that dies partway
 /// should wait its turn like any other rather than retry on every build.
 pub fn sweep_if_due(store: &Path, max_bytes: u64, interval: Duration) -> Result<Option<GcOutcome>> {
+    if !claim_sweep(store, interval)? {
+        return Ok(None);
+    }
+    gc(store, max_bytes).map(Some)
+}
+
+/// Atomically stamp a due sweep before its callers perform coordinated GC.
+pub(crate) fn claim_sweep(store: &Path, interval: Duration) -> Result<bool> {
     let stamp = store.join(SWEEP_STAMP);
     if let Ok(metadata) = std::fs::metadata(&stamp)
         && let Ok(modified) = metadata.modified()
         && let Ok(since) = modified.elapsed()
         && since < interval
     {
-        return Ok(None);
+        return Ok(false);
     }
     crate::util::write_atomic(&stamp, b"")?;
-    gc(store, max_bytes).map(Some)
+    Ok(true)
 }
 
 /// What the checkout registry says about the identities in this store.

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -21,6 +21,7 @@ const CAS_DIR: &str = "cas/v1";
 const ACTION_RESULTS_DIR: &str = "action-results/v1";
 const CHECKOUTS_DIR: &str = "checkouts/v1";
 const SWEEP_STAMP: &str = "gc/v1/last-sweep";
+const SWEEP_LOCK: &str = "gc/v1/sweep.lock";
 const CHECKOUT_RECORD_VERSION: u8 = 1;
 
 /// How long a checkout's claim outlives the last build that renewed it.
@@ -242,6 +243,11 @@ pub fn sweep_if_due(store: &Path, max_bytes: u64, interval: Duration) -> Result<
 
 /// Atomically stamp a due sweep before its callers perform coordinated GC.
 pub(crate) fn claim_sweep(store: &Path, interval: Duration) -> Result<bool> {
+    let lock_path = store.join(SWEEP_LOCK);
+    std::fs::create_dir_all(lock_path.parent().expect("sweep lock has a parent"))?;
+    let mut lock = fslock::LockFile::open(&lock_path)?;
+    lock.lock()?;
+
     let stamp = store.join(SWEEP_STAMP);
     if let Ok(metadata) = std::fs::metadata(&stamp)
         && let Ok(modified) = metadata.modified()

--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -531,6 +531,31 @@ fn sweeps_only_once_within_the_interval() {
 }
 
 #[test]
+fn concurrent_callers_claim_only_one_sweep() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = std::sync::Arc::new(directory.path().to_path_buf());
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+    let callers = (0..8)
+        .map(|_| {
+            let store = store.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                claim_sweep(&store, Duration::from_secs(3600)).unwrap()
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let claimed = callers
+        .into_iter()
+        .map(|caller| caller.join().unwrap())
+        .filter(|claimed| *claimed)
+        .count();
+
+    assert_eq!(claimed, 1);
+}
+
+#[test]
 fn does_not_count_its_own_bookkeeping_against_the_budget() {
     let directory = tempfile::tempdir().unwrap();
     let store = directory.path().join("store");

--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -141,6 +141,18 @@ fn leaves_a_store_within_budget_alone() {
 }
 
 #[test]
+fn dry_run_reports_evictions_without_removing_objects() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+    let digest = store_object(store, b"kept for now");
+
+    let outcome = gc_dry_run(store, 0).unwrap();
+
+    assert_eq!(outcome.removed_objects, 1);
+    assert!(LocalCas::new(store).find(&digest).unwrap().is_some());
+}
+
+#[test]
 fn a_blocked_unrooted_object_does_not_cost_a_rooted_one() {
     let locked = PathBuf::from("locked-unrooted");
     let removable = PathBuf::from("removable-unrooted");

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -25,8 +25,9 @@ use crate::config::Config;
 use eyre::{Context, Result};
 use mbx_cache_core::CacheDigest;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const VIEWS_DIR: &str = "v1";
 const VIEW_RECORD_VERSION: u8 = 1;
@@ -50,6 +51,9 @@ pub struct ViewStats {
 pub struct PruneOutcome {
     pub removed_views: u64,
     pub removed_bytes: u64,
+    pub removed_stale_views: u64,
+    pub removed_live_views: u64,
+    pub remaining_bytes: u64,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -479,26 +483,87 @@ pub fn stats(root: &Path) -> Result<ViewStats> {
 /// usually serve, but it would also delete something the person who owns that
 /// directory can still see, which is a different kind of surprise.
 pub fn prune(root: &Path) -> Result<PruneOutcome> {
+    collect(root, None, None, false)
+}
+
+/// Collect abandoned, expired, and over-budget managed target directories.
+///
+/// Limits are opt-in. Abandoned checkouts are always collected; live views
+/// are considered oldest-first only when an age or size policy requests it.
+pub fn collect(
+    root: &Path,
+    max_bytes: Option<u64>,
+    max_age: Option<Duration>,
+    dry_run: bool,
+) -> Result<PruneOutcome> {
     let mut outcome = PruneOutcome::default();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    let mut entries = Vec::new();
     for (record_path, directory) in views(root)? {
         let Some(record) = read_view_record(&record_path) else {
             // A record this build cannot read names no checkout, and a target
             // directory nobody can trace is not one to delete on a guess.
             continue;
         };
-        if crate::store::checkout_is_live(&record.workspace_root) {
+        let bytes = tree_bytes(&directory);
+        entries.push((
+            record_path,
+            directory,
+            record.updated_secs,
+            bytes,
+            crate::store::checkout_is_live(&record.workspace_root),
+        ));
+    }
+    let mut remaining = entries.iter().map(|entry| entry.3).sum::<u64>();
+    let mut selected = HashSet::new();
+    for (record_path, _, updated, bytes, live) in &entries {
+        let expired = max_age.is_some_and(|age| now.saturating_sub(*updated) > age.as_secs());
+        if !live || expired {
+            selected.insert(record_path.clone());
+            remaining = remaining.saturating_sub(*bytes);
+        }
+    }
+    if let Some(max_bytes) = max_bytes
+        && remaining > max_bytes
+    {
+        entries.sort_by_key(|entry| entry.2);
+        for (record_path, _, _, bytes, _) in &entries {
+            if remaining <= max_bytes {
+                break;
+            }
+            if selected.insert(record_path.clone()) {
+                remaining = remaining.saturating_sub(*bytes);
+            }
+        }
+    }
+
+    for (record_path, directory, _, bytes, live) in entries {
+        if !selected.contains(&record_path) {
             continue;
         }
-        let bytes = tree_bytes(&directory);
-        match std::fs::remove_dir_all(&directory) {
+        let removal = if dry_run {
+            Ok(())
+        } else {
+            std::fs::remove_dir_all(&directory)
+        };
+        match removal {
             Ok(()) => {
                 outcome.removed_views += 1;
                 outcome.removed_bytes += bytes;
+                if live {
+                    outcome.removed_live_views += 1;
+                } else {
+                    outcome.removed_stale_views += 1;
+                }
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 outcome.removed_views += 1;
             }
             Err(error) => {
+                outcome.remaining_bytes = outcome.remaining_bytes.saturating_add(bytes);
                 log::warn!(
                     "could not remove the target directory {}: {error}",
                     directory.display()
@@ -507,7 +572,8 @@ pub fn prune(root: &Path) -> Result<PruneOutcome> {
             }
         }
         // Last, so a failed removal above leaves the record to try again with.
-        if let Err(error) = std::fs::remove_file(&record_path)
+        if !dry_run
+            && let Err(error) = std::fs::remove_file(&record_path)
             && error.kind() != std::io::ErrorKind::NotFound
         {
             log::warn!(
@@ -516,6 +582,7 @@ pub fn prune(root: &Path) -> Result<PruneOutcome> {
             );
         }
     }
+    outcome.remaining_bytes = remaining;
     Ok(outcome)
 }
 

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -512,10 +512,12 @@ pub(crate) fn collect(
         .map(|duration| duration.as_secs())
         .unwrap_or_default();
     let mut entries = Vec::new();
+    let mut uncollectable_bytes = 0_u64;
     for (record_path, directory) in views(root)? {
         let Some(record) = read_view_record(&record_path) else {
             // A record this build cannot read names no checkout, and a target
             // directory nobody can trace is not one to delete on a guess.
+            uncollectable_bytes = uncollectable_bytes.saturating_add(tree_bytes(&directory));
             continue;
         };
         let bytes = tree_bytes(&directory);
@@ -527,7 +529,10 @@ pub(crate) fn collect(
             crate::store::checkout_is_live(&record.workspace_root),
         ));
     }
-    let mut remaining = entries.iter().map(|entry| entry.3).sum::<u64>();
+    let mut remaining = entries
+        .iter()
+        .map(|entry| entry.3)
+        .fold(uncollectable_bytes, u64::saturating_add);
     let mut selected = HashSet::new();
     for (record_path, _, updated, bytes, live) in &entries {
         let expired = max_age.is_some_and(|age| now.saturating_sub(*updated) > age.as_secs());

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -576,6 +576,11 @@ pub(crate) fn collect(
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 outcome.removed_views += 1;
+                if live {
+                    outcome.removed_live_views += 1;
+                } else {
+                    outcome.removed_stale_views += 1;
+                }
             }
             Err(error) => {
                 remaining = remaining.saturating_add(bytes);

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -573,7 +573,7 @@ pub(crate) fn collect(
                 outcome.removed_views += 1;
             }
             Err(error) => {
-                outcome.remaining_bytes = outcome.remaining_bytes.saturating_add(bytes);
+                remaining = remaining.saturating_add(bytes);
                 log::warn!(
                     "could not remove the target directory {}: {error}",
                     directory.display()

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -51,6 +51,12 @@ pub struct ViewStats {
 pub struct PruneOutcome {
     pub removed_views: u64,
     pub removed_bytes: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct CollectionOutcome {
+    pub removed_views: u64,
+    pub removed_bytes: u64,
     pub removed_stale_views: u64,
     pub removed_live_views: u64,
     pub remaining_bytes: u64,
@@ -483,20 +489,24 @@ pub fn stats(root: &Path) -> Result<ViewStats> {
 /// usually serve, but it would also delete something the person who owns that
 /// directory can still see, which is a different kind of surprise.
 pub fn prune(root: &Path) -> Result<PruneOutcome> {
-    collect(root, None, None, false)
+    let outcome = collect(root, None, None, false)?;
+    Ok(PruneOutcome {
+        removed_views: outcome.removed_views,
+        removed_bytes: outcome.removed_bytes,
+    })
 }
 
 /// Collect abandoned, expired, and over-budget managed target directories.
 ///
 /// Limits are opt-in. Abandoned checkouts are always collected; live views
 /// are considered oldest-first only when an age or size policy requests it.
-pub fn collect(
+pub(crate) fn collect(
     root: &Path,
     max_bytes: Option<u64>,
     max_age: Option<Duration>,
     dry_run: bool,
-) -> Result<PruneOutcome> {
-    let mut outcome = PruneOutcome::default();
+) -> Result<CollectionOutcome> {
+    let mut outcome = CollectionOutcome::default();
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs())

--- a/crates/mbx/src/target_tests.rs
+++ b/crates/mbx/src/target_tests.rs
@@ -410,6 +410,21 @@ fn leaves_a_target_directory_it_cannot_trace() {
 }
 
 #[test]
+fn counts_a_target_directory_it_cannot_trace() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = test_config(directory.path(), true);
+    let workspace = checkout(directory.path(), "project");
+    let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
+    std::fs::write(managed.join("artifact"), vec![0_u8; 7]).unwrap();
+    std::fs::write(view_record_path(&config.target.root, &workspace), b"{").unwrap();
+
+    let outcome = collect(&config.target.root, Some(0), None, false).unwrap();
+
+    assert_eq!(outcome.remaining_bytes, 7);
+    assert!(managed.exists());
+}
+
+#[test]
 fn counts_nothing_before_anything_is_placed() {
     let directory = tempfile::tempdir().unwrap();
     assert_eq!(

--- a/crates/mbx/src/target_tests.rs
+++ b/crates/mbx/src/target_tests.rs
@@ -14,8 +14,6 @@ fn test_config(root: &Path, views: bool) -> Config {
         target: TargetSettings {
             views,
             root: root.join("targets"),
-            max_bytes: None,
-            max_age: None,
         },
     }
 }
@@ -323,9 +321,6 @@ fn frees_the_target_directory_of_a_checkout_that_is_gone() {
         PruneOutcome {
             removed_views: 1,
             removed_bytes: 512,
-            removed_stale_views: 1,
-            remaining_bytes: 256,
-            ..PruneOutcome::default()
         }
     );
     assert!(!removed.exists());
@@ -343,7 +338,6 @@ fn keeps_the_target_directory_of_an_idle_checkout() {
 
     let outcome = prune(&config.target.root).unwrap();
 
-    assert_eq!(outcome.remaining_bytes, 7);
     assert_eq!(outcome.removed_views, 0);
     assert!(managed.join("artifact").exists());
 }

--- a/crates/mbx/src/target_tests.rs
+++ b/crates/mbx/src/target_tests.rs
@@ -14,6 +14,8 @@ fn test_config(root: &Path, views: bool) -> Config {
         target: TargetSettings {
             views,
             root: root.join("targets"),
+            max_bytes: None,
+            max_age: None,
         },
     }
 }
@@ -321,6 +323,9 @@ fn frees_the_target_directory_of_a_checkout_that_is_gone() {
         PruneOutcome {
             removed_views: 1,
             removed_bytes: 512,
+            removed_stale_views: 1,
+            remaining_bytes: 256,
+            ..PruneOutcome::default()
         }
     );
     assert!(!removed.exists());
@@ -338,8 +343,61 @@ fn keeps_the_target_directory_of_an_idle_checkout() {
 
     let outcome = prune(&config.target.root).unwrap();
 
-    assert_eq!(outcome, PruneOutcome::default());
+    assert_eq!(outcome.remaining_bytes, 7);
+    assert_eq!(outcome.removed_views, 0);
     assert!(managed.join("artifact").exists());
+}
+
+#[test]
+fn target_budget_collects_oldest_live_view_first() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = test_config(directory.path(), true);
+    let old_workspace = checkout(directory.path(), "old");
+    let new_workspace = checkout(directory.path(), "new");
+    let old = place(
+        &config,
+        &old_workspace,
+        &old_workspace.join("target"),
+        false,
+    )
+    .unwrap();
+    let new = place(
+        &config,
+        &new_workspace,
+        &new_workspace.join("target"),
+        false,
+    )
+    .unwrap();
+    std::fs::write(old.join("artifact"), vec![0_u8; 5]).unwrap();
+    std::fs::write(new.join("artifact"), vec![0_u8; 10]).unwrap();
+    let old_record = view_record_path(&config.target.root, &old_workspace);
+    let mut record: ViewRecord =
+        serde_json::from_slice(&std::fs::read(&old_record).unwrap()).unwrap();
+    record.updated_secs = 1;
+    std::fs::write(&old_record, serde_json::to_vec(&record).unwrap()).unwrap();
+
+    let outcome = collect(&config.target.root, Some(10), None, false).unwrap();
+
+    assert_eq!(outcome.removed_live_views, 1);
+    assert_eq!(outcome.removed_bytes, 5);
+    assert_eq!(outcome.remaining_bytes, 10);
+    assert!(!old.exists());
+    assert!(new.exists());
+}
+
+#[test]
+fn dry_run_leaves_selected_target_views_in_place() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = test_config(directory.path(), true);
+    let workspace = checkout(directory.path(), "project");
+    let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
+    std::fs::write(managed.join("artifact"), b"outputs").unwrap();
+
+    let outcome = collect(&config.target.root, Some(0), None, true).unwrap();
+
+    assert_eq!(outcome.removed_live_views, 1);
+    assert!(managed.join("artifact").exists());
+    assert!(view_record_path(&config.target.root, &workspace).exists());
 }
 
 #[test]

--- a/crates/mbx/src/target_tests.rs
+++ b/crates/mbx/src/target_tests.rs
@@ -410,6 +410,22 @@ fn leaves_a_target_directory_it_cannot_trace() {
 }
 
 #[test]
+fn missing_selected_directory_counts_as_stale_removal() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = test_config(directory.path(), true);
+    let workspace = checkout(directory.path(), "project");
+    let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
+    std::fs::remove_dir_all(&workspace).unwrap();
+    std::fs::remove_dir_all(&managed).unwrap();
+
+    let outcome = collect(&config.target.root, None, None, false).unwrap();
+
+    assert_eq!(outcome.removed_views, 1);
+    assert_eq!(outcome.removed_stale_views, 1);
+    assert_eq!(outcome.removed_live_views, 0);
+}
+
+#[test]
 fn counts_a_target_directory_it_cannot_trace() {
     let directory = tempfile::tempdir().unwrap();
     let config = test_config(directory.path(), true);

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -64,6 +64,8 @@ pub fn parse_duration(value: &str) -> Result<Duration> {
         (digits, 60 * 1_000)
     } else if let Some(digits) = value.strip_suffix('h') {
         (digits, 60 * 60 * 1_000)
+    } else if let Some(digits) = value.strip_suffix('d') {
+        (digits, 24 * 60 * 60 * 1_000)
     } else {
         (value, 1_000)
     };

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,7 +54,7 @@ Install a persistent rustc wrapper for plain Cargo commands.
 
 ## `mbx gc`
 
-- **Usage:** `mbx gc [--max-size <SIZE>] [--json] [--dry-run]`
+- **Usage:** `mbx gc [FLAGS]`
 
 Collect stale managed targets and evict cached objects until the store fits a size budget.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,7 +54,7 @@ Install a persistent rustc wrapper for plain Cargo commands.
 
 ## `mbx gc`
 
-- **Usage:** `mbx gc [--max-size <SIZE>] [--json]`
+- **Usage:** `mbx gc [--max-size <SIZE>] [--json] [--dry-run]`
 
 Collect stale managed targets and evict cached objects until the store fits a size budget.
 
@@ -63,6 +63,7 @@ A missing cached object is rebuilt when it is needed again.
 ### Flags
 - **`--max-size <SIZE>`** — Size the store may occupy afterwards, for example 20GiB. Defaults to the configured budget.
 - **`--json`** — Print a stable machine-readable report.
+- **`--dry-run`** — Show what collection would remove without changing any files.
 - **`-h --help`** — Print help
 
 ## `mbx cache`
@@ -154,6 +155,14 @@ Minimum interval between automatic sweeps.
 - **Set with:** `MBX_GC_MAX_SIZE`
 
 Action-store budget.
+
+### `gc.max_total_size`
+
+- **Type:** `option<string>`
+- **Optional:** true
+- **Set with:** `MBX_GC_MAX_TOTAL_SIZE`
+
+Combined action-store and managed-target budget.
 
 ### `http.download_timeout`
 
@@ -256,6 +265,22 @@ Share eligible compilations that read `OUT_DIR`.
 - **Set with:** `MBX_STATS_REPORT`
 
 Write a JSON build report to this path.
+
+### `target.max_age`
+
+- **Type:** `option<duration>`
+- **Optional:** true
+- **Set with:** `MBX_TARGET_MAX_AGE`
+
+Collect live managed targets that have not been used this long.
+
+### `target.max_size`
+
+- **Type:** `option<string>`
+- **Optional:** true
+- **Set with:** `MBX_TARGET_MAX_SIZE`
+
+Managed-target budget. Live views are collected oldest-first when set.
 
 ### `target.root`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,10 +17,13 @@ share_out_dir = false
 [gc]
 auto = true
 max_size = "20GiB"
+max_total_size = "50GiB"
 interval = "1h"
 
 [target]
 views = true
+max_size = "30GiB"
+max_age = "30d"
 
 [remote]
 url = "https://cache.example.com"

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -24,9 +24,23 @@ mbx records the checkout associated with each target view. Once that
 checkout no longer exists, `mbx gc` can remove its target directory. Cached
 compilations shared with a live checkout remain protected.
 
-Managed target directories are collected when their checkout disappears; they
-are not counted against `gc.max_size`. The size budget covers cached objects
-and action results.
+Managed target directories are collected when their checkout disappears. By
+default, live checkouts keep their outputs indefinitely. Optional retention
+limits can collect the least-recently-used live views as well:
+
+```toml
+[target]
+max_size = "30GiB"
+max_age = "30d"
+
+[gc]
+# Covers both managed targets and the action store.
+max_total_size = "50GiB"
+```
+
+`target.max_size` and `target.max_age` are deliberately unset by default.
+`gc.max_size` continues to cover cached objects and action results only. Use
+`mbx gc --dry-run` to inspect the effect of any policy without deleting files.
 
 ## When mbx leaves a target alone
 


### PR DESCRIPTION
## Summary
- add opt-in managed-target size and age limits, with oldest-live-view collection
- add an optional whole-cache ceiling coordinating target and action-store budgets
- add `mbx gc --dry-run` using the same selection logic without changing files
- report abandoned versus live target views and remaining storage

Defaults remain non-destructive for live checkouts: target limits and the whole-cache ceiling are unset unless configured.

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `mise run check:docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when managed targets and cache objects are deleted and can evict live checkout outputs when retention limits are set; defaults stay off, but misconfiguration could surprise users with rebuilds.
> 
> **Overview**
> Adds **opt-in retention** for managed `target` views and optional coordination with the action-store budget, while keeping live checkouts untouched unless limits are configured.
> 
> New settings (`target.max_size`, `target.max_age`, `gc.max_total_size`) load as `RetentionSettings` and drive **`target::collect`**: abandoned checkouts are always eligible; live views can be dropped by **max age** or **oldest-first** when a size cap applies. **`mbx gc --dry-run`** runs the same selection for both managed targets and the action store (`gc_dry_run`) without deleting files, and human/JSON output now distinguishes **stale vs live** removals and **remaining** target bytes.
> 
> **`mbx gc` and post-build sweeps** reserve the action-store allowance first, then shrink the store budget when `max_total_size` is set. Automatic sweeps use **`claim_sweep`** with an **`fslock`** lock so concurrent builds stamp at most one sweep per interval. Duration config now accepts day suffixes (e.g. `30d`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f16baf8a7c12d784f8054cc36a762954cd488e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mbx gc --dry-run` to preview cleanup without deleting files.
  * Added configurable managed-target size and age limits.
  * Added a combined retention limit for managed targets and cached data.
  * Cleanup now prioritizes stale, expired, and oldest items within configured budgets.
  * Duration settings now support day values such as `30d`.

* **Documentation**
  * Updated CLI, configuration, and managed-target documentation with retention options and dry-run examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->