### PR TITLE
chore: give every crate one synchronized version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+# One version for every crate in the workspace. release-plz keeps them in step
+# through the `version_group` in release-plz.toml, so a release moves all four
+# together rather than leaving each on a number of its own.
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.5.0"
+version.workspace = true
 description = "Action cache protocol, CAS, authentication, and transport primitives for mbx"
 edition.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.3.0" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.4.0" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.4.0"
+version.workspace = true
 description = "Conservative rustc action analysis and key construction for mbx"
 edition.workspace = true
 rust-version.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.5.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -19,7 +19,7 @@ dirs = "6"
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.5.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.0", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.4.0", default-features = false }
 rand = "0.10"
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx <SUBCOMMAND>`
 
-**Version:** 0.3.0
+**Version:** 0.4.0
 
 - **Usage:** `mbx <SUBCOMMAND>`
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,8 +8,11 @@ git_release_enable = true
 # later. release-plz.yml undrafts it once the upload succeeds.
 git_release_draft = true
 
+# Every crate shares one version: a single group is what makes release-plz
+# bump them together instead of computing a separate number for each.
 [[package]]
 name = "mbx"
+version_group = "mbx"
 publish = true
 # release-plz would otherwise tag the binary crate `mbx-vX.Y.Z`. The README's
 # install URLs are written against `v{version}`, and this is the tag people
@@ -19,6 +22,7 @@ git_release_enable = true
 
 [[package]]
 name = "mbx-cache-core"
+version_group = "mbx"
 publish = true
 # A library: crates.io is its distribution. A GitHub release for it would carry
 # no assets and would sit drafted forever, since only the `mbx` tag is undrafted.
@@ -26,10 +30,12 @@ git_release_enable = false
 
 [[package]]
 name = "mbx-cache-protocol"
+version_group = "mbx"
 publish = true
 git_release_enable = false
 
 [[package]]
 name = "mbx-cache-rustc"
+version_group = "mbx"
 publish = true
 git_release_enable = false


### PR DESCRIPTION
The four crates had drifted onto three different numbers: `mbx` and `mbx-cache-protocol` inherited the workspace's 0.3.0, while `mbx-cache-core` had been hand-set to 0.5.0 and `mbx-cache-rustc` to 0.4.0 — breaking their inheritance. release-plz then computed a separate bump for each, which is why [#70](https://github.com/jdx/mr-boxington/pull/70) proposes four crates at three versions.

All four now take `version.workspace = true`, and a shared `version_group` in `release-plz.toml` keeps them in step, so one release moves the whole workspace together.

## Why 0.4.0

| crate | published (crates.io index) | in tree before | after |
| --- | --- | --- | --- |
| `mbx` | 0.3.0 | 0.3.0 | 0.4.0 |
| `mbx-cache-core` | 0.3.0 | 0.5.0 | 0.4.0 |
| `mbx-cache-rustc` | 0.3.0 | 0.4.0 | 0.4.0 |
| `mbx-cache-protocol` | unpublished | 0.3.0 | 0.4.0 |

0.3.0 is the highest version any of these has actually published, so 0.4.0 moves all of them forward legally. The in-tree 0.5.0 and 0.4.0 were never published or tagged, so correcting them regresses nothing.

## Verification

- **Behavior, not documentation**: applied this exact config to a clone of the real repo and ran release-plz 0.3.160. It resolves `mbx-cache-protocol`, `mbx-cache-core`, `mbx-cache-rustc`, and `mbx` all to **0.4.0** — against today's 0.4.0/0.5.0 spread. `version_group` is a per-package field; I confirmed `shared_version` (my first guess) is rejected by this release-plz version.
- `cargo semver-checks --workspace --exclude mbx --baseline-rev origin/main --all-features` passes (exit 0), including the `mbx-cache-core v0.5.0 -> v0.4.0` correction.
- `cargo test -p mbx`, `cargo clippy … -D warnings`, `bats test` (16/16), `mbx --version` → `mbx 0.4.0`.
- `Cargo.lock` regenerated; `docs/cli/index.md` regenerated because the generated reference embeds the version.

## Separate problem this does not fix

[#70](https://github.com/jdx/mr-boxington/pull/70) is currently failing `check:docs`, and every future release PR will too: `docs/cli/index.md` carries `**Version:** 0.3.0`, release-plz bumps `Cargo.toml` but cannot regenerate docs, and release-plz 0.3.160 has no hook to do it (I probed for one). Either the version comes out of the generated reference — the site nav already shows it from `Cargo.toml` — or the release workflow regenerates docs after opening the PR. Happy to do either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and packaging metadata only; no runtime or API behavior changes beyond aligning unpublished in-tree version numbers with crates.io.
> 
> **Overview**
> Unifies **all four workspace crates** on a single **0.4.0** version instead of the previous split (e.g. `mbx-cache-core` at 0.5.0 vs others at 0.3.0/0.4.0).
> 
> Each crate now uses **`version.workspace = true`**, with the canonical version and release notes living in the root **`Cargo.toml`**. **`release-plz.toml`** adds **`version_group = "mbx"`** on every package so release-plz bumps them together in one release. Internal path dependencies and **`Cargo.lock`** are updated to **0.4.0**, and the generated CLI docs **`docs/cli/index.md`** show the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd35a7eddc48eb983e42e1428bdc7968a0c68f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->