### PR TITLE
fix: restore the build after a merge skewed a verify call

### DIFF
--- a/crates/mbx/src/store.rs
+++ b/crates/mbx/src/store.rs
@@ -216,6 +216,9 @@ pub fn largest(store: &Path, limit: usize) -> Result<Vec<LargestEntry>> {
 pub fn verify(store: &Path) -> Result<VerifyOutcome> {
     let cas = LocalCas::new(store);
     let action_cache = mbx_cache_core::LocalActionCache::new(store);
+    // Verification reports the store as it is on disk and removes nothing, so
+    // no object is pending removal the way one is mid-sweep.
+    let virtually_removed = HashSet::new();
     let mut outcome = VerifyOutcome::default();
     for entry in walk_files(&store.join(CAS_DIR))? {
         let Some(digest) = addressed_digest(store, &entry.path, false) else {
@@ -232,7 +235,7 @@ pub fn verify(store: &Path) -> Result<VerifyOutcome> {
         };
         outcome.checked_action_results += 1;
         if !matches!(action_cache.find(&digest), Ok(Some(_)))
-            || action_result_is_dangling(&cas, &entry.path)?
+            || action_result_is_dangling(&cas, &entry.path, &virtually_removed)?
         {
             outcome.problems.push(entry.path);
         }

--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -116,6 +116,27 @@ fn verification_reports_a_corrupt_object() {
 }
 
 #[test]
+fn verification_reports_a_result_whose_objects_are_gone() {
+    let directory = tempfile::tempdir().unwrap();
+    let output = store_object(directory.path(), b"output");
+    let action = store_result(directory.path(), "compile", std::slice::from_ref(&output));
+    let result_path = LocalActionCache::new(directory.path())
+        .path_for(&action)
+        .unwrap();
+    let cas = LocalCas::new(directory.path());
+    std::fs::remove_file(cas.path_for(&action).unwrap()).unwrap();
+
+    let outcome = verify(directory.path()).unwrap();
+
+    assert_eq!(outcome.checked_action_results, 1);
+    assert!(
+        outcome.problems.contains(&result_path),
+        "a result pointing at a missing object is a problem: {:?}",
+        outcome.problems
+    );
+}
+
+#[test]
 fn inspection_ignores_in_progress_staging_paths() {
     let directory = tempfile::tempdir().unwrap();
     let action = store_result(directory.path(), "compile", &[]);


### PR DESCRIPTION
`mbx cache verify` (#63) was written against the two-argument
`action_result_is_dangling`, while the retention work (#62) had given it a
third parameter for the objects a dry-run sweep treats as already gone. Each
branch compiled against its own base; main got both and stopped compiling.

Verification reports the store as it is on disk and removes nothing, so it
passes an empty set. The regression test covers the call itself: nothing
else exercised verify against a result whose objects are missing, which is
why a signature mismatch on that line reached main.

## Verification

- `cargo test -p mbx` — 150 unit + 21 integration tests pass, including the new
  `verification_reports_a_result_whose_objects_are_gone`.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean.
- `mbx cache verify` runs against a real store.

Worth noting for the stack: this is why the four PRs on top of it exist as a
stack rather than four independent branches. The same skew that broke `main`
here is what a stack prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile fix and a targeted test; verify behavior aligns with existing dangling-result detection using an empty dry-run set.
> 
> **Overview**
> Fixes a **build break** after two branches landed on main: GC retention added a third argument to `action_result_is_dangling` (objects a dry-run sweep treats as gone), while `verify` still called the old two-argument form.
> 
> **`verify`** now passes an empty `virtually_removed` set, with a short comment that verification only inspects disk and never simulates eviction. Action-result checks still use the same dangling-object logic as sweeps, but with nothing marked virtually removed.
> 
> Adds **`verification_reports_a_result_whose_objects_are_gone`**, which deletes a CAS blob an action result still references and asserts `verify` flags that result path—exercising the updated call path that nothing else covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738449f7ae742811e3caf45b75d2d3110e6eefce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification now correctly detects action results that reference missing stored objects.
  * Verification accurately reports affected result descriptors as problematic.
* **Tests**
  * Added coverage for missing object references during store verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->