### PR TITLE
feat: report what mbx has saved on this machine

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -1,6 +1,6 @@
 //! The mbx command line.
 
-use crate::config::{Config, RetentionSettings};
+use crate::config::{CliSettings, Config, RetentionSettings};
 use crate::session::CacheSession;
 use crate::util::workspace_root;
 use crate::{policy, store, target};
@@ -177,11 +177,11 @@ pub fn run() -> Result<ExitCode> {
     if let Commands::Doctor(args) = &cli.command {
         return crate::doctor::run_loaded(Config::load(), args.json);
     }
-    let (config, retention) = Config::load_with_retention()?;
+    let (config, settings) = Config::load_for_cli()?;
     match cli.command {
         Commands::Doctor(_) => unreachable!("doctor was handled before configuration loading"),
         Commands::Explain(args) => {
-            crate::explain::run_with_retention(&config, &retention, &args.arguments())
+            crate::explain::run_with_settings(&config, &settings, &args.arguments())
         }
         Commands::Setup(args) => setup(args.action()?),
         Commands::Gc(args) => gc(
@@ -190,7 +190,7 @@ pub fn run() -> Result<ExitCode> {
                 .map_or(config.gc.max_bytes, |requested| requested.as_u64()),
             args.dry_run,
             args.json,
-            &retention,
+            &settings.retention,
         )
         .map(|()| ExitCode::SUCCESS),
         Commands::Cache(args) => match args.command {
@@ -218,7 +218,7 @@ pub fn run() -> Result<ExitCode> {
             }
         },
         Commands::Prefetch(args) => prefetch(&config, &args.cargo_args),
-        Commands::Cargo(arguments) => cargo(&config, &retention, &arguments),
+        Commands::Cargo(arguments) => cargo(&config, &settings, &arguments),
     }
 }
 
@@ -450,8 +450,8 @@ fn same_file_contents(left: &Path, right: &Path) -> Result<bool> {
         == mbx_cache_core::CacheDigest::blake3_file(right)?)
 }
 
-fn cargo(config: &Config, retention: &RetentionSettings, arguments: &[String]) -> Result<ExitCode> {
-    cargo_with_retention_and_bypass_log(config, retention, arguments, None)
+fn cargo(config: &Config, settings: &CliSettings, arguments: &[String]) -> Result<ExitCode> {
+    cargo_with_settings_and_bypass_log(config, settings, arguments, None)
 }
 
 pub(crate) fn cargo_with_bypass_log(
@@ -459,20 +459,16 @@ pub(crate) fn cargo_with_bypass_log(
     arguments: &[String],
     bypass_log: Option<&Path>,
 ) -> Result<ExitCode> {
-    cargo_with_retention_and_bypass_log(
-        config,
-        &RetentionSettings::default(),
-        arguments,
-        bypass_log,
-    )
+    cargo_with_settings_and_bypass_log(config, &CliSettings::default(), arguments, bypass_log)
 }
 
-pub(crate) fn cargo_with_retention_and_bypass_log(
+pub(crate) fn cargo_with_settings_and_bypass_log(
     config: &Config,
-    retention: &RetentionSettings,
+    settings: &CliSettings,
     arguments: &[String],
     bypass_log: Option<&Path>,
 ) -> Result<ExitCode> {
+    let retention = &settings.retention;
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     // Release builds publish artifacts that must not depend on a cache, and a
     // tag build has no later build to share with anyway.
@@ -545,7 +541,7 @@ pub(crate) fn cargo_with_retention_and_bypass_log(
         .enable_all()
         .build()?;
 
-    let status = runtime.block_on(async {
+    let session_outcome = runtime.block_on(async {
         let session = CacheSession::start(session_dir.path(), config).await?;
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
         if let Some(path) = bypass_log {
@@ -586,16 +582,59 @@ pub(crate) fn cargo_with_retention_and_bypass_log(
             log::warn!("the build manifest was not committed: {error}");
         }
 
-        match session.finish().await {
-            Ok(stats) => crate::session::display_stats(&stats, config),
-            Err(error) => log::warn!("the cache session did not shut down cleanly: {error}"),
-        }
-        status
+        let stats = match session.finish().await {
+            Ok(stats) => {
+                crate::session::display_stats(&stats, config);
+                Some(stats)
+            }
+            Err(error) => {
+                log::warn!("the cache session did not shut down cleanly: {error}");
+                None
+            }
+        };
+        Ok((status, stats))
     });
+    // A session that never started still leaves collection to do, so the error
+    // travels as the build's result rather than short-circuiting past the sweep.
+    let (status, stats) = match session_outcome {
+        Ok((status, stats)) => (status, stats),
+        Err(error) => (Err(error), None),
+    };
     // Outside the runtime, so a walk of the whole store cannot occupy a worker
     // thread, and after cargo has exited, so it adds nothing to the build the
     // user is waiting on.
-    sweep_store(config, retention);
+    let mut delta = sweep_store(config, retention);
+    // Removing the checkout's own `target/` on the way in freed disk too, and
+    // it is the largest single reclaim a first build ever reports -- but the
+    // user confirmed it, so it must not feed the counters the collection
+    // brags read: that directory had not outlived anything.
+    delta.freed_requested_bytes = removed_target_bytes.unwrap_or_default();
+    let facts = stats
+        .as_ref()
+        .map_or_else(crate::savings::SessionFacts::default, |stats| {
+            crate::savings::SessionFacts {
+                hits: stats.hits,
+                avoided_compiler_ns: stats.avoided_compiler_duration_ns,
+            }
+        });
+    if let Some(stats) = &stats {
+        // A session that was never consulted did not build anything worth
+        // counting as a build; storing its zeroes would dilute every average.
+        if crate::session::session_was_active(stats) {
+            delta.builds = 1;
+        }
+        delta.cached_compilations = stats.hits;
+        delta.avoided_compiler_ns = stats.avoided_compiler_duration_ns;
+        delta.reflinked_bytes = stats.reflinked_output_bytes;
+    }
+    // Unconditional, including on a run that built nothing: a sweep that came
+    // due during `cargo build --help` really did reclaim those bytes, and the
+    // lifetime total is wrong if they go unrecorded.
+    if let Some(line) =
+        crate::savings::record_and_describe(&config.store_dir(), &delta, &facts, settings.savings)
+    {
+        crate::session::note(&line);
+    }
     status
 }
 
@@ -729,10 +768,14 @@ fn gc(
         Ok(outcome) => outcome,
         Err(error) => {
             match pruned {
-                Ok(pruned) if !json && pruned.removed_views > 0 => {
-                    println!("{}", target_removals(&pruned, dry_run));
+                Ok(pruned) => {
+                    // Credit what the targets gave back even though the store
+                    // sweep failed: those bytes are gone from the disk either way.
+                    record_collection(&store, 0, pruned.removed_bytes, dry_run);
+                    if !json && pruned.removed_views > 0 {
+                        println!("{}", target_removals(&pruned, dry_run));
+                    }
                 }
-                Ok(_) => {}
                 Err(prune_error) => {
                     log::warn!("target directories were not collected: {prune_error}");
                 }
@@ -740,6 +783,12 @@ fn gc(
             return Err(error);
         }
     };
+    record_collection(
+        &store,
+        outcome.removed_bytes,
+        pruned.as_ref().map_or(0, |pruned| pruned.removed_bytes),
+        dry_run,
+    );
     if json {
         let pruned = pruned?;
         print_json(&GcReport {
@@ -766,6 +815,23 @@ fn gc(
         }
     }
     Ok(())
+}
+
+/// Add what a collection reclaimed to this machine's lifetime totals.
+///
+/// A dry run reclaimed nothing, so it contributes nothing.
+fn record_collection(store: &Path, store_bytes: u64, target_bytes: u64, dry_run: bool) {
+    if dry_run || (store_bytes == 0 && target_bytes == 0) {
+        return;
+    }
+    crate::savings::record_quietly(
+        store,
+        &crate::savings::Delta {
+            freed_store_bytes: store_bytes,
+            freed_target_bytes: target_bytes,
+            ..crate::savings::Delta::default()
+        },
+    );
 }
 
 fn print_gc_store_outcome(outcome: &store::GcOutcome, dry_run: bool) {
@@ -810,19 +876,22 @@ fn evictions(outcome: &store::GcOutcome) -> String {
 ///
 /// Reported like the cache summary beside it: a sweep that evicted nothing says
 /// nothing. A sweep that fails is logged and forgotten -- the build is already
-/// over, and its exit status is the build's answer, not the collector's.
-fn sweep_store(config: &Config, retention: &RetentionSettings) {
+/// over, and its exit status is the build's answer, not the collector's. What it
+/// freed is returned so the lifetime totals can count it.
+fn sweep_store(config: &Config, retention: &RetentionSettings) -> crate::savings::Delta {
+    let mut delta = crate::savings::Delta::default();
     if !config.gc.auto {
-        return;
+        return delta;
     }
     match store::claim_sweep(&config.store_dir(), config.gc.interval) {
         Ok(false) => {}
         Ok(true) => {
-            let collected_target_bytes = prune_targets(config, retention, config.gc.max_bytes);
+            let pruned = prune_targets(config, retention, config.gc.max_bytes);
+            delta.freed_target_bytes = pruned.freed_bytes;
             let store_budget = retention
                 .max_total_bytes
                 .map_or(config.gc.max_bytes, |total| {
-                    let target_bytes = collected_target_bytes.unwrap_or_else(|| {
+                    let target_bytes = pruned.remaining_bytes.unwrap_or_else(|| {
                         target::stats(&config.target.root)
                             .map(|stats| stats.bytes)
                             .unwrap_or_default()
@@ -833,18 +902,29 @@ fn sweep_store(config: &Config, retention: &RetentionSettings) {
                 Ok(outcome) => outcome,
                 Err(error) => {
                     log::warn!("the store was not swept: {error}");
-                    return;
+                    return delta;
                 }
             };
+            delta.freed_store_bytes = outcome.removed_bytes;
             if outcome.removed_bytes > 0 {
                 crate::session::note(&format!("gc: {}", evictions(&outcome)));
             }
         }
         Err(error) => {
             log::warn!("the store was not swept: {error}");
-            let _ = prune_targets(config, retention, config.gc.max_bytes);
+            delta.freed_target_bytes =
+                prune_targets(config, retention, config.gc.max_bytes).freed_bytes;
         }
     }
+    delta
+}
+
+/// What one target collection left behind, and what it reclaimed.
+struct PruneReport {
+    /// `None` when collection failed, so a caller sizing a combined budget
+    /// knows to measure rather than assume.
+    remaining_bytes: Option<u64>,
+    freed_bytes: u64,
 }
 
 /// Collect target views as the other half of a due automatic sweep.
@@ -852,7 +932,7 @@ fn prune_targets(
     config: &Config,
     retention: &RetentionSettings,
     store_reserve: u64,
-) -> Option<u64> {
+) -> PruneReport {
     // A target directory whose checkout is gone is the largest thing
     // collection ever frees, and walking for it on every build would be the
     // slowest, so callers keep this inside the store sweep's throttle.
@@ -867,11 +947,17 @@ fn prune_targets(
             if pruned.removed_views > 0 {
                 crate::session::note(&format!("gc: {}", target_removals(&pruned, false)));
             }
-            Some(pruned.remaining_bytes)
+            PruneReport {
+                remaining_bytes: Some(pruned.remaining_bytes),
+                freed_bytes: pruned.removed_bytes,
+            }
         }
         Err(error) => {
             log::warn!("target directories were not collected: {error}");
-            None
+            PruneReport {
+                remaining_bytes: None,
+                freed_bytes: 0,
+            }
         }
     }
 }
@@ -1050,6 +1136,13 @@ fn cache_remove(config: &Config, workspace: &Path) -> Result<()> {
         workspace.display()
     );
     if let Some(bytes) = target_bytes {
+        crate::savings::record_quietly(
+            &config.store_dir(),
+            &crate::savings::Delta {
+                freed_requested_bytes: bytes,
+                ..crate::savings::Delta::default()
+            },
+        );
         println!(
             "freed managed target directory ({})",
             ByteSize::b(bytes).display().iec()

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -100,6 +100,13 @@ pub(crate) struct RawConfig {
     /// Share eligible compilations that read `OUT_DIR`.
     #[usage(env = "MBX_SHARE_OUT_DIR", default = false)]
     share_out_dir: bool,
+    /// How the savings line after a build reads.
+    #[usage(
+        env = "MBX_SAVINGS",
+        default = "quips",
+        choices("quips", "plain", "off")
+    )]
+    savings: String,
     /// Append the full reason for every bypassed compilation to this path.
     #[usage(key = "bypass_log", env = "MBX_BYPASS_LOG", scope = "env")]
     _bypass_log: Option<PathBuf>,
@@ -253,6 +260,58 @@ pub(crate) struct RetentionSettings {
     pub max_total_bytes: Option<u64>,
 }
 
+/// Settings only the command line consumes.
+///
+/// The library target is semver-checked, and `Config` is a public struct
+/// callers can construct, so a knob the binary alone reads does not belong on
+/// it: adding a field there is a breaking change to an API this crate does not
+/// mean to offer.
+#[derive(Debug, Clone)]
+pub(crate) struct CliSettings {
+    pub retention: RetentionSettings,
+    pub savings: SavingsStyle,
+}
+
+/// Matches the declared defaults: a derived `Default` would silence the savings
+/// line, which is the opposite of what an unconfigured machine should get.
+impl Default for CliSettings {
+    fn default() -> Self {
+        Self {
+            retention: RetentionSettings::default(),
+            savings: SavingsStyle::default(),
+        }
+    }
+}
+
+/// How the line about accumulated savings reads.
+///
+/// The quips are the product's voice and the default; `plain` is the same
+/// facts in the register of the `cache:` and `gc:` lines beside them, for
+/// people who want their build logs to keep a straight face; `off` keeps the
+/// totals without printing anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum SavingsStyle {
+    #[default]
+    Quips,
+    Plain,
+    Off,
+}
+
+impl std::str::FromStr for SavingsStyle {
+    type Err = eyre::Report;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "quips" => Ok(Self::Quips),
+            "plain" => Ok(Self::Plain),
+            "off" => Ok(Self::Off),
+            other => Err(eyre::eyre!(
+                "savings must be quips, plain, or off, not {other:?}"
+            )),
+        }
+    }
+}
+
 /// The retention a run gets when nobody resolved configuration for it.
 ///
 /// These are the unmeasured fallbacks rather than the disk-scaled budgets: a
@@ -292,19 +351,19 @@ impl Default for HttpSettings {
 impl Config {
     /// Load configuration for this machine.
     pub fn load() -> Result<Self> {
-        Self::load_with_retention().map(|(config, _)| config)
+        Self::load_for_cli().map(|(config, _)| config)
     }
 
-    pub(crate) fn load_with_retention() -> Result<(Self, RetentionSettings)> {
+    pub(crate) fn load_for_cli() -> Result<(Self, CliSettings)> {
         let env = EnvLayer::from_process();
         let file = config_file_path().map(|path| FileLayer::at(path, FileScope::Global));
-        Self::from_layers_with_retention(&env, file.as_ref())
+        Self::from_layers_for_cli(&env, file.as_ref())
     }
 
-    fn from_layers_with_retention(
+    fn from_layers_for_cli(
         env: &EnvLayer,
         file: Option<&FileLayer>,
-    ) -> Result<(Self, RetentionSettings)> {
+    ) -> Result<(Self, CliSettings)> {
         Self::from_layers_measuring(env, file, crate::util::disk_total_bytes)
     }
 
@@ -312,7 +371,7 @@ impl Config {
         env: &EnvLayer,
         file: Option<&FileLayer>,
         measure_disk: impl Fn(&Path) -> Option<u64>,
-    ) -> Result<(Self, RetentionSettings)> {
+    ) -> Result<(Self, CliSettings)> {
         let mut layers = Layers::new().then(env);
         if let Some(file) = file {
             layers = layers.then(file);
@@ -341,7 +400,7 @@ impl Config {
     fn from_raw_measuring(
         raw: RawConfig,
         measure_disk: impl Fn(&Path) -> Option<u64>,
-    ) -> Result<(Self, RetentionSettings)> {
+    ) -> Result<(Self, CliSettings)> {
         let cache_dir = raw.cache_dir.or_else(default_cache_dir).ok_or_else(|| {
             eyre::eyre!("could not determine a cache directory; set MBX_CACHE_DIR")
         })?;
@@ -425,7 +484,13 @@ impl Config {
             },
             http,
         };
-        Ok((config, retention))
+        Ok((
+            config,
+            CliSettings {
+                retention,
+                savings: raw.savings.parse().wrap_err("invalid savings")?,
+            },
+        ))
     }
 
     /// Apply the deliberately small, safe policy surface from `.mbx.toml` at
@@ -548,21 +613,28 @@ mod tests {
     const TEST_DISK: u64 = 400 * GIB;
 
     fn configured(file: Option<&str>, values: &[(&str, &str)]) -> Result<Config> {
-        configured_with_retention(file, values).map(|(config, _)| config)
+        configured_for_cli(file, values).map(|(config, _)| config)
     }
 
-    fn configured_with_retention(
+    fn configured_for_cli(
+        file: Option<&str>,
+        values: &[(&str, &str)],
+    ) -> Result<(Config, CliSettings)> {
+        configured_on_disk(file, values, Some(TEST_DISK))
+    }
+
+    fn configured_retention(
         file: Option<&str>,
         values: &[(&str, &str)],
     ) -> Result<(Config, RetentionSettings)> {
-        configured_on_disk(file, values, Some(TEST_DISK))
+        configured_for_cli(file, values).map(|(config, settings)| (config, settings.retention))
     }
 
     fn configured_on_disk(
         file: Option<&str>,
         values: &[(&str, &str)],
         disk_total_bytes: Option<u64>,
-    ) -> Result<(Config, RetentionSettings)> {
+    ) -> Result<(Config, CliSettings)> {
         configured_measuring(file, values, move |_| disk_total_bytes)
     }
 
@@ -572,7 +644,7 @@ mod tests {
         file: Option<&str>,
         values: &[(&str, &str)],
         measure_disk: impl Fn(&Path) -> Option<u64>,
-    ) -> Result<(Config, RetentionSettings)> {
+    ) -> Result<(Config, CliSettings)> {
         let env = EnvLayer::new(
             values
                 .iter()
@@ -635,7 +707,7 @@ mod tests {
 
     #[test]
     fn defaults_apply_without_configuration() {
-        let (config, retention) = configured_with_retention(None, &[]).unwrap();
+        let (config, retention) = configured_retention(None, &[]).unwrap();
         assert_eq!(config.http.timeout, DEFAULT_HTTP_TIMEOUT);
         assert_eq!(config.http.download_timeout, DEFAULT_HTTP_DOWNLOAD_TIMEOUT);
         assert_eq!(config.http.retries, DEFAULT_HTTP_RETRIES);
@@ -682,7 +754,8 @@ mod tests {
             (None, STORE_BUDGET.fallback, TARGET_BUDGET.fallback),
         ];
         for (disk, store, target) in cases {
-            let (config, retention) = configured_on_disk(None, &[], disk).unwrap();
+            let (config, settings) = configured_on_disk(None, &[], disk).unwrap();
+            let retention = settings.retention;
             assert_eq!(config.gc.max_bytes, store, "store budget for {disk:?}");
             assert_eq!(
                 retention.target_max_bytes,
@@ -727,12 +800,13 @@ mod tests {
 
     #[test]
     fn configured_budgets_outrank_the_disk() {
-        let (config, retention) = configured_on_disk(
+        let (config, settings) = configured_on_disk(
             None,
             &[("MBX_GC_MAX_SIZE", "3GiB"), ("MBX_TARGET_MAX_SIZE", "7GiB")],
             Some(8_000 * GIB),
         )
         .unwrap();
+        let retention = settings.retention;
 
         assert_eq!(config.gc.max_bytes, 3 * GIB);
         assert_eq!(retention.target_max_bytes, Some(7 * GIB));
@@ -743,7 +817,7 @@ mod tests {
         // A scratch volume for targets is exactly why these are measured apart:
         // sizing a 4TiB disk from a 64GiB home directory would prune it to the
         // floor.
-        let (config, retention) = configured_measuring(
+        let (config, settings) = configured_measuring(
             None,
             &[("MBX_CACHE_DIR", "/cache"), ("MBX_TARGET_ROOT", "/scratch")],
             |path| {
@@ -758,7 +832,7 @@ mod tests {
 
         assert_eq!(config.gc.max_bytes, STORE_BUDGET.floor, "5% of 64GiB");
         assert_eq!(
-            retention.target_max_bytes,
+            settings.retention.target_max_bytes,
             Some(MAX_SCALED_BUDGET),
             "10% of 4TiB, at the ceiling"
         );
@@ -777,7 +851,7 @@ mod tests {
 
     #[test]
     fn none_turns_a_retention_limit_off() {
-        let (_, retention) = configured_with_retention(
+        let (_, retention) = configured_retention(
             None,
             &[
                 ("MBX_TARGET_MAX_SIZE", "none"),
@@ -802,7 +876,7 @@ mod tests {
 
     #[test]
     fn reads_target_and_whole_cache_retention_limits() {
-        let (_, retention) = configured_with_retention(
+        let (_, retention) = configured_retention(
             None,
             &[
                 ("MBX_TARGET_MAX_SIZE", "8GiB"),
@@ -982,6 +1056,24 @@ mod tests {
     }
 
     #[test]
+    fn savings_default_to_quips_with_plain_and_off_as_choices() {
+        let (_, settings) = configured_for_cli(None, &[]).unwrap();
+        assert_eq!(
+            settings.savings,
+            SavingsStyle::Quips,
+            "an unconfigured machine gets the voice"
+        );
+        let (_, settings) = configured_for_cli(None, &[("MBX_SAVINGS", "plain")]).unwrap();
+        assert_eq!(settings.savings, SavingsStyle::Plain);
+        let (_, settings) = configured_for_cli(None, &[("MBX_SAVINGS", "off")]).unwrap();
+        assert_eq!(settings.savings, SavingsStyle::Off);
+        assert!(
+            configured_for_cli(None, &[("MBX_SAVINGS", "sarcastic")]).is_err(),
+            "an unknown style is an error, not a silent default"
+        );
+    }
+
+    #[test]
     fn the_usage_spec_declares_files_environment_and_defaults() {
         let spec = RawConfig::spec_kdl();
         assert!(spec.contains(r#"file "<config directory>/mbx/config.toml""#));
@@ -994,5 +1086,7 @@ mod tests {
         // generated reference has to describe them instead.
         assert!(spec.contains("5% of the cache disk"));
         assert!(spec.contains("10% of the cache disk"));
+        assert!(spec.contains(r#"env "MBX_SAVINGS""#));
+        assert!(spec.contains(r#"default="quips""#));
     }
 }

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -1,6 +1,6 @@
 //! Actionable explanations for conservative cache bypasses.
 
-use crate::config::{Config, RetentionSettings};
+use crate::config::{CliSettings, Config};
 use eyre::{Context, Result};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -14,15 +14,15 @@ pub fn run(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     finish(&log, status)
 }
 
-pub(crate) fn run_with_retention(
+pub(crate) fn run_with_settings(
     config: &Config,
-    retention: &RetentionSettings,
+    settings: &CliSettings,
     arguments: &[String],
 ) -> Result<ExitCode> {
     let directory = tempfile::Builder::new().prefix("mbx-explain-").tempdir()?;
     let log = directory.path().join("bypasses.tsv");
     let status =
-        crate::cli::cargo_with_retention_and_bypass_log(config, retention, arguments, Some(&log))?;
+        crate::cli::cargo_with_settings_and_bypass_log(config, settings, arguments, Some(&log))?;
     finish(&log, status)
 }
 

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod doctor;
 pub mod explain;
 pub mod policy;
+pub(crate) mod savings;
 pub mod session;
 pub mod store;
 pub mod target;

--- a/crates/mbx/src/savings.rs
+++ b/crates/mbx/src/savings.rs
@@ -1,0 +1,428 @@
+//! What mbx has saved on this machine, accumulated across builds.
+//!
+//! A single build's statistics say what just happened; they cannot say what
+//! switching to mbx has been worth, because the compilations it skipped and the
+//! directories it collected are spread over months. This module keeps a running
+//! total beside the store and turns it into one line after a build.
+//!
+//! ```text
+//! <store>/savings/v1/tally.json   the totals
+//! <store>/savings/v1/tally.lock   held while they are updated
+//! ```
+//!
+//! The tally is bookkeeping, not cache content: it is never an input to a
+//! cache key, and the collector never walks it. Losing it costs a number in a
+//! message, so every failure here is logged and forgotten rather than raised.
+
+use crate::config::SavingsStyle;
+use crate::util::{format_duration, write_atomic};
+use bytesize::ByteSize;
+use eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub(crate) const TALLY_FILE: &str = "savings/v1/tally.json";
+const TALLY_LOCK: &str = "savings/v1/tally.lock";
+const TALLY_VERSION: u8 = 1;
+
+/// Running totals for one machine.
+///
+/// `serde(default)` rather than `deny_unknown_fields`: a tally written by a
+/// newer mbx must degrade to a smaller number, never to an error that costs a
+/// build its savings line.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct Tally {
+    pub version: u8,
+    /// When counting started, so a total can say what it spans.
+    pub since_secs: u64,
+    pub builds: u64,
+    pub cached_compilations: u64,
+    pub avoided_compiler_ns: u64,
+    pub reflinked_bytes: u64,
+    pub freed_target_bytes: u64,
+    pub freed_store_bytes: u64,
+    /// Bytes the user asked to have removed: a confirmed `target/` migration,
+    /// or `mbx cache remove`. Kept apart from the collection counters because
+    /// every line about those brags that nobody had to do anything -- which is
+    /// exactly untrue of a removal somebody confirmed.
+    pub freed_requested_bytes: u64,
+    /// Counters a newer mbx wrote that this one does not know about.
+    ///
+    /// Every record rewrites the whole file, so without this an older binary
+    /// would silently drop a newer one's totals while leaving its version
+    /// number in place. Carried through untouched instead.
+    #[serde(flatten)]
+    unknown: BTreeMap<String, serde_json::Value>,
+}
+
+/// What one command contributed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct Delta {
+    pub builds: u64,
+    pub cached_compilations: u64,
+    pub avoided_compiler_ns: u64,
+    pub reflinked_bytes: u64,
+    pub freed_target_bytes: u64,
+    pub freed_store_bytes: u64,
+    pub freed_requested_bytes: u64,
+}
+
+impl Delta {
+    fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// What this one command did, for the lines that describe the run rather than
+/// the lifetime.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct SessionFacts {
+    pub hits: u64,
+    pub avoided_compiler_ns: u64,
+}
+
+fn tally_path(store: &Path) -> PathBuf {
+    store.join(TALLY_FILE)
+}
+
+/// Add `delta` to the stored totals and return the result.
+///
+/// Runs after cargo has exited, so the lock it takes and the two small files it
+/// touches are not on anything the user is waiting for. Concurrent commands
+/// serialize on the lock the same way sweeps do.
+pub(crate) fn record(store: &Path, delta: &Delta) -> Result<Tally> {
+    let lock_path = store.join(TALLY_LOCK);
+    std::fs::create_dir_all(
+        lock_path
+            .parent()
+            .expect("the tally lock path has a parent"),
+    )
+    .wrap_err_with(|| format!("failed to create {}", lock_path.display()))?;
+    let mut lock = fslock::LockFile::open(&lock_path)?;
+    lock.lock()?;
+
+    let path = tally_path(store);
+    let mut tally = read(&path);
+    if tally.version == 0 {
+        tally.version = TALLY_VERSION;
+        tally.since_secs = now_secs();
+    }
+    tally.builds = tally.builds.saturating_add(delta.builds);
+    tally.cached_compilations = tally
+        .cached_compilations
+        .saturating_add(delta.cached_compilations);
+    tally.avoided_compiler_ns = tally
+        .avoided_compiler_ns
+        .saturating_add(delta.avoided_compiler_ns);
+    tally.reflinked_bytes = tally.reflinked_bytes.saturating_add(delta.reflinked_bytes);
+    tally.freed_target_bytes = tally
+        .freed_target_bytes
+        .saturating_add(delta.freed_target_bytes);
+    tally.freed_store_bytes = tally
+        .freed_store_bytes
+        .saturating_add(delta.freed_store_bytes);
+    tally.freed_requested_bytes = tally
+        .freed_requested_bytes
+        .saturating_add(delta.freed_requested_bytes);
+
+    let mut contents = serde_json::to_vec_pretty(&tally)?;
+    contents.push(b'\n');
+    write_atomic(&path, &contents)?;
+    Ok(tally)
+}
+
+/// Read the tally, treating anything unreadable as a fresh start.
+///
+/// A tally that cannot be parsed has already lost its history, and refusing to
+/// count from here would lose every future build's as well.
+fn read(path: &Path) -> Tally {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or_default()
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_secs())
+        .unwrap_or_default()
+}
+
+/// Thresholds below which a number is not worth a line of the user's attention.
+const MIN_SESSION_HITS: u64 = 5;
+const MIN_SESSION_AVOIDED: Duration = Duration::from_secs(30);
+const MIN_LIFETIME_AVOIDED: Duration = Duration::from_secs(30 * 60);
+const MIN_FREED_BYTES: u64 = 1024 * 1024 * 1024;
+const MIN_FREED_TARGET_BYTES: u64 = 5 * 1024 * 1024 * 1024;
+const MIN_REFLINKED_BYTES: u64 = 1024 * 1024 * 1024;
+const MIN_CACHED_COMPILATIONS: u64 = 250;
+
+/// One `format!` per line, with the locals in scope: a pool of tellings reads
+/// as copy to be edited, not as code, so every telling gets exactly one line.
+macro_rules! tellings {
+    ($($line:literal),+ $(,)?) => { vec![$(format!($line)),+] };
+}
+
+/// One fact worth telling, in every voice it can be told in.
+struct Candidate {
+    /// The mascot's variants: a cache box in a monocle, deadpan, mentioning
+    /// the chores exactly once. One is chosen at random per build.
+    cheeky: Vec<String>,
+    /// The same fact in the register of the `cache:` and `gc:` lines.
+    plain: String,
+}
+
+/// The facts this machine has earned the right to mention.
+///
+/// Every line carries a number this machine actually produced -- a line that
+/// could have been written before the build ran is an advertisement, not a
+/// report. Thresholds keep small numbers quiet.
+fn facts_worth_telling(tally: &Tally, facts: &SessionFacts) -> Vec<Candidate> {
+    let freed = tally
+        .freed_target_bytes
+        .saturating_add(tally.freed_store_bytes);
+    let mut eligible = Vec::new();
+
+    if facts.hits >= MIN_SESSION_HITS
+        && facts.avoided_compiler_ns >= duration_ns(MIN_SESSION_AVOIDED)
+    {
+        let hits = facts.hits;
+        let dur = nanos(facts.avoided_compiler_ns);
+        eligible.push(Candidate {
+            cheeky: tellings![
+                "mbx: served {hits} compilations from cache; rustc showed up ready to do {dur} of work and was sent home",
+                "mbx: {hits} compilations you did not wait for. the {dur} is yours now. spend it wisely.",
+                "mbx: this build borrowed {hits} compilations from an earlier one. rustc was not informed. ({dur} saved)",
+                "mbx: {hits} compilations arrived precompiled. somewhere a fan is not spinning. ({dur} saved)",
+                "mbx: cargo asked for {hits} compilations; mbx had them filed under already-done. ({dur} saved)",
+                "mbx: {hits} compilations replayed from cache. rustc's services were not required. ({dur} saved)",
+                "mbx: intercepted {hits} compilations before rustc could get attached. ({dur} saved)",
+                "mbx: rustc had {dur} of work planned. mbx had {hits} of its answers already.",
+                "mbx: {hits} compilations answered from memory. rustc can finish its coffee. ({dur} saved)",
+                "mbx: rustc arrived to find {hits} compilations already done. awkward. ({dur} saved)",
+                "mbx: quietly substituted {hits} cached compilations. nobody noticed. that is the job. ({dur} saved)",
+                "mbx: {hits} compilations in, zero compiled. {dur} returned to circulation.",
+            ],
+            plain: format!(
+                "savings: {hits} compilations restored from cache this build, avoiding {dur} of compiler time"
+            ),
+        });
+    }
+    if tally.avoided_compiler_ns >= duration_ns(MIN_LIFETIME_AVOIDED) {
+        let dur = nanos(tally.avoided_compiler_ns);
+        let over = builds(tally.builds);
+        eligible.push(Candidate {
+            cheeky: tellings![
+                "mbx: {dur} of compiling skipped across {over}. rustc suspects nothing.",
+                "mbx: {dur} refunded over {over}. no receipt necessary.",
+                "mbx: rustc believes it compiled everything. it is down {dur} across {over}. let it believe.",
+                "mbx: has saved {dur} across {over}. this line is the only thanks it needs.",
+                "mbx: across {over}, rustc has been excused from {dur} of its duties.",
+                "mbx: {dur} not spent compiling, over {over}. what you did instead is between you and the terminal.",
+                "mbx: the running total stands at {dur} across {over}. nobody is counting except the box.",
+                "mbx: {dur} of compilation avoided across {over}. imagine the fan noise. now stop.",
+                "mbx: {dur} saved across {over}. put it toward something with a progress bar.",
+                "mbx: {dur} of rustc's calendar cleared across {over}.",
+                "mbx: {dur} unspent across {over}. compounding, in a sense.",
+            ],
+            plain: format!("savings: {dur} of compiler time avoided across {over}"),
+        });
+    }
+    if freed >= MIN_FREED_BYTES {
+        let size = iec(freed);
+        eligible.push(Candidate {
+            cheeky: tellings![
+                "mbx: {size} of build debris binned so far. cargo clean remains unemployed.",
+                "mbx: has quietly disposed of {size} of build leftovers. nobody saw anything.",
+                "mbx: {size} reclaimed to date. the disk sends its regards.",
+                "mbx: {size} of build debris has left the building.",
+                "mbx: swept up {size} so far. the broom is content-addressed.",
+                "mbx: {size} tidied away. you may continue not thinking about it.",
+                "mbx: {size} reclaimed while you were busy compiling other things.",
+                "mbx: {size} of old build output has been shown the door.",
+                "mbx: disposed of {size} without being asked. that is rather the point.",
+                "mbx: the sweep found {size} nobody would miss. nobody has.",
+            ],
+            plain: format!("savings: {size} reclaimed by collection so far"),
+        });
+    }
+    if tally.freed_target_bytes >= MIN_FREED_TARGET_BYTES {
+        let size = iec(tally.freed_target_bytes);
+        eligible.push(Candidate {
+            cheeky: tellings![
+                "mbx: {size} of target/ had outlived its checkouts. it has been dealt with.",
+                "mbx: found {size} of target/ whose checkouts left long ago. the estate has been settled.",
+                "mbx: your deleted worktrees left {size} behind. left. past tense.",
+                "mbx: {size} of target/ belonged to checkouts that no longer exist. neither does it.",
+                "mbx: cleaned up {size} after checkouts that left without saying goodbye.",
+                "mbx: {size} of outputs had survived their checkouts. an unnatural state, now corrected.",
+                "mbx: the checkouts are gone. their {size} has gone to join them.",
+                "mbx: {size} of target/ was waiting for checkouts that are never coming back. it has stopped waiting.",
+                "mbx: escorted {size} of ownerless outputs off the premises.",
+                "mbx: worktrees come and go. their {size} now goes with them.",
+            ],
+            plain: format!("savings: {size} of abandoned target directories reclaimed"),
+        });
+    }
+    if tally.reflinked_bytes >= MIN_REFLINKED_BYTES {
+        let size = iec(tally.reflinked_bytes);
+        eligible.push(Candidate {
+            cheeky: tellings![
+                "mbx: every checkout believes it owns {size} of outputs. the disk keeps one copy and says nothing.",
+                "mbx: {size} of outputs, one copy, several very confident checkouts.",
+                "mbx: reflinked {size} into place. copying is for people with disk to spare.",
+                "mbx: {size} of outputs exist once and appear everywhere. do not tell the checkouts.",
+                "mbx: {size} of target/ is an elaborate illusion. the disk is in on it.",
+                "mbx: lent the same {size} to every checkout at once. none of them has checked.",
+                "mbx: {size} shared among checkouts that each believe they are an only child.",
+                "mbx: {size} on loan to every checkout simultaneously. the paperwork is an inode.",
+                "mbx: {size} of outputs materialized by reflink. the copy machine stays off.",
+                "mbx: {size} in every checkout, {size} on disk. arithmetic declined to comment.",
+            ],
+            plain: format!("savings: {size} of outputs reflinked rather than copied"),
+        });
+    }
+    if tally.cached_compilations >= MIN_CACHED_COMPILATIONS {
+        let count = tally.cached_compilations;
+        eligible.push(Candidate {
+            cheeky: tellings![
+                "mbx: {count} compilations, each compiled once and served warm ever since",
+                "mbx: {count} cache hits and counting. rustc thinks it has been busy.",
+                "mbx: {count} compilations on file. the box remembers.",
+                "mbx: {count} compilations old. not one compiled twice.",
+                "mbx: {count} compilations served. the monocle stays on.",
+                "mbx: {count} compilations dispensed from stock. inventory immaculate.",
+                "mbx: {count} compilations, and the box has forgotten none of them.",
+                "mbx: {count} compilations retrieved with a straight face.",
+                "mbx: {count} compilations. rustc did each once; mbx did the rest of the showing up.",
+                "mbx: {count} compilations served. ask rustc how many it remembers doing.",
+            ],
+            plain: format!("savings: {count} compilations served from cache to date"),
+        });
+    }
+    eligible
+}
+
+/// One line about what mbx has saved, or nothing worth saying yet.
+///
+/// Which fact appears -- and, in the default style, which telling of it -- is
+/// random. A machine that qualifies for several facts should not recite them
+/// in a fixed order, and a joke wears out at exactly the speed it repeats.
+/// `pick` is injected so tests can reach every line; callers use [`quip`].
+fn quip_choosing(
+    tally: &Tally,
+    facts: &SessionFacts,
+    style: SavingsStyle,
+    mut pick: impl FnMut(usize) -> usize,
+) -> Option<String> {
+    if style == SavingsStyle::Off {
+        return None;
+    }
+    let mut eligible = facts_worth_telling(tally, facts);
+    if eligible.is_empty() {
+        return None;
+    }
+    let index = pick(eligible.len()) % eligible.len();
+    let candidate = eligible.swap_remove(index);
+    match style {
+        SavingsStyle::Quips => {
+            let mut variants = candidate.cheeky;
+            let index = pick(variants.len()) % variants.len();
+            Some(variants.swap_remove(index))
+        }
+        SavingsStyle::Plain => Some(candidate.plain),
+        SavingsStyle::Off => unreachable!("handled above"),
+    }
+}
+
+pub(crate) fn quip(tally: &Tally, facts: &SessionFacts, style: SavingsStyle) -> Option<String> {
+    use rand::RngExt as _;
+    quip_choosing(tally, facts, style, |len| rand::rng().random_range(0..len))
+}
+
+fn iec(bytes: u64) -> String {
+    ByteSize::b(bytes).display().iec().to_string()
+}
+
+/// A duration the way a person would say it: "6h 14m", "2m 51s", "45s".
+///
+/// [`format_duration`] is for measurements and renders six hours as
+/// `22440.00s`, which is no way to tell somebody good news. Two units carry
+/// all the precision a brag needs.
+fn nanos(nanoseconds: u64) -> String {
+    let total = Duration::from_nanos(nanoseconds).as_secs();
+    if total == 0 {
+        return format_duration(Duration::from_nanos(nanoseconds));
+    }
+    let units = [(86_400, "d"), (3_600, "h"), (60, "m"), (1, "s")];
+    // The two largest units that are actually present. A zero unit in between
+    // must not spend a slot: "1d 0h" would hide real minutes behind it and
+    // understate the number this line exists to state.
+    let mut parts = Vec::new();
+    let mut rest = total;
+    for (size, suffix) in units {
+        let amount = rest / size;
+        rest %= size;
+        if amount > 0 {
+            parts.push(format!("{amount}{suffix}"));
+            if parts.len() == 2 {
+                break;
+            }
+        }
+    }
+    parts.join(" ")
+}
+
+/// "1 build" is not "1 builds", and the one machine that hits it would be the
+/// machine of someone deciding whether to keep mbx.
+fn builds(count: u64) -> String {
+    if count == 1 {
+        "1 build".to_string()
+    } else {
+        format!("{count} builds")
+    }
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    crate::util::duration_ns(duration)
+}
+
+/// Record `delta` without letting a bookkeeping failure reach the build.
+///
+/// Callers are past the point where anything can be done about an error: cargo
+/// has exited and its status is the answer the user came for.
+pub(crate) fn record_quietly(store: &Path, delta: &Delta) -> Option<Tally> {
+    match record(store, delta) {
+        Ok(tally) => Some(tally),
+        Err(error) => {
+            log::debug!("savings were not recorded: {error}");
+            None
+        }
+    }
+}
+
+/// Record and, when there is something worth saying, return the line to say.
+pub(crate) fn record_and_describe(
+    store: &Path,
+    delta: &Delta,
+    facts: &SessionFacts,
+    style: SavingsStyle,
+) -> Option<String> {
+    // A run that neither compiled nor collected anything moves no counter, so
+    // it does not write -- not even to start the file. A sweep that came due
+    // during `cargo build --help` did free bytes, and that delta is not empty,
+    // so those are still counted.
+    if delta.is_empty() && facts.hits == 0 {
+        return None;
+    }
+    let tally = record_quietly(store, delta)?;
+    quip(&tally, facts, style)
+}
+
+#[cfg(test)]
+#[path = "savings_tests.rs"]
+mod tests;

--- a/crates/mbx/src/savings_tests.rs
+++ b/crates/mbx/src/savings_tests.rs
@@ -1,0 +1,404 @@
+use super::*;
+
+const GIB: u64 = 1024 * 1024 * 1024;
+
+fn session_delta(hits: u64) -> Delta {
+    Delta {
+        builds: 1,
+        cached_compilations: hits,
+        ..Delta::default()
+    }
+}
+
+#[test]
+fn totals_accumulate_across_commands() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+
+    let first = record(store, &session_delta(3)).unwrap();
+    assert_eq!(first.version, 1);
+    assert_eq!(first.builds, 1);
+    assert_eq!(first.cached_compilations, 3);
+
+    let second = record(
+        store,
+        &Delta {
+            builds: 1,
+            cached_compilations: 4,
+            freed_target_bytes: 2 * GIB,
+            ..Delta::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(second.builds, 2);
+    assert_eq!(second.cached_compilations, 7);
+    assert_eq!(second.freed_target_bytes, 2 * GIB);
+    assert_eq!(
+        second.since_secs, first.since_secs,
+        "the start of counting is stamped once"
+    );
+}
+
+#[test]
+fn a_tally_nobody_can_parse_starts_over_instead_of_failing() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+    record(store, &session_delta(2)).unwrap();
+    crate::util::write_atomic(&store.join(TALLY_FILE), b"not json at all").unwrap();
+
+    let tally = record(store, &session_delta(5)).unwrap();
+
+    assert_eq!(tally.builds, 1, "counting restarts from the corrupt file");
+    assert_eq!(tally.cached_compilations, 5);
+    assert_eq!(tally.version, 1);
+}
+
+#[test]
+fn a_missing_store_directory_is_created() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path().join("never").join("existed");
+
+    let tally = record(&store, &session_delta(1)).unwrap();
+
+    assert_eq!(tally.builds, 1);
+    assert!(store.join(TALLY_FILE).exists());
+}
+
+#[test]
+fn counters_from_a_newer_mbx_survive_a_write_by_this_one() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+    crate::util::write_atomic(
+        &store.join(TALLY_FILE),
+        br#"{"version":2,"builds":7,"nanoseconds_saved_by_something_new":42}"#,
+    )
+    .unwrap();
+
+    let tally = record(store, &session_delta(1)).unwrap();
+
+    assert_eq!(tally.builds, 8, "known counters still accumulate");
+    let written: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(store.join(TALLY_FILE)).unwrap()).unwrap();
+    assert_eq!(
+        written["nanoseconds_saved_by_something_new"], 42,
+        "a counter this binary does not know must not be dropped: {written}"
+    );
+    assert_eq!(written["version"], 2, "and its version is left alone");
+}
+
+#[test]
+fn a_sweep_during_a_help_run_still_counts_what_it_freed() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+
+    // `build --help` compiles nothing, but an automatic sweep can come due
+    // during it and those bytes are gone from the disk for real.
+    let line = record_and_describe(
+        store,
+        &Delta {
+            freed_store_bytes: 3 * GIB,
+            ..Delta::default()
+        },
+        &SessionFacts::default(),
+        SavingsStyle::Quips,
+    );
+
+    assert!(line.is_some(), "3GiB reclaimed is worth reporting");
+    let tally = record(store, &Delta::default()).unwrap();
+    assert_eq!(tally.freed_store_bytes, 3 * GIB);
+    assert_eq!(tally.builds, 0, "but it was not a build");
+}
+
+#[test]
+fn nothing_is_written_before_the_first_run_that_does_something() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+
+    assert_eq!(
+        record_and_describe(
+            store,
+            &Delta::default(),
+            &SessionFacts::default(),
+            SavingsStyle::Quips
+        ),
+        None
+    );
+
+    assert!(
+        !store.join(TALLY_FILE).exists(),
+        "an inert run leaves no tally behind"
+    );
+}
+
+#[test]
+fn a_confirmed_removal_is_not_bragged_about_as_collection() {
+    // The user said yes to removing this target/; every collection line claims
+    // nobody had to do anything. Those bytes are counted, not performed.
+    let tally = Tally {
+        version: 1,
+        builds: 1,
+        freed_requested_bytes: 30 * GIB,
+        ..Tally::default()
+    };
+    assert_eq!(
+        quip(&tally, &SessionFacts::default(), SavingsStyle::Quips),
+        None,
+        "consented bytes earn no unattended-cleanup line"
+    );
+    let recorded = {
+        let directory = tempfile::tempdir().unwrap();
+        record(
+            directory.path(),
+            &Delta {
+                freed_requested_bytes: 30 * GIB,
+                ..Delta::default()
+            },
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        recorded.freed_requested_bytes,
+        30 * GIB,
+        "but they are still in the ledger"
+    );
+}
+
+#[test]
+fn durations_keep_their_remainders() {
+    let cases = [
+        (6 * 3600 + 14 * 60, "6h 14m"),
+        (86_400 + 5 * 60, "1d 5m"),
+        (6 * 3600, "6h"),
+        (61, "1m 1s"),
+        (86_400 + 3600 + 60, "1d 1h"),
+        (45, "45s"),
+    ];
+    for (seconds, expected) in cases {
+        assert_eq!(
+            nanos(crate::util::duration_ns(Duration::from_secs(seconds))),
+            expected,
+            "for {seconds}s"
+        );
+    }
+}
+
+#[test]
+fn a_quiet_machine_has_nothing_to_say() {
+    let tally = Tally {
+        version: 1,
+        builds: 3,
+        cached_compilations: 4,
+        ..Tally::default()
+    };
+    assert_eq!(
+        quip(&tally, &SessionFacts::default(), SavingsStyle::Quips),
+        None
+    );
+}
+
+/// A tally that clears every threshold, so all facts are on the table.
+fn boastful_tally() -> Tally {
+    Tally {
+        version: 1,
+        builds: 87,
+        cached_compilations: 4_312,
+        avoided_compiler_ns: crate::util::duration_ns(Duration::from_secs(6 * 3600 + 14 * 60)),
+        reflinked_bytes: 22 * GIB,
+        freed_target_bytes: 41 * GIB,
+        freed_store_bytes: 6 * GIB,
+        ..Tally::default()
+    }
+}
+
+fn busy_session() -> SessionFacts {
+    SessionFacts {
+        hits: 143,
+        avoided_compiler_ns: crate::util::duration_ns(Duration::from_secs(171)),
+    }
+}
+
+#[test]
+fn every_line_names_the_number_that_earned_it() {
+    let tally = boastful_tally();
+    let candidates = facts_worth_telling(&tally, &busy_session());
+    // In declaration order; every telling of a fact must carry its figure,
+    // or a random draw could produce a brag with nothing behind it.
+    let figures: [&[&str]; 6] = [
+        &["143", "2m 51s"],
+        &["6h 14m", "87 builds"],
+        &["47.0 GiB"],
+        &["41.0 GiB"],
+        &["22.0 GiB"],
+        &["4312"],
+    ];
+    assert_eq!(candidates.len(), figures.len());
+    for (candidate, expected) in candidates.iter().zip(figures) {
+        for line in candidate.cheeky.iter().chain([&candidate.plain]) {
+            for figure in expected {
+                assert!(line.contains(figure), "{line:?} should contain {figure:?}");
+            }
+        }
+    }
+}
+
+#[test]
+fn the_random_draw_can_reach_every_line() {
+    let tally = boastful_tally();
+    let facts = busy_session();
+    let candidates = facts_worth_telling(&tally, &facts);
+    let pool: usize = candidates.iter().map(|fact| fact.cheeky.len()).sum();
+
+    let widest = candidates
+        .iter()
+        .map(|fact| fact.cheeky.len())
+        .max()
+        .unwrap();
+    let mut seen = std::collections::HashSet::new();
+    for fact in 0..candidates.len() {
+        for variant in 0..widest {
+            let mut draws = [fact, variant].into_iter();
+            let line = quip_choosing(&tally, &facts, SavingsStyle::Quips, |_| {
+                draws.next().unwrap_or(0)
+            })
+            .unwrap();
+            seen.insert(line);
+        }
+    }
+
+    assert_eq!(seen.len(), pool, "every variant is reachable: {seen:#?}");
+}
+
+#[test]
+fn thresholds_gate_facts_not_the_whole_mouth() {
+    // Only the lifetime-count fact qualifies here; whichever draw happens,
+    // that is the fact reported.
+    let tally = Tally {
+        version: 1,
+        builds: 30,
+        cached_compilations: 9_000,
+        ..Tally::default()
+    };
+    for _ in 0..20 {
+        let line = quip(&tally, &SessionFacts::default(), SavingsStyle::Quips).unwrap();
+        assert!(line.contains("9000"), "{line:?}");
+    }
+}
+
+#[test]
+fn plain_style_states_the_fact_without_the_bit() {
+    let tally = boastful_tally();
+    for _ in 0..20 {
+        let line = quip(&tally, &busy_session(), SavingsStyle::Plain).unwrap();
+        assert!(
+            line.starts_with("savings: "),
+            "plain lines read like the cache/gc notes: {line:?}"
+        );
+    }
+}
+
+#[test]
+fn off_keeps_quiet_even_with_plenty_to_say() {
+    assert_eq!(
+        quip(&boastful_tally(), &busy_session(), SavingsStyle::Off),
+        None
+    );
+}
+
+#[test]
+fn consecutive_builds_do_not_recite_one_line() {
+    // Probabilistic, but with a pool this size, 200 draws repeating one line
+    // means the randomness is broken, not unlucky.
+    let tally = boastful_tally();
+    let facts = busy_session();
+    let distinct: std::collections::HashSet<_> = (0..200)
+        .map(|_| quip(&tally, &facts, SavingsStyle::Quips).unwrap())
+        .collect();
+    assert!(distinct.len() > 1, "200 draws produced one line");
+}
+
+#[test]
+fn a_build_that_did_nothing_stays_silent() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+    // Seed totals large enough that every lifetime threshold is met.
+    record(
+        store,
+        &Delta {
+            builds: 10,
+            cached_compilations: 5_000,
+            reflinked_bytes: 20 * GIB,
+            ..Delta::default()
+        },
+    )
+    .unwrap();
+
+    let before = std::fs::read(store.join(TALLY_FILE)).unwrap();
+    let silent = record_and_describe(
+        store,
+        &Delta::default(),
+        &SessionFacts::default(),
+        SavingsStyle::Quips,
+    );
+    assert_eq!(silent, None, "a no-op run reports nothing");
+    assert_eq!(
+        std::fs::read(store.join(TALLY_FILE)).unwrap(),
+        before,
+        "and does not even touch the totals"
+    );
+
+    let spoken = record_and_describe(
+        store,
+        &Delta {
+            builds: 1,
+            cached_compilations: 6,
+            ..Delta::default()
+        },
+        &SessionFacts {
+            hits: 6,
+            ..SessionFacts::default()
+        },
+        SavingsStyle::Quips,
+    );
+    assert!(spoken.is_some(), "a run that used the cache reports");
+}
+
+#[test]
+fn quips_can_be_turned_off_without_stopping_the_tally() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = directory.path();
+    let delta = Delta {
+        builds: 1,
+        cached_compilations: 5_000,
+        ..Delta::default()
+    };
+
+    let line = record_and_describe(
+        store,
+        &delta,
+        &SessionFacts {
+            hits: 20,
+            ..SessionFacts::default()
+        },
+        SavingsStyle::Off,
+    );
+
+    assert_eq!(line, None);
+    let tally = record(store, &Delta::default()).unwrap();
+    assert_eq!(
+        tally.cached_compilations, 5_000,
+        "the totals are kept even when nothing is printed"
+    );
+}
+
+/// Not an assertion so much as a proofreading bench: run with `--nocapture`
+/// to read the whole pool the way users will, with lifelike numbers.
+#[test]
+fn the_full_pool_reads_like_a_person_wrote_it() {
+    for candidate in facts_worth_telling(&boastful_tally(), &busy_session()) {
+        for line in &candidate.cheeky {
+            println!("{line}");
+        }
+        println!("  ({})", candidate.plain);
+        println!();
+    }
+}

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -509,6 +509,15 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
     }
 }
 
+/// Whether the cache took part in this build at all.
+///
+/// A run that never consulted or stored anything -- `cargo --help`, a build
+/// cargo declined -- has nothing to report and should not be counted as a
+/// build in the lifetime totals.
+pub(crate) fn session_was_active(stats: &AgentStats) -> bool {
+    should_display_stats(stats)
+}
+
 fn should_display_stats(stats: &AgentStats) -> bool {
     stats.lookups > 0
         || stats.unconsulted > 0

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -143,6 +143,20 @@ File containing a bearer token.
 
 Remote cache URL.
 
+## `savings`
+
+- **Type:** `string`
+- **Default:** `quips`
+- **Set with:** `MBX_SAVINGS`
+
+How the savings line after a build reads.
+
+**Choices:**
+- `quips`
+- `plain`
+- `off`
+
+
 ## `share_out_dir`
 
 - **Type:** `bool`


### PR DESCRIPTION
Per-build statistics say what just happened; they cannot say what switching
to mbx has been worth, because the compilations it skipped and the
directories it collected are spread over months. A tally beside the store
accumulates cached compilations, avoided compiler time, reflinked bytes, and
bytes reclaimed by collection, and one line after a build reports whichever
total has something to say.

Every line is anchored to a number this machine produced — a line that could
have been written before the build ran would be an advertisement, not a
report. The voice is the mascot's: a cache box in a monocle, deadpan,
mentioning the chores exactly once. Each fact carries a pool of tellings,
drawn at random, because a joke wears out at exactly the speed it repeats.
Thresholds keep small numbers quiet.

The voice is the default; `savings` opts out of it rather than into it:

```toml
savings = "quips"  # default: the pool below
savings = "plain"  # same facts, register of the cache:/gc: lines
savings = "off"    # keep the totals, print nothing
```

(`MBX_SAVINGS` from the environment; an unknown style is an error, not a
silent default.)

Recording happens whenever a run moved a counter — including a `build --help`
whose due sweep really freed bytes — and an inert run writes nothing. The
tally is bookkeeping, never a cache input, and the collector does not walk
it: every failure recording it is logged and dropped.

Settings the binary alone reads live on a crate-private CliSettings rather
than the public Config, which is semver-checked and constructible by callers.

## The pool

63 lines across the six facts, drawn at random. A sample:

```text
mbx: served 143 compilations from cache; rustc showed up ready to do 2m 51s of work and was sent home
mbx: 143 compilations you did not wait for. the 2m 51s is yours now. spend it wisely.
mbx: this build borrowed 143 compilations from an earlier one. rustc was not informed. (2m 51s saved)
mbx: 143 compilations arrived precompiled. somewhere a fan is not spinning. (2m 51s saved)
mbx: cargo asked for 143 compilations; mbx had them filed under already-done. (2m 51s saved)
mbx: 143 compilations replayed from cache. rustc's services were not required. (2m 51s saved)
mbx: intercepted 143 compilations before rustc could get attached. (2m 51s saved)
mbx: rustc had 2m 51s of work planned. mbx had 143 of its answers already.
mbx: 143 compilations answered from memory. rustc can finish its coffee. (2m 51s saved)
mbx: rustc arrived to find 143 compilations already done. awkward. (2m 51s saved)
mbx: quietly substituted 143 cached compilations. nobody noticed. that is the job. (2m 51s saved)
mbx: 143 compilations in, zero compiled. 2m 51s returned to circulation.
```

The full pool: `cargo test the_full_pool -- --nocapture`. Each telling lives
on one line of `savings.rs` via a tiny `tellings![...]` macro, so adding one
is adding one line. Durations render humanely ("6h 14m", never "22440.00s"),
and one build is "1 build".

## Verification

- `cargo test -p mbx` — all pass, including tests that every telling of a
  fact carries its figure, that the random draw can reach every line, that
  thresholds gate facts, that plain stays dry, that off stays silent, that
  inert runs write nothing, and that help-run sweeps still count.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean.
- `mise run render:docs && mise run check:docs` — `savings` and its choices
  land in the split CLI reference.
- `bats test` — 16/16.
- Manual, isolated cache: default prints a random line from the pool;
  `MBX_SAVINGS=plain` prints the dry form; `MBX_SAVINGS=off` prints nothing
  while the totals keep accruing; `MBX_SAVINGS=sarcastic` errors with the
  valid choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bookkeeping runs post-build with file locking; it does not affect cache keys or build outcomes, and tally errors are swallowed so builds still exit normally.
> 
> **Overview**
> Adds **machine-wide savings tracking**: a locked `savings/v1/tally.json` beside the action store accumulates cache hits, avoided compiler time, reflinked bytes, and bytes freed by GC/target collection (separate from user-confirmed removals).
> 
> After each `cargo` run, the CLI merges session stats and automatic sweep results into a **delta**, updates the tally (failures are logged only), and may print one **random** savings line when thresholds are met. Style is configurable via **`savings` / `MBX_SAVINGS`**: `quips` (default), `plain`, or `off`.
> 
> CLI-only knobs move to **`CliSettings`** (`load_for_cli` replaces `load_with_retention`). **`mbx gc`** and **`mbx cache remove`** also credit the tally; store GC failure still records target bytes reclaimed. **`session_was_active`** avoids counting no-op runs as builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3600ab877b071cffdf41545937d0a8fea45f5dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-build savings summaries showing cache benefits, avoided compilation time, and reclaimed storage.
  * Added configurable savings message styles: playful, plain, or disabled.
  * Added cumulative savings tracking across builds.

* **Bug Fixes**
  * Cleanup and savings reporting now continue even when session finalization encounters errors.
  * Improved accounting for reclaimed store and target storage.

* **Documentation**
  * Documented the `MBX_SAVINGS` configuration option and supported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->