### PR TITLE
ci: stop building macOS x64 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,6 @@ jobs:
             os: macos-latest
             runner: namespace-profile-endev-macos-arm64
             bin: mbx
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-            bin: mbx
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             runner: windows-latest
@@ -97,8 +93,6 @@ jobs:
         run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} build --release --locked --package mbx --target ${{ matrix.target }}
 
       - name: Check the binary runs
-        # Every target but this one is native to its runner.
-        if: matrix.target != 'x86_64-apple-darwin'
         shell: bash
         run: ./target/${{ matrix.target }}/release/${{ matrix.bin }} --version
 
@@ -126,7 +120,7 @@ jobs:
 
   attach:
     name: Attach to release
-    # Needs every target: a release carrying four of five archives is worse
+    # Needs every target: a release carrying three of four archives is worse
     # than one that arrives late, and the draft stays unpublished either way.
     needs: build
     runs-on: namespace-profile-endev-linux-amd64

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ tar -xzf "$archive" -C ~/.local/bin
 )
 ```
 
-Release archives also cover Linux ARM64, Apple Silicon, Intel macOS, and
-Windows x86-64. Every release includes `SHA256SUMS`.
+Release archives also cover Linux ARM64, Apple Silicon, and Windows x86-64.
+Every release includes `SHA256SUMS`.
 
 [See all installation options →](https://mr-boxington.jdx.dev/getting-started)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,8 +25,8 @@ tar -xzf "$archive" -C ~/.local/bin
 )
 ```
 
-Release archives are also available for Linux ARM64, Apple Silicon, Intel macOS,
-and Windows x86-64. See [GitHub Releases](https://github.com/jdx/mr-boxington/releases)
+Release archives are also available for Linux ARM64, Apple Silicon, and Windows
+x86-64. See [GitHub Releases](https://github.com/jdx/mr-boxington/releases)
 for downloads and `SHA256SUMS`.
 
 ### Cargo


### PR DESCRIPTION
## Summary

- remove the x86_64 Apple Darwin target from release builds
- run the binary smoke test unconditionally for the remaining native targets
- remove Intel macOS from documented release archive availability

## Testing

- `mise run build:docs`
- `mise x actionlint@1.7.12 -- actionlint -shellcheck= -config-file .github/actionlint.yaml .github/workflows/release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; no runtime or packaging logic changes, and users on Intel Mac can still install via Cargo or mise.
> 
> **Overview**
> Stops shipping **Intel macOS** (`x86_64-apple-darwin`) release binaries by dropping that target from the release workflow matrix, so GitHub Releases now attach **four** platform archives instead of five.
> 
> The post-build **`--version` smoke test** runs for every remaining matrix entry (the old skip for cross-built Intel macOS on ARM runners is removed). **README** and **getting-started** no longer list Intel macOS among downloadable release archives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a980329dabfb90c8fbae912ba81e9935422c3e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->