### PR TITLE
fix(docs): preserve source path in edit links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -93,7 +93,8 @@ export default defineConfig({
       { icon: "discord", link: "https://discord.gg/UBa7pJUN7Z" },
     ],
     editLink: {
-      pattern: "https://github.com/jdx/mr-boxington/edit/main/docs/:path",
+      pattern: ({ filePath }) =>
+        `https://github.com/jdx/mr-boxington/edit/main/docs/${filePath}`,
       text: "Edit this page on GitHub",
     },
     search: { provider: "local" },


### PR DESCRIPTION
## Summary

- generate edit links from VitePress’s original `filePath` explicitly
- keep rewritten routes from affecting their GitHub source URLs
- address the review finding in #81

## Testing

- `cd docs && aube run docs:build`
- verified `cli/cache/index.html` links to `docs/cli/cache.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress config change with no runtime or security impact.
> 
> **Overview**
> **Edit on GitHub** links in the docs now build URLs from VitePress’s original `filePath` via a function `editLink.pattern`, instead of the `:path` string template.
> 
> That keeps **rewritten routes** (e.g. `cli/cache.md` → `cli/cache/index.md`) from sending contributors to the wrong file on GitHub—pages like `cli/cache/` should open `docs/cli/cache.md` for editing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b0d7f8d69a17d021b74b8c3e41f8240fb11e805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->