### PR TITLE
feat(protocol): share remote cache contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,11 @@ jobs:
         id: semver-packages
         if: github.event_name == 'pull_request'
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           baseline_dir="$(mktemp -d)"
-          git worktree add --detach "$baseline_dir" "origin/${{ github.base_ref }}"
+          git worktree add --detach "$baseline_dir" "origin/$BASE_REF"
           packages="$({
             comm -12 \
               <(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members as $members | [.packages[] | select(.id as $id | $members | index($id)) | .name] | sort | .[]') \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,12 +128,26 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+      - name: Find packages present in both revisions
+        id: semver-packages
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          baseline_dir="$(mktemp -d)"
+          git worktree add --detach "$baseline_dir" "origin/${{ github.base_ref }}"
+          packages="$({
+            comm -12 \
+              <(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members as $members | [.packages[] | select(.id as $id | $members | index($id)) | .name] | sort | .[]') \
+              <(cargo metadata --manifest-path "$baseline_dir/Cargo.toml" --no-deps --format-version 1 | jq -r '.workspace_members as $members | [.packages[] | select(.id as $id | $members | index($id)) | .name] | sort | .[]')
+          } | paste -sd, -)"
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
       - name: Check workspace API against the PR base
         if: github.event_name == 'pull_request'
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         with:
           baseline-rev: origin/${{ github.base_ref }}
           feature-group: all-features
+          package: ${{ steps.semver-packages.outputs.packages }}
 
   fuzz:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,13 +1171,13 @@ dependencies = [
  "futures-util",
  "hex",
  "log",
+ "mbx-cache-protocol",
  "mockito",
  "rand 0.10.2",
  "reflink-copy",
  "reqwest",
  "serde",
  "serde_json",
- "serde_json_canonicalizer",
  "sha2",
  "strum",
  "tempfile",
@@ -1185,6 +1185,19 @@ dependencies = [
  "tokio-util",
  "url",
  "zstd",
+]
+
+[[package]]
+name = "mbx-cache-protocol"
+version = "0.3.0"
+dependencies = [
+ "blake3",
+ "eyre",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "3"
-members = ["crates/mbx", "crates/mbx-cache-core", "crates/mbx-cache-rustc"]
+members = [
+  "crates/mbx",
+  "crates/mbx-cache-core",
+  "crates/mbx-cache-protocol",
+  "crates/mbx-cache-rustc",
+]
 
 [workspace.package]
 version = "0.3.0"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(protocol)* consume remote wire types and constants from `mbx-cache-protocol`
+
 ## [0.3.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.2.0...mbx-cache-core-v0.3.0) - 2026-08-23
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -19,6 +19,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.3.0" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [
@@ -32,7 +33,6 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_json_canonicalizer = "0.3"
 sha2 = "0.11"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3"

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version.workspace = true
+version = "0.4.0"
 description = "Action cache protocol, CAS, authentication, and transport primitives for mbx"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -20,7 +20,6 @@ const MAX_EXECUTABLE_IDENTITY_SIZE: usize = 64 * 1024;
 const MAX_EXECUTABLE_IDENTITY_BYTES: usize = 256 * 1024;
 const TASK_ACTION_MANIFEST_VERSION: u8 = 1;
 const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
-const MAX_ACTION_PREDICTION_PAYLOAD: usize = 256 * 1024;
 const MAX_REMOTE_TRANSFERS: usize = 64;
 const MAX_PREFETCH_TRANSFERS: usize = 48;
 const MAX_PREFETCH_ACTION_BATCH: usize = 256;
@@ -408,13 +407,6 @@ pub struct CacheAgent {
     prefetch_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
 }
 
-#[derive(Serialize)]
-struct TaskActionManifestSelector<'a> {
-    version: u8,
-    kind: &'static str,
-    task: &'a str,
-}
-
 #[derive(Debug, Clone, Default)]
 struct TaskActionState {
     manifest: String,
@@ -685,13 +677,7 @@ impl CacheAgent {
     }
 
     fn task_manifest_selector(task: &str) -> Result<(Vec<u8>, CacheDigest)> {
-        let bytes = canonical_json(&TaskActionManifestSelector {
-            version: 1,
-            kind: "task_action_manifest",
-            task,
-        })?;
-        let digest = CacheDigest::blake3(&bytes);
-        Ok((bytes, digest))
+        TaskActionManifest::selector(task)
     }
 
     fn persist_task_manifest(&self, manifest: &TaskActionManifest) -> Result<()> {
@@ -2011,38 +1997,19 @@ pub fn task_manifest_actions(store: &Path, task: &str) -> Result<Vec<CacheDigest
 }
 
 fn validate_action_prediction(prediction: &ActionPrediction) -> Result<()> {
-    prediction.invocation.validate()?;
-    prediction.action.validate()?;
-    if prediction.adapter.is_empty()
-        || !prediction
-            .adapter
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
-    {
-        bail!("invalid action prediction adapter");
+    if prediction.validate() {
+        Ok(())
+    } else {
+        bail!("invalid action prediction")
     }
-    if prediction.payload.len() > MAX_ACTION_PREDICTION_PAYLOAD {
-        bail!("action prediction payload is too large");
-    }
-    serde_json::from_str::<serde_json::Value>(&prediction.payload)?;
-    Ok(())
 }
 
 fn validate_task_manifest(manifest: &TaskActionManifest, task: &str) -> Result<()> {
-    if manifest.version != TASK_ACTION_MANIFEST_VERSION || manifest.task != task {
-        bail!("task action manifest has an invalid identity");
+    if manifest.task == task && manifest.validate() {
+        Ok(())
+    } else {
+        bail!("invalid task action manifest")
     }
-    if manifest.predictions.len() > MAX_TASK_ACTION_PREDICTIONS {
-        bail!("task action manifest contains too many predictions");
-    }
-    let mut invocations = BTreeMap::new();
-    for prediction in &manifest.predictions {
-        validate_action_prediction(prediction)?;
-        if invocations.insert(&prediction.invocation, ()).is_some() {
-            bail!("task action manifest contains duplicate predictions");
-        }
-    }
-    Ok(())
 }
 
 fn merge_task_manifests(

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1,7 +1,7 @@
 use crate::{
-    BlobSource, BlobUpload, CacheDigest, CacheDirectory, LocalActionCache, LocalCas,
-    ManifestPutOutcome, RemoteActionResult, RemoteCacheClient, RemoteCacheMode, RustcMetadata,
-    canonical_json,
+    ActionPrediction, BlobSource, BlobUpload, CacheDigest, CacheDirectory, LocalActionCache,
+    LocalCas, ManifestPutOutcome, RemoteActionResult, RemoteCacheClient, RemoteCacheMode,
+    RustcMetadata, TaskActionManifest, canonical_json,
 };
 use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
@@ -290,21 +290,6 @@ pub struct AgentStats {
     pub copied_output_bytes: u64,
 }
 
-/// Adapter-owned data needed to reconstruct an action before fresh dependency
-/// discovery is available.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ActionPrediction {
-    /// Invocation digest used to locate this prediction.
-    pub invocation: CacheDigest,
-    /// Full action digest produced when the prediction was recorded.
-    pub action: CacheDigest,
-    /// Adapter name that owns and understands `payload`.
-    pub adapter: String,
-    /// Adapter-defined serialized input prediction.
-    pub payload: String,
-}
-
 #[derive(Default)]
 struct AtomicAgentStats {
     lookups: AtomicU64,
@@ -421,14 +406,6 @@ pub struct CacheAgent {
     remote_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct TaskActionManifest {
-    version: u8,
-    task: String,
-    predictions: Vec<ActionPrediction>,
 }
 
 #[derive(Serialize)]

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -40,8 +40,7 @@ use reqwest::header::{
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
 use std::collections::BTreeSet;
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -53,33 +52,20 @@ mod agent;
 mod local;
 
 pub use agent::{
-    AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRemoteCache, AgentRequest, AgentResponse,
-    AgentStats, CacheAgent, RestoreStats, is_task_identity, task_manifest_actions,
+    AGENT_PROTOCOL_VERSION, AgentRemoteCache, AgentRequest, AgentResponse, AgentStats, CacheAgent,
+    RestoreStats, is_task_identity, task_manifest_actions,
 };
 pub use local::{LocalActionCache, LocalCas};
-
-/// Major version of the HTTP cache protocol implemented by this crate.
-pub const PROTOCOL_VERSION: u8 = 1;
-const PROTOCOL_HEADER: &str = "mbx-cache-protocol";
-const NAMESPACE_HEADER: &str = "mbx-cache-namespace";
-/// Media type for canonical [`RemoteActionResult`] JSON records.
-pub const ACTION_RESULT_MEDIA_TYPE: &str = "application/vnd.mbx.cache-action-result.v1+json";
-/// Media type for canonical [`CacheDirectory`] JSON records.
-pub const DIRECTORY_MEDIA_TYPE: &str = "application/vnd.mbx.cache-directory.v1+json";
-/// Media type for adapter-specific action metadata blobs.
-pub const CLIENT_METADATA_MEDIA_TYPE: &str = "application/vnd.mbx.cache-client-metadata.v1+json";
-/// Media type for task-to-action prediction manifests.
-pub const TASK_ACTION_MANIFEST_MEDIA_TYPE: &str =
-    "application/vnd.mbx.cache-task-action-manifest.v1+json";
-/// Media type for opaque content-addressed blobs.
-pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
-/// Media type for framed batches of content-addressed blobs.
-pub const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mbx.cache-blob-pack.v1";
-const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mbx.cache-digests.v1+json";
-const BLOB_PACK_BLOBS_HEADER: &str = "mbx-cache-pack-blobs";
-const BLOB_PACK_BYTES_HEADER: &str = "mbx-cache-pack-bytes";
-const BLOB_PACK_MAGIC: &[u8; 8] = b"MBXPACK1";
-const BLOB_PACK_HEADER_BYTES: u64 = 1 + 32 + 8;
+pub use mbx_cache_protocol::{
+    ACTION_RESULT_MEDIA_TYPE, ActionPrediction, ActionResult as RemoteActionResult,
+    BLOB_MEDIA_TYPE, BLOB_PACK_BLOBS_HEADER, BLOB_PACK_BYTES_HEADER, BLOB_PACK_HEADER_BYTES,
+    BLOB_PACK_MAGIC, BLOB_PACK_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, Capabilities,
+    CapabilityFeatures, CapabilityLimits, CapabilityProtocol, DIGEST_LIST_MEDIA_TYPE,
+    DIRECTORY_MEDIA_TYPE, Digest as CacheDigest, DigestAlgorithm, Directory as CacheDirectory,
+    DirectoryNode as CacheDirectoryNode, FileNode as CacheFileNode, NAMESPACE_HEADER,
+    PROTOCOL_HEADER, PROTOCOL_VERSION, RustcMetadata, SymlinkNode as CacheSymlinkNode,
+    TASK_ACTION_MANIFEST_MEDIA_TYPE, TaskActionManifest,
+};
 /// Cap the JSON bodies a remote cache can hand back. Blob downloads are bounded
 /// by the size their digest promises, but action results and manifests carry no
 /// such claim, so without an explicit ceiling a hostile or broken server can
@@ -97,7 +83,7 @@ const BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT: usize = MAX_STAGED_BLOB_PACK_ITEMS / 4;
 /// Action digests are computed from these bytes, so callers must not use
 /// serde's struct field order as part of the wire contract.
 pub fn canonical_json(value: &impl Serialize) -> Result<Vec<u8>> {
-    Ok(serde_json_canonicalizer::to_vec(value)?)
+    Ok(mbx_cache_protocol::canonical_json(value)?)
 }
 
 #[derive(
@@ -157,196 +143,6 @@ pub struct RemoteCacheConfig {
     pub download_timeout: Duration,
     /// Number of attempts after the initial request for retryable failures.
     pub retries: i64,
-}
-
-/// Algorithm-tagged digest and byte length of a cache object.
-///
-/// Digests received from an external source should be checked with
-/// [`CacheDigest::validate`] before they are used to construct paths.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct CacheDigest {
-    /// Hash algorithm name (`blake3` or `sha256`).
-    pub algorithm: String,
-    /// Lowercase hexadecimal hash value.
-    pub hash: String,
-    /// Exact uncompressed object length in bytes.
-    pub size: u64,
-}
-
-impl CacheDigest {
-    /// Compute a BLAKE3 digest for an in-memory object.
-    pub fn blake3(bytes: &[u8]) -> Self {
-        Self {
-            algorithm: "blake3".into(),
-            hash: blake3::hash(bytes).to_hex().to_string(),
-            size: bytes.len() as u64,
-        }
-    }
-
-    /// Hash a file while counting the bytes read in the same streaming pass.
-    pub fn blake3_file(path: &Path) -> Result<Self> {
-        let (hash, size) = hash_file_blake3(path)?;
-        Ok(Self {
-            algorithm: "blake3".into(),
-            hash,
-            size,
-        })
-    }
-
-    /// Validate the algorithm name and hexadecimal hash representation.
-    pub fn validate(&self) -> Result<()> {
-        if self.algorithm != "blake3" && self.algorithm != "sha256" {
-            bail!("unsupported remote cache digest algorithm");
-        }
-        if self.hash.len() != 64
-            || !self
-                .hash
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-        {
-            bail!("invalid remote cache digest");
-        }
-        Ok(())
-    }
-
-    /// Return whether `bytes` have this digest and declared length.
-    pub fn matches_bytes(&self, bytes: &[u8]) -> Result<bool> {
-        self.validate()?;
-        if self.size != bytes.len() as u64 {
-            return Ok(false);
-        }
-        let hash = match self.algorithm.as_str() {
-            "blake3" => blake3::hash(bytes).to_hex().to_string(),
-            "sha256" => hex::encode(sha2::Sha256::digest(bytes)),
-            _ => unreachable!("digest algorithm was validated"),
-        };
-        Ok(self.hash == hash)
-    }
-
-    /// Stream a file and return whether it has this digest and length.
-    pub fn matches_file(&self, path: &Path) -> Result<bool> {
-        self.validate()?;
-        let (hash, size) = match self.algorithm.as_str() {
-            "blake3" => hash_file_blake3(path)?,
-            "sha256" => hash_file_sha256(path)?,
-            _ => unreachable!("digest algorithm was validated"),
-        };
-        Ok(self.size == size && self.hash == hash)
-    }
-}
-
-fn hash_file_blake3(path: &Path) -> Result<(String, u64)> {
-    let mut file = File::open(path)?;
-    let mut hasher = blake3::Hasher::new();
-    let mut buffer = [0; 64 * 1024];
-    let mut size = 0;
-    loop {
-        let count = file.read(&mut buffer)?;
-        if count == 0 {
-            break;
-        }
-        hasher.update(&buffer[..count]);
-        size += count as u64;
-    }
-    Ok((hasher.finalize().to_hex().to_string(), size))
-}
-
-fn hash_file_sha256(path: &Path) -> Result<(String, u64)> {
-    let mut file = File::open(path)?;
-    let mut hasher = sha2::Sha256::new();
-    let mut buffer = [0; 64 * 1024];
-    let mut size = 0;
-    loop {
-        let count = file.read(&mut buffer)?;
-        if count == 0 {
-            break;
-        }
-        hasher.update(&buffer[..count]);
-        size += count as u64;
-    }
-    Ok((hex::encode(hasher.finalize()), size))
-}
-
-/// A canonical action-result record referencing objects in the CAS.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RemoteActionResult {
-    /// Digest of the canonical action descriptor this record satisfies.
-    pub action: CacheDigest,
-    /// Optional adapter metadata blob, such as [`RustcMetadata`].
-    #[serde(default)]
-    pub metadata: Option<CacheDigest>,
-    /// Optional digest of the root [`CacheDirectory`] containing outputs.
-    #[serde(default)]
-    pub output_root: Option<CacheDigest>,
-    /// Action-result schema version.
-    pub version: u8,
-}
-
-/// A canonical directory object stored in the CAS.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct CacheDirectory {
-    /// Child directory entries, sorted canonically by name.
-    pub directories: Vec<CacheDirectoryNode>,
-    /// Child file entries, sorted canonically by name.
-    pub files: Vec<CacheFileNode>,
-    /// Child symbolic-link entries, sorted canonically by name.
-    pub symlinks: Vec<CacheSymlinkNode>,
-    /// Directory-object schema version.
-    pub version: u8,
-}
-
-/// A child directory entry in a canonical cache directory.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct CacheDirectoryNode {
-    /// Digest of the child [`CacheDirectory`].
-    pub digest: CacheDigest,
-    /// Platform mode bits recorded for the directory.
-    pub mode: u32,
-    /// Single path-component name within the parent directory.
-    pub name: String,
-}
-
-/// A file entry in a canonical cache directory.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct CacheFileNode {
-    /// Digest of the file contents.
-    pub digest: CacheDigest,
-    /// Whether the file should be restored as executable.
-    pub executable: bool,
-    /// Platform mode bits recorded for the file.
-    pub mode: u32,
-    /// Single path-component name within the parent directory.
-    pub name: String,
-}
-
-/// A symbolic-link entry in a canonical cache directory.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct CacheSymlinkNode {
-    /// Platform mode bits recorded for the symbolic link.
-    pub mode: u32,
-    /// Single path-component name within the parent directory.
-    pub name: String,
-    /// Link target text exactly as recorded by the producer.
-    pub target: String,
-}
-
-/// Rust-specific action metadata stored alongside compiled outputs.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RustcMetadata {
-    /// Metadata schema version.
-    pub version: u8,
-    /// Adapter-defined output kind.
-    pub kind: String,
-    /// Digest of captured compiler standard output.
-    pub stdout: CacheDigest,
-    /// Digest of captured compiler standard error.
-    pub stderr: CacheDigest,
 }
 
 /// Backing data for a blob upload.
@@ -470,37 +266,7 @@ fn optional_u64_header(headers: &HeaderMap, name: &str) -> Result<Option<u64>> {
     Ok(Some(value))
 }
 
-#[derive(Debug, Deserialize)]
-struct RemoteCacheCapabilities {
-    protocol: CapabilityProtocol,
-    #[serde(default)]
-    features: CapabilityFeatures,
-    #[serde(default)]
-    limits: CapabilityLimits,
-    /// Content codings the server accepts and produces; always includes
-    /// `identity`, and compression is used only when `zstd` is offered.
-    #[serde(default)]
-    compressors: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CapabilityProtocol {
-    major: u8,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct CapabilityFeatures {
-    #[serde(default)]
-    blob_packs: bool,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct CapabilityLimits {
-    #[serde(default)]
-    max_batch_items: u64,
-    #[serde(default)]
-    max_pack_bytes: u64,
-}
+type RemoteCacheCapabilities = Capabilities;
 
 #[derive(Debug, Clone, Copy)]
 struct BlobPackLimits {

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Publish the versioned remote-cache wire types, capability schema, media types,
+  headers, and blob-pack framing shared by mbx clients and servers.

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mbx-cache-protocol"
+version.workspace = true
+description = "Shared wire contract for mbx remote cache clients and servers"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+blake3 = "1"
+eyre = "0.6"
+hex = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_json_canonicalizer = "0.3"
+sha2 = "0.11"

--- a/crates/mbx-cache-protocol/src/lib.rs
+++ b/crates/mbx-cache-protocol/src/lib.rs
@@ -354,18 +354,29 @@ impl TaskActionManifest {
 
     /// Digest selecting this task identity's action manifest.
     pub fn selector_digest(&self) -> Digest {
+        Self::selector(&self.task)
+            .expect("manifest task identity must be valid")
+            .1
+    }
+
+    /// Canonical selector bytes and digest for a task identity.
+    pub fn selector(task: &str) -> eyre::Result<(Vec<u8>, Digest)> {
+        if !valid_task_identity(task) {
+            eyre::bail!("invalid task action manifest identity");
+        }
         let selector = canonical_json(&TaskActionManifestSelector {
             kind: "task_action_manifest",
-            task: &self.task,
+            task,
             version: 1,
-        })
-        .expect("manifest selector must serialize");
-        Digest::blake3(&selector)
+        })?;
+        let digest = Digest::blake3(&selector);
+        Ok((selector, digest))
     }
 }
 
 impl ActionPrediction {
-    fn validate(&self) -> bool {
+    /// Whether the prediction satisfies the version-one wire invariants.
+    pub fn validate(&self) -> bool {
         self.action.algorithm == DigestAlgorithm::Blake3.as_str()
             && self.action.validate().is_ok()
             && self.invocation.algorithm == DigestAlgorithm::Blake3.as_str()
@@ -497,11 +508,21 @@ mod tests {
 
     #[test]
     fn canonical_json_is_independent_of_map_insertion_order() {
-        let left = serde_json::json!({"z": 1, "a": true});
-        let right = serde_json::json!({"a": true, "z": 1});
+        #[derive(Serialize)]
+        struct ZThenA {
+            z: u8,
+            a: bool,
+        }
+
+        #[derive(Serialize)]
+        struct AThenZ {
+            a: bool,
+            z: u8,
+        }
+
         assert_eq!(
-            canonical_json(&left).unwrap(),
-            canonical_json(&right).unwrap()
+            canonical_json(&ZThenA { z: 1, a: true }).unwrap(),
+            canonical_json(&AThenZ { a: true, z: 1 }).unwrap()
         );
     }
 }

--- a/crates/mbx-cache-protocol/src/lib.rs
+++ b/crates/mbx-cache-protocol/src/lib.rs
@@ -1,0 +1,507 @@
+//! Wire types and constants shared by mbx remote cache clients and servers.
+//!
+//! These records are protocol-owned: changing their serialized shape or a
+//! framing constant is a wire-format change. Transport, authentication, local
+//! storage, and adapter behavior deliberately live outside this crate.
+#![deny(missing_docs)]
+
+use serde::{Deserialize, Serialize};
+use sha2::Digest as _;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+/// Major version of the HTTP cache protocol.
+pub const PROTOCOL_VERSION: u8 = 1;
+/// Header carrying the negotiated cache protocol version.
+pub const PROTOCOL_HEADER: &str = "mbx-cache-protocol";
+/// Header carrying the caller's isolated cache namespace.
+pub const NAMESPACE_HEADER: &str = "mbx-cache-namespace";
+/// Media type for canonical [`ActionResult`] JSON records.
+pub const ACTION_RESULT_MEDIA_TYPE: &str = "application/vnd.mbx.cache-action-result.v1+json";
+/// Media type for canonical [`Directory`] JSON records.
+pub const DIRECTORY_MEDIA_TYPE: &str = "application/vnd.mbx.cache-directory.v1+json";
+/// Media type for adapter-specific action metadata blobs.
+pub const CLIENT_METADATA_MEDIA_TYPE: &str = "application/vnd.mbx.cache-client-metadata.v1+json";
+/// Media type for task-to-action prediction manifests.
+pub const TASK_ACTION_MANIFEST_MEDIA_TYPE: &str =
+    "application/vnd.mbx.cache-task-action-manifest.v1+json";
+/// Media type for opaque content-addressed blobs.
+pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
+/// Media type for framed batches of content-addressed blobs.
+pub const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mbx.cache-blob-pack.v1";
+/// Media type for a JSON list of digests.
+pub const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mbx.cache-digests.v1+json";
+/// Header declaring the number of blobs in a blob pack.
+pub const BLOB_PACK_BLOBS_HEADER: &str = "mbx-cache-pack-blobs";
+/// Header declaring the total payload bytes in a blob pack.
+pub const BLOB_PACK_BYTES_HEADER: &str = "mbx-cache-pack-bytes";
+/// Magic prefix identifying a version-one blob pack.
+pub const BLOB_PACK_MAGIC: &[u8; 8] = b"MBXPACK1";
+/// Bytes before each blob pack payload: algorithm, hash, and length.
+pub const BLOB_PACK_HEADER_BYTES: u64 = 1 + 32 + 8;
+/// Maximum number of digests in a batch request supported by the protocol.
+pub const MAX_BATCH_ITEMS: usize = 10_000;
+/// Maximum predictions carried by one task action manifest.
+pub const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
+/// Maximum serialized adapter payload in one action prediction.
+pub const MAX_ACTION_PREDICTION_PAYLOAD: usize = 256 * 1024;
+
+/// Serialize a protocol record using the JSON Canonicalization Scheme.
+pub fn canonical_json(value: &impl Serialize) -> serde_json::Result<Vec<u8>> {
+    serde_json_canonicalizer::to_vec(value)
+}
+
+/// Algorithm-tagged digest and exact byte length of a cache object.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Digest {
+    /// Hash algorithm name (`blake3` or `sha256`).
+    pub algorithm: String,
+    /// Lowercase hexadecimal hash value.
+    pub hash: String,
+    /// Exact uncompressed object length in bytes.
+    pub size: u64,
+}
+
+impl Digest {
+    /// Compute a BLAKE3 digest for in-memory bytes.
+    pub fn blake3(bytes: &[u8]) -> Self {
+        Self {
+            algorithm: DigestAlgorithm::Blake3.into(),
+            hash: blake3::hash(bytes).to_hex().to_string(),
+            size: bytes.len() as u64,
+        }
+    }
+
+    /// Hash a file with BLAKE3 while counting bytes in the same pass.
+    pub fn blake3_file(path: &Path) -> eyre::Result<Self> {
+        let (hash, size) = hash_file(path, DigestAlgorithm::Blake3)?;
+        Ok(Self {
+            algorithm: DigestAlgorithm::Blake3.into(),
+            hash,
+            size,
+        })
+    }
+
+    /// Validate the algorithm and lowercase hexadecimal representation.
+    pub fn validate(&self) -> eyre::Result<()> {
+        self.algorithm_kind()?;
+        if self.hash.len() != 64
+            || !self
+                .hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            eyre::bail!("invalid remote cache digest");
+        }
+        Ok(())
+    }
+
+    /// Return whether `bytes` have this digest and declared length.
+    pub fn matches_bytes(&self, bytes: &[u8]) -> eyre::Result<bool> {
+        self.validate()?;
+        if self.size != bytes.len() as u64 {
+            return Ok(false);
+        }
+        let hash = match self.algorithm_kind()? {
+            DigestAlgorithm::Blake3 => blake3::hash(bytes).to_hex().to_string(),
+            DigestAlgorithm::Sha256 => hex::encode(sha2::Sha256::digest(bytes)),
+        };
+        Ok(self.hash == hash)
+    }
+
+    /// Stream a file and return whether it has this digest and length.
+    pub fn matches_file(&self, path: &Path) -> eyre::Result<bool> {
+        self.validate()?;
+        let (hash, size) = hash_file(path, self.algorithm_kind()?)?;
+        Ok(self.size == size && self.hash == hash)
+    }
+
+    /// Stable storage key containing the algorithm, hash, and byte length.
+    pub fn key(&self) -> String {
+        format!("{}/{}/{}", self.algorithm, self.hash, self.size)
+    }
+
+    /// Parse the algorithm tag into its closed version-one enum.
+    pub fn algorithm_kind(&self) -> eyre::Result<DigestAlgorithm> {
+        Ok(self.algorithm.parse()?)
+    }
+}
+
+/// Hash algorithms supported by protocol version one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DigestAlgorithm {
+    /// BLAKE3.
+    Blake3,
+    /// SHA-256.
+    Sha256,
+}
+
+impl DigestAlgorithm {
+    /// Lowercase name serialized on the wire and used in endpoint paths.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Blake3 => "blake3",
+            Self::Sha256 => "sha256",
+        }
+    }
+}
+
+impl fmt::Display for DigestAlgorithm {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for DigestAlgorithm {
+    type Err = ParseDigestAlgorithmError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "blake3" => Ok(Self::Blake3),
+            "sha256" => Ok(Self::Sha256),
+            _ => Err(ParseDigestAlgorithmError),
+        }
+    }
+}
+
+impl From<DigestAlgorithm> for String {
+    fn from(algorithm: DigestAlgorithm) -> Self {
+        algorithm.as_str().into()
+    }
+}
+
+/// A digest algorithm name was outside the version-one contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseDigestAlgorithmError;
+
+impl fmt::Display for ParseDigestAlgorithmError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("unsupported remote cache digest algorithm")
+    }
+}
+
+impl std::error::Error for ParseDigestAlgorithmError {}
+
+fn hash_file(path: &Path, algorithm: DigestAlgorithm) -> eyre::Result<(String, u64)> {
+    let mut file = File::open(path)?;
+    let mut buffer = [0; 64 * 1024];
+    let mut size = 0;
+    let mut blake3 = blake3::Hasher::new();
+    let mut sha256 = sha2::Sha256::new();
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        match algorithm {
+            DigestAlgorithm::Blake3 => {
+                blake3.update(&buffer[..count]);
+            }
+            DigestAlgorithm::Sha256 => {
+                sha256.update(&buffer[..count]);
+            }
+        }
+        size += count as u64;
+    }
+    let hash = match algorithm {
+        DigestAlgorithm::Blake3 => blake3.finalize().to_hex().to_string(),
+        DigestAlgorithm::Sha256 => hex::encode(sha256.finalize()),
+    };
+    Ok((hash, size))
+}
+
+/// A canonical action-result record referencing objects in the CAS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionResult {
+    /// Digest of the canonical action descriptor this record satisfies.
+    pub action: Digest,
+    /// Optional adapter metadata blob.
+    #[serde(default)]
+    pub metadata: Option<Digest>,
+    /// Optional digest of the root [`Directory`] containing outputs.
+    #[serde(default)]
+    pub output_root: Option<Digest>,
+    /// Action-result schema version.
+    pub version: u8,
+}
+
+/// A canonical directory object stored in the CAS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Directory {
+    /// Child directory entries, sorted canonically by name.
+    pub directories: Vec<DirectoryNode>,
+    /// Child file entries, sorted canonically by name.
+    pub files: Vec<FileNode>,
+    /// Child symbolic-link entries, sorted canonically by name.
+    pub symlinks: Vec<SymlinkNode>,
+    /// Directory-object schema version.
+    pub version: u8,
+}
+
+/// A child directory entry in a canonical cache directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectoryNode {
+    /// Digest of the child [`Directory`].
+    pub digest: Digest,
+    /// Platform mode bits recorded for the directory.
+    pub mode: u32,
+    /// Single path-component name within the parent directory.
+    pub name: String,
+}
+
+/// A file entry in a canonical cache directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileNode {
+    /// Digest of the file contents.
+    pub digest: Digest,
+    /// Whether the file should be restored as executable.
+    pub executable: bool,
+    /// Platform mode bits recorded for the file.
+    pub mode: u32,
+    /// Single path-component name within the parent directory.
+    pub name: String,
+}
+
+/// A symbolic-link entry in a canonical cache directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SymlinkNode {
+    /// Platform mode bits recorded for the symbolic link.
+    pub mode: u32,
+    /// Single path-component name within the parent directory.
+    pub name: String,
+    /// Link target text exactly as recorded by the producer.
+    pub target: String,
+}
+
+/// Rust-specific action metadata stored alongside compiled outputs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcMetadata {
+    /// Metadata schema version.
+    pub version: u8,
+    /// Adapter-defined output kind.
+    pub kind: String,
+    /// Digest of captured compiler standard output.
+    pub stdout: Digest,
+    /// Digest of captured compiler standard error.
+    pub stderr: Digest,
+}
+
+impl RustcMetadata {
+    /// Whether the metadata satisfies the version-one rustc schema invariants.
+    pub fn validate(&self) -> bool {
+        self.version == 1
+            && self.kind == "rustc"
+            && self.stdout.validate().is_ok()
+            && self.stderr.validate().is_ok()
+    }
+}
+
+/// Adapter-owned data needed to reconstruct an action from a prior task run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionPrediction {
+    /// Invocation digest used to locate this prediction.
+    pub invocation: Digest,
+    /// Full action digest produced when the prediction was recorded.
+    pub action: Digest,
+    /// Adapter name that owns and understands `payload`.
+    pub adapter: String,
+    /// Adapter-defined serialized input prediction.
+    pub payload: String,
+}
+
+/// Predictions associated with one stable task identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskActionManifest {
+    /// Manifest schema version.
+    pub version: u8,
+    /// Stable task identity.
+    pub task: String,
+    /// Predicted actions, uniquely keyed by invocation digest.
+    pub predictions: Vec<ActionPrediction>,
+}
+
+#[derive(Serialize)]
+struct TaskActionManifestSelector<'a> {
+    kind: &'static str,
+    task: &'a str,
+    version: u8,
+}
+
+impl TaskActionManifest {
+    /// Whether the manifest satisfies the version-one wire invariants.
+    pub fn validate(&self) -> bool {
+        let mut invocations = std::collections::BTreeSet::new();
+        self.version == 1
+            && valid_task_identity(&self.task)
+            && self.predictions.len() <= MAX_TASK_ACTION_PREDICTIONS
+            && self.predictions.iter().all(|prediction| {
+                prediction.validate() && invocations.insert(&prediction.invocation)
+            })
+    }
+
+    /// Digest selecting this task identity's action manifest.
+    pub fn selector_digest(&self) -> Digest {
+        let selector = canonical_json(&TaskActionManifestSelector {
+            kind: "task_action_manifest",
+            task: &self.task,
+            version: 1,
+        })
+        .expect("manifest selector must serialize");
+        Digest::blake3(&selector)
+    }
+}
+
+impl ActionPrediction {
+    fn validate(&self) -> bool {
+        self.action.algorithm == DigestAlgorithm::Blake3.as_str()
+            && self.action.validate().is_ok()
+            && self.invocation.algorithm == DigestAlgorithm::Blake3.as_str()
+            && self.invocation.validate().is_ok()
+            && !self.adapter.is_empty()
+            && self
+                .adapter
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            && self.payload.len() <= MAX_ACTION_PREDICTION_PAYLOAD
+            && serde_json::from_str::<serde_json::Value>(&self.payload).is_ok()
+    }
+}
+
+fn valid_task_identity(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Version advertised by a cache service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityProtocol {
+    /// Protocol major version.
+    pub major: u8,
+    /// Backward-compatible protocol revision.
+    #[serde(default)]
+    pub minor: u8,
+}
+
+/// Schemas supported for one action adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionKindCapability {
+    /// Action descriptor schema version.
+    pub action_schema: u8,
+    /// Adapter metadata schema version.
+    pub metadata_schema: u8,
+}
+
+/// Optional server protocol features.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityFeatures {
+    /// Conditional action-manifest endpoints are available.
+    #[serde(default)]
+    pub action_manifests: bool,
+    /// Missing-blob batch queries are available.
+    #[serde(default)]
+    pub batch: bool,
+    /// Framed blob-pack downloads are available.
+    #[serde(default)]
+    pub blob_packs: bool,
+    /// Resumable uploads are available.
+    #[serde(default)]
+    pub resumable_uploads: bool,
+    /// Delegated transfers are available.
+    #[serde(default)]
+    pub delegated_transfers: bool,
+}
+
+/// Server-advertised request and object limits.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityLimits {
+    /// Maximum digests accepted by one batch request.
+    #[serde(default)]
+    pub max_batch_items: u64,
+    /// Maximum blob size eligible for inline transfer.
+    #[serde(default)]
+    pub max_inline_blob_bytes: u64,
+    /// Maximum size of an individual blob.
+    #[serde(default)]
+    pub max_blob_bytes: u64,
+    /// Maximum declared payload bytes in one blob pack.
+    #[serde(default)]
+    pub max_pack_bytes: u64,
+}
+
+/// Cache service capabilities negotiated before optional protocol features.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capabilities {
+    /// Protocol version implemented by the server.
+    pub protocol: CapabilityProtocol,
+    /// Digest algorithms accepted by the service.
+    #[serde(default)]
+    pub digest_algorithms: Vec<String>,
+    /// Content codings accepted and produced by the service.
+    #[serde(default)]
+    pub compressors: Vec<String>,
+    /// Adapter schemas accepted by the service.
+    #[serde(default)]
+    pub action_kinds: BTreeMap<String, ActionKindCapability>,
+    /// Optional endpoint features.
+    #[serde(default)]
+    pub features: CapabilityFeatures,
+    /// Server-enforced request limits.
+    #[serde(default)]
+    pub limits: CapabilityLimits,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_validation_is_exact() {
+        let valid = Digest {
+            algorithm: DigestAlgorithm::Blake3.into(),
+            hash: "a".repeat(64),
+            size: 42,
+        };
+        assert!(valid.validate().is_ok());
+        assert!(
+            Digest {
+                hash: "A".repeat(64),
+                ..valid.clone()
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            Digest {
+                algorithm: "md5".into(),
+                ..valid
+            }
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn canonical_json_is_independent_of_map_insertion_order() {
+        let left = serde_json::json!({"z": 1, "a": true});
+        let right = serde_json::json!({"a": true, "z": 1});
+        assert_eq!(
+            canonical_json(&left).unwrap(),
+            canonical_json(&right).unwrap()
+        );
+    }
+}

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.3.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.3.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.0", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.3.0", default-features = false }
 rand = "0.10"
 reflink-copy = "0.1"

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -20,6 +20,12 @@ protocol-version decision are reviewed together.
 
 ## Remote cache protocol
 
+The dependency-light `mbx-cache-protocol` crate owns the remote wire records,
+capability schema, media types, headers, and blob-pack framing constants. Both
+the client and server compile against that crate; transport, authentication,
+storage, and adapter execution remain implementation details of their
+respective packages.
+
 Remote cache endpoints live below `/v{PROTOCOL_VERSION}/` and every request
 carries `mbx-cache-protocol` and `mbx-cache-namespace` headers. The v1 baseline
 uses these resources:


### PR DESCRIPTION
## Summary
- add a dependency-light `mbx-cache-protocol` crate that owns v1 remote wire records, capability types, media types, headers, and blob-pack framing
- keep `mbx-cache-core`’s existing public names and method signatures through re-exports
- move task-manifest invariants and selector hashing into the shared contract
- bump `mbx-cache-core` to 0.4.0 because moving public structs to the shared crate changes their Rust type identity, while preserving the v1 wire format
- document the client/server ownership boundary

## Server integration
Companion server PR jdx/mr-boxington-cache#39 compiles against the shared crate and removes its duplicate wire definitions.

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo package -p mbx-cache-protocol --allow-dirty --no-verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major public types moved to a new crate (semver bump) and shared wire validation changed homes; incorrect re-exports or validation drift could break clients or servers compiling against the contract.
> 
> **Overview**
> Introduces **`mbx-cache-protocol`**, a small crate that owns the v1 remote HTTP contract: wire JSON types, media types and headers, blob-pack framing, capabilities schema, canonical JSON, and task-manifest / prediction validation (including selector hashing).
> 
> **`mbx-cache-core`** drops its inlined definitions, depends on the new crate, and **re-exports** the same public names (`CacheDigest`, `RemoteActionResult`, etc.) so call sites keep familiar APIs while transport and agent logic stay in core. **`mbx-cache-core` is bumped to 0.4.0** because those types now come from another crate (Rust type identity changes) even though the on-the-wire v1 format is unchanged.
> 
> CI **public-api** semver checks now run only on workspace packages that exist on **both** the PR and base branch, avoiding false failures when a new crate is added. **`docs/protocol-compatibility.md`** documents the client/server boundary. **`mbx`** and **`mbx-cache-rustc`** pin **`mbx-cache-core` 0.4.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70a5fed660482adcf7f144b025ed74ae896b5eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->