### PR TITLE
fix(docs): avoid cache route collision

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,6 +17,9 @@ export default defineConfig({
   lastUpdated: true,
   appearance: "force-dark",
   cleanUrls: true,
+  rewrites: {
+    "cli/cache.md": "cli/cache/index.md",
+  },
   sitemap: {
     hostname: "https://mr-boxington.jdx.dev",
   },


### PR DESCRIPTION
## Summary

- rewrite the generated `cli/cache.md` route to `cli/cache/index.md`
- avoid the `cache.html` and `cache/` static-hosting collision
- preserve existing `/cli/cache` links

Follow-up to https://github.com/jdx/mr-boxington/pull/79#discussion_r3854932319

## Verification

- `mise run check:docs`
- `mise run build:docs`
- confirmed `cli/cache/index.html` exists and `cli/cache.html` does not

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress routing change with no runtime or security impact.
> 
> **Overview**
> Fixes a **static-hosting conflict** where the CLI cache overview page and nested `/cli/cache/*` routes both wanted the same URL shape (`cache.html` vs `cache/`).
> 
> Adds a VitePress **`rewrites`** rule so `cli/cache.md` builds as **`cli/cache/index.md`**, yielding `cli/cache/index.html` instead of a sibling `cache.html`. Existing nav and sidebar links to **`/cli/cache`** stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2901260b4b051415ae8724e87a94a9fbc1ab6d0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->