### PR TITLE
ci: stop checking the CLI library's public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref }}
+          # The CLI crate's library target exists so the binary and its
+          # integration tests can share application code; it is not an API
+          # anything outside this workspace is meant to build against, which
+          # `crates/mbx/src/lib.rs` says outright. Checking it would mean a
+          # major bump every time the CLI gains a setting, or contorting
+          # internal types to avoid one. The published API lives in
+          # mbx-cache-core and mbx-cache-rustc, which stay checked.
+          UNCHECKED_PACKAGES: mbx
         run: |
           baseline_dir="$(mktemp -d)"
           git worktree add --detach "$baseline_dir" "origin/$BASE_REF"
@@ -141,7 +149,14 @@ jobs:
             comm -12 \
               <(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members as $members | [.packages[] | select(.id as $id | $members | index($id)) | .name] | sort | .[]') \
               <(cargo metadata --manifest-path "$baseline_dir/Cargo.toml" --no-deps --format-version 1 | jq -r '.workspace_members as $members | [.packages[] | select(.id as $id | $members | index($id)) | .name] | sort | .[]')
-          } | paste -sd, -)"
+          } | { grep -vxF "$UNCHECKED_PACKAGES" || true; } | paste -sd, -)"
+          # An empty list would make the action check every package rather than
+          # nothing, so say what happened instead. `|| true` above keeps grep's
+          # no-match exit out of pipefail's way so this message is reachable.
+          if [ -z "$packages" ]; then
+            echo "no shared packages left to check" >&2
+            exit 1
+          fi
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
       - name: Check workspace API against the PR base
         if: github.event_name == 'pull_request'

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -7,6 +7,12 @@
 //! This library target exists so the executable and integration tests can
 //! share application code; it is not a stable embedding API. Applications
 //! should use `mbx-cache-core` or `mbx-cache-rustc` instead.
+//!
+//! Nothing here carries a compatibility guarantee, and CI's public-API check
+//! skips this package for that reason -- see `UNCHECKED_PACKAGES` in
+//! `.github/workflows/ci.yml`. Types the CLI alone reads may gain fields in a
+//! patch release. Do not restore the check to "protect" these items: it would
+//! only force a major bump every time the CLI gains a setting.
 
 pub mod cli;
 pub mod config;


### PR DESCRIPTION
`crates/mbx`'s library target exists so the binary and its integration tests
can share application code; `lib.rs` has always said it is not an embedding
API, and nothing outside this workspace builds against it. Checking it for
semver compatibility charged a real cost for that non-guarantee: every new
CLI setting either became a major bump or had to be routed around the public
`Config` to avoid one.

The check now skips this package and keeps covering mbx-cache-core and
mbx-cache-rustc, which are the published API and are consumed by
jdx/mbx-cache. `lib.rs` records why, so the exclusion does not read as an
oversight worth "fixing" later.

Two shell details: grep's no-match exit is swallowed so the empty-list guard
below it is reachable under pipefail, and an empty package list fails loudly
because the action would otherwise interpret it as "check everything".

## Why now

Adding a CLI setting in this stack (`quips`) meant routing it around the
public `Config` struct, because `Config` is `pub` with `pub` fields and
therefore constructible by callers — so any new field is a major break to
cargo-semver-checks. That is a real cost paid for a guarantee `lib.rs`
explicitly disclaims and nobody relies on.

The alternative fix, `#[non_exhaustive]` on every settings struct, keeps the
check meaningful but only helps hypothetical embedders — and it costs them
struct-literal construction. Given the CLI library exists for this workspace's
own crates to share code, dropping the check is the honest option.

`mbx-cache-core` and `mbx-cache-rustc` remain checked. They are the published
API and are consumed by [`jdx/mbx-cache`](https://github.com/jdx/mbx-cache).

## Verification

- Simulated the modified step locally under `bash -eo pipefail` (matching the
  Actions `shell: bash` default): resolves to
  `mbx-cache-core,mbx-cache-protocol,mbx-cache-rustc`.
- Simulated the all-excluded case: the guard is reached and fails with a
  message, rather than handing the action an empty list it would read as
  "check every package".
- `actionlint` with `shellcheck` clean on the changed workflow.

## Note

This does not unblock anything in the current stack — those PRs already pass
the check. It removes the constraint from future settings. I would leave
`CliSettings` where it is regardless: knobs only the binary reads belong
crate-private on the merits, not just for semver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI semver scope and crate docs; published cache crates stay semver-gated and runtime behavior is unchanged.
> 
> **Overview**
> **CI no longer runs `cargo-semver-checks` on the `mbx` crate.** The public-API job still compares every other shared workspace package against the PR base; `mbx` is filtered out via `UNCHECKED_PACKAGES` because its `lib` target is only for the binary and in-repo tests, not a supported embedding API (`mbx-cache-core` and `mbx-cache-rustc` remain checked).
> 
> The workflow step also **fails explicitly** if filtering leaves no packages (empty input would make the action check the whole workspace) and uses **`grep … || true`** so a no-match under `pipefail` does not skip that guard.
> 
> **`crates/mbx/src/lib.rs`** documents the same policy: no semver guarantee on CLI-internal types, a pointer to `UNCHECKED_PACKAGES`, and a note not to re-enable the check for “protection.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41aeff73387df41a1b70b5f81d5eeb02b89a9e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

