### PR TITLE
ci: guard the last two workflows against overlapping runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,18 @@ on:
         required: true
         type: string
 
+# One asset upload per tag. `release-plz.yml` already serializes the runs it
+# starts itself, so this is about the dispatch entry point: re-running a failed
+# build by hand while the automated release is still uploading would have two
+# runs writing the same asset names. `--clobber` keeps that from erroring, but
+# the release would briefly carry a mix of two builds' files.
+#
+# Keyed by tag so re-running v0.1.0 never waits on v0.2.0, and not cancelling,
+# because a half-uploaded set of assets is the thing being avoided.
+concurrency:
+  group: release-assets-${{ inputs.tag }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,6 +5,13 @@ on:
 
 permissions: {}
 
+# Superseded pushes to a pull request have nothing to say: this only reads the
+# workflow files, so cancelling an in-flight run costs a result nobody wanted
+# and saves the runner. Same pattern as ci.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Audited all six workflows. Three already had the group they want; two did not.

| workflow | triggers | before | after |
| --- | --- | --- | --- |
| `ci.yml` | push, PR | cancels superseded runs per ref | unchanged — correct |
| `docs.yml` | push main, dispatch | queues Pages deploys per ref | unchanged — correct |
| `measure.yml` | push main, cron | serializes on one `performance-history` group | unchanged — correct |
| `release-plz.yml` | push main, dispatch | release job unguarded | fixed in #87 |
| `release.yml` | workflow_call, dispatch | **none** | `release-assets-<tag>`, no cancel |
| `zizmor.yml` | PR | **none** | cancels superseded runs per ref |

## `release.yml`

Uploads assets to a GitHub release. The runs `release-plz.yml` starts are already serialized by that workflow's group (#87), so this is about the **dispatch** entry point — re-running a failed build by hand while the automated release is still uploading puts two runs on the same asset names. `gh release upload --clobber` stops that from erroring, which makes the failure mode a quiet one: a release briefly carrying a mix of two builds' files.

Keyed by tag so re-running `v0.1.0` never queues behind `v0.2.0`; `cancel-in-progress: false` because a half-uploaded asset set is exactly what this prevents.

## `zizmor.yml`

Mutates nothing — it reads workflow files on pull requests. The only cost of overlap is runner time on results nobody will read, so it cancels superseded runs the way `ci.yml` does.

## Verification

- `actionlint` (with shellcheck) clean on both files — which also confirms `inputs.tag` is valid in a workflow-level `concurrency` expression.
- `zizmor --min-severity high` clean.
- Parsed both files to confirm the groups resolve as intended.

Complements #87; touches different files, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow metadata changes; no application or release logic is modified beyond run scheduling.
> 
> **Overview**
> Adds **GitHub Actions concurrency** to the two workflows that were still unguarded after the workflow audit.
> 
> **`release.yml`** now serializes runs per release tag (`release-assets-${{ inputs.tag }}`) with **`cancel-in-progress: false`**, so manual `workflow_dispatch` retries cannot overlap an in-flight automated upload and leave a release with a mixed set of clobbered assets. Different tags do not block each other.
> 
> **`zizmor.yml`** uses the same **`workflow-ref` group with cancel** as `ci.yml`, dropping superseded PR runs that only lint workflow files and save runner time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec3e87c5f616f285a74a43f11545fe49a62f17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->