### PR TITLE
feat: make landing demo interactive and tag output

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ mbx keeps a running total of what that has been worth and reports one line of
 it after a build:
 
 ```text
-mbx: 41.7 GiB of target/ had outlived its checkouts. it has been dealt with.
+mbx[savings]: 41.7 GiB of target/ had outlived its checkouts. it has been dealt with.
 ```
 
 The line is drawn from a pool, so it does not repeat itself. Prefer a build

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -530,7 +530,7 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     };
     if let Some(bytes) = removed_target_bytes {
         crate::session::note(&format!(
-            "freed {} by removing the existing target/ directory",
+            "mbx[gc]: freed {} by removing the existing target/ directory",
             ByteSize::b(bytes).display().iec()
         ));
     }
@@ -686,18 +686,18 @@ fn mark_explained(store: &Path) {
 /// rather than described.
 fn first_run_notice(config: &Config, retention: &RetentionSettings, reflinks: bool) -> String {
     let mut lines =
-        vec!["mbx: first build on this machine -- here is the arrangement:".to_string()];
+        vec!["mbx[setup]: first build on this machine -- here is the arrangement:".to_string()];
     // Collection is what the rest of this describes, so a machine that turned
     // it off is told what it has instead of what it does not.
     if config.gc.auto {
         lines.push(format!(
-            "mbx:   compiled work is cached once in {} and shared with every checkout and worktree; the store sweeps itself back to {}",
+            "mbx[setup]:   compiled work is cached once in {} and shared with every checkout and worktree; the store sweeps itself back to {}",
             config.cache_dir.display(),
             ByteSize::b(config.gc.max_bytes).display().iec(),
         ));
     } else {
         lines.push(format!(
-            "mbx:   compiled work is cached once in {} and shared with every checkout and worktree; automatic collection is off, so `mbx gc` is the only thing that reclaims it",
+            "mbx[setup]:   compiled work is cached once in {} and shared with every checkout and worktree; automatic collection is off, so `mbx gc` is the only thing that reclaims it",
             config.cache_dir.display(),
         ));
     }
@@ -706,7 +706,7 @@ fn first_run_notice(config: &Config, retention: &RetentionSettings, reflinks: bo
     // sharing that every restore will quietly turn into a copy.
     if reflinks {
         lines.push(
-            "mbx:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk"
+            "mbx[setup]:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk"
                 .to_string(),
         );
     }
@@ -725,12 +725,12 @@ fn first_run_notice(config: &Config, retention: &RetentionSettings, reflinks: bo
             ));
         }
         lines.push(format!(
-            "mbx:   target/ directories are managed and collected when {}",
+            "mbx[setup]:   target/ directories are managed and collected when {}",
             join_clauses(&reasons),
         ));
     }
     lines.push(
-        "mbx:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable".to_string(),
+        "mbx[setup]:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable".to_string(),
     );
 
     lines.join("\n")
@@ -1015,7 +1015,7 @@ fn sweep_store(config: &Config, retention: &RetentionSettings) -> crate::savings
             };
             delta.freed_store_bytes = outcome.removed_bytes;
             if outcome.removed_bytes > 0 {
-                crate::session::note(&format!("gc: {}", evictions(&outcome)));
+                crate::session::note(&format!("mbx[gc]: {}", evictions(&outcome)));
             }
         }
         Err(error) => {
@@ -1053,7 +1053,7 @@ fn prune_targets(
     ) {
         Ok(pruned) => {
             if pruned.removed_views > 0 {
-                crate::session::note(&format!("gc: {}", target_removals(&pruned, false)));
+                crate::session::note(&format!("mbx[gc]: {}", target_removals(&pruned, false)));
             }
             PruneReport {
                 remaining_bytes: Some(pruned.remaining_bytes),

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -286,7 +286,7 @@ impl Default for CliSettings {
 /// How the line about accumulated savings reads.
 ///
 /// The quips are the product's voice and the default; `plain` is the same
-/// facts in the register of the `cache:` and `gc:` lines beside them, for
+/// facts in the register of the `mbx[cache]:` and `mbx[gc]:` lines beside them, for
 /// people who want their build logs to keep a straight face; `off` keeps the
 /// totals without printing anything.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/mbx/src/main.rs
+++ b/crates/mbx/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> ExitCode {
     match mbx::cli::run() {
         Ok(code) => code,
         Err(error) => {
-            eprintln!("mbx: {error:#}");
+            eprintln!("mbx[error]: {error:#}");
             ExitCode::FAILURE
         }
     }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -93,7 +93,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
                         );
                     }
                     Err(error) => {
-                        eprintln!("mbx warning: compiler timing was not refreshed: {error:#}");
+                        eprintln!("mbx[warning]: compiler timing was not refreshed: {error:#}");
                     }
                 }
                 if verify {
@@ -106,7 +106,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             }
             Ok(None) => {}
             Err(error) => {
-                eprintln!("mbx warning: result was not restored: {error:#}");
+                eprintln!("mbx[warning]: result was not restored: {error:#}");
             }
         }
     }
@@ -130,7 +130,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             }
             Ok(None) => {}
             Err(error) => {
-                eprintln!("mbx warning: prediction was not restored: {error:#}");
+                eprintln!("mbx[warning]: prediction was not restored: {error:#}");
             }
         }
     }
@@ -166,7 +166,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
         let matched = cached_matches(&cached, &output);
         record_verification(matched, cached.restore);
         if !matched {
-            eprintln!("mbx warning: shadow verification diverged from cached output");
+            eprintln!("mbx[warning]: shadow verification diverged from cached output");
         }
         return Ok(exit_code(output.status));
     }
@@ -195,7 +195,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             Ok(())
         })();
         if let Err(error) = publication {
-            eprintln!("mbx warning: result was not stored: {error:#}");
+            eprintln!("mbx[warning]: result was not stored: {error:#}");
         }
     }
     Ok(exit_code(output.status))
@@ -408,7 +408,7 @@ fn record_prediction(
         Result::<()>::Ok(())
     })();
     if let Err(error) = result {
-        eprintln!("mbx warning: action prediction was not recorded: {error:#}");
+        eprintln!("mbx[warning]: action prediction was not recorded: {error:#}");
     }
 }
 
@@ -481,7 +481,7 @@ fn record_prediction_value(invocation: CacheDigest, action: CacheDigest, payload
         }
     })();
     if let Err(error) = result {
-        eprintln!("mbx warning: action prediction was not recorded: {error:#}");
+        eprintln!("mbx[warning]: action prediction was not recorded: {error:#}");
     }
 }
 
@@ -695,11 +695,11 @@ fn record_verification(matched: bool, restore: RestoreStats) {
     match responses.map(|responses| responses.into_iter().next()) {
         Ok(Some(AgentResponse::ActionVerificationRecorded)) => {}
         Ok(Some(AgentResponse::Error { message })) => {
-            eprintln!("mbx warning: verification was not recorded: {message}");
+            eprintln!("mbx[warning]: verification was not recorded: {message}");
         }
-        Ok(_) => eprintln!("mbx warning: verification was not recorded"),
+        Ok(_) => eprintln!("mbx[warning]: verification was not recorded"),
         Err(error) => {
-            eprintln!("mbx warning: verification was not recorded: {error:#}");
+            eprintln!("mbx[warning]: verification was not recorded: {error:#}");
         }
     }
 }
@@ -724,7 +724,7 @@ fn persist_outputs(staged: StagedOutputs) -> Result<()> {
                     Ok(()) => {}
                     Err(remove_error) if remove_error.kind() == std::io::ErrorKind::NotFound => {}
                     Err(remove_error) => eprintln!(
-                        "mbx warning: failed to roll back {}: {remove_error}",
+                        "mbx[warning]: failed to roll back {}: {remove_error}",
                         destination.display()
                     ),
                 }
@@ -743,11 +743,11 @@ fn record_action_hit(action: &CacheDigest, restore: RestoreStats) {
     match responses.map(|responses| responses.into_iter().next()) {
         Ok(Some(AgentResponse::ActionHitRecorded)) => {}
         Ok(Some(AgentResponse::Error { message })) => {
-            eprintln!("mbx warning: hit was not recorded: {message}");
+            eprintln!("mbx[warning]: hit was not recorded: {message}");
         }
-        Ok(_) => eprintln!("mbx warning: hit was not recorded"),
+        Ok(_) => eprintln!("mbx[warning]: hit was not recorded"),
         Err(error) => {
-            eprintln!("mbx warning: hit was not recorded: {error:#}");
+            eprintln!("mbx[warning]: hit was not recorded: {error:#}");
         }
     }
 }

--- a/crates/mbx/src/savings.rs
+++ b/crates/mbx/src/savings.rs
@@ -172,7 +172,7 @@ struct Candidate {
     /// The mascot's variants: a cache box in a monocle, deadpan, mentioning
     /// the chores exactly once. One is chosen at random per build.
     cheeky: Vec<String>,
-    /// The same fact in the register of the `cache:` and `gc:` lines.
+    /// The same fact in the register of the `mbx[cache]:` and `mbx[gc]:` lines.
     plain: String,
 }
 
@@ -194,21 +194,21 @@ fn facts_worth_telling(tally: &Tally, facts: &SessionFacts) -> Vec<Candidate> {
         let dur = nanos(facts.avoided_compiler_ns);
         eligible.push(Candidate {
             cheeky: tellings![
-                "mbx: served {hits} compilations from cache; rustc showed up ready to do {dur} of work and was sent home",
-                "mbx: {hits} compilations you did not wait for. the {dur} is yours now. spend it wisely.",
-                "mbx: this build borrowed {hits} compilations from an earlier one. rustc was not informed. ({dur} saved)",
-                "mbx: {hits} compilations arrived precompiled. somewhere a fan is not spinning. ({dur} saved)",
-                "mbx: cargo asked for {hits} compilations; mbx had them filed under already-done. ({dur} saved)",
-                "mbx: {hits} compilations replayed from cache. rustc's services were not required. ({dur} saved)",
-                "mbx: intercepted {hits} compilations before rustc could get attached. ({dur} saved)",
-                "mbx: rustc had {dur} of work planned. mbx had {hits} of its answers already.",
-                "mbx: {hits} compilations answered from memory. rustc can finish its coffee. ({dur} saved)",
-                "mbx: rustc arrived to find {hits} compilations already done. awkward. ({dur} saved)",
-                "mbx: quietly substituted {hits} cached compilations. nobody noticed. that is the job. ({dur} saved)",
-                "mbx: {hits} compilations in, zero compiled. {dur} returned to circulation.",
+                "mbx[savings]: served {hits} compilations from cache; rustc showed up ready to do {dur} of work and was sent home",
+                "mbx[savings]: {hits} compilations you did not wait for. the {dur} is yours now. spend it wisely.",
+                "mbx[savings]: this build borrowed {hits} compilations from an earlier one. rustc was not informed. ({dur} saved)",
+                "mbx[savings]: {hits} compilations arrived precompiled. somewhere a fan is not spinning. ({dur} saved)",
+                "mbx[savings]: cargo asked for {hits} compilations; mbx had them filed under already-done. ({dur} saved)",
+                "mbx[savings]: {hits} compilations replayed from cache. rustc's services were not required. ({dur} saved)",
+                "mbx[savings]: intercepted {hits} compilations before rustc could get attached. ({dur} saved)",
+                "mbx[savings]: rustc had {dur} of work planned. mbx had {hits} of its answers already.",
+                "mbx[savings]: {hits} compilations answered from memory. rustc can finish its coffee. ({dur} saved)",
+                "mbx[savings]: rustc arrived to find {hits} compilations already done. awkward. ({dur} saved)",
+                "mbx[savings]: quietly substituted {hits} cached compilations. nobody noticed. that is the job. ({dur} saved)",
+                "mbx[savings]: {hits} compilations in, zero compiled. {dur} returned to circulation.",
             ],
             plain: format!(
-                "savings: {hits} compilations restored from cache this build, avoiding {dur} of compiler time"
+                "mbx[savings]: {hits} compilations restored from cache this build, avoiding {dur} of compiler time"
             ),
         });
     }
@@ -217,91 +217,91 @@ fn facts_worth_telling(tally: &Tally, facts: &SessionFacts) -> Vec<Candidate> {
         let over = builds(tally.builds);
         eligible.push(Candidate {
             cheeky: tellings![
-                "mbx: {dur} of compiling skipped across {over}. rustc suspects nothing.",
-                "mbx: {dur} refunded over {over}. no receipt necessary.",
-                "mbx: rustc believes it compiled everything. it is down {dur} across {over}. let it believe.",
-                "mbx: has saved {dur} across {over}. this line is the only thanks it needs.",
-                "mbx: across {over}, rustc has been excused from {dur} of its duties.",
-                "mbx: {dur} not spent compiling, over {over}. what you did instead is between you and the terminal.",
-                "mbx: the running total stands at {dur} across {over}. nobody is counting except the box.",
-                "mbx: {dur} of compilation avoided across {over}. imagine the fan noise. now stop.",
-                "mbx: {dur} saved across {over}. put it toward something with a progress bar.",
-                "mbx: {dur} of rustc's calendar cleared across {over}.",
-                "mbx: {dur} unspent across {over}. compounding, in a sense.",
+                "mbx[savings]: {dur} of compiling skipped across {over}. rustc suspects nothing.",
+                "mbx[savings]: {dur} refunded over {over}. no receipt necessary.",
+                "mbx[savings]: rustc believes it compiled everything. it is down {dur} across {over}. let it believe.",
+                "mbx[savings]: has saved {dur} across {over}. this line is the only thanks it needs.",
+                "mbx[savings]: across {over}, rustc has been excused from {dur} of its duties.",
+                "mbx[savings]: {dur} not spent compiling, over {over}. what you did instead is between you and the terminal.",
+                "mbx[savings]: the running total stands at {dur} across {over}. nobody is counting except the box.",
+                "mbx[savings]: {dur} of compilation avoided across {over}. imagine the fan noise. now stop.",
+                "mbx[savings]: {dur} saved across {over}. put it toward something with a progress bar.",
+                "mbx[savings]: {dur} of rustc's calendar cleared across {over}.",
+                "mbx[savings]: {dur} unspent across {over}. compounding, in a sense.",
             ],
-            plain: format!("savings: {dur} of compiler time avoided across {over}"),
+            plain: format!("mbx[savings]: {dur} of compiler time avoided across {over}"),
         });
     }
     if freed >= MIN_FREED_BYTES {
         let size = iec(freed);
         eligible.push(Candidate {
             cheeky: tellings![
-                "mbx: {size} of build debris binned so far. cargo clean remains unemployed.",
-                "mbx: has quietly disposed of {size} of build leftovers. nobody saw anything.",
-                "mbx: {size} reclaimed to date. the disk sends its regards.",
-                "mbx: {size} of build debris has left the building.",
-                "mbx: swept up {size} so far. the broom is content-addressed.",
-                "mbx: {size} tidied away. you may continue not thinking about it.",
-                "mbx: {size} reclaimed while you were busy compiling other things.",
-                "mbx: {size} of old build output has been shown the door.",
-                "mbx: disposed of {size} without being asked. that is rather the point.",
-                "mbx: the sweep found {size} nobody would miss. nobody has.",
+                "mbx[savings]: {size} of build debris binned so far. cargo clean remains unemployed.",
+                "mbx[savings]: has quietly disposed of {size} of build leftovers. nobody saw anything.",
+                "mbx[savings]: {size} reclaimed to date. the disk sends its regards.",
+                "mbx[savings]: {size} of build debris has left the building.",
+                "mbx[savings]: swept up {size} so far. the broom is content-addressed.",
+                "mbx[savings]: {size} tidied away. you may continue not thinking about it.",
+                "mbx[savings]: {size} reclaimed while you were busy compiling other things.",
+                "mbx[savings]: {size} of old build output has been shown the door.",
+                "mbx[savings]: disposed of {size} without being asked. that is rather the point.",
+                "mbx[savings]: the sweep found {size} nobody would miss. nobody has.",
             ],
-            plain: format!("savings: {size} reclaimed by collection so far"),
+            plain: format!("mbx[savings]: {size} reclaimed by collection so far"),
         });
     }
     if tally.freed_target_bytes >= MIN_FREED_TARGET_BYTES {
         let size = iec(tally.freed_target_bytes);
         eligible.push(Candidate {
             cheeky: tellings![
-                "mbx: {size} of target/ had outlived its checkouts. it has been dealt with.",
-                "mbx: found {size} of target/ whose checkouts left long ago. the estate has been settled.",
-                "mbx: your deleted worktrees left {size} behind. left. past tense.",
-                "mbx: {size} of target/ belonged to checkouts that no longer exist. neither does it.",
-                "mbx: cleaned up {size} after checkouts that left without saying goodbye.",
-                "mbx: {size} of outputs had survived their checkouts. an unnatural state, now corrected.",
-                "mbx: the checkouts are gone. their {size} has gone to join them.",
-                "mbx: {size} of target/ was waiting for checkouts that are never coming back. it has stopped waiting.",
-                "mbx: escorted {size} of ownerless outputs off the premises.",
-                "mbx: worktrees come and go. their {size} now goes with them.",
+                "mbx[savings]: {size} of target/ had outlived its checkouts. it has been dealt with.",
+                "mbx[savings]: found {size} of target/ whose checkouts left long ago. the estate has been settled.",
+                "mbx[savings]: your deleted worktrees left {size} behind. left. past tense.",
+                "mbx[savings]: {size} of target/ belonged to checkouts that no longer exist. neither does it.",
+                "mbx[savings]: cleaned up {size} after checkouts that left without saying goodbye.",
+                "mbx[savings]: {size} of outputs had survived their checkouts. an unnatural state, now corrected.",
+                "mbx[savings]: the checkouts are gone. their {size} has gone to join them.",
+                "mbx[savings]: {size} of target/ was waiting for checkouts that are never coming back. it has stopped waiting.",
+                "mbx[savings]: escorted {size} of ownerless outputs off the premises.",
+                "mbx[savings]: worktrees come and go. their {size} now goes with them.",
             ],
-            plain: format!("savings: {size} of abandoned target directories reclaimed"),
+            plain: format!("mbx[savings]: {size} of abandoned target directories reclaimed"),
         });
     }
     if tally.reflinked_bytes >= MIN_REFLINKED_BYTES {
         let size = iec(tally.reflinked_bytes);
         eligible.push(Candidate {
             cheeky: tellings![
-                "mbx: every checkout believes it owns {size} of outputs. the disk keeps one copy and says nothing.",
-                "mbx: {size} of outputs, one copy, several very confident checkouts.",
-                "mbx: reflinked {size} into place. copying is for people with disk to spare.",
-                "mbx: {size} of outputs exist once and appear everywhere. do not tell the checkouts.",
-                "mbx: {size} of target/ is an elaborate illusion. the disk is in on it.",
-                "mbx: lent the same {size} to every checkout at once. none of them has checked.",
-                "mbx: {size} shared among checkouts that each believe they are an only child.",
-                "mbx: {size} on loan to every checkout simultaneously. the paperwork is an inode.",
-                "mbx: {size} of outputs materialized by reflink. the copy machine stays off.",
-                "mbx: {size} in every checkout, {size} on disk. arithmetic declined to comment.",
+                "mbx[savings]: every checkout believes it owns {size} of outputs. the disk keeps one copy and says nothing.",
+                "mbx[savings]: {size} of outputs, one copy, several very confident checkouts.",
+                "mbx[savings]: reflinked {size} into place. copying is for people with disk to spare.",
+                "mbx[savings]: {size} of outputs exist once and appear everywhere. do not tell the checkouts.",
+                "mbx[savings]: {size} of target/ is an elaborate illusion. the disk is in on it.",
+                "mbx[savings]: lent the same {size} to every checkout at once. none of them has checked.",
+                "mbx[savings]: {size} shared among checkouts that each believe they are an only child.",
+                "mbx[savings]: {size} on loan to every checkout simultaneously. the paperwork is an inode.",
+                "mbx[savings]: {size} of outputs materialized by reflink. the copy machine stays off.",
+                "mbx[savings]: {size} in every checkout, {size} on disk. arithmetic declined to comment.",
             ],
-            plain: format!("savings: {size} of outputs reflinked rather than copied"),
+            plain: format!("mbx[savings]: {size} of outputs reflinked rather than copied"),
         });
     }
     if tally.cached_compilations >= MIN_CACHED_COMPILATIONS {
         let count = tally.cached_compilations;
         eligible.push(Candidate {
             cheeky: tellings![
-                "mbx: {count} compilations, each compiled once and served warm ever since",
-                "mbx: {count} cache hits and counting. rustc thinks it has been busy.",
-                "mbx: {count} compilations on file. the box remembers.",
-                "mbx: {count} compilations old. not one compiled twice.",
-                "mbx: {count} compilations served. the monocle stays on.",
-                "mbx: {count} compilations dispensed from stock. inventory immaculate.",
-                "mbx: {count} compilations, and the box has forgotten none of them.",
-                "mbx: {count} compilations retrieved with a straight face.",
-                "mbx: {count} compilations. rustc did each once; mbx did the rest of the showing up.",
-                "mbx: {count} compilations served. ask rustc how many it remembers doing.",
+                "mbx[savings]: {count} compilations, each compiled once and served warm ever since",
+                "mbx[savings]: {count} cache hits and counting. rustc thinks it has been busy.",
+                "mbx[savings]: {count} compilations on file. the box remembers.",
+                "mbx[savings]: {count} compilations old. not one compiled twice.",
+                "mbx[savings]: {count} compilations served. the monocle stays on.",
+                "mbx[savings]: {count} compilations dispensed from stock. inventory immaculate.",
+                "mbx[savings]: {count} compilations, and the box has forgotten none of them.",
+                "mbx[savings]: {count} compilations retrieved with a straight face.",
+                "mbx[savings]: {count} compilations. rustc did each once; mbx did the rest of the showing up.",
+                "mbx[savings]: {count} compilations served. ask rustc how many it remembers doing.",
             ],
-            plain: format!("savings: {count} compilations served from cache to date"),
+            plain: format!("mbx[savings]: {count} compilations served from cache to date"),
         });
     }
     eligible

--- a/crates/mbx/src/savings_tests.rs
+++ b/crates/mbx/src/savings_tests.rs
@@ -290,7 +290,7 @@ fn plain_style_states_the_fact_without_the_bit() {
     for _ in 0..20 {
         let line = quip(&tally, &busy_session(), SavingsStyle::Plain).unwrap();
         assert!(
-            line.starts_with("savings: "),
+            line.starts_with("mbx[savings]: "),
             "plain lines read like the cache/gc notes: {line:?}"
         );
     }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -417,7 +417,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         return;
     }
     note(&format!(
-        "cache: {} hits, {} misses, {} prefetched; {} downloaded, {} uploaded, {} stored locally",
+        "mbx[cache]: {} hits, {} misses, {} prefetched; {} downloaded, {} uploaded, {} stored locally",
         stats.hits,
         cache_misses(stats),
         stats.prefetched_actions,
@@ -431,7 +431,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         // reads as though the cache was asked and had nothing, rather than that
         // it was never asked. These compilations are still stored afterwards.
         note(&format!(
-            "cache could not look up {} compilations: no usable dep-info from an earlier build and no prediction to derive an action key from",
+            "mbx[cache]: could not look up {} compilations: no usable dep-info from an earlier build and no prediction to derive an action key from",
             stats.unconsulted,
         ));
     }
@@ -445,7 +445,9 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
             .map(|(kind, count)| format!("{count} {kind}"))
             .collect::<Vec<_>>()
             .join(", ");
-        note(&format!("cache bypassed {total} compilations: {detail}"));
+        note(&format!(
+            "mbx[cache]: bypassed {total} compilations: {detail}"
+        ));
     }
     if !stats.compiler.is_empty() || stats.avoided_compiler_duration_ns > 0 {
         let spent = stats.compiler.values().fold(0_u64, |total, compiler| {
@@ -465,14 +467,14 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
             .collect::<Vec<_>>()
             .join(", ");
         note(&format!(
-            "compiler time: {} estimated avoided; {} spent ({detail})",
+            "mbx[cache]: compiler time: {} estimated avoided; {} spent ({detail})",
             format_nanos(stats.avoided_compiler_duration_ns),
             format_nanos(spent),
         ));
         let slow = slow_compilations(stats);
         if !slow.is_empty() {
             note(&format!(
-                "slowest uncached crates: {}",
+                "mbx[cache]: slowest uncached crates: {}",
                 slow.into_iter()
                     .map(|(name, duration)| format!("{name} {}", format_nanos(*duration)))
                     .collect::<Vec<_>>()
@@ -484,7 +486,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         .remote_manifest_lookup_duration_ns
         .saturating_add(stats.remote_action_lookup_duration_ns);
     note(&format!(
-        "cache timing: {} session, {} prefetch; cumulative {} remote lookup, {} blob transfer, {} CAS write, {} materialization",
+        "mbx[cache]: timing: {} session, {} prefetch; cumulative {} remote lookup, {} blob transfer, {} CAS write, {} materialization",
         format_nanos(stats.session_duration_ns),
         format_nanos(stats.prefetch_duration_ns),
         format_nanos(remote_lookup_duration_ns),
@@ -494,7 +496,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
     ));
     if stats.restored_output_files > 0 {
         note(&format!(
-            "cache materialization: {} outputs ({}) reflinked, {} outputs ({}) copied",
+            "mbx[cache]: materialization: {} outputs ({}) reflinked, {} outputs ({}) copied",
             stats.reflinked_output_files,
             ByteSize::b(stats.reflinked_output_bytes).display().iec(),
             stats.copied_output_files,
@@ -503,7 +505,7 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
     }
     if stats.verifications > 0 {
         note(&format!(
-            "cache qualification: {} verified, {} diverged",
+            "mbx[cache]: qualification: {} verified, {} diverged",
             stats.verifications, stats.divergences,
         ));
     }
@@ -867,7 +869,7 @@ pub fn is_rustc_shim() -> bool {
 pub fn run_rustc_shim() -> ExitCode {
     let mut arguments = std::env::args_os().skip(1);
     let Some(rustc) = arguments.next() else {
-        eprintln!("mbx: the rustc shim expected the rustc executable as its first argument");
+        eprintln!("mbx[error]: the rustc shim expected the rustc executable as its first argument");
         return ExitCode::from(1);
     };
     let arguments = arguments.collect::<Vec<_>>();
@@ -877,7 +879,7 @@ pub fn run_rustc_shim() -> ExitCode {
             Err(error) => {
                 record_bypass(&error);
                 #[cfg(debug_assertions)]
-                eprintln!("mbx: rustc cache bypassed: {error:#}");
+                eprintln!("mbx[warning]: rustc cache bypassed: {error:#}");
             }
         }
     }
@@ -905,7 +907,7 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
         use std::os::unix::process::CommandExt as _;
 
         let error = command.exec();
-        eprintln!("mbx: the rustc shim failed to execute rustc: {error}");
+        eprintln!("mbx[error]: the rustc shim failed to execute rustc: {error}");
         ExitCode::from(1)
     }
     #[cfg(windows)]
@@ -937,7 +939,7 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
                 unsafe { windows_sys::Win32::System::Threading::ExitProcess(exit_code) }
             }
             Err(error) => {
-                eprintln!("mbx: the rustc shim failed to execute rustc: {error}");
+                eprintln!("mbx[error]: the rustc shim failed to execute rustc: {error}");
                 ExitCode::from(1)
             }
         }
@@ -1032,7 +1034,7 @@ fn append_bypass_log(kind: &str, error: &eyre::Report) {
         static WARNED: std::sync::Once = std::sync::Once::new();
         WARNED.call_once(|| {
             eprintln!(
-                "mbx warning: {BYPASS_LOG_ENV} was not written ({}): {problem}",
+                "mbx[warning]: {BYPASS_LOG_ENV} was not written ({}): {problem}",
                 Path::new(&path).display()
             );
         });

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -647,7 +647,7 @@ fn a_build_sweeps_the_store_to_its_budget() {
     );
 
     assert!(
-        stderr.contains("gc: evicted"),
+        stderr.contains("mbx[gc]: evicted"),
         "the sweep should say what it evicted: {stderr}"
     );
     let stats = mbx(store.path(), &["cache", "stats"]);
@@ -675,7 +675,10 @@ fn automatic_sweeps_can_be_turned_off() {
         ],
     );
 
-    assert!(!stderr.contains("gc:"), "no sweep should run: {stderr}");
+    assert!(
+        !stderr.contains("mbx[gc]:"),
+        "no sweep should run: {stderr}"
+    );
     let stats = mbx(store.path(), &["cache", "stats"]);
     assert!(
         !stats.contains("objects: 0"),

--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -46,16 +46,16 @@ onMounted(() => {
       >
         <div v-if="buildsRun === 0" class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
         <template v-if="buildsRun >= 1">
-          <div class="build-output">
+          <div class="build-output cold-build">
             <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
             <div class="line"><span class="verb">   Compiling</span> libc v0.2.174</div>
             <div class="line"><span class="verb">   Compiling</span> serde v1.0.219</div>
             <div class="line dim">            … 193 more crates …</div>
             <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time">3m 41s</span></div>
+            <div aria-hidden="true" class="line gap"></div>
+            <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">git worktree add ../review &amp;&amp; cd ../review</span></div>
+            <div v-if="buildsRun === 1" class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
           </div>
-          <div aria-hidden="true" class="line gap"></div>
-          <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">git worktree add ../review &amp;&amp; cd ../review</span></div>
-          <div v-if="buildsRun === 1" class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
         </template>
         <template v-if="buildsRun >= 2">
           <div class="build-output warm-build">
@@ -149,6 +149,10 @@ onMounted(() => {
 .build-output .line:nth-child(3) { animation-delay: 0.4s; }
 .build-output .line:nth-child(4) { animation-delay: 0.55s; }
 .build-output .line:nth-child(5) { animation-delay: 0.85s; }
+
+.cold-build .line:nth-child(6) { animation-delay: 0.85s; }
+.cold-build .line:nth-child(7) { animation-delay: 1.05s; }
+.cold-build .line:nth-child(8) { animation-delay: 1.25s; }
 
 .warm-build .line:nth-child(2) { animation-delay: 0.35s; }
 .warm-build .line:nth-child(3) { animation-delay: 0.55s; }

--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -18,6 +18,13 @@ const quips = [
 // Leave the SSR render empty so hydration agrees, then make the one random
 // choice in the browser. The line arrives with the rest of the transcript.
 const quip = ref("");
+const buildsRun = ref(0);
+
+function runBuild() {
+  if (buildsRun.value < 2) {
+    buildsRun.value += 1;
+  }
+}
 onMounted(() => {
   quip.value = quips[Math.floor(Math.random() * quips.length)];
 });
@@ -33,22 +40,36 @@ onMounted(() => {
         <span class="label">two checkouts · one cache</span>
       </div>
       <div
-        aria-label="Terminal transcript: the first checkout compiles every crate in 3 minutes 41 seconds; a fresh worktree finishes in 4.9 seconds with 191 cache hits, and mbx adds one deadpan line about what the cache has saved over time"
+        aria-live="polite"
         class="screen"
-        role="img"
+        role="log"
       >
-        <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
-        <div class="line"><span class="verb">   Compiling</span> libc v0.2.174</div>
-        <div class="line"><span class="verb">   Compiling</span> serde v1.0.219</div>
-        <div class="line dim">            … 193 more crates …</div>
-        <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time">3m 41s</span></div>
-        <div aria-hidden="true" class="line gap"></div>
-        <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">git worktree add ../review &amp;&amp; cd ../review</span></div>
-        <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
-        <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time fast">4.9s</span></div>
-        <div class="line cache">cache: 191 hits, 3 misses, 187 prefetched; 0 B downloaded, 0 B uploaded, 412.6 MiB stored locally</div>
-        <div class="line quip">{{ quip }}</div>
-        <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
+        <div v-if="buildsRun === 0" class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
+        <template v-if="buildsRun >= 1">
+          <div class="build-output">
+            <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
+            <div class="line"><span class="verb">   Compiling</span> libc v0.2.174</div>
+            <div class="line"><span class="verb">   Compiling</span> serde v1.0.219</div>
+            <div class="line dim">            … 193 more crates …</div>
+            <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time">3m 41s</span></div>
+          </div>
+          <div aria-hidden="true" class="line gap"></div>
+          <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">git worktree add ../review &amp;&amp; cd ../review</span></div>
+          <div v-if="buildsRun === 1" class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
+        </template>
+        <template v-if="buildsRun >= 2">
+          <div class="build-output warm-build">
+            <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
+            <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time fast">4.9s</span></div>
+            <div class="line cache">cache: 191 hits, 3 misses, 187 prefetched; 0 B downloaded, 0 B uploaded, 412.6 MiB stored locally</div>
+            <div class="line quip">{{ quip }}</div>
+            <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
+          </div>
+        </template>
+      </div>
+      <div v-if="buildsRun < 2" class="controls">
+        <button class="run" type="button" @click="runBuild">run cargo build</button>
+        <span class="progress">build {{ buildsRun + 1 }} of 2</span>
       </div>
     </div>
     <p class="caption">The second checkout never compiles what the first already did — locally or in CI.</p>
@@ -123,18 +144,16 @@ onMounted(() => {
   white-space: pre;
 }
 
-.line:nth-child(1) { animation-delay: 0.25s; }
-.line:nth-child(2) { animation-delay: 0.85s; }
-.line:nth-child(3) { animation-delay: 1.15s; }
-.line:nth-child(4) { animation-delay: 1.45s; }
-.line:nth-child(5) { animation-delay: 2.2s; }
-.line:nth-child(6) { animation-delay: 2.2s; }
-.line:nth-child(7) { animation-delay: 2.7s; }
-.line:nth-child(8) { animation-delay: 3.5s; }
-.line:nth-child(9) { animation-delay: 4.1s; }
-.line:nth-child(10) { animation-delay: 4.55s; }
-.line:nth-child(11) { animation-delay: 5.05s; }
-.line:nth-child(12) { animation-delay: 5.45s; }
+.build-output .line:nth-child(1) { animation-delay: 0.05s; }
+.build-output .line:nth-child(2) { animation-delay: 0.25s; }
+.build-output .line:nth-child(3) { animation-delay: 0.4s; }
+.build-output .line:nth-child(4) { animation-delay: 0.55s; }
+.build-output .line:nth-child(5) { animation-delay: 0.85s; }
+
+.warm-build .line:nth-child(2) { animation-delay: 0.35s; }
+.warm-build .line:nth-child(3) { animation-delay: 0.55s; }
+.warm-build .line:nth-child(4) { animation-delay: 0.75s; }
+.warm-build .line:nth-child(5) { animation-delay: 0.95s; }
 
 .gap {
   height: 0.9em;
@@ -184,12 +203,59 @@ onMounted(() => {
 }
 
 .cursor {
-  animation: mbx-line-in 0.45s ease 5.45s both, mbx-blink 1.1s steps(1) 5.9s infinite;
+  animation: mbx-blink 1.1s steps(1) infinite;
   background: var(--vp-c-brand-1);
   display: inline-block;
   height: 1.1em;
   vertical-align: text-bottom;
   width: 0.55em;
+}
+
+.controls {
+  align-items: center;
+  border-top: 1px solid rgb(var(--mbx-amber-rgb) / 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px 20px 20px;
+}
+
+.run {
+  background: linear-gradient(135deg, var(--mbx-amber-bright), var(--mbx-amber-deep));
+  border: 0;
+  border-radius: 9px;
+  box-shadow: 0 12px 28px -12px rgb(var(--mbx-amber-rgb) / 0.75);
+  color: var(--mbx-ink);
+  cursor: pointer;
+  font-family: var(--vp-font-family-mono);
+  font-size: 17px;
+  font-weight: 700;
+  min-height: 48px;
+  padding: 12px 28px;
+  transition: box-shadow 0.2s ease, filter 0.2s ease, transform 0.2s ease;
+}
+
+.run:hover {
+  box-shadow: 0 16px 34px -12px rgb(var(--mbx-amber-rgb) / 0.9);
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+
+.run:active {
+  transform: translateY(1px);
+}
+
+.run:focus-visible {
+  outline: 3px solid var(--mbx-teal-light);
+  outline-offset: 3px;
+}
+
+.progress {
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .caption {

--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -6,14 +6,14 @@ import { onMounted, ref } from "vue";
 // line is drawn at random per build. Pick one when the demo mounts and keep it
 // for the lifetime of the page, just like one invocation of mbx would.
 const quips = [
-  "mbx: served 191 compilations from cache; rustc showed up ready to do 3m 36s of work and was sent home",
-  "mbx: 6h 14m of compiling skipped across 87 builds. rustc suspects nothing.",
-  "mbx: 47.0 GiB of build debris binned so far. cargo clean remains unemployed.",
-  "mbx: your deleted worktrees left 41.0 GiB behind. left. past tense.",
-  "mbx: every checkout believes it owns 22.0 GiB of outputs. the disk keeps one copy and says nothing.",
-  "mbx: 4312 compilations on file. the box remembers.",
-  "mbx: rustc believes it compiled everything. it is down 6h 14m across 87 builds. let it believe.",
-  "mbx: 22.0 GiB in every checkout, 22.0 GiB on disk. arithmetic declined to comment.",
+  "mbx[savings]: served 191 compilations from cache; rustc showed up ready to do 3m 36s of work and was sent home",
+  "mbx[savings]: 6h 14m of compiling skipped across 87 builds. rustc suspects nothing.",
+  "mbx[savings]: 47.0 GiB of build debris binned so far. cargo clean remains unemployed.",
+  "mbx[savings]: your deleted worktrees left 41.0 GiB behind. left. past tense.",
+  "mbx[savings]: every checkout believes it owns 22.0 GiB of outputs. the disk keeps one copy and says nothing.",
+  "mbx[savings]: 4312 compilations on file. the box remembers.",
+  "mbx[savings]: rustc believes it compiled everything. it is down 6h 14m across 87 builds. let it believe.",
+  "mbx[savings]: 22.0 GiB in every checkout, 22.0 GiB on disk. arithmetic declined to comment.",
 ];
 // Leave the SSR render empty so hydration agrees, then make the one random
 // choice in the browser. The line arrives with the rest of the transcript.
@@ -61,7 +61,7 @@ onMounted(() => {
           <div class="build-output warm-build">
             <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
             <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time fast">4.9s</span></div>
-            <div class="line cache">cache: 191 hits, 3 misses, 187 prefetched; 0 B downloaded, 0 B uploaded, 412.6 MiB stored locally</div>
+            <div class="line cache">mbx[cache]: 191 hits, 3 misses, 187 prefetched; 0 B downloaded, 0 B uploaded, 412.6 MiB stored locally</div>
             <div class="line quip">{{ quip }}</div>
             <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
           </div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,11 +57,11 @@ configuration and nothing to tune before the first build.
 The first build on a machine says what it arranged:
 
 ```text
-mbx: first build on this machine -- here is the arrangement:
-mbx:   compiled work is cached once in /home/you/.cache/mbx and shared with every checkout and worktree; the store sweeps itself back to 50.0 GiB
-mbx:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk
-mbx:   target/ directories are managed and collected when their checkout disappears, they sit unused for 30 days, or they together outgrow 100.0 GiB
-mbx:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable
+mbx[setup]: first build on this machine -- here is the arrangement:
+mbx[setup]:   compiled work is cached once in /home/you/.cache/mbx and shared with every checkout and worktree; the store sweeps itself back to 50.0 GiB
+mbx[setup]:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk
+mbx[setup]:   target/ directories are managed and collected when their checkout disappears, they sit unused for 30 days, or they together outgrow 100.0 GiB
+mbx[setup]:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable
 ```
 
 The budgets are a share of the disk holding the cache, so the numbers above
@@ -86,9 +86,9 @@ exit unsuccessfully.
 After a build that used the cache, mbx prints a summary to stderr:
 
 ```text
-cache: 139 hits, 8 misses, 147 prefetched; 312.4 MiB downloaded, 0 B uploaded, 280.1 MiB stored locally
-cache could not look up 4 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from
-cache bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
+mbx[cache]: 139 hits, 8 misses, 147 prefetched; 312.4 MiB downloaded, 0 B uploaded, 280.1 MiB stored locally
+mbx[cache]: could not look up 4 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from
+mbx[cache]: bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
 ```
 
 These are three different outcomes: a miss means mbx looked up an action and


### PR DESCRIPTION
## Summary

- start the landing-page terminal demo at an idle prompt
- add a prominent `run cargo build` button that advances one build per click
- reveal the cold build first and the cached worktree build on the second click
- tag mbx output consistently by category, including `mbx[cache]:` and `mbx[savings]:`
- keep the demo, CLI output, tests, and documentation in sync

## Verification

- `cargo test -p mbx`
- `mise run check:docs`
- `mise run build:docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly stderr copy and documentation; the only behavioral risk is tooling that matched the old unprefixed `cache:`/`gc:`/`mbx:` strings.
> 
> **Overview**
> **User-visible mbx messages now use a single `mbx[category]:` prefix** so build logs are easier to scan and filter. Categories include **`mbx[cache]:`** (hits, bypasses, timing), **`mbx[gc]:`** (sweeps and target cleanup), **`mbx[setup]:`** (first-run arrangement), **`mbx[savings]:`** (quips and plain savings lines), **`mbx[warning]:`**, and **`mbx[error]:`**. Plain savings style now uses the same prefix instead of a bare `savings:` line. README, getting-started, integration tests, and unit tests were updated to match.
> 
> The **docs home terminal demo** no longer auto-plays the full transcript: it starts at an idle prompt, exposes a **run cargo build** control that advances **build 1 of 2** then **2 of 2**, and reveals the cold compile/worktree setup on the first click and the fast cached build (including `mbx[cache]:` and a random `mbx[savings]:` quip) on the second. The terminal region uses **`aria-live`** / **`role="log"`** for accessibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ed96fd22c400f4bdf3c279da161aab92efdfe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->