### PR TITLE
feat(config): add safe workspace policy

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -192,7 +192,10 @@ pub(crate) fn cargo_with_bypass_log(
         return run_cargo(&cargo, arguments, BTreeMap::new());
     }
 
+    let working_dir = std::env::current_dir()?;
+    let mut roots = resolve_roots(&cargo, arguments, &working_dir);
     let mut config = config.clone();
+    config.apply_workspace_policy(&roots.workspace_root)?;
     let incremental = policy::incremental_allowed(config.incremental);
     if config.incremental && !incremental {
         log::warn!(
@@ -211,8 +214,6 @@ pub(crate) fn cargo_with_bypass_log(
     config.incremental = incremental;
     let config = &config;
 
-    let working_dir = std::env::current_dir()?;
-    let mut roots = resolve_roots(&cargo, arguments, &working_dir);
     let migrate_existing = prompt_to_manage_existing_target(config, &roots, arguments)?;
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -1,12 +1,13 @@
-//! Configuration, resolved from environment variables over an optional file.
+//! Configuration, resolved from environment variables over optional files.
 //!
-//! Precedence is environment, then the platform configuration file, then defaults.
+//! Precedence is environment, then the workspace policy, then the platform
+//! configuration file, then defaults.
 
 use crate::util::parse_duration;
 use bytesize::ByteSize;
 use eyre::{Context, Result, bail};
 use mbx_cache_core::RemoteCacheMode;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use usage_config::{EnvLayer, FileLayer, FileScope, Layers};
 
@@ -265,6 +266,53 @@ impl Config {
         })
     }
 
+    /// Apply the deliberately small, safe policy surface from `.mbx.toml` at
+    /// the resolved Cargo workspace root.
+    pub fn apply_workspace_policy(&mut self, workspace_root: &Path) -> Result<()> {
+        self.apply_workspace_policy_with(workspace_root, |name| std::env::var_os(name).is_some())
+    }
+
+    fn apply_workspace_policy_with(
+        &mut self,
+        workspace_root: &Path,
+        environment_contains: impl Fn(&str) -> bool,
+    ) -> Result<()> {
+        let path = workspace_root.join(".mbx.toml");
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).wrap_err_with(|| format!("failed to read {}", path.display()));
+            }
+        };
+        let document = contents
+            .parse::<toml_edit::DocumentMut>()
+            .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
+
+        for (key, value) in document.iter() {
+            if !matches!(key, "incremental" | "share_out_dir") {
+                bail!(
+                    "{} contains unsupported workspace setting {key:?}; only incremental and share_out_dir are allowed",
+                    path.display()
+                );
+            }
+            let value = value
+                .as_bool()
+                .ok_or_else(|| eyre::eyre!("{}.{} must be a boolean", path.display(), key))?;
+            match key {
+                "incremental" if !environment_contains("MBX_INCREMENTAL") => {
+                    self.incremental = value;
+                }
+                "share_out_dir" if !environment_contains("MBX_SHARE_OUT_DIR") => {
+                    self.share_out_dir = value;
+                }
+                "incremental" | "share_out_dir" => {}
+                _ => unreachable!("workspace policy keys were validated above"),
+            }
+        }
+        Ok(())
+    }
+
     /// Where cached actions and blobs live.
     pub fn store_dir(&self) -> PathBuf {
         self.cache_dir.join("actions")
@@ -450,6 +498,74 @@ mod tests {
         assert!(config.incremental);
         let config = configured(Some(file), &[("MBX_INCREMENTAL", "0")]).unwrap();
         assert!(!config.incremental);
+    }
+
+    #[test]
+    fn workspace_policy_overrides_global_safe_settings() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join(".mbx.toml"),
+            "incremental = true\nshare_out_dir = true\n",
+        )
+        .unwrap();
+        let mut config =
+            configured(Some("incremental = false\nshare_out_dir = false"), &[]).unwrap();
+
+        config
+            .apply_workspace_policy_with(directory.path(), |_| false)
+            .unwrap();
+
+        assert!(config.incremental);
+        assert!(config.share_out_dir);
+    }
+
+    #[test]
+    fn environment_overrides_workspace_policy() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join(".mbx.toml"),
+            "incremental = true\nshare_out_dir = true\n",
+        )
+        .unwrap();
+        let mut config = configured(None, &[]).unwrap();
+
+        config
+            .apply_workspace_policy_with(directory.path(), |_| true)
+            .unwrap();
+
+        assert!(!config.incremental);
+        assert!(!config.share_out_dir);
+    }
+
+    #[test]
+    fn workspace_policy_rejects_every_setting_outside_the_allowlist() {
+        for setting in [
+            "cache_dir = \"elsewhere\"",
+            "verify = true",
+            "[remote]\nurl = \"https://example.com\"",
+            "[gc]\nauto = false",
+            "[target]\nviews = false",
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            std::fs::write(directory.path().join(".mbx.toml"), setting).unwrap();
+            let mut config = configured(None, &[]).unwrap();
+            let error = config
+                .apply_workspace_policy_with(directory.path(), |_| false)
+                .unwrap_err();
+            assert!(
+                error.to_string().contains("unsupported workspace setting"),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_workspace_policy_is_ignored() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = configured(None, &[]).unwrap();
+        config
+            .apply_workspace_policy_with(directory.path(), |_| false)
+            .unwrap();
     }
 
     #[test]

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -209,6 +209,26 @@ fn incremental_is_opt_in_and_reaches_cargo() {
     );
 }
 
+#[test]
+fn workspace_policy_reaches_cargo() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+    std::fs::write(project.path().join(".mbx.toml"), "incremental = true\n").unwrap();
+
+    let stats = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("workspace-policy.json"),
+    );
+
+    assert!(
+        incremental_sessions(project.path()) > 0,
+        "the checked-in workspace policy should reach cargo: {stats}"
+    );
+}
+
 /// How many incremental sessions rustc left behind. Cargo creates the directory
 /// either way, so its contents are the only evidence that anything used it.
 fn incremental_sessions(project: &Path) -> usize {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
 # Configuration
 
-mbx loads environment variables over `mbx/config.toml` in the platform
-configuration directory, then falls back to defaults. This honors platform and
-XDG overrides through the operating system's configuration-directory lookup.
-Unknown TOML keys are rejected so misspelled settings do not silently do
-nothing.
+mbx loads environment variables over `.mbx.toml` at the resolved Cargo
+workspace root, then `mbx/config.toml` in the platform configuration directory,
+then defaults. This honors platform and XDG overrides through the operating
+system's configuration-directory lookup. Unknown TOML keys are rejected so
+misspelled settings do not silently do nothing.
 
 ## Example
 
@@ -32,6 +32,21 @@ timeout = "30s"
 download_timeout = "10m"
 retries = 3
 ```
+
+## Workspace policy
+
+A repository may check in a `.mbx.toml` containing only the two build-policy
+switches below:
+
+```toml
+incremental = false
+share_out_dir = false
+```
+
+Environment variables still win. Machine paths, remote-cache configuration,
+credentials, diagnostics, target placement, and garbage collection are not
+accepted from a repository-owned file. mbx reports an error instead of applying
+an unsafe or misspelled workspace setting.
 
 ## Settings
 


### PR DESCRIPTION
## Summary
- load `.mbx.toml` from Cargo’s resolved workspace root
- allow only `incremental` and `share_out_dir`, with environment variables retaining highest precedence
- reject paths, remote credentials/endpoints, cleanup controls, diagnostics, and unknown keys from repository-owned policy
- document the precedence and cover the behavior end to end

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `mise run check:docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to two opt-in build-policy booleans with env override and strict allowlisting; no credentials or paths from the repo.
> 
> **Overview**
> Repositories can commit a **`.mbx.toml`** at the Cargo workspace root so **`incremental`** and **`share_out_dir`** apply to everyone on that project without per-machine setup.
> 
> **Precedence** is now environment variables, then workspace policy, then the global `mbx/config.toml`, then defaults. During `mbx` cargo runs, workspace roots are resolved first, then `apply_workspace_policy` layers in those two booleans unless `MBX_INCREMENTAL` or `MBX_SHARE_OUT_DIR` is already set.
> 
> Anything else in `.mbx.toml` (paths, remote cache, GC, unknown keys) **errors** instead of being applied. Unit and integration tests cover overrides, rejection, and incremental behavior reaching Cargo; configuration docs describe the new file and precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8bb78a01282a9b2de3fa1040352fbfc5d8ff33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->