### PR TITLE
fix: probe reflinks across the span the restore actually copies

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -509,9 +509,17 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     // arrives after the explanation of what a managed one is for. One existence
     // check, and only on the cargo path.
     if !cargo_help_requested(arguments) && !was_explained(&config.store_dir()) {
-        // Probed rather than assumed, and probed only on the one run that
-        // will say something about it.
-        let reflinks = crate::util::reflinks_work(&config.cache_dir);
+        // Probed rather than assumed, probed only on the one run that will
+        // say something about it, and probed between the two places the real
+        // copy spans: the store, and wherever this build's outputs will land
+        // -- the managed root normally, cargo's own directory when placement
+        // is off or the location was asked for.
+        let outputs_root = if config.target.views && !roots.target_dir_requested {
+            &config.target.root
+        } else {
+            &roots.target_dir
+        };
+        let reflinks = crate::util::reflinks_work(&config.cache_dir, outputs_root);
         crate::session::note(&first_run_notice(config, retention, reflinks));
         mark_explained(&config.store_dir());
     }

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -505,25 +505,6 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     config.incremental = incremental;
     let config = &config;
 
-    // Before the prompt below, so the offer to replace an existing `target/`
-    // arrives after the explanation of what a managed one is for. One existence
-    // check, and only on the cargo path.
-    if !cargo_help_requested(arguments) && !was_explained(&config.store_dir()) {
-        // Probed rather than assumed, probed only on the one run that will
-        // say something about it, and probed between the two places the real
-        // copy spans: the store, and wherever this build's outputs will land
-        // -- the managed root normally, cargo's own directory when placement
-        // is off or the location was asked for.
-        let outputs_root = if config.target.views && !roots.target_dir_requested {
-            &config.target.root
-        } else {
-            &roots.target_dir
-        };
-        let reflinks = crate::util::reflinks_work(&config.cache_dir, outputs_root);
-        crate::session::note(&first_run_notice(config, retention, reflinks));
-        mark_explained(&config.store_dir());
-    }
-
     let migrate_existing = prompt_to_manage_existing_target(config, &roots, arguments)?;
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will
@@ -561,6 +542,17 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
         // so collection does not treat it as idle.
         target::touch_managed(config, &roots.workspace_root, &roots.target_dir);
     }
+
+    // Probed rather than assumed, and only on the one run that will say
+    // something about it. Placement is best-effort, so wait until it has
+    // finished and probe the directory cargo will actually use rather than
+    // predicting that a managed target will win.
+    if !cargo_help_requested(arguments) && !was_explained(&config.store_dir()) {
+        let reflinks = crate::util::reflinks_work(&config.cache_dir, &roots.target_dir);
+        crate::session::note(&first_run_notice(config, retention, reflinks));
+        mark_explained(&config.store_dir());
+    }
+
     let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -195,22 +195,31 @@ fn disk_total_bytes_at(path: &Path) -> Option<u64> {
     }
 }
 
-/// Whether the filesystem holding `dir` can reflink.
+/// Whether a reflink from inside `source_dir` can land inside
+/// `destination_dir`.
 ///
 /// Answered by doing one, not by guessing from the platform: reflink support
-/// is a property of the mounted filesystem, and XFS on one machine has it
-/// where ext4 on the next does not. Any failure -- including `dir` not being
-/// creatable -- answers no, because every caller is deciding whether to
-/// promise sharing, and a promise needs more than a maybe.
-pub fn reflinks_work(dir: &Path) -> bool {
-    fn probe(dir: &Path) -> Option<()> {
-        std::fs::create_dir_all(dir).ok()?;
-        let directory = tempfile::tempdir_in(dir).ok()?;
-        let source = directory.path().join("source");
+/// is a property of the mounted filesystem, and it takes both ends -- a store
+/// on btrfs cannot reflink into a target directory on ext4, so probing one
+/// side alone proves nothing about the copy that actually happens. The
+/// destination is anchored at its nearest existing ancestor rather than
+/// created, because the real directory may be one cargo has not made yet and
+/// making it here would change what target placement later sees. Any failure
+/// answers no: every caller is deciding whether to promise sharing, and a
+/// promise needs more than a maybe.
+pub fn reflinks_work(source_dir: &Path, destination_dir: &Path) -> bool {
+    fn probe(source_dir: &Path, destination_dir: &Path) -> Option<()> {
+        std::fs::create_dir_all(source_dir).ok()?;
+        let anchor = destination_dir
+            .ancestors()
+            .find(|ancestor| ancestor.exists())?;
+        let source_temp = tempfile::tempdir_in(source_dir).ok()?;
+        let destination_temp = tempfile::tempdir_in(anchor).ok()?;
+        let source = source_temp.path().join("source");
         std::fs::write(&source, b"mbx reflink probe").ok()?;
-        reflink_copy::reflink(&source, directory.path().join("destination")).ok()
+        reflink_copy::reflink(&source, destination_temp.path().join("destination")).ok()
     }
-    probe(dir).is_some()
+    probe(source_dir, destination_dir).is_some()
 }
 
 /// Generate an unpredictable alphanumeric string.
@@ -261,6 +270,22 @@ mod tests {
         // directory is created.
         let missing = directory.path().join("not").join("created").join("yet");
         assert_eq!(disk_total_bytes(&missing), Some(total));
+    }
+
+    #[test]
+    fn the_reflink_probe_anchors_a_destination_nobody_created_yet() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("cache");
+        // The target directory does not exist before the first build; the
+        // probe must answer for the filesystem it will be created on, without
+        // creating it.
+        let unmade = directory.path().join("checkout").join("target");
+        assert_eq!(
+            reflinks_work(&store, &unmade),
+            reflinks_work(&store, directory.path()),
+            "a missing destination answers as its filesystem, not as a failure"
+        );
+        assert!(!unmade.exists(), "the probe must not create the directory");
     }
 
     #[test]


### PR DESCRIPTION
The first-run notice promised copy-free restores after proving a reflink
inside the cache directory alone. A reflink needs both ends on one
filesystem, and the restore's ends are the store and the target directory --
which is another volume when target.root points at one, or the checkout's
own filesystem when placement is off or a location was asked for. On such
machines the notice promised sharing that every restore quietly turned into
a copy.

The probe now spans the store and wherever this build's outputs will land.
The destination side anchors at its nearest existing ancestor rather than
being created, because the real target directory may be one cargo has not
made yet, and making it here would change what placement later sees.

Follow-up to #74, which merged while this was in review on the stack.
## Verification

- `cargo test -p mbx` — all pass, including a new test that a not-yet-created target directory answers as its filesystem without being created.
- Manual: fresh cache on one filesystem, notice line present; the line is absent when the destination cannot take a reflink from the store.

Found by Cursor Bugbot on #74 ([thread](https://github.com/jdx/mr-boxington/pull/74#discussion_r3855433426)) just as the stack merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes first-run messaging and a filesystem probe only; it reduces incorrect user-facing promises rather than altering cache or build semantics.
> 
> **Overview**
> The first-run notice could claim **copy-free restores via reflink** after probing only inside the cache store, even when restores copy from the store into a **target directory on another filesystem** (custom `target.root`, declined managed placement, etc.).
> 
> **`reflinks_work`** now takes **source and destination** paths and performs a real cross-path reflink probe. The destination side uses the **nearest existing ancestor** so a not-yet-created `target/` is evaluated without creating it (avoiding interference with later placement).
> 
> The **first-run notice** runs **after** target placement/migration so the probe uses **`roots.target_dir`**—the directory Cargo will actually write to—rather than running before the managed-target prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 084fd1517dc998a5f9a8d77a95c5a9a86b0f2d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->