### PR TITLE
docs: simplify the landing page for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,18 @@ mbx clippy --workspace     # cargo clippy --workspace, with caching
 mbx gc --dry-run           # preview what cleanup would reclaim
 ```
 
-The first build explains what it set up — where the cache lives, the budget it
-sweeps itself back to, and when a `target/` directory becomes collectable.
+The first build prints what it set up — where the cache lives, the budget it
+is pruned to, and when a `target/` directory becomes collectable.
 
 ## Why mbx?
 
 - **Warm every worktree.** Cache keys contain no checkout-specific absolute
   paths, so building one checkout warms its siblings automatically without
   sharing a Cargo target lock.
-- **Bounded disk, without a chore.** The action store sweeps itself back to a
-  budget, and managed `target/` directories go when their checkout disappears,
-  when they sit unused for 30 days, or when they outgrow their share of the
-  disk. Both budgets scale with the disk rather than assuming every machine is
-  the same size.
+- **Bounded disk, without a chore.** The action store prunes itself to a
+  budget, and managed `target/` directories are deleted when their checkout is
+  gone, unused for 30 days, or over their share of the disk. Both budgets
+  scale with the disk rather than assuming every machine is the same size.
 - **Warm CI safely.** GitHub Actions cache can warm fork pull requests from a
   cache built on `main`, while a self-hosted remote can serve trusted runners
   and teammates. Pull requests never publish remote objects.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ cargo install mbx
 Or install the latest Linux x86-64 release archive:
 
 ```sh
-(
-set -e
 mkdir -p ~/.local/bin
 archive=mbx-x86_64-unknown-linux-musl.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
@@ -75,7 +73,6 @@ curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
 grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
-)
 ```
 
 Release archives also cover Linux ARM64, Apple Silicon, and Windows x86-64.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">mr boxington</h1>
 
 <p align="center">
-  <strong><code>target/</code>, fixed: shared, self-pruning, drop-in.</strong><br>
-  Put mbx in front of any Cargo command. Compiled work is shared across worktrees and CI, build storage keeps itself inside a budget, and mbx tells you what it saved.
+  <strong>fix <code>target/</code></strong><br>
+  Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget.
 </p>
 
 <p align="center">
@@ -55,7 +55,7 @@ sweeps itself back to, and when a `target/` directory becomes collectable.
 With [mise](https://mise.jdx.dev):
 
 ```sh
-mise use -g github:jdx/mr-boxington
+mise use -g mr-boxington
 ```
 
 With Cargo:
@@ -100,10 +100,9 @@ it after a build:
 mbx[savings]: 41.7 GiB of target/ had outlived its checkouts. it has been dealt with.
 ```
 
-The line is drawn from a pool, so it does not repeat itself. Prefer a build
-log with a straight face? `savings = "plain"` states the same facts dryly, and
-`savings = "off"` keeps the totals without printing anything (`MBX_SAVINGS`
-from the environment). Inspect or collect the store explicitly with:
+The line is drawn from a pool, so it does not repeat itself. `savings =
+"plain"` states the same facts without the joke, and `savings = "off"` keeps
+the totals without printing anything (`MBX_SAVINGS` from the environment). Inspect or collect the store explicitly with:
 
 ```sh
 mbx cache stats

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ target directory.
 For GitHub-hosted CI, [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
 can install mbx and use GitHub Actions cache, saving only from the default
 branch and restoring in pull requests. Trusted environments can switch the
-same action to a compatible remote such as
-[`jdx/mbx-cache`](https://github.com/jdx/mbx-cache).
+same action to a compatible remote such as the self-hostable
+[cache server](https://mr-boxington.jdx.dev/cache-server).
 
 [Configure GitHub Actions →](https://mr-boxington.jdx.dev/github-actions)
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@
   <a href="PLAN.md">Road to v1</a>
 </p>
 
-> [!WARNING]
-> mr boxington is pre-1.0. The cache format and behavior may change without
-> notice, and releases are not a stability promise.
-
 `mbx` wraps ordinary Cargo commands with a content-addressed rustc cache. Cargo
 still resolves dependencies, plans builds, and links outputs; mbx restores
 supported compilations it has seen before. There is nothing to configure and

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -685,19 +685,18 @@ fn mark_explained(store: &Path) {
 /// be wrong on most machines. A limit somebody turned off is left unmentioned
 /// rather than described.
 fn first_run_notice(config: &Config, retention: &RetentionSettings, reflinks: bool) -> String {
-    let mut lines =
-        vec!["mbx[setup]: first build on this machine -- here is the arrangement:".to_string()];
+    let mut lines = vec!["mbx[setup]: first build on this machine".to_string()];
     // Collection is what the rest of this describes, so a machine that turned
     // it off is told what it has instead of what it does not.
     if config.gc.auto {
         lines.push(format!(
-            "mbx[setup]:   compiled work is cached once in {} and shared with every checkout and worktree; the store sweeps itself back to {}",
+            "mbx[setup]:   cache is {}, shared by every checkout and worktree, pruned to {}",
             config.cache_dir.display(),
             ByteSize::b(config.gc.max_bytes).display().iec(),
         ));
     } else {
         lines.push(format!(
-            "mbx[setup]:   compiled work is cached once in {} and shared with every checkout and worktree; automatic collection is off, so `mbx gc` is the only thing that reclaims it",
+            "mbx[setup]:   cache is {}, shared by every checkout and worktree; automatic collection is off, so only `mbx gc` reclaims it",
             config.cache_dir.display(),
         ));
     }
@@ -706,31 +705,29 @@ fn first_run_notice(config: &Config, retention: &RetentionSettings, reflinks: bo
     // sharing that every restore will quietly turn into a copy.
     if reflinks {
         lines.push(
-            "mbx[setup]:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk"
+            "mbx[setup]:   this filesystem supports reflinks, so target/ shares disk with the cache instead of copying"
                 .to_string(),
         );
     }
     if config.target.views && config.gc.auto {
-        let mut reasons = vec!["their checkout disappears".to_string()];
+        let mut reasons = vec!["its checkout is gone".to_string()];
         if let Some(age) = retention.target_max_age {
-            reasons.push(format!(
-                "they sit unused for {}",
-                crate::util::format_span(age)
-            ));
+            reasons.push(format!("unused for {}", crate::util::format_span(age)));
         }
         if let Some(bytes) = retention.target_max_bytes {
             reasons.push(format!(
-                "they together outgrow {}",
+                "over {} total",
                 ByteSize::b(bytes).display().iec()
             ));
         }
         lines.push(format!(
-            "mbx[setup]:   target/ directories are managed and collected when {}",
+            "mbx[setup]:   target/ is managed: deleted when {}",
             join_clauses(&reasons),
         ));
     }
     lines.push(
-        "mbx[setup]:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable".to_string(),
+        "mbx[setup]:   `mbx gc --dry-run` previews cleanup; every limit is configurable"
+            .to_string(),
     );
 
     lines.join("\n")

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -715,10 +715,7 @@ fn first_run_notice(config: &Config, retention: &RetentionSettings, reflinks: bo
             reasons.push(format!("unused for {}", crate::util::format_span(age)));
         }
         if let Some(bytes) = retention.target_max_bytes {
-            reasons.push(format!(
-                "over {} total",
-                ByteSize::b(bytes).display().iec()
-            ));
+            reasons.push(format!("over {} total", ByteSize::b(bytes).display().iec()));
         }
         lines.push(format!(
             "mbx[setup]:   target/ is managed: deleted when {}",

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -537,7 +537,7 @@ fn the_first_run_notice_states_the_resolved_caps() {
     assert!(notice.contains("12.0 GiB"), "{notice}");
     assert!(notice.contains("25.0 GiB"), "{notice}");
     assert!(notice.contains("30 days"), "{notice}");
-    assert!(notice.contains("their checkout disappears"), "{notice}");
+    assert!(notice.contains("its checkout is gone"), "{notice}");
 }
 
 #[test]
@@ -552,9 +552,9 @@ fn the_first_run_notice_omits_limits_that_are_off() {
 
     let notice = first_run_notice(&config, &retention, false);
 
-    assert!(notice.contains("their checkout disappears"), "{notice}");
-    assert!(!notice.contains("sit unused"), "{notice}");
-    assert!(!notice.contains("outgrow"), "{notice}");
+    assert!(notice.contains("its checkout is gone"), "{notice}");
+    assert!(!notice.contains("unused for"), "{notice}");
+    assert!(!notice.contains("GiB total"), "{notice}");
 }
 
 #[test]
@@ -566,11 +566,8 @@ fn the_first_run_notice_does_not_promise_collection_that_is_off() {
     let notice = first_run_notice(&config, &RetentionSettings::default(), false);
 
     assert!(notice.contains("automatic collection is off"), "{notice}");
-    assert!(!notice.contains("sweeps itself back to"), "{notice}");
-    assert!(
-        !notice.contains("target/ directories are managed"),
-        "{notice}"
-    );
+    assert!(!notice.contains("pruned to"), "{notice}");
+    assert!(!notice.contains("target/ is managed"), "{notice}");
 }
 
 #[test]
@@ -581,8 +578,8 @@ fn the_first_run_notice_skips_targets_it_does_not_manage() {
 
     let notice = first_run_notice(&config, &RetentionSettings::default(), false);
 
-    assert!(!notice.contains("target/ directories"), "{notice}");
-    assert!(notice.contains("sweeps itself back to"), "{notice}");
+    assert!(!notice.contains("target/ is managed"), "{notice}");
+    assert!(notice.contains("pruned to"), "{notice}");
 }
 
 #[test]
@@ -593,8 +590,8 @@ fn the_first_run_notice_promises_reflinks_only_when_proven() {
     let with = first_run_notice(&config, &RetentionSettings::default(), true);
     let without = first_run_notice(&config, &RetentionSettings::default(), false);
 
-    assert!(with.contains("can reflink"), "{with}");
-    assert!(with.contains("one copy on disk"), "{with}");
+    assert!(with.contains("supports reflinks"), "{with}");
+    assert!(with.contains("instead of copying"), "{with}");
     // A machine whose filesystem copies must not be told its restores are
     // free; silence beats a promise the disk will break.
     assert!(!without.contains("reflink"), "{without}");

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -90,7 +90,7 @@ export default defineConfig({
             ],
           },
           { text: "prefetch", link: "/cli/prefetch" },
-          { text: "CLI configuration", link: "/cli/configuration" },
+          { text: "Settings", link: "/configuration#settings" },
         ],
       },
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,8 @@ export default defineConfig({
         text: "Understand mbx",
         items: [
           { text: "How it works", link: "/how-it-works" },
+          { text: "How mbx compares", link: "/compared" },
+          { text: "Stability", link: "/stability" },
           { text: "Protocol compatibility", link: "/protocol-compatibility" },
           { text: "Cache results", link: "/cache-results" },
           { text: "Limits", link: "/limits" },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitepress";
+import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 
 const configDir = dirname(fileURLToPath(import.meta.url));
 const cargoToml = readFileSync(resolve(configDir, "../../Cargo.toml"), "utf8");
@@ -22,6 +23,11 @@ export default defineConfig({
   },
   sitemap: {
     hostname: "https://mr-boxington.jdx.dev",
+  },
+  markdown: {
+    config(md) {
+      md.use(tabsMarkdownPlugin);
+    },
   },
   themeConfig: {
     logo: "/logo.svg",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -18,6 +18,9 @@ export default defineConfig({
   lastUpdated: true,
   appearance: "force-dark",
   cleanUrls: true,
+  // The configuration reference is embedded into /configuration with an
+  // @include rather than shipped as its own page.
+  srcExclude: ["cli/configuration.md"],
   rewrites: {
     "cli/cache.md": "cli/cache/index.md",
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,6 +62,12 @@ export default defineConfig({
         ],
       },
       {
+        text: "Cookbook",
+        items: [
+          { text: "CI with fork pull requests", link: "/cookbook/fork-prs" },
+        ],
+      },
+      {
         text: "Understand mbx",
         items: [
           { text: "How it works", link: "/how-it-works" },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -58,6 +58,7 @@ export default defineConfig({
           { text: "Configuration", link: "/configuration" },
           { text: "GitHub Actions", link: "/github-actions" },
           { text: "Remote cache", link: "/remote-cache" },
+          { text: "Cache server", link: "/cache-server" },
           { text: "Managed targets", link: "/managed-targets" },
         ],
       },

--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -72,7 +72,7 @@ onMounted(() => {
         <span class="progress">build {{ buildsRun + 1 }} of 2</span>
       </div>
     </div>
-    <p class="caption">The second checkout never compiles what the first already did — locally or in CI.</p>
+    <p class="caption">Whatever one checkout compiles, the next one reuses — locally or in CI.</p>
   </section>
 </template>
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -220,10 +220,10 @@ body::after {
 .VPFeature .icon {
   background: linear-gradient(160deg, rgb(var(--mbx-amber-rgb) / 0.22), rgb(var(--mbx-teal-rgb) / 0.16));
   border: 1px solid rgb(var(--mbx-amber-rgb) / 0.25);
-  border-radius: 10px;
+  border-radius: 16px;
   font-size: 26px;
-  height: 52px;
-  width: 52px;
+  height: 88px;
+  width: 88px;
 }
 
 .VPFeature .title {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
+import { enhanceAppWithTabs } from "vitepress-plugin-tabs/client";
 import { h, onMounted, onUnmounted } from "vue";
 import { data as starsData } from "../stars.data";
 import EndevFooter from "./EndevFooter.vue";
@@ -16,7 +17,8 @@ export default {
       "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],
     });
   },
-  enhanceApp() {
+  enhanceApp({ app }) {
+    enhanceAppWithTabs(app);
     initBanner();
   },
   setup() {

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -11,6 +11,12 @@ importers:
       vitepress:
         specifier: ^1.6.3
         version: 1.6.4
+      vitepress-plugin-tabs:
+        specifier: ^0.9.1
+        version: 0.9.1(vitepress@1.6.4)(vue@3.5.41)
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.41
 
 packages:
 
@@ -792,6 +798,12 @@ packages:
       terser:
         optional: true
 
+  vitepress-plugin-tabs@0.9.1:
+    resolution: {integrity: sha512-cRys9pWhyl5YnxXZ3BAdSDW8DriuXBewYhmUu4bBlnzksEDjzbKUwbNi30T74Vi1UXnY1a19Ap6DJDTOWJWdzA==}
+    peerDependencies:
+      vitepress: ^1.0.0 || ^2.0.0-alpha.17
+      vue: ^3.5.0
+
   vitepress@1.6.4:
     resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
     hasBin: true
@@ -1553,6 +1565,11 @@ snapshots:
       rollup: 4.62.5
     optionalDependencies:
       fsevents: 2.3.3
+
+  vitepress-plugin-tabs@0.9.1(vitepress@1.6.4)(vue@3.5.41):
+    dependencies:
+      vitepress: 1.6.4
+      vue: 3.5.41
 
   vitepress@1.6.4:
     dependencies:

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -33,7 +33,7 @@ mbx explain build --workspace
 
 The command preserves Cargo's exit status after printing the explanation.
 
-## Why hit rate is not the whole story
+## Reading the hit rate
 
 A build can report a high hit rate among attempted lookups while spending most
 of its time on actions that were not looked up or were bypassed. Read all three

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -43,6 +43,38 @@ Native link steps always run, so an otherwise warm native binary build still
 has work to do. Binaries, tests, and `cdylib`s for supported self-contained
 WebAssembly targets are the exception and may be restored as hits.
 
+## Troubleshooting a low hit rate
+
+Run the build through `mbx explain` first — it collects the per-action
+records, groups identical causes, and prints guidance for each category:
+
+```sh
+mbx explain build --workspace
+```
+
+The usual causes, roughly in the order they show up:
+
+- **The store is cold.** A first build has no dep-info to derive keys from, so
+  "could not look up" dominates and everything is stored rather than restored.
+  The second build is the honest measurement.
+- **Incremental builds are enabled.** With `MBX_INCREMENTAL=1`, workspace
+  members compile incrementally, those compilations bypass the cache, and the
+  changed artifacts make crates above them miss too. See
+  [limits](/limits#incremental-compilations-are-not-cached).
+- **Link steps always run.** Native binaries, tests, and dylibs re-link even
+  when every compilation hit, so a warm build of a large binary still takes
+  time. Self-contained WebAssembly targets are the exception.
+- **The inputs actually differ.** A different toolchain, feature set, profile,
+  or `RUSTFLAGS` between two checkouts is a different key, and the summary
+  reports it as an ordinary miss. `cargo tree` and comparing the two commands
+  usually finds it.
+- **Build-script output paths.** A crate that embeds its `OUT_DIR` produces
+  checkout-specific inputs for its dependents. `MBX_SHARE_OUT_DIR=1` remaps
+  it; see [limits](/limits#out_dir-sharing-is-opt-in).
+- **CI restored nothing.** On GitHub Actions, check that the cache step
+  actually restored an entry — a changed `cache-generation` or a fresh
+  repository starts empty by design.
+
 ## Compiler time
 
 The session summary reports real compiler time by outcome and an estimate of

--- a/docs/cache-server.md
+++ b/docs/cache-server.md
@@ -1,0 +1,149 @@
+# Cache server
+
+[`jdx/mr-boxington-cache`](https://github.com/jdx/mr-boxington-cache) is the
+self-hostable remote cache server. It implements version 1 of the mbx
+action-cache protocol — immutable blobs, atomic action-result commits,
+namespace isolation, and streaming blob packs — and also serves
+[mise](https://mise.jdx.dev)'s task cache. Any server implementing the
+[protocol](/protocol-compatibility) works with mbx; this page documents the
+reference implementation.
+
+## Run it
+
+The repository's development stack starts the service, PostgreSQL, and MinIO:
+
+```sh
+docker compose up --build
+```
+
+For a standalone instance with filesystem storage:
+
+```sh
+cargo install mbx-cache
+mbx-cache \
+  --allow-anonymous \
+  --data-dir ./data \
+  --listen 127.0.0.1:8080
+```
+
+Anonymous access is intended only for a trusted local network. Production
+installations should terminate TLS at an ingress or proxy and configure
+tokens. The repository ships a Helm chart for horizontally scaled Kubernetes
+deployments and a Terraform-managed single-host example.
+
+Clients connect as described in [remote cache](/remote-cache): a `[remote]`
+URL, a required namespace, and a token or OIDC audience.
+
+## Configuration
+
+Every option has a matching environment variable and CLI flag; run
+`mbx-cache --help` for the complete list.
+
+| Environment variable | Default | Purpose |
+| --- | ---: | --- |
+| `MBX_CACHE_LISTEN` | `0.0.0.0:8080` | Listen address |
+| `MBX_CACHE_STORAGE` | `filesystem` | `filesystem` or `s3` |
+| `MBX_CACHE_DATA_DIR` | `/var/lib/mbx-cache` | Filesystem blob root |
+| `MBX_CACHE_DATABASE_URL` | `memory://` | PostgreSQL URL or development memory store |
+| `MBX_CACHE_S3_BUCKET` | — | Required for S3 storage |
+| `MBX_CACHE_S3_PREFIX` | `v1` | Object-key prefix |
+| `MBX_CACHE_S3_ENDPOINT` | AWS default | S3-compatible endpoint |
+| `MBX_CACHE_S3_REGION` | `us-east-1` | S3 region |
+| `MBX_CACHE_S3_PATH_STYLE` | `false` | Enable for MinIO and similar services |
+| `MBX_CACHE_TOKENS_JSON` | — | Static token grants |
+| `MBX_CACHE_OIDC_PROVIDERS_JSON` | — | Trusted OIDC providers and claim grants |
+| `MBX_CACHE_ALLOW_ANONYMOUS` | `false` | Allow access without configured grants |
+| `MBX_CACHE_MAX_BLOB_BYTES` | `5368709120` | Maximum upload size |
+
+AWS credentials use the standard SDK credential chain, including environment
+variables, workload identity, ECS, and EC2 roles.
+
+## Authorization
+
+Authorization is deny-by-default. Namespace patterns may be an exact name,
+`*`, or a prefix ending in `/*`.
+
+### Static tokens
+
+`MBX_CACHE_TOKENS_JSON` is an array of grants:
+
+```json
+[
+  {
+    "token": "replace-with-a-secret",
+    "read": ["acme/*", "public"],
+    "write": ["acme/project-a"]
+  }
+]
+```
+
+Rotate tokens by deploying the old and new grants together, moving clients to
+the new token, then removing the old grant. Inject the JSON through a secret
+rather than writing it into deployment configuration.
+
+### OIDC
+
+OIDC lets CI use short-lived identity tokens instead of stored secrets.
+Configure trusted issuers, acceptable audiences, and claim-based grants:
+
+```json
+[
+  {
+    "issuer": "https://token.actions.githubusercontent.com",
+    "audiences": ["https://cache.example.com"],
+    "rules": [
+      {
+        "claims": {
+          "repository": "acme/backend",
+          "repository_owner_id": "12345"
+        },
+        "read": ["acme/backend"],
+        "write": ["acme/backend"]
+      }
+    ]
+  }
+]
+```
+
+The server discovers the issuer's JWKS endpoint and verifies the signature,
+issuer, audience, expiry, not-before time, and subject before applying the
+first matching rule. Rules are alternatives; every claim within a rule must
+match exactly. Pin stable identity claims such as GitHub's numeric
+`repository_owner_id` alongside the repository name — names can be reclaimed,
+the ID cannot — and add `ref` or `environment` claims when only a narrower
+workflow identity should write. Symmetric JWT algorithms are never accepted.
+
+On the client side, mbx acquires the GitHub Actions job token itself: set
+`MBX_REMOTE_OIDC_AUDIENCE`, or use
+[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) with
+`backend: server` as shown in [GitHub Actions](/github-actions#cache-server).
+
+## Operations
+
+Blob storage is expired by the bucket's own lifecycle rule; the server removes
+the metadata those objects leave behind and exits without serving:
+
+```sh
+mbx-cache --sweep-metadata-older-than-days 35
+```
+
+Keep the sweep age longer than the storage lifecycle so objects expire first.
+A dangling reference is never fatal — a client that cannot fetch a blob treats
+the action as a miss and recompiles.
+
+Multiple stateless replicas can run against the same PostgreSQL database and
+S3 bucket. Readiness and liveness probes use `/v1/status`, and `/metrics`
+exposes Prometheus counters for actions, blobs, and blob-pack transfers with
+fixed, low-cardinality labels — namespaces, tokens, and digests never appear
+as labels. The server has no deletion endpoint; retention and disaster
+recovery are administrative concerns (back up PostgreSQL, use bucket
+versioning or replication as required).
+
+## Protocol
+
+The wire protocol — endpoints, media types, canonical hashing, and the
+evolution rules — is documented in
+[protocol compatibility](/protocol-compatibility). The
+[repository README](https://github.com/jdx/mr-boxington-cache) covers
+implementation details beyond it, including blob-pack framing and validation
+behavior.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -6,7 +6,7 @@ Read from, in ascending precedence — the last one that names a setting wins:
 - `<config directory>/mbx/config.toml` (global), toml
 
 
-## `bypass_log`
+### `bypass_log`
 
 - **Type:** `option<path>`
 - **Optional:** true
@@ -15,7 +15,7 @@ Read from, in ascending precedence — the last one that names a setting wins:
 
 Append the full reason for every bypassed compilation to this path.
 
-## `cache_dir`
+### `cache_dir`
 
 - **Type:** `option<path>`
 - **Optional:** true
@@ -24,7 +24,7 @@ Append the full reason for every bypassed compilation to this path.
 
 Cache root.
 
-## `gc.auto`
+### `gc.auto`
 
 - **Type:** `bool`
 - **Default:** `true`
@@ -32,7 +32,7 @@ Cache root.
 
 Sweep after a build when collection is due.
 
-## `gc.interval`
+### `gc.interval`
 
 - **Type:** `duration`
 - **Default:** `1h`
@@ -40,7 +40,7 @@ Sweep after a build when collection is due.
 
 Minimum interval between automatic sweeps.
 
-## `gc.max_size`
+### `gc.max_size`
 
 - **Type:** `option<string>`
 - **Optional:** true
@@ -49,7 +49,7 @@ Minimum interval between automatic sweeps.
 
 Action-store budget.
 
-## `gc.max_total_size`
+### `gc.max_total_size`
 
 - **Type:** `option<string>`
 - **Optional:** true
@@ -57,7 +57,7 @@ Action-store budget.
 
 Combined action-store and managed-target budget, or "none".
 
-## `http.download_timeout`
+### `http.download_timeout`
 
 - **Type:** `duration`
 - **Default:** `10m`
@@ -65,7 +65,7 @@ Combined action-store and managed-target budget, or "none".
 
 Blob download timeout.
 
-## `http.retries`
+### `http.retries`
 
 - **Type:** `int`
 - **Default:** `3`
@@ -73,7 +73,7 @@ Blob download timeout.
 
 Request retries.
 
-## `http.timeout`
+### `http.timeout`
 
 - **Type:** `duration`
 - **Default:** `30s`
@@ -81,7 +81,7 @@ Request retries.
 
 Connect and request timeout.
 
-## `incremental`
+### `incremental`
 
 - **Type:** `bool`
 - **Default:** `false`
@@ -89,7 +89,7 @@ Connect and request timeout.
 
 Let local workspace members compile incrementally.
 
-## `remote.mode`
+### `remote.mode`
 
 - **Type:** `string`
 - **Default:** `read-write`
@@ -103,7 +103,7 @@ Remote access mode.
 - `write-only`
 
 
-## `remote.namespace`
+### `remote.namespace`
 
 - **Type:** `option<string>`
 - **Optional:** true
@@ -111,7 +111,7 @@ Remote access mode.
 
 Remote namespace; required when a URL is configured.
 
-## `remote.oidc_audience`
+### `remote.oidc_audience`
 
 - **Type:** `option<string>`
 - **Optional:** true
@@ -119,7 +119,7 @@ Remote namespace; required when a URL is configured.
 
 CI OIDC audience.
 
-## `remote.token`
+### `remote.token`
 
 - **Type:** `option<string>`
 - **Optional:** true
@@ -127,7 +127,7 @@ CI OIDC audience.
 
 Bearer token for the remote cache.
 
-## `remote.token_file`
+### `remote.token_file`
 
 - **Type:** `option<path>`
 - **Optional:** true
@@ -135,7 +135,7 @@ Bearer token for the remote cache.
 
 File containing a bearer token.
 
-## `remote.url`
+### `remote.url`
 
 - **Type:** `option<url>`
 - **Optional:** true
@@ -143,7 +143,7 @@ File containing a bearer token.
 
 Remote cache URL.
 
-## `savings`
+### `savings`
 
 - **Type:** `string`
 - **Default:** `quips`
@@ -157,7 +157,7 @@ How the savings line after a build reads.
 - `off`
 
 
-## `share_out_dir`
+### `share_out_dir`
 
 - **Type:** `bool`
 - **Default:** `false`
@@ -165,7 +165,7 @@ How the savings line after a build reads.
 
 Share eligible compilations that read `OUT_DIR`.
 
-## `stats_report`
+### `stats_report`
 
 - **Type:** `option<path>`
 - **Optional:** true
@@ -173,7 +173,7 @@ Share eligible compilations that read `OUT_DIR`.
 
 Write a JSON build report to this path.
 
-## `target.max_age`
+### `target.max_age`
 
 - **Type:** `duration`
 - **Default:** `30d`
@@ -181,7 +181,7 @@ Write a JSON build report to this path.
 
 Collect live managed targets unused this long, or "none".
 
-## `target.max_size`
+### `target.max_size`
 
 - **Type:** `option<string>`
 - **Optional:** true
@@ -190,7 +190,7 @@ Collect live managed targets unused this long, or "none".
 
 Managed-target budget, or "none". Live views are collected oldest-first.
 
-## `target.root`
+### `target.root`
 
 - **Type:** `option<path>`
 - **Optional:** true
@@ -199,7 +199,7 @@ Managed-target budget, or "none". Live views are collected oldest-first.
 
 Managed target root.
 
-## `target.views`
+### `target.views`
 
 - **Type:** `bool`
 - **Default:** `true`
@@ -207,7 +207,7 @@ Managed target root.
 
 Let mbx place eligible target directories under the managed root.
 
-## `verify`
+### `verify`
 
 - **Type:** `bool`
 - **Default:** `false`

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -27,4 +27,4 @@
 
 ## Configuration
 
-- [Settings](/cli/configuration.md)
+- [Settings](/configuration#settings)

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -1,0 +1,52 @@
+# How mbx compares
+
+## sccache
+
+[sccache](https://github.com/mozilla/sccache) is the established compiler
+cache, and it aims wider: it caches C, C++, and CUDA alongside Rust and can
+distribute compilation across machines. mbx only caches rustc, and spends that
+narrower scope on problems sccache does not attempt:
+
+- **No daemon.** sccache runs a background server that builds talk to. mbx
+  starts an in-process agent for each command and exits with it; there is
+  nothing to start, restart, or leave running.
+- **Managed `target/` directories.** mbx stores outputs once in a
+  content-addressed store, reflinks them into each checkout's `target/`, and
+  collects directories whose checkout is gone. sccache caches compilations but
+  leaves every `target/` to grow on its own.
+- **Keys built for worktrees.** Workspace, registry, toolchain, and sysroot
+  paths are mapped to placeholders before they enter a key, so equivalent
+  checkouts share compilations even when their absolute paths differ.
+- **Per-build accounting.** Every build reports hits, misses, lookups it could
+  not attempt, and deliberate bypasses, so a low hit rate has a visible cause
+  rather than a global counter.
+- **CI write policy.** The client itself refuses to publish remote objects
+  from pull requests, unprotected branches, and tag builds, on top of whatever
+  the server enforces.
+
+If you need C/C++ caching or distributed compilation, sccache is the right
+tool. Both wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
+the same build.
+
+## Tarball CI caches
+
+Actions such as `actions/cache` over `target/` (or `Swatinem/rust-cache`)
+save and restore the whole directory as one archive. That is simple and needs
+no extra tooling, but the archive is all-or-nothing: one changed crate still
+uploads and downloads everything, the entry grows until it hits the platform's
+size cap, and stale artifacts accumulate inside it.
+
+mbx restores exactly the actions a build needs from a store it prunes itself.
+[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) uses
+GitHub Actions cache as the transport for that store, so it composes the
+per-action granularity with the platform cache you already have. See
+[GitHub Actions](/github-actions).
+
+## Cargo's incremental compilation
+
+Incremental compilation speeds up recompiling the crate you are editing inside
+one checkout. It does nothing across checkouts, worktrees, or CI runners, and
+its artifacts are checkout-specific by design. mbx solves the complementary
+problem — the dependency graph, everywhere — and leaves the inner loop to
+rustc. The two interact: see
+[incremental builds](/configuration#incremental-builds).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,8 +3,8 @@
 mbx loads environment variables over `.mbx.toml` at the resolved Cargo
 workspace root, then `mbx/config.toml` in the platform configuration directory,
 then defaults. This honors platform and XDG overrides through the operating
-system's configuration-directory lookup. Unknown TOML keys are rejected so
-misspelled settings do not silently do nothing.
+system's configuration-directory lookup. Unknown TOML keys are rejected, so a
+misspelled setting is an error rather than a silent no-op.
 
 ## Disk-scaled defaults
 
@@ -72,8 +72,9 @@ types, defaults, choices, and environment-only diagnostics—is generated from
 the same usage-rs declaration mbx uses at runtime. See
 [CLI configuration reference](/cli/configuration).
 
-`MBX_VERIFY=1` is deliberately slower. It qualifies correctness; it is not a
-normal build mode.
+`MBX_VERIFY=1` compiles and consults the cache side by side and compares the
+results. It is deliberately expensive — use it to qualify correctness, not for
+everyday builds.
 
 ## Explicit remote prefetch
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,12 +66,7 @@ credentials, diagnostics, target placement, and garbage collection are not
 accepted from a repository-owned file. mbx reports an error instead of applying
 an unsafe or misspelled workspace setting.
 
-## Settings
-
-The complete settings reference—including TOML keys, environment variables,
-types, defaults, choices, and environment-only diagnostics—is generated from
-the same usage-rs declaration mbx uses at runtime. See
-[CLI configuration reference](/cli/configuration).
+## Verify mode
 
 `MBX_VERIFY=1` compiles and consults the cache side by side and compares the
 results. It is deliberately expensive — use it to qualify correctness, not for
@@ -96,3 +91,12 @@ disables it because a fresh runner has no incremental state to reuse.
 
 Sizes accept SI and IEC units. `20GB` and `20GiB` are different values. Durations
 accept values such as `30s`, `15m`, and `1h`.
+
+## Settings
+
+Every setting, generated from the same usage-rs declaration mbx uses at
+runtime.
+
+<!-- The line range skips the generated header and file-precedence preamble;
+     the top of this page describes precedence more completely. -->
+<!--@include: ./cli/configuration.md{9,}-->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ Every value below is optional; these are shown set explicitly.
 cache_dir = "/var/cache/mbx"
 incremental = false
 share_out_dir = false
+savings = "quips"        # or "plain", "off"
 
 [gc]
 auto = true
@@ -76,19 +77,13 @@ the same usage-rs declaration mbx uses at runtime. See
 results. It is deliberately expensive — use it to qualify correctness, not for
 everyday builds.
 
-## Explicit remote prefetch
+## The savings line
 
-After a command has published its action manifest, another machine can warm
-the same build without running Cargo:
-
-```sh
-mbx prefetch build --workspace --release
-```
-
-The workspace's `Cargo.lock` and complete Cargo argument list select the same
-manifest as a normal mbx build. Prefetch requires a configured remote in
-`read-only` or `read-write` mode, waits for every predicted action, and returns
-an error when the manifest lookup fails.
+`savings` controls the one-line report of accumulated savings after a build
+(`MBX_SAVINGS` from the environment). `quips` — the default — draws the line
+from a pool of dry one-liners, `plain` states the same facts in the register
+of the other `mbx[...]` lines, and `off` keeps the totals without printing
+anything.
 
 ## Incremental builds
 

--- a/docs/cookbook/fork-prs.md
+++ b/docs/cookbook/fork-prs.md
@@ -1,0 +1,92 @@
+# CI with fork pull requests
+
+Open-source repositories take pull requests from forks, and forks change what
+a CI run may hold: GitHub withholds secrets and OIDC tokens from
+fork-triggered runs, so a fork's job cannot authenticate to a
+[cache server](/remote-cache). mbx's own [write policy](/remote-cache#read-and-write-policy)
+already keeps every pull request read-only — the remaining question is which
+backend each run should use.
+
+The recipe: trusted runs talk to the cache server, fork pull requests fall
+back to GitHub Actions cache, which needs no credentials.
+
+```yaml
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  id-token: write # GitHub withholds OIDC from fork runs on its own
+
+env:
+  # A fork PR cannot mint an OIDC token, so it uses the GitHub backend.
+  MBX_BACKEND: >-
+    ${{ github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository
+        && 'github' || 'server' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Optional: a push to main also saves the local store into GitHub
+      # Actions cache, so fork PRs restore warm despite never reaching the
+      # server. The github backend only saves from the default branch, so
+      # the event guard is all this step needs.
+      - name: Mirror the store for fork pull requests
+        if: github.event_name == 'push'
+        uses: jdx/mr-boxington-action@v1
+        with:
+          backend: github
+      - uses: jdx/mr-boxington-action@v1
+        with:
+          backend: ${{ env.MBX_BACKEND }}
+          server-url: https://cache.example.com
+          namespace: acme/backend
+          oidc-audience: mbx-cache
+      - run: mbx test --workspace
+```
+
+## How it works
+
+- **The backend expression** treats pushes and same-repository pull requests
+  as trusted — both come from people with push access — and everything else
+  as a fork. Fork runs get the [GitHub Actions cache backend](/github-actions),
+  which restores without credentials and never lets a pull request save.
+- **`id-token: write` is safe to declare at the workflow level.** GitHub
+  refuses to issue OIDC tokens to fork-triggered runs regardless of the
+  declared permission, which is exactly why the fork path must not pick the
+  server backend: it would fail asking for a token it can never have.
+- **The mirror step** is what keeps fork PRs warm. Their runs can restore only
+  from GitHub Actions cache, and nothing would ever populate it if every
+  trusted build used the server alone. Running the github backend alongside
+  the server on `main` pushes saves the store after the build (action steps
+  clean up in reverse order, so the mirror's save runs last), and fork PRs
+  restore that entry.
+
+## Hardening
+
+The single-workflow recipe above trusts the platform to withhold fork
+credentials. Projects that want the trust boundary to be structural rather
+than conditional split it in two: a router workflow whose `trusted` and
+`untrusted` jobs are mutually exclusive, each calling a shared
+`workflow_call` implementation with different permissions and inputs.
+[tak's ci.yml](https://github.com/jdx/tak/blob/main/.github/workflows/ci.yml)
+is a living example. What the split buys:
+
+- An untrusted run never declares `id-token: write` at all, and its first step
+  can assert `ACTIONS_ID_TOKEN_REQUEST_URL` is absent rather than assume it.
+- Trust can be narrower than "same repository" — tak only trusts one account,
+  so a compromised collaborator token still cannot reach the server.
+- Each trust level can use its own runner pool, keeping fork code off
+  self-hosted runners.
+- A `final` job asserts that exactly one route ran and succeeded, giving
+  branch protection a single required check.
+
+Whichever shape you use, pin third-party actions to full commit SHAs in a real
+workflow — a mutable tag can be retargeted at any time.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,8 +14,6 @@ mise use -g mr-boxington
 == Linux x86-64
 
 ```sh
-(
-set -e
 mkdir -p ~/.local/bin
 archive=mbx-x86_64-unknown-linux-musl.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
@@ -23,14 +21,11 @@ curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
 grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
-)
 ```
 
 == Linux ARM64
 
 ```sh
-(
-set -e
 mkdir -p ~/.local/bin
 archive=mbx-aarch64-unknown-linux-musl.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
@@ -38,14 +33,11 @@ curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
 grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
-)
 ```
 
 == macOS
 
 ```sh
-(
-set -e
 mkdir -p ~/.local/bin
 archive=mbx-aarch64-apple-darwin.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
@@ -53,7 +45,6 @@ curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
 grep "  $archive$" SHA256SUMS | shasum -a 256 --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
-)
 ```
 
 == Windows
@@ -85,11 +76,15 @@ cargo install mbx
 
 ## Supported platforms
 
-Release binaries cover Linux x86-64 and ARM64 (static musl builds), macOS on
-Apple Silicon, and Windows x86-64; other platforms with a Rust toolchain can
-build from source with `cargo install mbx`. mbx wraps whichever Cargo and
-rustc are active, including rustup-managed toolchains — `mbx doctor` reports
-the pair it found.
+Release binaries cover:
+
+- Linux x86-64 and ARM64 (static musl builds)
+- macOS on Apple Silicon
+- Windows x86-64
+
+Other platforms with a Rust toolchain can build from source with
+`cargo install mbx`. mbx wraps whichever Cargo and rustc are active, including
+rustup-managed toolchains — `mbx doctor` reports the pair it found.
 
 Reflinked output restoration needs a filesystem with copy-on-write file
 cloning: APFS on macOS, btrfs or XFS on Linux, ReFS (Dev Drive) on Windows.
@@ -136,6 +131,18 @@ or disable each limit.
 
 ```sh
 mbx doctor
+```
+
+```text
+  ok  cargo        cargo 1.98.0 (797e8a9bc 2026-08-05)
+  ok  rustc        rustc 1.98.0 (88d9e12ae 2026-08-18)
+  ok  cache        /home/you/.cache/mbx is writable
+  ok  config       20.0 GiB budget, automatic gc enabled, managed targets enabled at /home/you/.cache/mbx/targets
+  ok  reflink      supported by the cache filesystem
+  ok  setup        no plain-cargo wrapper installed; mbx wraps cargo directly
+  ok  remote       not configured; using the local cache
+
+0 failures, 0 warnings
 ```
 
 Doctor checks the Cargo and rustc executables, cache write access, filesystem

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,8 @@ mise use -g mr-boxington
 
 ### Release archive
 
-Linux x86-64:
+:::tabs
+== Linux x86-64
 
 ```sh
 (
@@ -25,9 +26,56 @@ tar -xzf "$archive" -C ~/.local/bin
 )
 ```
 
-Release archives are also available for Linux ARM64, Apple Silicon, and Windows
-x86-64. See [GitHub Releases](https://github.com/jdx/mr-boxington/releases)
-for downloads and `SHA256SUMS`.
+== Linux ARM64
+
+```sh
+(
+set -e
+mkdir -p ~/.local/bin
+archive=mbx-aarch64-unknown-linux-musl.tar.gz
+release=https://github.com/jdx/mr-boxington/releases/latest/download
+curl -fsSLO "$release/$archive"
+curl -fsSLO "$release/SHA256SUMS"
+grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
+tar -xzf "$archive" -C ~/.local/bin
+)
+```
+
+== macOS
+
+```sh
+(
+set -e
+mkdir -p ~/.local/bin
+archive=mbx-aarch64-apple-darwin.tar.gz
+release=https://github.com/jdx/mr-boxington/releases/latest/download
+curl -fsSLO "$release/$archive"
+curl -fsSLO "$release/SHA256SUMS"
+grep "  $archive$" SHA256SUMS | shasum -a 256 --check --strict -
+tar -xzf "$archive" -C ~/.local/bin
+)
+```
+
+== Windows
+
+```powershell
+$archive = "mbx-x86_64-pc-windows-msvc.zip"
+$release = "https://github.com/jdx/mr-boxington/releases/latest/download"
+Invoke-WebRequest "$release/$archive" -OutFile $archive
+Invoke-WebRequest "$release/SHA256SUMS" -OutFile SHA256SUMS
+$expected = (Select-String -Path SHA256SUMS -Pattern $archive).Line.Split(" ")[0]
+if ((Get-FileHash $archive -Algorithm SHA256).Hash -ne $expected.ToUpper()) {
+  throw "checksum mismatch"
+}
+Expand-Archive $archive -DestinationPath "$env:LOCALAPPDATA\Programs\mbx"
+```
+
+Add `%LOCALAPPDATA%\Programs\mbx` to `PATH`.
+
+:::
+
+Every release publishes its archives and `SHA256SUMS` on
+[GitHub Releases](https://github.com/jdx/mr-boxington/releases).
 
 ### Cargo
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,11 +55,11 @@ Cargo's configuration, and there is nothing to tune before the first build.
 The first build on a machine prints what it set up:
 
 ```text
-mbx[setup]: first build on this machine -- here is the arrangement:
-mbx[setup]:   compiled work is cached once in /home/you/.cache/mbx and shared with every checkout and worktree; the store sweeps itself back to 50.0 GiB
-mbx[setup]:   this filesystem can reflink, so outputs land in target/ without copying -- many checkouts, one copy on disk
-mbx[setup]:   target/ directories are managed and collected when their checkout disappears, they sit unused for 30 days, or they together outgrow 100.0 GiB
-mbx[setup]:   nothing else to run; `mbx gc --dry-run` previews a cleanup and every cap is configurable
+mbx[setup]: first build on this machine
+mbx[setup]:   cache is /home/you/.cache/mbx, shared by every checkout and worktree, pruned to 50.0 GiB
+mbx[setup]:   this filesystem supports reflinks, so target/ shares disk with the cache instead of copying
+mbx[setup]:   target/ is managed: deleted when its checkout is gone, unused for 30 days, or over 100.0 GiB total
+mbx[setup]:   `mbx gc --dry-run` previews cleanup; every limit is configurable
 ```
 
 The budgets are a share of the disk holding the cache, so the numbers above

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,6 +35,22 @@ for downloads and `SHA256SUMS`.
 cargo install mbx
 ```
 
+## Supported platforms
+
+Release binaries cover Linux x86-64 and ARM64 (static musl builds), macOS on
+Apple Silicon, and Windows x86-64; other platforms with a Rust toolchain can
+build from source with `cargo install mbx`. mbx wraps whichever Cargo and
+rustc are active, including rustup-managed toolchains — `mbx doctor` reports
+the pair it found.
+
+Reflinked output restoration needs a filesystem with copy-on-write file
+cloning: APFS on macOS, btrfs or XFS on Linux, ReFS (Dev Drive) on Windows.
+mbx probes the actual cache and target locations rather than assuming from
+the platform, and copies bytes where cloning is unavailable — caching still
+works on ext4 or NTFS, it just spends the disk twice. On Windows, managed
+target directories also need Developer Mode or a privileged process to create
+the `target` link; see [managed target directories](/managed-targets).
+
 ## Run a build
 
 Put `mbx` before cargo's subcommand:
@@ -96,8 +112,11 @@ mbx deliberately declined to cache the action. See [Cache results](/cache-result
 ## Inspect the store
 
 ```sh
-mbx cache dir
-mbx cache stats
+mbx cache dir       # where the store lives
+mbx cache stats     # size and contents of the store
+mbx cache projects  # cache use attributed to recorded workspaces
+mbx cache largest   # the largest objects and action results
+mbx cache verify    # check local objects against their digests
 mbx gc
 mbx gc --dry-run
 mbx gc --max-size 20GiB

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 ### mise
 
 ```sh
-mise use -g github:jdx/mr-boxington
+mise use -g mr-boxington
 ```
 
 ### Release archive
@@ -47,14 +47,12 @@ mbx clippy --workspace --all-targets
 
 The command and its arguments are passed to Cargo unchanged. Cargo still owns
 dependency resolution, feature unification, build planning, and linking. mbx
-also forwards Cargo aliases and installed subcommands.
-
-That is the whole setup. There is nothing to install into Cargo's
-configuration and nothing to tune before the first build.
+also forwards Cargo aliases and installed subcommands. Nothing goes into
+Cargo's configuration, and there is nothing to tune before the first build.
 
 ## The first build
 
-The first build on a machine says what it arranged:
+The first build on a machine prints what it set up:
 
 ```text
 mbx[setup]: first build on this machine -- here is the arrangement:

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -71,7 +71,7 @@ commit SHAs in a real workflow.
 ## Cache server
 
 For trusted runners and teams, mbx can talk to a compatible remote server such
-as [`jdx/mbx-cache`](https://github.com/jdx/mbx-cache). The action exports the
+as the self-hostable [cache server](/cache-server). The action exports the
 remote configuration for subsequent steps:
 
 ```yaml

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -94,3 +94,7 @@ Only a push to a protected branch may write. Pull requests degrade to read-only,
 and tag or release builds do not use the remote cache at all. If fork authors
 must not reach the host, use the GitHub backend for those jobs instead. A bearer
 token can be supplied with the action's `token` input when OIDC is unavailable.
+
+For a repository that combines both backends — the server for trusted runs, the
+GitHub cache for fork pull requests — see
+[CI with fork pull requests](/cookbook/fork-prs).

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -54,7 +54,7 @@ custom save policies need to share the same entry:
 - uses: jdx/mise-action@v4
   with:
     cache: false
-    install_args: github:jdx/mr-boxington
+    install_args: mr-boxington
 - run: mbx test --workspace
 - run: mbx gc --max-size 3GB
   if: always()

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -95,6 +95,14 @@ and tag or release builds do not use the remote cache at all. If fork authors
 must not reach the host, use the GitHub backend for those jobs instead. A bearer
 token can be supplied with the action's `token` input when OIDC is unavailable.
 
+::: warning Release builds are never cached
+In a tag or release build (or with `MBX_RELEASE=1`), mbx runs plain Cargo —
+no local or remote cache — because published artifacts must not depend on any
+cache being correct. Hold the rest of the workflow to the same rule: release
+jobs should not restore `target/` through `actions/cache` or rust-cache, and
+should not use any other compiler cache.
+:::
+
 For a repository that combines both backends — the server for trusted runs, the
 GitHub cache for fork pull requests — see
 [CI with fork pull requests](/cookbook/fork-prs).

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -11,8 +11,8 @@ subcommand.
 5. A hit restores the action's outputs; a miss runs the real compiler and publishes the result.
 6. The agent exits with the build. There is no persistent daemon.
 
-Every mbx command works this way; there is no separate mode to install or keep
-current.
+Every mbx command works this way; there is no separate mode to turn on and no
+component to keep up to date.
 
 ## Portable keys
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: "mr boxington"
-  text: "target/, fixed: shared, self-pruning, drop-in."
-  tagline: Put mbx in front of any Cargo command. Compiled work is shared across worktrees and CI, build storage keeps itself inside a budget, and mbx tells you what it saved.
+  text: "fix target/"
+  tagline: Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget.
   image:
     src: /logo.svg
     alt: Mr Boxington, a friendly cache box
@@ -20,33 +20,36 @@ hero:
       link: /github-actions
 
 features:
-  - icon: "⚙️"
+  - icon:
+      src: /features/drop-in.svg
+      alt: A golden gear
+      width: 64
+      height: 64
     title: Drop it in front of cargo
-    details: Put mbx before build, test, or clippy. Nothing to configure and nothing to install into Cargo; the first build explains what it set up.
+    details: mbx build, mbx test, mbx clippy. Nothing to configure, no daemon to manage, nothing to install into Cargo.
     link: /getting-started
-  - icon: "🌳"
+  - icon:
+      src: /features/worktrees.svg
+      alt: A tree growing small cache boxes
+      width: 64
+      height: 64
     title: Warm every worktree
-    details: Cache keys contain no checkout-specific absolute paths, so building one checkout warms its siblings automatically.
+    details: Build in one checkout and every other worktree starts warm.
     link: /cache-results
-  - icon: "☁️"
+  - icon:
+      src: /features/ci.svg
+      alt: A cloud with upload and download arrows
+      width: 64
+      height: 64
     title: Warm CI runners
-    details: Use a remote cache or GitHub Actions cache while untrusted pull requests remain read-only.
+    details: Share the same cache with CI through a remote cache or GitHub Actions.
     link: /github-actions
-  - icon: "🧹"
+  - icon:
+      src: /features/prune.svg
+      alt: A broom sweeping
+      width: 64
+      height: 64
     title: Prune automatically
-    details: Budgets scale with the disk. Managed target directories go when their checkout disappears, when they sit unused for 30 days, or when they outgrow their share.
+    details: Stale or oversized target directories clean themselves up.
     link: /managed-targets
-  - icon: "🧾"
-    title: Keeps receipts
-    details: One line after a build says what the cache was worth — compilations skipped, hours refunded, gigabytes binned. Deadpan included; savings = "plain" if your logs must keep a straight face.
-    link: /getting-started#read-the-result
-  - icon: "🔍"
-    title: Never lies about a hit
-    details: mbx reports hits, misses, what it could not look up, and what it deliberately bypassed. A high hit rate cannot hide work that never entered the cache.
-    link: /cache-results
 ---
-
-::: warning Experimental
-mr boxington is pre-1.0. The cache format and behavior may change without notice,
-and releases are not a stability promise.
-:::

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -47,8 +47,7 @@ a build server do not need the same configuration:
 | `gc.max_size` (action store) | 5% of the disk | 5GiB to 100GiB |
 | `target.max_size` (managed targets) | 10% of the disk | 10GiB to 100GiB |
 
-Scaled budgets are rounded down to a whole 5GiB, so the cap reads like a
-number somebody chose rather than a measurement. When the disk cannot be
+Scaled budgets are rounded down to a whole 5GiB. When the disk cannot be
 measured, mbx uses 20GiB and 30GiB respectively. Any value you set outright
 wins, and `mbx gc --dry-run` previews the effect of a policy without deleting
 anything.
@@ -72,7 +71,7 @@ rather than a silently ignored setting, so a typo cannot disable collection.
 collection exists to prevent. `MBX_TARGET_VIEWS=0` opts out of managed target
 directories altogether, and a directory that is still reached through an
 existing `target` symlink keeps counting as in use, so turning placement off
-does not put existing outputs on a clock.
+does not schedule existing outputs for deletion.
 
 Each budget is measured against the disk that actually holds it, so putting
 `target.root` on a large scratch volume sizes the target budget from that

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,13 +8,22 @@
     "docs:preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.6.3"
+    "vitepress": "^1.6.3",
+    "vitepress-plugin-tabs": "^0.9.1"
   },
   "pnpm": {
     "supportedArchitectures": {
-      "os": ["linux", "darwin"],
-      "cpu": ["x64", "arm64"],
-      "libc": ["glibc"]
+      "os": [
+        "linux",
+        "darwin"
+      ],
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ]
     },
     "allowBuilds": {
       "esbuild": true

--- a/docs/public/features/ci.svg
+++ b/docs/public/features/ci.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="A cloud syncing with arrows">
+  <defs>
+    <linearGradient id="cloud" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f6ecd2"/>
+      <stop offset="1" stop-color="#e8b95f"/>
+    </linearGradient>
+    <linearGradient id="uparrow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6d693"/>
+      <stop offset="1" stop-color="#c4862c"/>
+    </linearGradient>
+  </defs>
+  <!-- cloud -->
+  <path d="M36 82a20 20 0 0 1-3-39.8A27 27 0 0 1 85 36a19 19 0 0 1 7 46Z"
+        fill="url(#cloud)" stroke="#53350f" stroke-width="7" stroke-linejoin="round"/>
+  <path d="M30 56a15 15 0 0 1 9-12" fill="none" stroke="#fdf7e6" stroke-width="5" stroke-linecap="round" opacity=".8"/>
+  <!-- upload / download arrows -->
+  <g stroke="#53350f" stroke-width="6" stroke-linejoin="round">
+    <path d="M47 90 60 104h-7v16H41v-16h-7Z" fill="url(#uparrow)"/>
+    <path d="M88 120 75 106h7V90h12v16h7Z" fill="#35555c"/>
+  </g>
+</svg>

--- a/docs/public/features/drop-in.svg
+++ b/docs/public/features/drop-in.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="A golden gear">
+  <defs>
+    <linearGradient id="gear" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6d693"/>
+      <stop offset="1" stop-color="#c4862c"/>
+    </linearGradient>
+  </defs>
+  <g stroke="#53350f" stroke-width="7" stroke-linejoin="round">
+    <g fill="url(#gear)">
+      <rect x="54" y="10" width="20" height="108" rx="6"/>
+      <rect x="54" y="10" width="20" height="108" rx="6" transform="rotate(45 64 64)"/>
+      <rect x="54" y="10" width="20" height="108" rx="6" transform="rotate(90 64 64)"/>
+      <rect x="54" y="10" width="20" height="108" rx="6" transform="rotate(135 64 64)"/>
+      <circle cx="64" cy="64" r="36"/>
+    </g>
+    <circle cx="64" cy="64" r="14" fill="#f6ecd2"/>
+  </g>
+  <path d="M41 48a29 29 0 0 1 11-11" fill="none" stroke="#f6ecd2" stroke-width="5" stroke-linecap="round" opacity=".7"/>
+</svg>

--- a/docs/public/features/prune.svg
+++ b/docs/public/features/prune.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="A broom sweeping">
+  <defs>
+    <linearGradient id="bristles" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6d693"/>
+      <stop offset="1" stop-color="#c4862c"/>
+    </linearGradient>
+  </defs>
+  <!-- handle -->
+  <path d="M96 12 60 68" fill="none" stroke="#53350f" stroke-width="18" stroke-linecap="round"/>
+  <path d="M96 12 60 68" fill="none" stroke="#a5772b" stroke-width="8" stroke-linecap="round"/>
+  <!-- bristle head -->
+  <path d="M52 62 26 104q-4 7 4 8l48 6q8 1 6-7L70 66q-2-7-9-8t-9 4Z"
+        fill="url(#bristles)" stroke="#53350f" stroke-width="7" stroke-linejoin="round"/>
+  <path d="M44 76l-9 30M56 78l-2 32M66 78l8 31" fill="none" stroke="#53350f" stroke-width="4" stroke-linecap="round" opacity=".55"/>
+  <!-- binding band -->
+  <path d="M49 67q10-8 22 1l3 9q-15-9-29 1Z" fill="#f6ecd2" stroke="#53350f" stroke-width="5" stroke-linejoin="round"/>
+  <!-- dust sparkles -->
+  <g fill="#e8b95f">
+    <path d="M99 78l3 7 7 3-7 3-3 7-3-7-7-3 7-3Z"/>
+    <circle cx="112" cy="104" r="4"/>
+    <circle cx="94" cy="112" r="3"/>
+  </g>
+</svg>

--- a/docs/public/features/worktrees.svg
+++ b/docs/public/features/worktrees.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="A tree growing small cache boxes">
+  <defs>
+    <linearGradient id="leaf" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#9db95c"/>
+      <stop offset="1" stop-color="#5d7f3a"/>
+    </linearGradient>
+    <linearGradient id="fruit" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6d693"/>
+      <stop offset="1" stop-color="#c4862c"/>
+    </linearGradient>
+  </defs>
+  <!-- trunk -->
+  <path d="M57 118V76q0-8-8-14M71 118V80q0-10 10-18" fill="none" stroke="#53350f" stroke-width="21" stroke-linecap="round"/>
+  <path d="M57 118V76q0-8-8-14M71 118V80q0-10 10-18" fill="none" stroke="#a5772b" stroke-width="9" stroke-linecap="round"/>
+  <!-- canopy: outlined circles, then fill-only copies to hide the seams -->
+  <g stroke="#53350f" stroke-width="7">
+    <circle cx="42" cy="46" r="25" fill="url(#leaf)"/>
+    <circle cx="86" cy="48" r="23" fill="url(#leaf)"/>
+    <circle cx="64" cy="32" r="24" fill="url(#leaf)"/>
+  </g>
+  <g fill="url(#leaf)">
+    <circle cx="42" cy="46" r="21.5"/>
+    <circle cx="86" cy="48" r="19.5"/>
+    <circle cx="64" cy="32" r="20.5"/>
+  </g>
+  <path d="M46 24a22 22 0 0 1 12-8" fill="none" stroke="#f6ecd2" stroke-width="5" stroke-linecap="round" opacity=".55"/>
+  <!-- cache boxes as fruit -->
+  <g stroke="#53350f" stroke-width="5" stroke-linejoin="round" fill="url(#fruit)">
+    <rect x="26" y="48" width="16" height="16" rx="3"/>
+    <rect x="82" y="52" width="15" height="15" rx="3"/>
+    <rect x="58" y="28" width="15" height="15" rx="3"/>
+  </g>
+  <path d="M28 54h12M84 58h11M60 34h11" fill="none" stroke="#53350f" stroke-width="2.5"/>
+</svg>

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -42,6 +42,42 @@ This policy prevents untrusted code from publishing objects that later builds
 would trust. The server should still authenticate and authorize requests; the
 client-side policy is defense in depth, not an access-control boundary.
 
+## GitLab CI
+
+The write policy recognizes GitLab CI with the same shape as GitHub Actions: a
+push pipeline on a protected branch may write, merge requests and unprotected
+branches are read-only, and tag pipelines do not use the remote at all.
+
+The OIDC flow is GitHub-specific, so authenticate GitLab jobs with a bearer
+token in a masked, protected CI/CD variable:
+
+```yaml
+build:
+  variables:
+    MBX_REMOTE_URL: https://cache.example.com
+    MBX_REMOTE_NAMESPACE: acme/backend
+    MBX_REMOTE_MODE: read-write
+  script:
+    - mbx build --workspace
+```
+
+Set `MBX_REMOTE_TOKEN` in the project's CI/CD variables (masked, and limited
+to protected branches) rather than in the YAML.
+
+## Prefetch
+
+After a command has published its action manifest, another machine can warm
+the same build without running Cargo:
+
+```sh
+mbx prefetch build --workspace --release
+```
+
+The workspace's `Cargo.lock` and complete Cargo argument list select the same
+manifest as a normal mbx build. Prefetch requires a configured remote in
+`read-only` or `read-write` mode, waits for every predicted action, and returns
+an error when the manifest lookup fails.
+
 ## Transfer behavior
 
 Remote blobs are compressed with zstd. `MBX_HTTP_DOWNLOAD_TIMEOUT` is separate

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -15,7 +15,7 @@ mode = "read-write"
 ```
 
 The namespace isolates one project's cache from another. It is required when a
-remote URL is set.
+remote URL is set. To host your own server, see [cache server](/cache-server).
 
 ## Authenticate
 

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -36,7 +36,7 @@ Configured mode is constrained by the environment:
 | --- | --- |
 | Protected branch push on GitHub Actions or GitLab CI | Configured mode |
 | Pull request, merge request, local shell, or unprotected branch | Read-only; `write-only` becomes disabled |
-| Tag or release build | Remote cache disabled |
+| Tag or release build | All caching disabled — mbx runs plain Cargo |
 
 This policy prevents untrusted code from publishing objects that later builds
 would trust. The server should still authenticate and authorize requests; the

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,35 @@
+# Stability
+
+What an mbx upgrade can and cannot break.
+
+## The store is disposable
+
+The local store is a cache of work mbx can redo. Correctness never depends on
+its format: an entry a new version cannot read is a miss, and the compilation
+runs again. The worst case for any upgrade is a colder build, not a wrong one,
+and deleting the cache directory is always safe.
+
+Managed target directories live under a versioned root (`targets/v1/…`), and
+the `target` symlink in each checkout keeps working across upgrades.
+
+## JSON output is versioned
+
+`mbx doctor --json`, `mbx cache stats --json`, `mbx gc --json`, and
+`MBX_STATS_REPORT` emit versioned documents; fields are added compatibly and a
+shape change bumps the version. Scripts should read the version field and
+parse JSON rather than the human-readable `mbx[...]` stderr lines, which are
+written for people and may be reworded at any time.
+
+## Configuration
+
+Unknown TOML keys and invalid values are errors, so an upgrade that renames or
+retires a setting fails loudly instead of silently ignoring what you wrote.
+
+## Wire protocols and crates
+
+The shim/agent protocol is internal — both halves ship in one binary and
+require exact version equality, so there is nothing to keep compatible across
+machines. The remote cache protocol is versioned under `/v1/` with explicit
+evolution rules, and published Rust crates follow semantic versioning enforced
+by `cargo-semver-checks` in CI. See
+[protocol compatibility](/protocol-compatibility) for the details.

--- a/mise.toml
+++ b/mise.toml
@@ -87,8 +87,19 @@ run = "aube install && exec aube run docs:build"
 [tasks."render:docs"]
 description = "Generate reference documentation from the usage spec"
 depends = ["bootstrap"]
-run = "rm -rf docs/cli && ./target/mbx-bootstrap/mbx __usage_spec__ | usage generate markdown --file - --multi --replace-pre-with-code-fences --url-prefix /cli --out-dir docs/cli"
-run_windows = "Remove-Item -Recurse -Force -ErrorAction SilentlyContinue docs/cli; ./target/mbx-bootstrap/mbx.exe __usage_spec__ | usage generate markdown --file - --multi --replace-pre-with-code-fences --url-prefix /cli --out-dir docs/cli"
+# The configuration reference is not its own page: /configuration embeds it
+# with an @include, so its headings are demoted to sit under that page's
+# "Settings" section and the generated index links there instead.
+run = [
+  "rm -rf docs/cli && ./target/mbx-bootstrap/mbx __usage_spec__ | usage generate markdown --file - --multi --replace-pre-with-code-fences --url-prefix /cli --out-dir docs/cli",
+  "sed -i.bak -e 's/^## /### /' docs/cli/configuration.md && rm docs/cli/configuration.md.bak",
+  "sed -i.bak -e 's|(/cli/configuration.md)|(/configuration#settings)|' docs/cli/index.md && rm docs/cli/index.md.bak",
+]
+run_windows = [
+  "Remove-Item -Recurse -Force -ErrorAction SilentlyContinue docs/cli; ./target/mbx-bootstrap/mbx.exe __usage_spec__ | usage generate markdown --file - --multi --replace-pre-with-code-fences --url-prefix /cli --out-dir docs/cli",
+  "[IO.File]::WriteAllText('docs/cli/configuration.md', ([IO.File]::ReadAllText('docs/cli/configuration.md') -replace '(?m)^## ', '### '))",
+  "[IO.File]::WriteAllText('docs/cli/index.md', ([IO.File]::ReadAllText('docs/cli/index.md') -replace [regex]::Escape('(/cli/configuration.md)'), '(/configuration#settings)'))",
+]
 
 [tasks."check:docs"]
 description = "Check that generated documentation is current"

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -129,8 +129,8 @@ EOF
   assert_output --partial "first build on this machine"
   # The caps are resolved from this machine's disk, so assert the shape of the
   # explanation rather than the numbers in it.
-  assert_output --partial "sweeps itself back to"
-  assert_output --partial "their checkout disappears"
+  assert_output --partial "pruned to"
+  assert_output --partial "its checkout is gone"
 
   # A machine that has been told does not need telling again.
   run "$MBX_BIN" build --offline --manifest-path "$project/Cargo.toml"


### PR DESCRIPTION
Refreshes the landing page ahead of 1.0:

- Shortens the hero to **"fix target/"** with a tighter tagline: _"Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget."_
- Cuts the feature cards from six to four (drops the two reporting-themed cards) and rewords the rest down to one or two plain sentences
- Replaces the emoji card icons with custom SVG artwork drawn in the logo's style (gear, tree growing cache boxes, sync cloud, broom), rendered larger
- Rewords the terminal demo caption to "Whatever one checkout compiles, the next one reuses — locally or in CI."
- Removes the pre-1.0 experimental warnings from the landing page and README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, site tooling, and human-readable stderr setup lines; no cache logic or protocol behavior changes in the diff.
> 
> **Overview**
> Prepares public messaging for 1.0 by **simplifying the hero** (“fix target/”), **trimming homepage features** from six cards to four with custom SVG icons (larger in CSS), **rewording the terminal demo caption**, and **removing pre-1.0 experimental warnings** from the README and docs home.
> 
> **First-run setup text** in `first_run_notice` and matching docs/examples is tightened (e.g. “pruned to”, “target/ is managed: deleted when…”) with updated unit, integration, and Bats assertions.
> 
> The **docs site** gains tabbed install instructions (`vitepress-plugin-tabs`), embeds the generated settings reference on `/configuration` instead of a standalone CLI page (plus `render:docs` sed steps), and adds pages for **cache server**, **stability**, **compared** (sccache / tarball CI / incremental), and a **fork-PR CI cookbook**, with nav and cross-links refreshed. Install examples switch to `mise use -g mr-boxington`; remote-cache and GitHub Actions docs note tag/release builds disable caching and document GitLab CI, prefetch, and release-job guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa22f71df5d23d3925c26cbff40be034102ac17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the pre-1.0 warning about potential cache format and behavior changes.
  - Updated homepage messaging to clarify cache reuse across worktrees and CI, including automatic cleanup.
  - Simplified hero messaging and refreshed feature descriptions and icons.

- **Style**
  - Enlarged homepage feature icons and updated their corner radius for improved visibility.
  - Updated terminal caption text to better explain compiled output reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->