### PR TITLE
ci: refresh docs in release PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -199,11 +199,36 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Install documentation tools
+        if: steps.release-plz.outputs.prs_created == 'true'
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+
+      - name: Update generated documentation in the release PR
+        if: steps.release-plz.outputs.prs_created == 'true'
+        env:
+          RELEASE_PR: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          branch=$(jq -r '.head_branch' <<<"$RELEASE_PR")
+          git fetch origin "$branch"
+          git switch --force-create "$branch" FETCH_HEAD
+          mise run render:docs
+
+          if git diff --quiet -- docs/cli &&
+            test -z "$(git status --porcelain --untracked-files=all -- docs/cli)"; then
+            echo "Generated documentation is already current"
+            exit 0
+          fi
+
+          git add docs/cli
+          git commit -m "docs: update generated CLI reference"
+          git push origin "HEAD:$branch"


### PR DESCRIPTION
## Summary

- capture the release PR metadata emitted by release-plz
- check out the generated release branch and regenerate CLI documentation
- commit and push generated docs only when they changed
- authenticate the checkout with the release token so the workflow can update the branch

## Testing

- `mise exec actionlint -- actionlint -shellcheck= .github/workflows/release-plz.yml`
- exercised `mise run render:docs` against PR #70's release branch; it produced the expected `docs/cli/index.md` version update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes using an existing release token; doc updates are skipped when already current.
> 
> **Overview**
> Release PR automation now **regenerates and commits** `docs/cli` on the release-plz branch whenever a new release PR is opened, so version bumps in the release PR stay aligned with the published CLI reference.
> 
> The `release-plz-pr` job checks out with `RELEASE_PLZ_TOKEN` (replacing `persist-credentials: false`), reads release-plz’s `pr` output to get `head_branch`, runs `mise run render:docs`, and only commits/pushes when `docs/cli` actually changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac033b6db639992c7c8a1045100d48ab1c0f893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->