### PR TITLE
docs: show the product on the landing page

### DIFF
--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -1,3 +1,38 @@
+<script setup>
+import { onMounted, onUnmounted, ref } from "vue";
+
+// A sample of the savings pool, with numbers consistent with the transcript
+// below (191 hits; the cold build took 3m 41s, the warm one 4.9s). The real
+// line is drawn at random per build; rotating here is how a static page shows
+// that it does not repeat itself.
+const quips = [
+  "mbx: served 191 compilations from cache; rustc showed up ready to do 3m 36s of work and was sent home",
+  "mbx: 6h 14m of compiling skipped across 87 builds. rustc suspects nothing.",
+  "mbx: 47.0 GiB of build debris binned so far. cargo clean remains unemployed.",
+  "mbx: your deleted worktrees left 41.0 GiB behind. left. past tense.",
+  "mbx: every checkout believes it owns 22.0 GiB of outputs. the disk keeps one copy and says nothing.",
+  "mbx: 4312 compilations on file. the box remembers.",
+  "mbx: rustc believes it compiled everything. it is down 6h 14m across 87 builds. let it believe.",
+  "mbx: 22.0 GiB in every checkout, 22.0 GiB on disk. arithmetic declined to comment.",
+];
+// Server and first client render must agree, so rotation starts on mount --
+// and not at all for someone who asked for reduced motion, matching the
+// entrance animations this component already suppresses for them.
+const quip = ref(quips[0]);
+let at = 0;
+let timer;
+onMounted(() => {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return;
+  }
+  timer = setInterval(() => {
+    at = (at + 1) % quips.length;
+    quip.value = quips[at];
+  }, 4000);
+});
+onUnmounted(() => clearInterval(timer));
+</script>
+
 <template>
   <section class="MbxDemo" aria-label="mbx across two checkouts">
     <div class="window">
@@ -8,7 +43,7 @@
         <span class="label">two checkouts · one cache</span>
       </div>
       <div
-        aria-label="Terminal transcript: the first checkout compiles every crate in 3 minutes 41 seconds; a fresh worktree finishes in 4.9 seconds with 191 cache hits"
+        aria-label="Terminal transcript: the first checkout compiles every crate in 3 minutes 41 seconds; a fresh worktree finishes in 4.9 seconds with 191 cache hits, and mbx adds one deadpan line about what the cache has saved over time"
         class="screen"
         role="img"
       >
@@ -22,6 +57,7 @@
         <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
         <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time fast">4.9s</span></div>
         <div class="line cache">cache: 191 hits, 3 misses, 187 prefetched; 0 B downloaded, 0 B uploaded, 412.6 MiB stored locally</div>
+        <div class="line quip">{{ quip }}</div>
         <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
       </div>
     </div>
@@ -106,6 +142,7 @@
 .line:nth-child(9) { animation-delay: 2.15s; }
 .line:nth-child(10) { animation-delay: 2.35s; }
 .line:nth-child(11) { animation-delay: 2.6s; }
+.line:nth-child(12) { animation-delay: 2.85s; }
 
 .gap {
   height: 0.9em;
@@ -149,8 +186,12 @@
   color: var(--vp-c-brand-1);
 }
 
+.quip {
+  color: rgb(var(--mbx-amber-rgb) / 0.9);
+}
+
 .cursor {
-  animation: mbx-line-in 0.35s ease 2.6s both, mbx-blink 1.1s steps(1) 2.95s infinite;
+  animation: mbx-line-in 0.35s ease 2.85s both, mbx-blink 1.1s steps(1) 3.2s infinite;
   background: var(--vp-c-brand-1);
   display: inline-block;
   height: 1.1em;

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,16 @@ features:
     link: /github-actions
   - icon: "🧹"
     title: Prune automatically
-    details: Budgets scale with the disk. Managed target directories go when their checkout disappears, when they sit unused for 30 days, or when they outgrow their share — and mbx tells you what that saved.
+    details: Budgets scale with the disk. Managed target directories go when their checkout disappears, when they sit unused for 30 days, or when they outgrow their share.
     link: /managed-targets
+  - icon: "🧾"
+    title: Keeps receipts
+    details: One line after a build says what the cache was worth — compilations skipped, hours refunded, gigabytes binned. Deadpan included; savings = "plain" if your logs must keep a straight face.
+    link: /getting-started#read-the-result
+  - icon: "🔍"
+    title: Never lies about a hit
+    details: mbx reports hits, misses, what it could not look up, and what it deliberately bypassed. A high hit rate cannot hide work that never entered the cache.
+    link: /cache-results
 ---
 
 ::: warning Experimental


### PR DESCRIPTION
The landing page described mbx without ever demonstrating its voice. The
hero's terminal demo showed the two-checkout warm build, but nothing on the
page showed the savings line -- the most distinctive thing a build prints.

The demo transcript now ends with one line from the savings pool, rotating
through a sample every few seconds, because a static line would hide the
feature's point: it does not repeat itself. The numbers agree with the
transcript around it (191 hits; 3m 41s cold, 4.9s warm). Rotation starts on
mount so server and client render the same first line, and does not start at
all under prefers-reduced-motion, matching the entrance animations this
component already suppresses for that preference. The line sits inside the
transcript's role="img", so assistive technology gets one stable description
rather than an announcement every four seconds.

Two tiles join the grid, making it an even six: the savings line ("Keeps
receipts"), which had been squatting in the pruning tile's last clause, and
honest hit reporting ("Never lies about a hit"), which the README has led
with since the beginning but the landing page never mentioned.

An earlier revision of this change added a separate "What a warm build looks
like" markdown section instead; it duplicated the hero demo one screen lower
and is gone.

## Verification

- `mise run build:docs` — clean; the SSR HTML carries the first quip inside the
  hero transcript, the theme chunk carries all 8 plus the `matchMedia` guard,
  and the removed markdown section is absent from the rendered page.
- Six tiles render as an even grid; `/getting-started#read-the-result` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing UI only; no product, auth, or cache behavior changes.
> 
> **Overview**
> The landing page now **shows mbx’s post-build savings line** in the hero terminal demo, not just the warm-build transcript. **`HomeTerminal.vue`** adds a rotating sample from eight deadpan quips (every 4s after mount) so the static page hints that real builds don’t repeat the same line; the first quip matches SSR for hydration, rotation is skipped under **`prefers-reduced-motion`**, and the transcript **`aria-label`** describes the quip without live announcements.
> 
> The home **features grid grows to six tiles**: **Keeps receipts** (savings one-liner) and **Never lies about a hit** (honest hit/miss reporting), while the **Prune automatically** blurb no longer mentions “what that saved.” Entrance animation timing and **`.quip`** styling were adjusted for the extra transcript line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a94697b2663f49e5c27320d88c4b0fcbe20dd087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


