### PR TITLE
feat: add explicit remote prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ supported compilations it has seen before.
 mbx build                  # cargo build, with caching
 mbx test --all-features    # cargo test --all-features, with caching
 mbx clippy --workspace     # cargo clippy --workspace, with caching
+mbx prefetch build         # warm a recorded build from the remote cache
 mbx setup                  # cache future plain cargo commands locally
 ```
 

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -476,12 +476,28 @@ impl CacheAgent {
 
     /// Load the last committed action manifest for a task into this session.
     pub async fn begin_task(&self, task: &str) -> Result<String> {
+        self.begin_task_with_remote_errors(task, false).await
+    }
+
+    /// Load a task and finish its prefetch, surfacing remote lookup failures.
+    pub async fn prefetch_task(&self, task: &str) -> Result<String> {
+        let run = self.begin_task_with_remote_errors(task, true).await?;
+        self.wait_for_prefetches().await;
+        Ok(run)
+    }
+
+    async fn begin_task_with_remote_errors(&self, task: &str, strict: bool) -> Result<String> {
         validate_task_identity(task)?;
         let (remote_manifest, mut remote_etag) = if self.remote_mode.reads() {
             match self.get_remote_task_manifest(task).await {
                 Ok(Some((manifest, etag))) => (Some(manifest), Some(etag)),
                 Ok(None) => (None, None),
                 Err(error) => {
+                    if strict {
+                        return Err(error).wrap_err_with(|| {
+                            format!("remote task action manifest lookup failed for {task}")
+                        });
+                    }
                     warn!("remote task action manifest lookup failed for {task}: {error}");
                     (None, None)
                 }
@@ -554,7 +570,6 @@ impl CacheAgent {
         }
     }
 
-    #[cfg(test)]
     async fn wait_for_prefetches(&self) {
         let tasks = std::mem::take(&mut *self.prefetch_tasks.lock().unwrap());
         for task in tasks {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -37,8 +37,18 @@ enum Commands {
     Gc(GcArgs),
     /// Inspect the local store.
     Cache(CacheArgs),
+    /// Download predicted remote artifacts without running Cargo.
+    Prefetch(PrefetchArgs),
     #[usage(external_subcommand)]
     Cargo(Vec<String>),
+}
+
+#[derive(usage::Args)]
+#[usage(unknown_flags = "value", dont_delimit_trailing_values = true)]
+struct PrefetchArgs {
+    /// Cargo subcommand and arguments whose previous manifest should be warmed.
+    #[usage(value_name = "CARGO_ARGS", required = true)]
+    cargo_args: Vec<String>,
 }
 
 #[derive(usage::Args)]
@@ -84,7 +94,11 @@ enum CacheCommands {
 
 /// Parse the command line and run it.
 pub fn run() -> Result<ExitCode> {
-    let cli = Cli::parse();
+    let original = std::env::args_os().collect::<Vec<_>>();
+    let mut cli = Cli::parse();
+    if let Commands::Prefetch(args) = &mut cli.command {
+        args.cargo_args = original_prefetch_arguments(&original)?;
+    }
     let config = Config::load()?;
     match cli.command {
         Commands::Explain(args) => crate::explain::run(&config, &args.arguments()),
@@ -102,8 +116,59 @@ pub fn run() -> Result<ExitCode> {
             }
             CacheCommands::Stats => cache_stats(&config).map(|()| ExitCode::SUCCESS),
         },
+        Commands::Prefetch(args) => prefetch(&config, &args.cargo_args),
         Commands::Cargo(arguments) => cargo(&config, &arguments),
     }
+}
+
+fn original_prefetch_arguments(arguments: &[std::ffi::OsString]) -> Result<Vec<String>> {
+    let Some(index) = arguments
+        .iter()
+        .position(|argument| argument == std::ffi::OsStr::new("prefetch"))
+    else {
+        eyre::bail!("could not recover prefetch arguments");
+    };
+    arguments[index + 1..]
+        .iter()
+        .map(|argument| {
+            argument
+                .to_str()
+                .map(str::to_owned)
+                .ok_or_else(|| eyre::eyre!("Cargo arguments must be valid UTF-8"))
+        })
+        .collect()
+}
+
+fn prefetch(config: &Config, arguments: &[String]) -> Result<ExitCode> {
+    if config.remote.url.is_none() {
+        eyre::bail!("remote prefetch requires remote.url or MBX_REMOTE_URL");
+    }
+    if !config.remote.mode.reads() {
+        eyre::bail!("remote prefetch requires a read-capable remote.mode");
+    }
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let working_dir = std::env::current_dir()?;
+    let roots = resolve_roots(&cargo, arguments, &working_dir);
+    let session_dir = tempfile::Builder::new().prefix("mbx-prefetch-").tempdir()?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let stats = runtime.block_on(async {
+        let session = CacheSession::start(session_dir.path(), config).await?;
+        session.prefetch(&roots.workspace_root, arguments).await?;
+        session.finish().await
+    })?;
+    if stats.prefetch_runs == 0 {
+        println!("no recorded actions for this workspace and Cargo command");
+    } else {
+        println!(
+            "prefetched {} actions; {} downloaded and {} stored locally",
+            stats.prefetched_actions,
+            ByteSize::b(stats.downloaded_bytes).display().iec(),
+            ByteSize::b(stats.stored_bytes).display().iec()
+        );
+    }
+    Ok(ExitCode::SUCCESS)
 }
 
 fn setup() -> Result<()> {

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -140,12 +140,7 @@ fn original_prefetch_arguments(arguments: &[std::ffi::OsString]) -> Result<Vec<S
 }
 
 fn prefetch(config: &Config, arguments: &[String]) -> Result<ExitCode> {
-    if config.remote.url.is_none() {
-        eyre::bail!("remote prefetch requires remote.url or MBX_REMOTE_URL");
-    }
-    if !config.remote.mode.reads() {
-        eyre::bail!("remote prefetch requires a read-capable remote.mode");
-    }
+    validate_prefetch_config(config, policy::release_context())?;
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let working_dir = std::env::current_dir()?;
     let roots = resolve_roots(&cargo, arguments, &working_dir);
@@ -169,6 +164,19 @@ fn prefetch(config: &Config, arguments: &[String]) -> Result<ExitCode> {
         );
     }
     Ok(ExitCode::SUCCESS)
+}
+
+fn validate_prefetch_config(config: &Config, release_context: bool) -> Result<()> {
+    if config.remote.url.is_none() {
+        eyre::bail!("remote prefetch requires remote.url or MBX_REMOTE_URL");
+    }
+    if !config.remote.mode.reads() {
+        eyre::bail!("remote prefetch requires a read-capable remote.mode");
+    }
+    if release_context {
+        eyre::bail!("remote prefetch is disabled in release contexts");
+    }
+    Ok(())
 }
 
 fn setup() -> Result<()> {

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -423,6 +423,19 @@ fn prefetch_preserves_cargo_flags_and_the_rustc_separator() {
 }
 
 #[test]
+fn prefetch_rejects_release_contexts_instead_of_succeeding_without_remote_work() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut config = managed_target_config(directory.path());
+    config.remote.url = Some("https://cache.example.test".into());
+    config.remote.mode = mbx_cache_core::RemoteCacheMode::ReadOnly;
+
+    let error = validate_prefetch_config(&config, true).unwrap_err();
+
+    assert!(error.to_string().contains("disabled in release contexts"));
+    assert!(validate_prefetch_config(&config, false).is_ok());
+}
+
+#[test]
 fn cli_exposes_its_usage_spec() {
     let spec = Cli::to_kdl();
     assert!(spec.contains("external_subcommand #true"));

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -395,6 +395,34 @@ fn explain_forwards_cargo_flags_and_the_rustc_separator() {
 }
 
 #[test]
+fn prefetch_preserves_cargo_flags_and_the_rustc_separator() {
+    let argv = [
+        "mbx",
+        "prefetch",
+        "test",
+        "--workspace",
+        "--",
+        "--nocapture",
+    ]
+    .map(std::ffi::OsStr::new);
+
+    let cli = Cli::try_parse_from(&argv).unwrap();
+
+    let Commands::Prefetch(args) = cli.command else {
+        panic!("prefetch should remain an mbx command");
+    };
+    assert_eq!(args.cargo_args, ["test", "--workspace", "--nocapture"]);
+    let original = argv
+        .iter()
+        .map(|argument| argument.to_os_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        original_prefetch_arguments(&original).unwrap(),
+        ["test", "--workspace", "--", "--nocapture"]
+    );
+}
+
+#[test]
 fn cli_exposes_its_usage_spec() {
     let spec = Cli::to_kdl();
     assert!(spec.contains("external_subcommand #true"));

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -171,6 +171,13 @@ impl CacheSession {
         action_run
     }
 
+    /// Warm the recorded actions for a Cargo command without running Cargo.
+    pub async fn prefetch(&self, workspace_root: &Path, command: &[String]) -> Result<()> {
+        let identity = build_identity(workspace_root, command);
+        self.agent.prefetch_task(&identity).await?;
+        Ok(())
+    }
+
     /// Stop the agent and collect this session's statistics.
     pub async fn finish(&self) -> Result<AgentStats> {
         if let Some(shutdown) = self.shutdown.lock().unwrap().take() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,6 +78,18 @@ Summarize what the store holds.
 ### Flags
 - **`-h --help`** — Print help
 
+## `mbx prefetch`
+
+- **Usage:** `mbx prefetch <CARGO_ARGS>…`
+
+Download predicted remote artifacts without running Cargo.
+
+### Arguments
+- **`<CARGO_ARGS>…`** — Cargo subcommand and arguments whose previous manifest should be warmed.
+
+### Flags
+- **`-h --help`** — Print help
+
 ## Configuration
 
 Read from, in ascending precedence — the last one that names a setting wins:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,20 @@ the same usage-rs declaration mbx uses at runtime. See
 `MBX_VERIFY=1` is deliberately slower. It qualifies correctness; it is not a
 normal build mode.
 
+## Explicit remote prefetch
+
+After a command has published its action manifest, another machine can warm
+the same build without running Cargo:
+
+```sh
+mbx prefetch build --workspace --release
+```
+
+The workspace's `Cargo.lock` and complete Cargo argument list select the same
+manifest as a normal mbx build. Prefetch requires a configured remote in
+`read-only` or `read-write` mode, waits for every predicted action, and returns
+an error when the manifest lookup fails.
+
 ## Incremental builds
 
 `MBX_INCREMENTAL=1` stops mbx from forcing `CARGO_INCREMENTAL=0` locally. This


### PR DESCRIPTION
## Summary
- add `mbx prefetch <cargo args...>` to warm a previously recorded build without invoking Cargo
- derive the exact same workspace/command manifest identity as a normal build, including preserved `--` separators
- wait for every predicted action and report downloaded/local bytes
- require a read-capable configured remote and surface manifest lookup failures

Normal builds retain their existing best-effort remote fallback behavior.

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- generated documentation check
- smoke-tested missing-remote diagnostics and exit status

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New remote I/O path and stricter manifest errors on prefetch, but normal builds keep best-effort remote fallback; misconfiguration or release-context misuse fails fast at the CLI.
> 
> **Overview**
> Adds **`mbx prefetch <cargo args…>`** so another machine can pull predicted remote cache artifacts for a previously recorded workspace/command **without running Cargo**.
> 
> Prefetch uses the same manifest identity as a normal build (`Cargo.lock` + full argument list). The CLI re-parses argv so the **`--`** rustc separator is preserved, then starts a short cache session, loads the task manifest, waits for background prefetches, and prints action count plus downloaded/stored bytes (or a message when nothing was recorded).
> 
> **Cache agent:** `prefetch_task` loads the manifest in **strict** mode—remote manifest lookup failures **error** instead of the warn-and-continue behavior used during ordinary builds—and blocks until prefetch work finishes. Regular `begin_task` behavior is unchanged.
> 
> **Guards:** prefetch requires a configured remote URL and a read-capable `remote.mode`, and is **rejected in release contexts** (aligned with release builds not using the remote cache). README and generated CLI/configuration docs document the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d79006f86e0898900545c250ceefb532be5b397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->