### PR TITLE
fix: deflake two tests that race the machine

### DIFF
--- a/crates/mbx/src/store_tests.rs
+++ b/crates/mbx/src/store_tests.rs
@@ -637,9 +637,14 @@ fn forgets_a_claim_no_build_has_renewed() {
         &serde_json::to_vec(&stale).unwrap(),
     )
     .unwrap();
-    // Filesystems with coarse timestamps can otherwise tie this object with
-    // the action descriptor and output tree created immediately afterward.
-    age(&store, &orphan, Duration::from_secs(1));
+    // The orphan must sort strictly oldest. One second was enough to beat
+    // coarse filesystem timestamps, but it also raced the wall clock: the
+    // descriptor and output tree above were written before `age` reads "now",
+    // so a runner that stalls past the margin between those two moments makes
+    // them the oldest objects instead, and collection under a barely-reduced
+    // budget evicts one of them and leaves the orphan alone. An hour outruns
+    // any plausible stall.
+    age(&store, &orphan, Duration::from_secs(60 * 60));
 
     assert_eq!(stats(&store).unwrap().stale_checkouts, 1);
     gc(&store, stats(&store).unwrap().total_bytes() - 1).unwrap();

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -83,12 +83,29 @@ fn transparent_rustc_replaces_the_shim_process() {
         mbx::session::install_shim(Path::new(env!("CARGO_BIN_EXE_mbx")), directory.path()).unwrap();
     let pid_file = directory.path().join("compiler.pid");
 
-    let mut child = Command::new(shim)
-        .arg("/bin/sh")
-        .args(["-c", "printf '%s' \"$$\" > \"$1\"", "sh"])
-        .arg(&pid_file)
-        .spawn()
-        .unwrap();
+    // Retried because exec of a just-written executable can transiently fail
+    // with ETXTBSY: a sibling test may fork while its own shim copy is still
+    // open for write, and until that child reaches its exec, the inherited
+    // descriptor (cloexec or not) counts as a writer of this file too.
+    let mut child = {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let attempt = Command::new(&shim)
+                .arg("/bin/sh")
+                .args(["-c", "printf '%s' \"$$\" > \"$1\"", "sh"])
+                .arg(&pid_file)
+                .spawn();
+            match attempt {
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::ExecutableFileBusy
+                        && std::time::Instant::now() < deadline =>
+                {
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                other => break other.unwrap(),
+            }
+        }
+    };
     let shim_pid = child.id();
     let status = child.wait().unwrap();
 


### PR DESCRIPTION
forgets_a_claim_no_build_has_renewed backdates its orphan object by one
second so eviction visits it first. That margin was chosen against coarse
filesystem timestamps, but it also races elapsed time: the action descriptor
and output tree are written before `age` reads "now", so a runner that
stalls for more than a second between those two moments leaves them older
than the orphan. Collection under a barely-reduced budget then evicts one of
them instead, and the test fails with the orphan still present -- seen on a
loaded windows-latest runner whose suite took 38 seconds.

An hour outruns any plausible stall and still costs nothing: the test only
needs the orphan to sort strictly oldest.

## Second flake, same PR

`transparent_rustc_replaces_the_shim_process` failed once on a loaded
ubuntu-latest runner with ETXTBSY: a sibling test forks while this test's
fresh shim copy is still open for write, and until that child execs, the
inherited descriptor counts as a writer of the file. The spawn now retries
ETXTBSY for up to five seconds; any other error still fails on the first
attempt. Both failures were root-caused from stack PRs whose diffs could not
have caused them, which is what made them recognizable as pre-existing races.

## Verification

- The test passes locally; the fix widens a margin rather than changing what is asserted.
- Root-caused from [this windows-latest failure](https://github.com/jdx/mr-boxington/actions/runs/32872596004/job/97882941807) on #77 — a PR whose diff is a workflow file and a doc comment, which is what pointed at a pre-existing race rather than the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only test timing and retry logic; no production cache, GC, or shim behavior is modified.
> 
> **Overview**
> Fixes two flaky tests without changing production behavior.
> 
> In **`forgets_a_claim_no_build_has_renewed`**, the orphan CAS object is backdated via `age` so GC under a tight byte budget evicts it first. The margin was **1 second**, which could lose to real elapsed time on slow CI (descriptor/output written before `age` reads “now”), so GC dropped the wrong object and the orphan survived. **`age` now uses one hour** so the orphan stays strictly oldest; comments document the race.
> 
> On Unix, **`transparent_rustc_replaces_the_shim_process`** **retries spawning the freshly installed shim** for up to 5 seconds when spawn fails with **`ExecutableFileBusy` (ETXTBSY)**, with 20 ms sleeps—covering parallel tests that still have the shim file open for write after fork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67d4d9ccfbf6ff00e031d1e6653c712b1e8bc647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
