### PR TITLE
feat: add cache inspection commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ or collect it explicitly with:
 
 ```sh
 mbx cache stats
+mbx cache projects
+mbx cache largest --limit 10
+mbx cache verify
+mbx cache remove /path/to/workspace
 mbx gc
 mbx gc --max-size 3GB
 ```

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -141,6 +141,27 @@ enum CacheCommands {
     Dir(JsonArgs),
     /// Summarize what the store holds.
     Stats(JsonArgs),
+    /// Show cache use attributed to recorded workspaces.
+    Projects,
+    /// List the largest objects and action-result records.
+    Largest(LargestArgs),
+    /// Verify local objects and action results.
+    Verify,
+    /// Remove one workspace's managed target and cache claims.
+    Remove(RemoveCacheArgs),
+}
+
+#[derive(usage::Args)]
+struct LargestArgs {
+    /// Maximum entries to print.
+    #[usage(long, default = "20")]
+    limit: usize,
+}
+
+#[derive(usage::Args)]
+struct RemoveCacheArgs {
+    /// Workspace root to forget.
+    workspace: PathBuf,
 }
 
 /// Parse the command line and run it.
@@ -179,6 +200,14 @@ pub fn run() -> Result<ExitCode> {
             }
             CacheCommands::Stats(args) => {
                 cache_stats(&config, args.json).map(|()| ExitCode::SUCCESS)
+            }
+            CacheCommands::Projects => cache_projects(&config).map(|()| ExitCode::SUCCESS),
+            CacheCommands::Largest(args) => {
+                cache_largest(&config, args.limit).map(|()| ExitCode::SUCCESS)
+            }
+            CacheCommands::Verify => cache_verify(&config),
+            CacheCommands::Remove(args) => {
+                cache_remove(&config, &args.workspace).map(|()| ExitCode::SUCCESS)
             }
         },
         Commands::Prefetch(args) => prefetch(&config, &args.cargo_args),
@@ -850,6 +879,78 @@ struct GcTargetReport {
 
 fn print_json(value: &impl serde::Serialize) -> Result<()> {
     println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn cache_projects(config: &Config) -> Result<()> {
+    let projects = store::projects(&config.store_dir())?;
+    if projects.is_empty() {
+        println!("no recorded workspaces");
+        return Ok(());
+    }
+    for project in projects {
+        let state = if project.live { "live" } else { "stale" };
+        println!(
+            "{}\t{} actions\t{} targets\t{} identities\t{state}",
+            project.workspace_root.display(),
+            ByteSize::b(project.action_bytes).display().iec(),
+            ByteSize::b(project.target_bytes).display().iec(),
+            project.identities,
+        );
+    }
+    Ok(())
+}
+
+fn cache_largest(config: &Config, limit: usize) -> Result<()> {
+    for entry in store::largest(&config.store_dir(), limit)? {
+        let path = entry
+            .path
+            .strip_prefix(config.store_dir())
+            .unwrap_or(&entry.path);
+        println!(
+            "{}\t{}\t{}",
+            ByteSize::b(entry.bytes).display().iec(),
+            entry.kind,
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn cache_verify(config: &Config) -> Result<ExitCode> {
+    let outcome = store::verify(&config.store_dir())?;
+    println!(
+        "verified {} objects and {} action results",
+        outcome.checked_objects, outcome.checked_action_results
+    );
+    for path in &outcome.problems {
+        println!("invalid: {}", path.display());
+    }
+    Ok(if outcome.problems.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    })
+}
+
+fn cache_remove(config: &Config, workspace: &Path) -> Result<()> {
+    let working_dir = std::env::current_dir()?;
+    let requested = absolute(&working_dir, &workspace.to_string_lossy());
+    let workspace = std::fs::canonicalize(&requested).unwrap_or(requested);
+    let target_bytes = target::remove_workspace(&config.target.root, &workspace)?;
+    let removed = store::remove_project(&config.store_dir(), &workspace)?;
+    println!(
+        "removed {} checkout records for {}",
+        removed.removed_checkout_records,
+        workspace.display()
+    );
+    if let Some(bytes) = target_bytes {
+        println!(
+            "freed managed target directory ({})",
+            ByteSize::b(bytes).display().iec()
+        );
+    }
+    println!("shared cache objects remain available to other workspaces and normal GC");
     Ok(())
 }
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -936,7 +936,8 @@ fn cache_verify(config: &Config) -> Result<ExitCode> {
 fn cache_remove(config: &Config, workspace: &Path) -> Result<()> {
     let working_dir = std::env::current_dir()?;
     let requested = absolute(&working_dir, &workspace.to_string_lossy());
-    let workspace = std::fs::canonicalize(&requested).unwrap_or(requested);
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let workspace = cache_workspace_root(&cargo, &requested);
     let target_bytes = target::remove_workspace(&config.target.root, &workspace)?;
     let removed = store::remove_project(&config.store_dir(), &workspace)?;
     println!(
@@ -952,6 +953,23 @@ fn cache_remove(config: &Config, workspace: &Path) -> Result<()> {
     }
     println!("shared cache objects remain available to other workspaces and normal GC");
     Ok(())
+}
+
+/// Resolve the workspace exactly as Cargo does when recording cache ownership.
+///
+/// Filesystem canonicalization is not interchangeable with Cargo's reported
+/// root: on Windows it can introduce a `\\?\` prefix, and symlink spellings can
+/// differ too. Both checkout records and managed-target keys use the metadata
+/// spelling, so removal must obtain that same identity or it can silently miss
+/// the workspace it was asked to forget.
+fn cache_workspace_root(cargo: &std::ffi::OsStr, requested: &Path) -> PathBuf {
+    let arguments = vec![
+        "--manifest-path".to_string(),
+        requested.join("Cargo.toml").to_string_lossy().into_owned(),
+    ];
+    cargo_roots(cargo, &arguments, None)
+        .map(|roots| roots.workspace_root)
+        .unwrap_or_else(|| requested.to_path_buf())
 }
 
 /// Settings the shim maps out of its cache keys.

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -65,6 +65,49 @@ fn reads_the_roots_cargo_reports() {
 }
 
 #[test]
+fn cache_removal_uses_the_workspace_identity_reported_by_cargo() {
+    let directory = tempfile::tempdir().unwrap();
+    let requested = directory.path().join("workspace-alias");
+    std::fs::create_dir_all(&requested).unwrap();
+    std::fs::write(
+        requested.join("Cargo.toml"),
+        "[package]\nname = \"cache-remove-root\"\nversion = \"0.0.0\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir(requested.join("src")).unwrap();
+    std::fs::write(requested.join("src/lib.rs"), "").unwrap();
+
+    let reported = cache_workspace_root(std::ffi::OsStr::new("cargo"), &requested);
+
+    let metadata = std::process::Command::new("cargo")
+        .args([
+            "metadata",
+            "--no-deps",
+            "--format-version",
+            "1",
+            "--manifest-path",
+        ])
+        .arg(requested.join("Cargo.toml"))
+        .output()
+        .unwrap();
+    assert!(metadata.status.success());
+    assert_eq!(
+        reported,
+        parse_cargo_roots(&metadata.stdout).unwrap().workspace_root
+    );
+}
+
+#[test]
+fn cache_removal_preserves_the_requested_spelling_when_cargo_cannot_resolve_it() {
+    let requested = PathBuf::from("/workspace/that/does/not/exist");
+
+    assert_eq!(
+        cache_workspace_root(std::ffi::OsStr::new("definitely-not-cargo"), &requested),
+        requested
+    );
+}
+
+#[test]
 fn records_whether_anyone_asked_where_the_target_directory_goes() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path();

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -13,7 +13,7 @@ use mbx_cache_core::{
     task_manifest_actions,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -63,6 +63,34 @@ pub struct GcOutcome {
     pub remaining_bytes: u64,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct ProjectUsage {
+    pub workspace_root: PathBuf,
+    pub identities: u64,
+    pub action_bytes: u64,
+    pub target_bytes: u64,
+    pub live: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct LargestEntry {
+    pub kind: &'static str,
+    pub path: PathBuf,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct VerifyOutcome {
+    pub checked_objects: u64,
+    pub checked_action_results: u64,
+    pub problems: Vec<PathBuf>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct RemoveProjectOutcome {
+    pub removed_checkout_records: u64,
+}
+
 /// One checkout's claim on the actions a build identity recorded.
 ///
 /// The target directory is not read back by anything yet; it is recorded
@@ -91,6 +119,134 @@ pub fn stats(store: &Path) -> Result<StoreStats> {
         live_checkouts: checkouts.live_records,
         stale_checkouts: checkouts.stale_records.len() as u64,
     })
+}
+
+/// Attribute cache and target bytes to each recorded workspace.
+///
+/// Shared objects are counted for every workspace that can reach them. That
+/// makes each row answer "how much keeps this workspace warm" without
+/// pretending shared storage can be divided exactly between projects.
+pub fn projects(store: &Path) -> Result<Vec<ProjectUsage>> {
+    let mut projects: BTreeMap<PathBuf, (BTreeSet<String>, bool, u64)> = BTreeMap::new();
+    let root = store.join(CHECKOUTS_DIR);
+    for identity_entry in read_dir_or_empty(&root)? {
+        let identity = identity_entry.file_name().to_string_lossy().into_owned();
+        if !is_task_identity(&identity) || !identity_entry.file_type()?.is_dir() {
+            continue;
+        }
+        for entry in walk_files(&identity_entry.path())? {
+            let Some(record) = read_checkout_record(&entry.path) else {
+                continue;
+            };
+            let project = projects.entry(record.workspace_root.clone()).or_default();
+            project.0.insert(identity.clone());
+            project.1 |= checkout_is_live(&record.workspace_root);
+            project.2 = project.2.max(tree_bytes(&record.target_dir));
+        }
+    }
+    let action_cache = mbx_cache_core::LocalActionCache::new(store);
+    let mut usages = Vec::new();
+    for (workspace_root, (identities, live, target_bytes)) in projects {
+        let mut paths = rooted_objects(store, &identities)?;
+        for identity in &identities {
+            for action in task_manifest_actions(store, identity).unwrap_or_default() {
+                if let Ok(path) = action_cache.path_for(&action) {
+                    paths.insert(path);
+                }
+            }
+        }
+        let action_bytes = paths
+            .iter()
+            .filter_map(|path| std::fs::metadata(path).ok())
+            .map(|metadata| metadata.len())
+            .sum();
+        usages.push(ProjectUsage {
+            workspace_root,
+            identities: identities.len() as u64,
+            action_bytes,
+            target_bytes,
+            live,
+        });
+    }
+    usages.sort_by(|left, right| {
+        right
+            .action_bytes
+            .saturating_add(right.target_bytes)
+            .cmp(&left.action_bytes.saturating_add(left.target_bytes))
+            .then_with(|| left.workspace_root.cmp(&right.workspace_root))
+    });
+    Ok(usages)
+}
+
+/// Return the largest blobs and action-result records in descending order.
+pub fn largest(store: &Path, limit: usize) -> Result<Vec<LargestEntry>> {
+    let mut entries = Vec::new();
+    for (kind, root) in [
+        ("object", store.join(CAS_DIR)),
+        ("action result", store.join(ACTION_RESULTS_DIR)),
+    ] {
+        entries.extend(walk_files(&root)?.into_iter().map(|entry| LargestEntry {
+            kind,
+            path: entry.path,
+            bytes: entry.size,
+        }));
+    }
+    entries.sort_by(|left, right| {
+        right
+            .bytes
+            .cmp(&left.bytes)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    entries.truncate(limit);
+    Ok(entries)
+}
+
+/// Verify every addressable CAS object and action-result record.
+pub fn verify(store: &Path) -> Result<VerifyOutcome> {
+    let cas = LocalCas::new(store);
+    let action_cache = mbx_cache_core::LocalActionCache::new(store);
+    let mut outcome = VerifyOutcome::default();
+    for entry in walk_files(&store.join(CAS_DIR))? {
+        outcome.checked_objects += 1;
+        let Some(digest) = digest_from_path(&entry.path, false) else {
+            outcome.problems.push(entry.path);
+            continue;
+        };
+        if !matches!(cas.find(&digest), Ok(Some(_))) {
+            outcome.problems.push(entry.path);
+        }
+    }
+    for entry in walk_files(&store.join(ACTION_RESULTS_DIR))? {
+        outcome.checked_action_results += 1;
+        let Some(digest) = digest_from_path(&entry.path, true) else {
+            outcome.problems.push(entry.path);
+            continue;
+        };
+        if !matches!(action_cache.find(&digest), Ok(Some(_)))
+            || action_result_is_dangling(&cas, &entry.path)?
+        {
+            outcome.problems.push(entry.path);
+        }
+    }
+    outcome.problems.sort();
+    Ok(outcome)
+}
+
+/// Remove checkout claims belonging to exactly one workspace.
+pub fn remove_project(store: &Path, workspace_root: &Path) -> Result<RemoveProjectOutcome> {
+    let mut outcome = RemoveProjectOutcome::default();
+    for entry in walk_files(&store.join(CHECKOUTS_DIR))? {
+        if read_checkout_record(&entry.path)
+            .is_some_and(|record| record.workspace_root == workspace_root)
+        {
+            std::fs::remove_file(&entry.path)?;
+            outcome.removed_checkout_records += 1;
+            if let Some(parent) = entry.path.parent() {
+                let _ = std::fs::remove_dir(parent);
+            }
+        }
+    }
+    Ok(outcome)
 }
 
 /// Record that `workspace_root` built `identity`.
@@ -574,6 +730,56 @@ fn walk_files(root: &Path) -> Result<Vec<Entry>> {
         }
     }
     Ok(entries)
+}
+
+fn read_dir_or_empty(root: &Path) -> Result<Vec<std::fs::DirEntry>> {
+    match std::fs::read_dir(root) {
+        Ok(entries) => entries
+            .collect::<std::io::Result<Vec<_>>>()
+            .map_err(Into::into),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to read {}", root.display())),
+    }
+}
+
+fn digest_from_path(path: &Path, action_result: bool) -> Option<CacheDigest> {
+    let name = path.file_name()?.to_str()?;
+    let name = if action_result {
+        name.strip_suffix(".json")?
+    } else {
+        name
+    };
+    let (hash, size) = name.rsplit_once('-')?;
+    let algorithm = path.parent()?.parent()?.file_name()?.to_str()?.to_string();
+    let digest = CacheDigest {
+        algorithm,
+        hash: hash.to_string(),
+        size: size.parse().ok()?,
+    };
+    digest.validate().ok()?;
+    Some(digest)
+}
+
+fn tree_bytes(root: &Path) -> u64 {
+    let mut bytes = 0_u64;
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.is_file() {
+            bytes = bytes.saturating_add(metadata.len());
+        } else if metadata.is_dir()
+            && let Ok(entries) = std::fs::read_dir(path)
+        {
+            pending.extend(
+                entries
+                    .filter_map(std::result::Result::ok)
+                    .map(|entry| entry.path()),
+            );
+        }
+    }
+    bytes
 }
 
 #[cfg(test)]

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -140,8 +140,10 @@ pub fn projects(store: &Path) -> Result<Vec<ProjectUsage>> {
                 continue;
             };
             let project = projects.entry(record.workspace_root.clone()).or_default();
-            project.0.insert(identity.clone());
-            project.1 |= checkout_is_live(&record.workspace_root);
+            if claim_is_live(&record) {
+                project.0.insert(identity.clone());
+                project.1 = true;
+            }
             project.2 = project
                 .2
                 .max(cached_tree_bytes(&mut target_sizes, &record.target_dir));

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -128,6 +128,7 @@ pub fn stats(store: &Path) -> Result<StoreStats> {
 /// pretending shared storage can be divided exactly between projects.
 pub fn projects(store: &Path) -> Result<Vec<ProjectUsage>> {
     let mut projects: BTreeMap<PathBuf, (BTreeSet<String>, bool, u64)> = BTreeMap::new();
+    let mut target_sizes = BTreeMap::new();
     let root = store.join(CHECKOUTS_DIR);
     for identity_entry in read_dir_or_empty(&root)? {
         let identity = identity_entry.file_name().to_string_lossy().into_owned();
@@ -141,7 +142,9 @@ pub fn projects(store: &Path) -> Result<Vec<ProjectUsage>> {
             let project = projects.entry(record.workspace_root.clone()).or_default();
             project.0.insert(identity.clone());
             project.1 |= checkout_is_live(&record.workspace_root);
-            project.2 = project.2.max(tree_bytes(&record.target_dir));
+            project.2 = project
+                .2
+                .max(cached_tree_bytes(&mut target_sizes, &record.target_dir));
         }
     }
     let action_cache = mbx_cache_core::LocalActionCache::new(store);
@@ -760,9 +763,27 @@ fn digest_from_path(path: &Path, action_result: bool) -> Option<CacheDigest> {
     Some(digest)
 }
 
+fn cached_tree_bytes(cache: &mut BTreeMap<PathBuf, u64>, root: &Path) -> u64 {
+    *cache
+        .entry(root.to_path_buf())
+        .or_insert_with(|| tree_bytes(root))
+}
+
 fn tree_bytes(root: &Path) -> u64 {
+    let Ok(root_metadata) = std::fs::metadata(root) else {
+        return 0;
+    };
+    if root_metadata.is_file() {
+        return root_metadata.len();
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return 0;
+    };
     let mut bytes = 0_u64;
-    let mut pending = vec![root.to_path_buf()];
+    let mut pending = entries
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
     while let Some(path) = pending.pop() {
         let Ok(metadata) = std::fs::symlink_metadata(&path) else {
             continue;

--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -186,15 +186,20 @@ pub fn projects(store: &Path) -> Result<Vec<ProjectUsage>> {
 /// Return the largest blobs and action-result records in descending order.
 pub fn largest(store: &Path, limit: usize) -> Result<Vec<LargestEntry>> {
     let mut entries = Vec::new();
-    for (kind, root) in [
-        ("object", store.join(CAS_DIR)),
-        ("action result", store.join(ACTION_RESULTS_DIR)),
+    for (kind, root, action_result) in [
+        ("object", store.join(CAS_DIR), false),
+        ("action result", store.join(ACTION_RESULTS_DIR), true),
     ] {
-        entries.extend(walk_files(&root)?.into_iter().map(|entry| LargestEntry {
-            kind,
-            path: entry.path,
-            bytes: entry.size,
-        }));
+        entries.extend(
+            walk_files(&root)?
+                .into_iter()
+                .filter(|entry| addressed_digest(store, &entry.path, action_result).is_some())
+                .map(|entry| LargestEntry {
+                    kind,
+                    path: entry.path,
+                    bytes: entry.size,
+                }),
+        );
     }
     entries.sort_by(|left, right| {
         right
@@ -212,21 +217,19 @@ pub fn verify(store: &Path) -> Result<VerifyOutcome> {
     let action_cache = mbx_cache_core::LocalActionCache::new(store);
     let mut outcome = VerifyOutcome::default();
     for entry in walk_files(&store.join(CAS_DIR))? {
-        outcome.checked_objects += 1;
-        let Some(digest) = digest_from_path(&entry.path, false) else {
-            outcome.problems.push(entry.path);
+        let Some(digest) = addressed_digest(store, &entry.path, false) else {
             continue;
         };
+        outcome.checked_objects += 1;
         if !matches!(cas.find(&digest), Ok(Some(_))) {
             outcome.problems.push(entry.path);
         }
     }
     for entry in walk_files(&store.join(ACTION_RESULTS_DIR))? {
-        outcome.checked_action_results += 1;
-        let Some(digest) = digest_from_path(&entry.path, true) else {
-            outcome.problems.push(entry.path);
+        let Some(digest) = addressed_digest(store, &entry.path, true) else {
             continue;
         };
+        outcome.checked_action_results += 1;
         if !matches!(action_cache.find(&digest), Ok(Some(_)))
             || action_result_is_dangling(&cas, &entry.path)?
         {
@@ -763,6 +766,18 @@ fn digest_from_path(path: &Path, action_result: bool) -> Option<CacheDigest> {
     };
     digest.validate().ok()?;
     Some(digest)
+}
+
+fn addressed_digest(store: &Path, path: &Path, action_result: bool) -> Option<CacheDigest> {
+    let digest = digest_from_path(path, action_result)?;
+    let canonical = if action_result {
+        mbx_cache_core::LocalActionCache::new(store)
+            .path_for(&digest)
+            .ok()?
+    } else {
+        LocalCas::new(store).path_for(&digest).ok()?
+    };
+    (canonical == path).then_some(digest)
 }
 
 fn cached_tree_bytes(cache: &mut BTreeMap<PathBuf, u64>, root: &Path) -> u64 {

--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -90,6 +90,68 @@ fn reports_an_empty_store() {
 }
 
 #[test]
+fn lists_largest_entries_in_descending_order() {
+    let directory = tempfile::tempdir().unwrap();
+    store_object(directory.path(), b"small");
+    store_object(directory.path(), b"a much larger object");
+
+    let entries = largest(directory.path(), 1).unwrap();
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].kind, "object");
+    assert_eq!(entries[0].bytes, 20);
+}
+
+#[test]
+fn verification_reports_a_corrupt_object() {
+    let directory = tempfile::tempdir().unwrap();
+    let digest = store_object(directory.path(), b"original");
+    let path = LocalCas::new(directory.path()).path_for(&digest).unwrap();
+    std::fs::write(&path, b"corrupt!").unwrap();
+
+    let outcome = verify(directory.path()).unwrap();
+
+    assert_eq!(outcome.checked_objects, 1);
+    assert_eq!(outcome.problems, vec![path]);
+}
+
+#[test]
+fn attributes_reachable_cache_bytes_to_a_workspace() {
+    let directory = tempfile::tempdir().unwrap();
+    let workspace = directory.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let output = store_object(directory.path(), b"artifact");
+    let action = store_result(directory.path(), "compile", &[output]);
+    record_build(directory.path(), &"a".repeat(64), &workspace, &[action]);
+
+    let projects = projects(directory.path()).unwrap();
+
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].workspace_root, workspace);
+    assert_eq!(projects[0].identities, 1);
+    assert!(projects[0].action_bytes > 0);
+    assert!(projects[0].live);
+}
+
+#[test]
+fn removes_only_the_requested_workspaces_checkout_claims() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = directory.path().join("first");
+    let second = directory.path().join("second");
+    std::fs::create_dir_all(&first).unwrap();
+    std::fs::create_dir_all(&second).unwrap();
+    record_build(directory.path(), &"a".repeat(64), &first, &[]);
+    record_build(directory.path(), &"b".repeat(64), &second, &[]);
+
+    let outcome = remove_project(directory.path(), &first).unwrap();
+
+    assert_eq!(outcome.removed_checkout_records, 1);
+    let remaining = projects(directory.path()).unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].workspace_root, second);
+}
+
+#[test]
 fn counts_objects_and_results() {
     let directory = tempfile::tempdir().unwrap();
     let store = directory.path();

--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -116,6 +116,42 @@ fn verification_reports_a_corrupt_object() {
 }
 
 #[test]
+fn inspection_ignores_in_progress_staging_paths() {
+    let directory = tempfile::tempdir().unwrap();
+    let action = store_result(directory.path(), "compile", &[]);
+    let cas_path = LocalCas::new(directory.path()).path_for(&action).unwrap();
+    let result_path = LocalActionCache::new(directory.path())
+        .path_for(&action)
+        .unwrap();
+    let staging_file = tempfile::NamedTempFile::new_in(cas_path.parent().unwrap()).unwrap();
+    std::fs::write(staging_file.path(), vec![b'x'; 1_024]).unwrap();
+    let staging_directory = tempfile::tempdir_in(result_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        staging_directory.path().join("result.json"),
+        vec![b'x'; 2_048],
+    )
+    .unwrap();
+
+    let entries = largest(directory.path(), 10).unwrap();
+    let outcome = verify(directory.path()).unwrap();
+
+    assert_eq!(entries.len(), 3);
+    assert!(
+        entries
+            .iter()
+            .all(|entry| entry.path != staging_file.path())
+    );
+    assert!(
+        entries
+            .iter()
+            .all(|entry| !entry.path.starts_with(staging_directory.path()))
+    );
+    assert_eq!(outcome.checked_objects, 2);
+    assert_eq!(outcome.checked_action_results, 1);
+    assert!(outcome.problems.is_empty());
+}
+
+#[test]
 fn attributes_reachable_cache_bytes_to_a_workspace() {
     let directory = tempfile::tempdir().unwrap();
     let workspace = directory.path().join("workspace");

--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -133,6 +133,40 @@ fn attributes_reachable_cache_bytes_to_a_workspace() {
     assert!(projects[0].live);
 }
 
+#[test]
+fn project_usage_excludes_expired_claims() {
+    let directory = tempfile::tempdir().unwrap();
+    let workspace = directory.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let action = store_result(directory.path(), "compile", &[]);
+    let identity = "a".repeat(64);
+    record_build(directory.path(), &identity, &workspace, &[action]);
+    let stale = CheckoutRecord {
+        version: CHECKOUT_RECORD_VERSION,
+        workspace_root: workspace.clone(),
+        target_dir: workspace.join("target"),
+        updated_secs: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - CHECKOUT_RETENTION.as_secs()
+            - 1,
+    };
+    crate::util::write_atomic(
+        &checkout_record_path(directory.path(), &identity, &workspace),
+        &serde_json::to_vec(&stale).unwrap(),
+    )
+    .unwrap();
+
+    let projects = projects(directory.path()).unwrap();
+
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].workspace_root, workspace);
+    assert_eq!(projects[0].identities, 0);
+    assert_eq!(projects[0].action_bytes, 0);
+    assert!(!projects[0].live);
+}
+
 #[cfg(unix)]
 #[test]
 fn project_usage_follows_a_recorded_target_symlink() {

--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -133,6 +133,38 @@ fn attributes_reachable_cache_bytes_to_a_workspace() {
     assert!(projects[0].live);
 }
 
+#[cfg(unix)]
+#[test]
+fn project_usage_follows_a_recorded_target_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let workspace = directory.path().join("workspace");
+    let actual_target = directory.path().join("managed-target");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&actual_target).unwrap();
+    std::fs::write(actual_target.join("artifact"), b"compiled").unwrap();
+    symlink(&actual_target, workspace.join("target")).unwrap();
+    record_build(directory.path(), &"a".repeat(64), &workspace, &[]);
+
+    let projects = projects(directory.path()).unwrap();
+
+    assert_eq!(projects[0].target_bytes, 8);
+}
+
+#[test]
+fn target_sizes_are_cached_by_recorded_path() {
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("target");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join("artifact"), b"first").unwrap();
+    let mut cache = BTreeMap::new();
+
+    assert_eq!(cached_tree_bytes(&mut cache, &target), 5);
+    std::fs::write(target.join("artifact"), b"changed after the walk").unwrap();
+    assert_eq!(cached_tree_bytes(&mut cache, &target), 5);
+}
+
 #[test]
 fn removes_only_the_requested_workspaces_checkout_claims() {
     let directory = tempfile::tempdir().unwrap();

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -59,6 +59,34 @@ pub struct MigrationOutcome {
     pub removed_bytes: Option<u64>,
 }
 
+/// Remove the managed target view owned by exactly one workspace.
+pub fn remove_workspace(root: &Path, workspace_root: &Path) -> Result<Option<u64>> {
+    let record_path = view_record_path(root, workspace_root);
+    let Some(record) = read_view_record(&record_path) else {
+        return Ok(None);
+    };
+    if record.workspace_root != workspace_root {
+        return Ok(None);
+    }
+    let directory = record_path.with_extension("");
+    let bytes = tree_bytes(&directory);
+    match std::fs::remove_dir_all(&directory) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    std::fs::remove_file(&record_path).or_else(|error| {
+        (error.kind() == std::io::ErrorKind::NotFound)
+            .then_some(())
+            .ok_or(error)
+    })?;
+    let link = workspace_root.join("target");
+    if std::fs::read_link(&link).is_ok_and(|destination| destination == directory) {
+        remove_link(&link)?;
+    }
+    Ok(Some(bytes))
+}
+
 /// Whether an interactive caller may offer to remove this target directory.
 ///
 /// Match placement's eligibility rules exactly, then require a real directory.

--- a/crates/mbx/src/target_tests.rs
+++ b/crates/mbx/src/target_tests.rs
@@ -329,6 +329,22 @@ fn frees_the_target_directory_of_a_checkout_that_is_gone() {
 }
 
 #[test]
+fn explicitly_removes_one_workspaces_managed_target() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = test_config(directory.path(), true);
+    let workspace = checkout(directory.path(), "project");
+    let managed = place(&config, &workspace, &workspace.join("target"), false).unwrap();
+    std::fs::write(managed.join("artifact"), b"outputs").unwrap();
+
+    let bytes = remove_workspace(&config.target.root, &workspace).unwrap();
+
+    assert_eq!(bytes, Some(7));
+    assert!(!managed.exists());
+    assert!(!workspace.join("target").exists());
+    assert_eq!(stats(&config.target.root).unwrap(), ViewStats::default());
+}
+
+#[test]
 fn keeps_the_target_directory_of_an_idle_checkout() {
     let directory = tempfile::tempdir().unwrap();
     let config = test_config(directory.path(), true);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,6 +94,48 @@ Summarize what the store holds.
 - **`--json`** — Print a stable machine-readable report.
 - **`-h --help`** — Print help
 
+## `mbx cache projects`
+
+- **Usage:** `mbx cache projects`
+
+Show cache use attributed to recorded workspaces.
+
+### Flags
+- **`-h --help`** — Print help
+
+## `mbx cache largest`
+
+- **Usage:** `mbx cache largest [--limit <LIMIT>]`
+
+List the largest objects and action-result records.
+
+### Flags
+- **`--limit <LIMIT>`** — Maximum entries to print.
+
+  **Default:** `20`
+- **`-h --help`** — Print help
+
+## `mbx cache verify`
+
+- **Usage:** `mbx cache verify`
+
+Verify local objects and action results.
+
+### Flags
+- **`-h --help`** — Print help
+
+## `mbx cache remove`
+
+- **Usage:** `mbx cache remove <WORKSPACE>`
+
+Remove one workspace's managed target and cache claims.
+
+### Arguments
+- **`<WORKSPACE>`** — Workspace root to forget.
+
+### Flags
+- **`-h --help`** — Print help
+
 ## `mbx prefetch`
 
 - **Usage:** `mbx prefetch <CARGO_ARGS>…`

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -71,6 +71,10 @@ Turning placement off does not delete a target directory mbx already manages.
 The existing `target` link continues to work, and collection can still reclaim
 the directory after its checkout disappears.
 
+To remove one workspace's managed target immediately and forget its cache
+claims, run `mbx cache remove /path/to/workspace`. Shared objects stay available
+to other workspaces and are reclaimed by normal garbage collection.
+
 ::: warning Windows
 Creating the link requires Developer Mode or a privileged process on Windows.
 If Windows cannot create it, mbx lets Cargo use its ordinary target directory.


### PR DESCRIPTION
## Summary
- add `mbx cache projects` with workspace-attributed action and target usage
- add `mbx cache largest --limit N` for oversized local entries
- add full local CAS and action-result integrity verification with a failing exit status
- add workspace-scoped removal for checkout claims and mbx-owned managed targets

Shared bytes are counted for every project that can reach them. Removal deliberately preserves shared objects for other workspaces and normal GC.

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- generated documentation check
- smoke-tested all read-only commands against an empty cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `cache remove` deletes checkout claims and managed target directories on disk; wrong workspace identity could miss records, though resolution is aligned with Cargo metadata and covered by tests.
> 
> **Overview**
> Extends **`mbx cache`** beyond `dir`/`stats` with **projects**, **largest**, **verify**, and **remove**, plus README and CLI docs for each.
> 
> **`mbx cache projects`** rolls up per-workspace action cache bytes (reachable via live checkout claims, with shared objects counted for every project that can reach them), managed **target** size from recorded paths, identity count, and live/stale status. **`mbx cache largest [--limit]`** lists the biggest CAS objects and action-result files, using canonical addressing so in-progress staging files are skipped. **`mbx cache verify`** walks those same addressable entries, checks integrity via the CAS/action cache APIs (including dangling action results), prints problems, and **exits non-zero** when anything is invalid.
> 
> **`mbx cache remove <workspace>`** resolves the workspace root the same way Cargo does when recording claims (`cache_workspace_root` / metadata, not filesystem canonicalization), drops that workspace’s checkout records via **`store::remove_project`**, removes its mbx-managed target view with **`target::remove_workspace`** (including the `target` symlink when it points at the managed dir), and leaves shared store blobs for other workspaces and normal GC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd60ef903113a82b59e741eec9de2b14359cd53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->