### PR TITLE
fix(release): bootstrap protocol publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -56,13 +56,14 @@ jobs:
           crate=mbx-cache-protocol
           version=$(cargo metadata --no-deps --format-version 1 |
             jq -r --arg crate "$crate" '.packages[] | select(.name == $crate).version')
-          endpoint="https://crates.io/api/v1/crates/$crate/$version"
+          crate_endpoint="https://crates.io/api/v1/crates/$crate"
+          version_endpoint="$crate_endpoint/$version"
           user_agent="mr-boxington release workflow (https://github.com/${{ github.repository }})"
           status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
-            --user-agent "$user_agent" "$endpoint")
+            --user-agent "$user_agent" "$crate_endpoint")
 
           if [ "$status" = 200 ]; then
-            echo "$crate $version is already published"
+            echo "$crate already exists; release-plz will publish version $version with OIDC"
             exit 0
           fi
           if [ "$status" != 404 ]; then
@@ -80,7 +81,7 @@ jobs:
           # The publish endpoint can return before the new version is visible
           # to release-plz through the crates.io API.
           for _ in $(seq 1 12); do
-            if curl --fail --silent --show-error --user-agent "$user_agent" "$endpoint" >/dev/null; then
+            if curl --fail --silent --show-error --user-agent "$user_agent" "$version_endpoint" >/dev/null; then
               exit 0
             fi
             sleep 5
@@ -121,16 +122,41 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "mbx tag: ${tag:-<none released>}"
 
-      # Merging a release PR and getting nothing back means the release did not
-      # happen. Without this the run goes green and the omission is only
-      # noticed when someone looks for the release.
-      - name: Reject an empty release result for a merged release PR
+      # An empty result is expected when re-running a completed release, or
+      # when bootstrapping the protocol crate was the only work. Verify the
+      # desired end state instead of rejecting those idempotent cases.
+      - name: Verify an empty release result for a merged release PR
         if: steps.mbx-tag.outputs.tag == '' && steps.release-pr.outputs.number != ''
         env:
-          RELEASE_PR: ${{ steps.release-pr.outputs.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::error::release-plz returned no release after merging release PR #$RELEASE_PR"
-          exit 1
+          user_agent="mr-boxington release workflow (https://github.com/${{ github.repository }})"
+          failed=false
+
+          while read -r crate version; do
+            endpoint="https://crates.io/api/v1/crates/$crate/$version"
+            if ! curl --fail --silent --show-error --user-agent "$user_agent" "$endpoint" >/dev/null; then
+              echo "::error::$crate $version is not published on crates.io"
+              failed=true
+            fi
+          done < <(cargo metadata --no-deps --format-version 1 | jq -r '
+            .workspace_members as $members
+            | .packages[]
+            | select(.id as $id | $members | index($id))
+            | select(.publish == null or (.publish | length > 0))
+            | [.name, .version]
+            | @tsv')
+
+          mbx_version=$(cargo metadata --no-deps --format-version 1 |
+            jq -r '.packages[] | select(.name == "mbx").version')
+          if ! gh release view "v$mbx_version" --repo "${{ github.repository }}" >/dev/null; then
+            echo "::error::GitHub release v$mbx_version does not exist"
+            failed=true
+          fi
+
+          if [ "$failed" = true ]; then
+            exit 1
+          fi
 
   # Binaries are attached to the draft, then the draft is published — so a
   # release is never visible without its assets.

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,6 +33,61 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Find the merged release PR
+        id: release-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          number=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '[.[] | select(.merged_at != null) | select(.head.ref | startswith("release-plz-"))][0].number // ""')
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      # Trusted publishing cannot create a crate. Bootstrap the protocol crate
+      # with a token restricted to `publish-new`, then wait until crates.io can
+      # see that exact version so release-plz recognizes it as already
+      # published. Once the crate exists this step never reads or uses the
+      # token; later versions use OIDC with the rest of the workspace.
+      - name: Bootstrap mbx-cache-protocol on crates.io
+        if: steps.release-pr.outputs.number != ''
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_PUBLISH_NEW_TOKEN }}
+        run: |
+          crate=mbx-cache-protocol
+          version=$(cargo metadata --no-deps --format-version 1 |
+            jq -r --arg crate "$crate" '.packages[] | select(.name == $crate).version')
+          endpoint="https://crates.io/api/v1/crates/$crate/$version"
+          user_agent="mr-boxington release workflow (https://github.com/${{ github.repository }})"
+          status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --user-agent "$user_agent" "$endpoint")
+
+          if [ "$status" = 200 ]; then
+            echo "$crate $version is already published"
+            exit 0
+          fi
+          if [ "$status" != 404 ]; then
+            echo "::error::crates.io returned HTTP $status while checking $crate $version"
+            exit 1
+          fi
+
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "::error::CRATES_IO_PUBLISH_NEW_TOKEN is required to publish the first $crate release"
+            exit 1
+          fi
+
+          cargo publish --locked --package "$crate"
+
+          # The publish endpoint can return before the new version is visible
+          # to release-plz through the crates.io API.
+          for _ in $(seq 1 12); do
+            if curl --fail --silent --show-error --user-agent "$user_agent" "$endpoint" >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::$crate $version did not become visible on crates.io"
+          exit 1
+
       # Exchanges the OIDC token for a short-lived crates.io token. Each crate
       # needs a Trusted Publisher naming this repository and this workflow
       # file, so renaming this file breaks publishing.
@@ -49,7 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
-      # This is a workspace: a run can release `mbx`, either library, or all of
+      # This is a workspace: a run can release `mbx`, any library, or all of
       # them, in whatever order release-plz reports. Taking `releases[0]` would
       # sometimes hand the binary-upload job a library's tag — attaching `mbx`
       # binaries to the wrong release and leaving the real one drafted forever.
@@ -70,17 +125,12 @@ jobs:
       # happen. Without this the run goes green and the omission is only
       # noticed when someone looks for the release.
       - name: Reject an empty release result for a merged release PR
-        if: steps.mbx-tag.outputs.tag == ''
+        if: steps.mbx-tag.outputs.tag == '' && steps.release-pr.outputs.number != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PR: ${{ steps.release-pr.outputs.number }}
         run: |
-          release_pr=$(gh api \
-            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-            --jq '[.[] | select(.merged_at != null) | select(.head.ref | startswith("release-plz-"))][0].number // ""')
-          if [ -n "$release_pr" ]; then
-            echo "::error::release-plz returned no release after merging release PR #$release_pr"
-            exit 1
-          fi
+          echo "::error::release-plz returned no release after merging release PR #$RELEASE_PR"
+          exit 1
 
   # Binaries are attached to the draft, then the draft is published — so a
   # release is never visible without its assets.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,22 +19,26 @@ bump does not release — only merging a release PR does.
 
 ## Tags and asset names
 
-The `mbx` crate is tagged `v{version}`; the two library crates are published to
+The `mbx` crate is tagged `v{version}`; the three library crates are published to
 crates.io but get no GitHub release of their own. Asset names carry no version
 (`mbx-x86_64-unknown-linux-musl.tar.gz`), which is what keeps
 `releases/latest/download/…` a stable URL.
 
 ## Setup this depends on
 
-Two things live outside the repository, and releases fail without them:
+These settings live outside the repository, and releases fail without them:
 
 - **`RELEASE_PLZ_TOKEN`** — a PAT with `contents: write` and
   `pull-requests: write`. The default `GITHUB_TOKEN` cannot be used: pushes made
   with it do not trigger workflows, so the release PR would never run CI.
-- **A crates.io Trusted Publisher for each of `mbx`, `mbx-cache-core`, and
-  `mbx-cache-rustc`**, naming this repository and the workflow file
-  `release-plz.yml`. Publishing uses OIDC, so no `CARGO_REGISTRY_TOKEN` exists
-  anywhere. **Renaming `release-plz.yml` breaks publishing** until the trusted
+- **`CRATES_IO_PUBLISH_NEW_TOKEN`** — a crates.io token restricted to the
+  `publish-new` endpoint. It bootstraps `mbx-cache-protocol`, because trusted
+  publishing cannot create a crate. Delete the secret after its first release.
+- **A crates.io Trusted Publisher for each of `mbx`, `mbx-cache-core`,
+  `mbx-cache-protocol`, and `mbx-cache-rustc`**, naming this repository and the
+  workflow file `release-plz.yml`. Configure the protocol publisher after its
+  bootstrap release; later publishing uses OIDC and does not need a registry
+  token. **Renaming `release-plz.yml` breaks publishing** until the trusted
   publishers are updated to match.
 
 ## When a release goes wrong

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,6 +25,11 @@ publish = true
 git_release_enable = false
 
 [[package]]
+name = "mbx-cache-protocol"
+publish = true
+git_release_enable = false
+
+[[package]]
 name = "mbx-cache-rustc"
 publish = true
 git_release_enable = false


### PR DESCRIPTION
## Summary

- add `mbx-cache-protocol` to the release-plz package configuration without a GitHub release
- publish its first version with the restricted `CRATES_IO_PUBLISH_NEW_TOKEN` only when a generated release PR is merged
- wait for crates.io visibility before release-plz continues with OIDC
- document the one-time bootstrap and subsequent trusted-publisher setup

Fixes the release blocker identified in #70.

## Verification

- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/release-plz.yml`
- `cargo publish --dry-run --locked --package mbx-cache-protocol`
- `git diff --check main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release path and introduces a one-time token publish step; mistakes could block or mis-verify releases, but scope is limited to CI and documented bootstrap.
> 
> **Overview**
> Unblocks releasing **`mbx-cache-protocol`** by registering it in **`release-plz.toml`** (crates.io only, no GitHub release) and extending **`release-plz.yml`** so merged release PRs can create the crate once via **`CRATES_IO_PUBLISH_NEW_TOKEN`**, then poll crates.io until that version is visible before **release-plz** runs with OIDC.
> 
> The workflow now detects the merged release PR up front, and when **release-plz** returns no **`mbx`** tag it **verifies** workspace crate versions on crates.io and the **`v{mbx_version}`** GitHub release instead of failing—so re-runs and bootstrap-only runs stay green. **`RELEASING.md`** documents the one-time **`publish-new`** secret, the fourth trusted publisher, and the “three library crates” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c306fb015ecaf5c76ec6466c371ca33cee707016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->