### PR TITLE
chore: release v0.4.0

### DIFF
--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.3.0...mbx-cache-core-v0.4.0) - 2026-08-25
+
+### Added
+
+- add installation doctor ([#57](https://github.com/jdx/mr-boxington/pull/57))
+- report compiler time saved and spent ([#59](https://github.com/jdx/mr-boxington/pull/59))
+- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
+- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))
+- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
+
+### Other
+
+- give every crate one synchronized version ([#86](https://github.com/jdx/mr-boxington/pull/86))
+- fuzz untrusted parser inputs ([#38](https://github.com/jdx/mr-boxington/pull/38))
+- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
+- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
+- move inline tests into focused modules ([#42](https://github.com/jdx/mr-boxington/pull/42))
+- define published Rust API surface ([#41](https://github.com/jdx/mr-boxington/pull/41))
+- *(cache)* avoid rereading reflinked outputs ([#44](https://github.com/jdx/mr-boxington/pull/44))
+
 ### Changed
 
 - *(protocol)* consume remote wire types and constants from `mbx-cache-protocol`

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-protocol-v0.4.0) - 2026-08-25
+
+### Added
+
+- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))
+
 ### Added
 
 - Publish the versioned remote-cache wire types, capability schema, media types,

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.3.0...mbx-cache-rustc-v0.4.0) - 2026-08-25
+
+### Added
+
+- report compiler time saved and spent ([#59](https://github.com/jdx/mr-boxington/pull/59))
+- support rustc response files ([#65](https://github.com/jdx/mr-boxington/pull/65))
+- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
+- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))
+- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
+- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
+
+### Other
+
+- give every crate one synchronized version ([#86](https://github.com/jdx/mr-boxington/pull/86))
+- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
+- move inline tests into focused modules ([#42](https://github.com/jdx/mr-boxington/pull/42))
+- define published Rust API surface ([#41](https://github.com/jdx/mr-boxington/pull/41))
+
 ## [0.2.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.1.0...mbx-cache-rustc-v0.2.0) - 2026-08-22
 
 ### Added

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/jdx/mr-boxington/compare/v0.3.0...v0.4.0) - 2026-08-25
+
+### Added
+
+- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
+- explain the cache and its caps on the first build ([#74](https://github.com/jdx/mr-boxington/pull/74))
+- report what mbx has saved on this machine ([#73](https://github.com/jdx/mr-boxington/pull/73))
+- scale disk budgets to the disk and prune idle targets by default ([#72](https://github.com/jdx/mr-boxington/pull/72))
+- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
+- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
+- add JSON inspection output ([#60](https://github.com/jdx/mr-boxington/pull/60))
+- add installation doctor ([#57](https://github.com/jdx/mr-boxington/pull/57))
+- report compiler time saved and spent ([#59](https://github.com/jdx/mr-boxington/pull/59))
+- complete setup lifecycle ([#61](https://github.com/jdx/mr-boxington/pull/61))
+- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
+- *(config)* add safe workspace policy ([#67](https://github.com/jdx/mr-boxington/pull/67))
+- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))
+- explain cache bypasses ([#58](https://github.com/jdx/mr-boxington/pull/58))
+- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
+- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
+- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))
+
+### Fixed
+
+- probe reflinks across the span the restore actually copies ([#84](https://github.com/jdx/mr-boxington/pull/84))
+- deflake two tests that race the machine ([#82](https://github.com/jdx/mr-boxington/pull/82))
+- restore the build after a merge skewed a verify call ([#71](https://github.com/jdx/mr-boxington/pull/71))
+
+### Other
+
+- give every crate one synchronized version ([#86](https://github.com/jdx/mr-boxington/pull/86))
+- stop checking the CLI library's public API ([#77](https://github.com/jdx/mr-boxington/pull/77))
+- wrap project cargo commands with mbx ([#34](https://github.com/jdx/mr-boxington/pull/34))
+- *(deps)* bump the cargo-dependencies group across 1 directory with 2 updates ([#55](https://github.com/jdx/mr-boxington/pull/55))
+- add Bats end-to-end harness ([#46](https://github.com/jdx/mr-boxington/pull/46))
+- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
+- move inline tests into focused modules ([#42](https://github.com/jdx/mr-boxington/pull/42))
+- define published Rust API surface ([#41](https://github.com/jdx/mr-boxington/pull/41))
+- *(cache)* avoid rereading reflinked outputs ([#44](https://github.com/jdx/mr-boxington/pull/44))
+- *(config)* generate settings docs with usage-rs ([#30](https://github.com/jdx/mr-boxington/pull/30))
+
 ### Added
 
 - *(cli)* run a Cargo command with actionable cache-bypass diagnostics using `mbx explain`


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.4.0
* `mbx-cache-core`: 0.3.0 -> 0.4.0
* `mbx-cache-rustc`: 0.3.0 -> 0.4.0
* `mbx`: 0.3.0 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.4.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-protocol-v0.4.0) - 2026-08-25

### Added

- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))

### Added

- Publish the versioned remote-cache wire types, capability schema, media types,
  headers, and blob-pack framing shared by mbx clients and servers.
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.4.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.3.0...mbx-cache-core-v0.4.0) - 2026-08-25

### Added

- add installation doctor ([#57](https://github.com/jdx/mr-boxington/pull/57))
- report compiler time saved and spent ([#59](https://github.com/jdx/mr-boxington/pull/59))
- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))
- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))

### Other

- give every crate one synchronized version ([#86](https://github.com/jdx/mr-boxington/pull/86))
- fuzz untrusted parser inputs ([#38](https://github.com/jdx/mr-boxington/pull/38))
- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
- move inline tests into focused modules ([#42](https://github.com/jdx/mr-boxington/pull/42))
- define published Rust API surface ([#41](https://github.com/jdx/mr-boxington/pull/41))
- *(cache)* avoid rereading reflinked outputs ([#44](https://github.com/jdx/mr-boxington/pull/44))

### Changed

- *(protocol)* consume remote wire types and constants from `mbx-cache-protocol`
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.4.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.3.0...mbx-cache-rustc-v0.4.0) - 2026-08-25

### Added

- report compiler time saved and spent ([#59](https://github.com/jdx/mr-boxington/pull/59))
- support rustc response files ([#65](https://github.com/jdx/mr-boxington/pull/65))
- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))
- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))

### Other

- give every crate one synchronized version ([#86](https://github.com/jdx/mr-boxington/pull/86))
- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
- move inline tests into focused modules ([#42](https://github.com/jdx/mr-boxington/pull/42))
- define published Rust API surface ([#41](https://github.com/jdx/mr-boxington/pull/41))
</blockquote>

## `mbx`

<blockquote>

## [0.4.0](https://github.com/jdx/mr-boxington/compare/v0.3.0...v0.4.0) - 2026-08-25

### Added

- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
- explain the cache and its caps on the first build ([#74](https://github.com/jdx/mr-boxington/pull/74))
- report what mbx has saved on this machine ([#73](https://github.com/jdx/mr-boxington/pull/73))
- scale disk budgets to the disk and prune idle targets by default ([#72](https://github.com/jdx/mr-boxington/pull/72))
- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
- add JSON inspection output ([#60](https://github.com/jdx/mr-boxington/pull/60))
- add installation doctor ([#57](https://github.com/jdx/mr-boxington/pull/57))
- report compiler time saved and spent ([#59](https://github.com/jdx/mr-boxington/pull/59))
- complete setup lifecycle ([#61](https://github.com/jdx/mr-boxington/pull/61))
- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
- *(config)* add safe workspace policy ([#67](https://github.com/jdx/mr-boxington/pull/67))
- *(protocol)* share remote cache contract ([#68](https://github.com/jdx/mr-boxington/pull/68))
- explain cache bypasses ([#58](https://github.com/jdx/mr-boxington/pull/58))
- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))

### Fixed

- probe reflinks across the span the restore actually copies ([#84](https://github.com/jdx/mr-boxington/pull/84))
- deflake two tests that race the machine ([#82](https://github.com/jdx/mr-boxington/pull/82))
- restore the build after a merge skewed a verify call ([#71](https://github.com/jdx/mr-boxington/pull/71))

### Other

- give every crate one synchronized version ([#86](https://github.com/jdx/mr-boxington/pull/86))
- stop checking the CLI library's public API ([#77](https://github.com/jdx/mr-boxington/pull/77))
- wrap project cargo commands with mbx ([#34](https://github.com/jdx/mr-boxington/pull/34))
- *(deps)* bump the cargo-dependencies group across 1 directory with 2 updates ([#55](https://github.com/jdx/mr-boxington/pull/55))
- add Bats end-to-end harness ([#46](https://github.com/jdx/mr-boxington/pull/46))
- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
- move inline tests into focused modules ([#42](https://github.com/jdx/mr-boxington/pull/42))
- define published Rust API surface ([#41](https://github.com/jdx/mr-boxington/pull/41))
- *(cache)* avoid rereading reflinked outputs ([#44](https://github.com/jdx/mr-boxington/pull/44))
- *(config)* generate settings docs with usage-rs ([#30](https://github.com/jdx/mr-boxington/pull/30))

### Added

- *(cli)* run a Cargo command with actionable cache-bypass diagnostics using `mbx explain`

### Changed

- *(cache)* restore verified outputs with observable copy-on-write materialization
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only release PR; no runtime or behavioral changes in the diff itself.
> 
> **Overview**
> **Release bookkeeping only:** this PR adds dated **`0.4.0` (2026-08-25)** sections to the changelogs for `mbx`, `mbx-cache-core`, `mbx-cache-rustc`, and `mbx-cache-protocol`, moving the accumulated release notes out of **`[Unreleased]`** for the synchronized **0.3.0 → 0.4.0** bump (protocol crate at **0.4.0**).
> 
> The new entries **document** what ships in the tag—remote cache contract in `mbx-cache-protocol`, CLI/ops work (installation doctor, cache inspection, JSON output, disk budgets, setup lifecycle, `mbx explain`), rustc/wasm and response-file caching, compiler time reporting, and a few listed fixes (reflink probing, test deflaking)—without changing application code in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87753e84e29d20b5eb2b97d9edde7004ae0d49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->