### PR TITLE
ci: never let two release-plz runs overlap

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,6 +12,24 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# One run at a time. Two runs would both publish: the release job creates tags
+# and pushes crates to crates.io, and a second run reaching that step while the
+# first is mid-publish either duplicates a version or fails half-way through a
+# workspace, leaving some crates released and some not. A queued run is also
+# correct on its own terms -- it re-reads main and finds the work already done.
+#
+# `cancel-in-progress: false` is the whole point: cancelling a publish is worse
+# than waiting for one. Merges to main are rare enough that the queue is short.
+#
+# Deliberately at workflow level rather than per job, so it also covers the
+# release job racing the *next* run's release-pr job, which rewrites the very
+# branch the release reads. One group here replaces the job-level guard the
+# release-pr job used to carry; repeating the same group name on a job inside a
+# run that already holds it risks the job waiting on its own run's lock.
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-plz-release:
     name: Release
@@ -191,10 +209,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # Never run two of these at once: they would race the same branch.
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
The `release-pr` job already guarded itself against a second copy racing its branch. The **`release` job had no guard at all** — and that is the one that creates tags and pushes crates to crates.io. Two pushes to main in quick succession start two runs whose release jobs can publish concurrently: either duplicating a version, or failing partway through the workspace and leaving some crates released and others not.

## Why workflow level rather than per job

A single group at the workflow level covers every job in the run, including one a per-job group cannot: the `release` job of run N racing the `release-pr` job of run N+1, which force-updates the very branch the release reads.

The `release-pr` job's own group is removed rather than left in place — duplicating the workflow's group name on a job inside a run that already holds that group risks the job queueing behind its own run.

`cancel-in-progress: false` is deliberate: cancelling a half-finished publish is worse than waiting for one, and a queued run simply re-reads main and finds the work already done. Merges to main are rare enough that the queue stays short.

## Verification

- `actionlint` (with shellcheck) clean.
- `zizmor --min-severity high` clean.
- Parsed the result to confirm exactly one workflow-level group and no remaining job-level groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that serializes release automation; it reduces publish race risk without altering application code or runtime behavior.
> 
> **Overview**
> Adds **workflow-level concurrency** to `release-plz.yml` so only one run executes at a time per ref (`release-plz-${{ github.ref }}`), with **`cancel-in-progress: false`** so in-flight publishes are never aborted.
> 
> This replaces the **job-level** concurrency guard that existed only on **`release-plz-pr`**. The **`release`** job (tags + crates.io) had no overlap protection; parallel runs could duplicate versions or partially publish the workspace. A single workflow lock also prevents **`release`** on run N from racing **`release-plz-pr`** on run N+1 while it rewrites the branch the release reads.
> 
> Duplicating the same group on a job inside a run that already holds the workflow lock is avoided by removing the per-job block entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df747222590b3c080e047ad5a18d0c1d4d85dcaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->