### PR TITLE
feat: explain the cache and its caps on the first build

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -499,6 +499,17 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     config.incremental = incremental;
     let config = &config;
 
+    // Before the prompt below, so the offer to replace an existing `target/`
+    // arrives after the explanation of what a managed one is for. One existence
+    // check, and only on the cargo path.
+    if !cargo_help_requested(arguments) && !was_explained(&config.store_dir()) {
+        // Probed rather than assumed, and probed only on the one run that
+        // will say something about it.
+        let reflinks = crate::util::reflinks_work(&config.cache_dir);
+        crate::session::note(&first_run_notice(config, retention, reflinks));
+        mark_explained(&config.store_dir());
+    }
+
     let migrate_existing = prompt_to_manage_existing_target(config, &roots, arguments)?;
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will
@@ -636,6 +647,97 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
         crate::session::note(&line);
     }
     status
+}
+
+/// Marks that this machine has been told what mbx set up.
+///
+/// A stamp of its own rather than a side effect of some other file: whether to
+/// explain mbx and whether to count a run's savings are unrelated questions,
+/// and answering both from one file forces every change to one to reason about
+/// the other.
+const NOTICE_STAMP: &str = "notice/v1/explained";
+
+fn was_explained(store: &Path) -> bool {
+    store.join(NOTICE_STAMP).exists()
+}
+
+/// Written immediately after the notice prints, so a build that fails later
+/// does not explain itself again.
+fn mark_explained(store: &Path) {
+    if let Err(error) = crate::util::write_atomic(&store.join(NOTICE_STAMP), b"") {
+        // Worth one line at debug: the cost is a repeated notice, and a store
+        // this cannot write to has larger problems than that.
+        log::debug!("the first-run notice was not recorded: {error}");
+    }
+}
+
+/// What mbx has arranged on this machine, said once.
+///
+/// A cache that manages its own disk should say so before it starts deleting
+/// things, and the numbers it prints are the resolved ones rather than the
+/// documented ones: budgets scale with the disk, so a fixed sentence here would
+/// be wrong on most machines. A limit somebody turned off is left unmentioned
+/// rather than described.
+fn first_run_notice(config: &Config, retention: &RetentionSettings, reflinks: bool) -> String {
+    let mut lines =
+        vec!["mbx: first build on this machine -- here is the arrangement:".to_string()];
+    // Collection is what the rest of this describes, so a machine that turned
+    // it off is told what it has instead of what it does not.
+    if config.gc.auto {
+        lines.push(format!(
+            "mbx:   compiled work is cached once in {} and shared with every checkout and worktree; the store sweeps itself back to {}",
+            config.cache_dir.display(),
+            ByteSize::b(config.gc.max_bytes).display().iec(),
+        ));
+    } else {
+        lines.push(format!(
+            "mbx:   compiled work is cached once in {} and shared with every checkout and worktree; automatic collection is off, so `mbx gc` is the only thing that reclaims it",
+            config.cache_dir.display(),
+        ));
+    }
+    // Only when a probe just proved it: this is a promise about what the
+    // user's disk will do, and a machine on ext4 must not be promised
+    // sharing that every restore will quietly turn into a copy.
+    if reflinks {
+        lines.push(
+            "mbx:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk"
+                .to_string(),
+        );
+    }
+    if config.target.views && config.gc.auto {
+        let mut reasons = vec!["their checkout disappears".to_string()];
+        if let Some(age) = retention.target_max_age {
+            reasons.push(format!(
+                "they sit unused for {}",
+                crate::util::format_span(age)
+            ));
+        }
+        if let Some(bytes) = retention.target_max_bytes {
+            reasons.push(format!(
+                "they together outgrow {}",
+                ByteSize::b(bytes).display().iec()
+            ));
+        }
+        lines.push(format!(
+            "mbx:   target/ directories are managed and collected when {}",
+            join_clauses(&reasons),
+        ));
+    }
+    lines.push(
+        "mbx:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable".to_string(),
+    );
+
+    lines.join("\n")
+}
+
+/// Join reasons as prose: "a", "a or b", "a, b, or c".
+fn join_clauses(clauses: &[String]) -> String {
+    match clauses {
+        [] => String::new(),
+        [only] => only.clone(),
+        [first, second] => format!("{first} or {second}"),
+        [rest @ .., last] => format!("{}, or {last}", rest.join(", ")),
+    }
 }
 
 /// Offer to replace an existing default target directory with a managed one.

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -511,6 +511,102 @@ fn cargo_help_does_not_trigger_target_migration() {
     assert!(!cargo_help_requested(&["build".into(), "--release".into()]));
 }
 
+#[test]
+fn the_first_run_notice_states_the_resolved_caps() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut config = managed_target_config(directory.path());
+    config.gc.max_bytes = 12 * 1024 * 1024 * 1024;
+    let retention = RetentionSettings {
+        target_max_bytes: Some(25 * 1024 * 1024 * 1024),
+        target_max_age: Some(std::time::Duration::from_secs(30 * 86_400)),
+        max_total_bytes: None,
+    };
+
+    let notice = first_run_notice(&config, &retention, false);
+
+    assert!(notice.contains("first build on this machine"));
+    assert!(notice.contains(&config.cache_dir.display().to_string()));
+    // The budgets scale with the disk, so the notice has to report what was
+    // resolved rather than a number written into the sentence.
+    assert!(notice.contains("12.0 GiB"), "{notice}");
+    assert!(notice.contains("25.0 GiB"), "{notice}");
+    assert!(notice.contains("30 days"), "{notice}");
+    assert!(notice.contains("their checkout disappears"), "{notice}");
+}
+
+#[test]
+fn the_first_run_notice_omits_limits_that_are_off() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = managed_target_config(directory.path());
+    let retention = RetentionSettings {
+        target_max_bytes: None,
+        target_max_age: None,
+        max_total_bytes: None,
+    };
+
+    let notice = first_run_notice(&config, &retention, false);
+
+    assert!(notice.contains("their checkout disappears"), "{notice}");
+    assert!(!notice.contains("sit unused"), "{notice}");
+    assert!(!notice.contains("outgrow"), "{notice}");
+}
+
+#[test]
+fn the_first_run_notice_does_not_promise_collection_that_is_off() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut config = managed_target_config(directory.path());
+    config.gc.auto = false;
+
+    let notice = first_run_notice(&config, &RetentionSettings::default(), false);
+
+    assert!(notice.contains("automatic collection is off"), "{notice}");
+    assert!(!notice.contains("sweeps itself back to"), "{notice}");
+    assert!(
+        !notice.contains("target/ directories are managed"),
+        "{notice}"
+    );
+}
+
+#[test]
+fn the_first_run_notice_skips_targets_it_does_not_manage() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut config = managed_target_config(directory.path());
+    config.target.views = false;
+
+    let notice = first_run_notice(&config, &RetentionSettings::default(), false);
+
+    assert!(!notice.contains("target/ directories"), "{notice}");
+    assert!(notice.contains("sweeps itself back to"), "{notice}");
+}
+
+#[test]
+fn the_first_run_notice_promises_reflinks_only_when_proven() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = managed_target_config(directory.path());
+
+    let with = first_run_notice(&config, &RetentionSettings::default(), true);
+    let without = first_run_notice(&config, &RetentionSettings::default(), false);
+
+    assert!(with.contains("can reflink"), "{with}");
+    assert!(with.contains("one copy on disk"), "{with}");
+    // A machine whose filesystem copies must not be told its restores are
+    // free; silence beats a promise the disk will break.
+    assert!(!without.contains("reflink"), "{without}");
+}
+
+#[test]
+fn reasons_read_as_prose() {
+    assert_eq!(join_clauses(&["one".to_string()]), "one");
+    assert_eq!(
+        join_clauses(&["one".to_string(), "two".to_string()]),
+        "one or two"
+    );
+    assert_eq!(
+        join_clauses(&["one".to_string(), "two".to_string(), "three".to_string()]),
+        "one, two, or three"
+    );
+}
+
 fn managed_target_config(root: &Path) -> Config {
     Config {
         cache_dir: root.join("cache"),

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -53,6 +53,31 @@ pub fn format_duration(duration: Duration) -> String {
     }
 }
 
+/// Format a long span the way a retention policy is written.
+///
+/// [`format_duration`] measures what a build spent and would render a month as
+/// `2592000.00s`. A policy is stated in coarse units, so this says "30 days".
+///
+/// The largest unit that divides evenly, never one that would round: this
+/// describes when files get deleted, and calling 36 hours "1 day" would
+/// understate that by a third.
+pub fn format_span(duration: Duration) -> String {
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+
+    let seconds = duration.as_secs();
+    let (amount, unit) = [(DAY, "day"), (HOUR, "hour"), (MINUTE, "minute")]
+        .into_iter()
+        .find(|(size, _)| seconds >= *size && seconds.is_multiple_of(*size))
+        .map_or((seconds, "second"), |(size, unit)| (seconds / size, unit));
+    if amount == 1 {
+        format!("1 {unit}")
+    } else {
+        format!("{amount} {unit}s")
+    }
+}
+
 /// Parse a duration written as a bare number of seconds or with a unit suffix.
 pub fn parse_duration(value: &str) -> Result<Duration> {
     let value = value.trim();
@@ -170,6 +195,24 @@ fn disk_total_bytes_at(path: &Path) -> Option<u64> {
     }
 }
 
+/// Whether the filesystem holding `dir` can reflink.
+///
+/// Answered by doing one, not by guessing from the platform: reflink support
+/// is a property of the mounted filesystem, and XFS on one machine has it
+/// where ext4 on the next does not. Any failure -- including `dir` not being
+/// creatable -- answers no, because every caller is deciding whether to
+/// promise sharing, and a promise needs more than a maybe.
+pub fn reflinks_work(dir: &Path) -> bool {
+    fn probe(dir: &Path) -> Option<()> {
+        std::fs::create_dir_all(dir).ok()?;
+        let directory = tempfile::tempdir_in(dir).ok()?;
+        let source = directory.path().join("source");
+        std::fs::write(&source, b"mbx reflink probe").ok()?;
+        reflink_copy::reflink(&source, directory.path().join("destination")).ok()
+    }
+    probe(dir).is_some()
+}
+
 /// Generate an unpredictable alphanumeric string.
 ///
 /// Only the Windows named-pipe endpoint needs this, but it is compiled
@@ -218,6 +261,20 @@ mod tests {
         // directory is created.
         let missing = directory.path().join("not").join("created").join("yet");
         assert_eq!(disk_total_bytes(&missing), Some(total));
+    }
+
+    #[test]
+    fn formats_spans_in_the_units_a_policy_is_written_in() {
+        assert_eq!(format_span(Duration::from_secs(30 * 86_400)), "30 days");
+        assert_eq!(format_span(Duration::from_secs(86_400)), "1 day");
+        // A policy of 36 hours is not "1 day": this text says when files go.
+        assert_eq!(format_span(Duration::from_secs(36 * 3_600)), "36 hours");
+        assert_eq!(format_span(Duration::from_secs(90 * 60)), "90 minutes");
+        assert_eq!(format_span(Duration::from_secs(45)), "45 seconds");
+        assert_eq!(format_span(Duration::from_secs(7_200)), "2 hours");
+        assert_eq!(format_span(Duration::from_secs(60)), "1 minute");
+        assert_eq!(format_span(Duration::from_secs(90)), "90 seconds");
+        assert_eq!(format_span(Duration::from_secs(5)), "5 seconds");
     }
 
     #[test]

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -104,3 +104,36 @@ setup() {
   assert_failure
   assert_output --regexp 'no such command: .*command-added-after-mbx'
 }
+
+@test "the first build explains what mbx set up, once" {
+  local project="$BATS_TEST_TMPDIR/first-run"
+  mkdir -p "$project/src"
+  cat >"$project/Cargo.toml" <<'EOF'
+[package]
+name = "first-run-fixture"
+version = "0.1.0"
+edition = "2021"
+EOF
+  echo 'fn main() {}' >"$project/src/main.rs"
+  run cargo generate-lockfile --offline --manifest-path "$project/Cargo.toml"
+  assert_success
+
+  # A help run does its own bookkeeping but must not consume the explanation:
+  # nothing was built and nothing was said.
+  run "$MBX_BIN" build --help --manifest-path "$project/Cargo.toml"
+  assert_success
+  refute_output --partial "first build on this machine"
+
+  run "$MBX_BIN" build --offline --manifest-path "$project/Cargo.toml"
+  assert_success
+  assert_output --partial "first build on this machine"
+  # The caps are resolved from this machine's disk, so assert the shape of the
+  # explanation rather than the numbers in it.
+  assert_output --partial "sweeps itself back to"
+  assert_output --partial "their checkout disappears"
+
+  # A machine that has been told does not need telling again.
+  run "$MBX_BIN" build --offline --manifest-path "$project/Cargo.toml"
+  assert_success
+  refute_output --partial "first build on this machine"
+}


### PR DESCRIPTION
A tool that manages its own disk should say so before it starts deleting
things. The first cargo run on a machine now prints where the cache lives,
the budget the store sweeps itself back to, and what makes a managed target
directory collectable.

The numbers come from the resolved configuration rather than the sentence:
budgets scale with the disk, so a fixed figure here would be wrong on most
machines. A limit somebody turned off goes unmentioned instead of being
described, and a machine with `gc.auto = false` is told collection is off
rather than promised sweeps that will not happen. It prints before the offer
to replace an existing `target/`, so that prompt arrives after the
explanation of what a managed one is for.

Recognizing a first run uses a stamp of its own (`notice/v1/explained`,
written right after the notice prints) rather than reading a file another
feature happens to write. Whether to explain mbx and whether to count a run's
savings are unrelated questions; answering both from the savings tally
coupled them, and each fix to one broke the other. The store directory would
not serve either — a plain cargo build through the persistent wrapper creates
that without mbx ever explaining itself.

## What it looks like

```text
mbx: first build on this machine -- here is the arrangement:
mbx:   compiled work is cached once in /home/you/.cache/mbx and shared with every checkout and worktree; the store sweeps itself back to 50.0 GiB
mbx:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk
mbx:   target/ directories are managed and collected when their checkout disappears, they sit unused for 30 days, or they together outgrow 100.0 GiB
mbx:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable
```

The reflink line appears only where a probe (the same one doctor runs) just
proved the filesystem supports it — a promise about the user's disk needs
more than a platform guess.

## Verification

- `cargo test -p mbx` — all pass, including unit tests for the resolved caps,
  omitted limits, unmanaged targets, and the collection-off wording.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean.
- `bats test` — 16/16, including a test asserting the notice appears on the
  first build, not the second, and is not consumed by a `--help` run.
- Manual, fresh cache: `build --help` leaves no stamp; the next real build
  prints the notice once; the build after that does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and a one-time filesystem probe; no changes to cache keys, GC logic, or build correctness beyond when text is shown.
> 
> **Overview**
> The first real `mbx` cargo build (not `--help`) now prints a **one-time** explanation of what the tool set up: shared cache path, resolved store budget, optional managed-`target/` collection rules, and whether reflinks work on this filesystem. Wording follows **resolved** config—disabled GC, unmanaged targets, and turned-off retention limits are omitted rather than mis-described.
> 
> The message runs **before** the prompt to replace an existing `target/`, and persistence uses a dedicated store stamp (`notice/v1/explained`) written right after printing so a failed build does not repeat the notice and this path stays independent of savings bookkeeping.
> 
> Supporting changes add `format_span` for human retention ages, a live `reflinks_work` probe under the cache dir, `join_clauses` for prose “when” lists, plus unit and Bats coverage for notice shape, help not consuming the stamp, and single-show behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb04a83271d50ad4e6684211d276bbea02d49cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



