### PR TITLE
ci: sign macOS release binaries

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -187,6 +187,9 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}
+    secrets:
+      CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
+      CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
   publish-release:
     name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
       tag:
         required: true
         type: string
+    secrets:
+      CERTIFICATES_P12:
+        required: true
+      CERTIFICATES_P12_PASS:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -65,6 +70,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Import macOS signing certificate
+        if: runner.os == 'macOS'
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
+
       - name: Bootstrap mbx
         shell: bash
         run: |
@@ -95,6 +107,17 @@ jobs:
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
         run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} build --release --locked --package mbx --target ${{ matrix.target }}
+
+      - name: Sign macOS binary
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          IDENTITY: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
+          BINARY: target/${{ matrix.target }}/release/${{ matrix.bin }}
+        run: |
+          codesign --force --sign "$IDENTITY" --options runtime --timestamp \
+            --prefix dev.jdx. "$BINARY"
+          codesign --verify --verbose=2 "$BINARY"
 
       - name: Check the binary runs
         # Every target but this one is native to its runner.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,6 +34,11 @@ These settings live outside the repository, and releases fail without them:
 - **`CRATES_IO_PUBLISH_NEW_TOKEN`** — a crates.io token restricted to the
   `publish-new` endpoint. It bootstraps `mbx-cache-protocol`, because trusted
   publishing cannot create a crate. Delete the secret after its first release.
+- **`CERTIFICATES_P12`** and **`CERTIFICATES_P12_PASS`** — the base64-encoded
+  Developer ID Application certificate and its password used by the other
+  jdx.dev CLI release workflows. The macOS jobs import the certificate and sign
+  `mbx` as `Developer ID Application: Jeffrey Dickey (4993Y37DX6)` before
+  creating the release archives.
 - **A crates.io Trusted Publisher for each of `mbx`, `mbx-cache-core`,
   `mbx-cache-protocol`, and `mbx-cache-rustc`**, naming this repository and the
   workflow file `release-plz.yml`. Configure the protocol publisher after its


### PR DESCRIPTION
## Summary

- import the shared jdx.dev Developer ID certificate in macOS release jobs
- sign and verify each macOS `mbx` binary before archiving
- forward and document the required certificate secrets

## Validation

- `mise exec actionlint@1.7.7 shellcheck@0.11.0 -- actionlint .github/workflows/release.yml .github/workflows/release-plz.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and handles signing credentials; failures or misconfigured secrets would block macOS assets from shipping, but scope is limited to CI and documented secrets.
> 
> **Overview**
> macOS release artifacts are now **Developer ID–signed** before they are archived, aligning `mbx` releases with other jdx.dev CLI workflows.
> 
> The reusable **`release.yml`** workflow declares required **`CERTIFICATES_P12`** / **`CERTIFICATES_P12_PASS`** secrets on `workflow_call`, imports the cert on macOS runners, then **`codesign`**s each built `mbx` binary (runtime hardening, timestamp, `dev.jdx.` prefix) and verifies the signature. **`release-plz.yml`** forwards those repo secrets into the upload-assets job. **`RELEASING.md`** documents the new release prerequisites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4eccf510f060b0c575424e5e0ca9ed80a429f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release builds by signing binaries with the required Developer ID certificate.
  * Added post-build signature verification to help ensure release artifacts are properly signed.

* **Documentation**
  * Documented the certificate prerequisites and signing process for macOS releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->