### PR TITLE
feat: cache compiler-bundled WebAssembly links

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ derives an action key, restores cached outputs when possible, or runs the real
 compiler and publishes a successful result.
 
 Anything mbx cannot model exactly bypasses the cache. Native linking is not
-cached; the intentionally narrow exception is `wasm32-unknown-unknown`, whose
-default linker ships inside the Rust toolchain. Incremental compilations bypass
-the cache. Correctness comes before hit rate.
+cached; built-in WebAssembly targets with self-contained linkers are the narrow
+exception because their linker, CRT, and libc inputs ship in the Rust toolchain.
+Incremental compilations bypass the cache. Correctness comes before hit rate.
 
 [Read the architecture and limits →](https://mr-boxington.jdx.dev/how-it-works)
 

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Cache linked outputs for built-in self-contained WebAssembly targets.
-
 ## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.1.0...mbx-cache-rustc-v0.2.0) - 2026-08-22
 
 ### Added

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cache linked outputs for built-in self-contained WebAssembly targets.
+
 ## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.1.0...mbx-cache-rustc-v0.2.0) - 2026-08-22
 
 ### Added

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -87,6 +87,17 @@ const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
     "tls-model",
 ];
 
+/// Built-in WebAssembly targets whose default linkers and CRT inputs ship in
+/// the Rust toolchain. Custom target specs never enter this list.
+const COMPILER_BUNDLED_WASM_TARGETS: &[&str] = &[
+    "wasm32-unknown-unknown",
+    "wasm32-wasip1",
+    "wasm32-wasip1-threads",
+    "wasm32-wasip2",
+    "wasm32v1-none",
+    "wasm64-unknown-unknown",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq, Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
 /// Reason an invocation cannot safely use the action cache.
@@ -287,7 +298,8 @@ impl RustcInvocation {
     ///
     /// Any flag whose cache semantics are not modeled returns a bypass reason
     /// instead of guessing. A successful parse only admits the initial
-    /// rlib/rmeta tier plus compiler-linked `wasm32-unknown-unknown` binaries.
+    /// rlib/rmeta tier plus binaries linked by compiler-bundled WebAssembly
+    /// toolchains.
     pub fn parse(arguments: &[OsString]) -> Result<Self, BypassReason> {
         Parser::new(arguments).parse()
     }
@@ -1011,20 +1023,39 @@ impl<'a> Parser<'a> {
                 .all(|crate_type| matches!(crate_type.as_str(), "lib" | "rlib"))
         {
             LinkOutput::Library
-        } else if self.target.as_deref() == Some("wasm32-unknown-unknown")
+        } else if self
+            .target
+            .as_deref()
+            .is_some_and(compiler_bundled_wasm_target)
             && ((self.test && self.crate_types.is_empty())
-                || self.crate_types.as_slice() == ["bin"])
+                || matches!(self.crate_types.as_slice(), [kind] if kind == "bin" || kind == "cdylib"))
         {
-            if self.parsed.iter().any(|argument| {
-                matches!(argument, Argument::Plain(value) if value == "--codegen=link-self-contained" || value.starts_with("--codegen=link-self-contained="))
+            if self.parsed.iter().any(|argument| match argument {
+                Argument::Plain(value) if value == "--codegen=link-self-contained" => false,
+                Argument::Plain(value) if value.starts_with("--codegen=link-self-contained=") => {
+                    !matches!(
+                        value.rsplit_once('=').map(|(_, value)| value),
+                        Some("y" | "yes" | "on" | "true")
+                    )
+                }
+                _ => false,
             }) {
                 return Err(BypassReason::UnknownCodegenOption(
                     "link-self-contained".into(),
                 ));
             }
-            // This target's built-in linker is rust-lld from the Rust
-            // toolchain. Unlike a native link, it has no implicit host CRT or
-            // system-library inputs outside the compiler identity.
+            if self.target.as_deref().is_some_and(|target| target.contains("wasi"))
+                && self.parsed.iter().any(|argument| {
+                    matches!(argument, Argument::Plain(value) if value.strip_prefix("--codegen=target-feature=").is_some_and(|features| features.split(',').any(|feature| feature == "-crt-static")))
+                })
+            {
+                return Err(BypassReason::UnknownCodegenOption(
+                    "target-feature=-crt-static".into(),
+                ));
+            }
+            // These targets use a linker and, where applicable, CRT objects
+            // and libc shipped in the Rust toolchain. Unlike native linking,
+            // there are no implicit host inputs outside compiler identity.
             LinkOutput::WasmExecutable
         } else if self.test {
             return Err(BypassReason::UnsupportedCrateType("test".into()));
@@ -1059,6 +1090,10 @@ impl<'a> Parser<'a> {
         }
         Ok(link_output)
     }
+}
+
+fn compiler_bundled_wasm_target(target: &str) -> bool {
+    COMPILER_BUNDLED_WASM_TARGETS.binary_search(&target).is_ok()
 }
 
 fn parse_emits(value: &str) -> Vec<Emit> {

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -191,13 +191,25 @@ fn resolves_a_compiler_linked_wasm_binary() {
 
 #[test]
 fn accepts_wasm_tests_but_not_native_tests() {
-    let wasm = args(&[
-        "--test",
-        "--emit=dep-info,link",
-        "--target=wasm32-unknown-unknown",
-        "src/lib.rs",
-    ]);
-    assert!(RustcInvocation::parse(&wasm).is_ok());
+    for target in COMPILER_BUNDLED_WASM_TARGETS {
+        let wasm = args(&[
+            "--test",
+            "--emit=dep-info,link",
+            &format!("--target={target}"),
+            "src/lib.rs",
+        ]);
+        assert!(
+            RustcInvocation::parse(&wasm).is_ok(),
+            "{target} should use its compiler-bundled linker"
+        );
+        let cdylib = args(&[
+            "--crate-type=cdylib",
+            "--emit=dep-info,link",
+            &format!("--target={target}"),
+            "src/lib.rs",
+        ]);
+        assert!(RustcInvocation::parse(&cdylib).is_ok());
+    }
 
     let implicit_binary = args(&[
         "--emit=dep-info,link",
@@ -214,6 +226,22 @@ fn accepts_wasm_tests_but_not_native_tests() {
         RustcInvocation::parse(&native),
         Err(BypassReason::UnsupportedCrateType("test".into()))
     );
+}
+
+#[test]
+fn rejects_webassembly_targets_that_require_external_toolchains() {
+    for target in ["wasm32-unknown-emscripten", "wasm32-wali-linux-musl"] {
+        let arguments = args(&[
+            "--crate-type=bin",
+            "--emit=dep-info,link",
+            &format!("--target={target}"),
+            "src/main.rs",
+        ]);
+        assert_eq!(
+            RustcInvocation::parse(&arguments),
+            Err(BypassReason::UnsupportedCrateType("bin".into()))
+        );
+    }
 }
 
 #[test]
@@ -243,6 +271,29 @@ fn custom_wasm_linker_modes_still_bypass() {
         RustcInvocation::parse(&arguments),
         Err(BypassReason::UnknownCodegenOption("linker".into()))
     );
+
+    let arguments = args(&[
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--target=wasm32-wasip1",
+        "-Ctarget-feature=-crt-static",
+        "src/main.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse(&arguments),
+        Err(BypassReason::UnknownCodegenOption(
+            "target-feature=-crt-static".into()
+        ))
+    );
+
+    let self_contained = args(&[
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--target=wasm32-wasip1",
+        "-Clink-self-contained=yes",
+        "src/main.rs",
+    ]);
+    assert!(RustcInvocation::parse(&self_contained).is_ok());
 }
 
 #[test]

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -40,5 +40,5 @@ of its time on actions that were not looked up or were bypassed. Read all three
 summary lines together, and compare wall-clock time when evaluating the cache.
 
 Native link steps always run, so an otherwise warm native binary build still
-has work to do. Default-linked `wasm32-unknown-unknown` binaries and tests are
-the exception and may be restored as hits.
+has work to do. Binaries, tests, and `cdylib`s for supported self-contained
+WebAssembly targets are the exception and may be restored as hits.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -59,8 +59,8 @@ platform, including when mbx has to use the copy fallback.
 ## Correctness first
 
 Unsupported crate types, unmodeled search paths, native linking, and
-incremental compilations bypass the shared action cache. The only linked
-programs admitted today are `wasm32-unknown-unknown` binaries and tests using
-the compiler-bundled default linker. `MBX_VERIFY=1` compiles while also
-consulting the cache and compares the result, providing a deliberately
-expensive qualification mode.
+incremental compilations bypass the shared action cache. Linked WebAssembly
+binaries, tests, and `cdylib`s are admitted only for a fixed allowlist of
+built-in targets whose default linker and system inputs ship with rustc.
+`MBX_VERIFY=1` compiles while also consulting the cache and compares the result,
+providing a deliberately expensive qualification mode.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -17,11 +17,20 @@ Native binaries and dynamic libraries always link. Their results can depend on
 an external linker, startup objects, and system libraries that rustc dep-info
 does not enumerate, so mbx bypasses them.
 
-The narrow exception is a binary or test for `wasm32-unknown-unknown` using its
-default compiler-bundled linker. mbx caches that link because all explicit
-artifacts are modeled inputs and the linker is covered by the Rust toolchain
-identity. Native targets, custom target specifications, native libraries,
-custom linkers, and custom `link-self-contained` modes remain uncached.
+The narrow exception is a binary, test, or `cdylib` for one of these built-in
+targets using its compiler-bundled self-contained linker:
+
+- `wasm32-unknown-unknown`
+- `wasm32-wasip1` and `wasm32-wasip1-threads`
+- `wasm32-wasip2`
+- `wasm32v1-none`
+- `wasm64-unknown-unknown`
+
+mbx caches those links because all explicit artifacts are modeled inputs and
+the linker, CRT objects, and bundled libc are covered by the Rust toolchain
+identity. Native targets, custom target specifications, external WebAssembly
+toolchains, native libraries, custom linkers, disabled WASI CRT bundling, and
+non-affirmative `link-self-contained` modes remain uncached.
 
 ## `OUT_DIR` sharing is opt-in
 


### PR DESCRIPTION
## Summary
- extend linked-output caching to built-in self-contained WASI, minimal wasm32, and wasm64 targets
- cache binaries, tests, and `cdylib` outputs when the linker/CRT inputs ship with rustc
- accept explicit affirmative `link-self-contained` settings
- keep external WebAssembly toolchains, custom targets/linkers, native libraries, and disabled WASI CRT bundling on the bypass path

The fixed allowlist follows rustc target specifications and platform documentation; no safety is inferred from arbitrary target names.

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- confirmed every allowlisted target is built into rustc 1.97.1
- smoke-compiled the installed wasm32 target with explicit self-contained linking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which rustc link invocations are cached versus bypassed; incorrect classification could restore wrong wasm artifacts, though the allowlist and conservative bypass rules limit exposure.
> 
> **Overview**
> Extends rustc action caching beyond `wasm32-unknown-unknown` to a fixed allowlist of built-in WebAssembly targets (WASI variants, `wasm32v1-none`, `wasm64-unknown-unknown`) when linking uses the toolchain-bundled self-contained linker.
> 
> **`mbx-cache-rustc`** now classifies **bin**, **test**, and **`cdylib`** link outputs on those targets as cacheable (`LinkOutput::WasmExecutable`). Non-affirmative `link-self-contained` settings still bypass; explicit `yes`/`on`/`true` is allowed. WASI builds that disable bundled CRT via `-Ctarget-feature=-crt-static` bypass. External wasm toolchains (e.g. emscripten) and custom linkers remain uncached.
> 
> README and docs (`how-it-works`, `limits`, `cache-results`) describe the broader exception and list the allowlisted triples. Tests iterate all bundled targets and cover new bypass/accept cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032796d962e366fa98419edbf9e389ac2945df96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->