### PR TITLE
chore: give every published crate its crates.io metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ rust-version = "1.91"
 license = "MIT"
 homepage = "https://github.com/jdx/mr-boxington"
 repository = "https://github.com/jdx/mr-boxington"
+# Every crate ships the workspace README, so a crates.io page describes the
+# whole tool rather than repeating a paragraph per crate.
+readme = "README.md"
 
 [profile.release]
 lto = "thin"

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+keywords = ["cache", "build-cache", "cas", "content-addressed", "rustc"]
+categories = ["development-tools::build-utils", "caching", "network-programming"]
+readme.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+keywords = ["cache", "build-cache", "protocol", "wire-format"]
+categories = ["development-tools::build-utils", "caching", "network-programming"]
+readme.workspace = true
 
 [dependencies]
 blake3 = "1"

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+keywords = ["cache", "build-cache", "rustc", "cargo"]
+categories = ["development-tools::build-utils", "caching"]
+readme.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+keywords = ["cache", "build-cache", "cargo", "rustc", "build"]
+categories = ["development-tools::build-utils", "development-tools::cargo-plugins", "command-line-utilities", "caching"]
+readme.workspace = true
+documentation = "https://mr-boxington.jdx.dev"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
All four crates publish with a description and nothing else: no keywords, no categories, no README. Their crates.io pages are correspondingly bare, and none of them are discoverable by search.

- **README** is inherited from the workspace (`readme.workspace = true`) rather than duplicated per crate. Cargo rewrites the path and copies the file into each `.crate`, verified with `cargo package --list` for all four — so one page describes the whole tool wherever a crate is read, and there is no second copy to drift.
- **Keywords and categories** are set per crate, since what someone searching for the CLI wants is not what they want from the wire-contract crate. Categories are all from the crates.io list (`development-tools::build-utils`, `development-tools::cargo-plugins`, `command-line-utilities`, `caching`, `network-programming`).
- **`documentation`** is set only on `mbx`, pointing at the docs site. The libraries keep the docs.rs default, which is what a reader of a library crate actually wants.

Verified `cargo package` succeeds for all four crates and that the generated manifest carries `readme = "README.md"`.

Part of the pre-1.0 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only packaging metadata with no runtime, security, or build-logic changes.
> 
> **Overview**
> Improves **crates.io discoverability** by filling in manifest metadata that was previously limited to descriptions.
> 
> The workspace now defines **`readme = "README.md"`**, and each published crate (`mbx`, `mbx-cache-core`, `mbx-cache-protocol`, `mbx-cache-rustc`) inherits it via **`readme.workspace = true`** so every `.crate` ships the same project README without per-crate copies. Each crate gets **tailored `keywords` and `categories`** for search; only the **`mbx`** binary crate adds **`documentation`** pointing at the public docs site, while library crates keep docs.rs defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27cf592143490b9396ce8751ffbce908a6aabef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added package metadata to improve crate discoverability on crates.io and docs.rs.
  - Linked workspace crates to the shared project README.
  - Added a documentation URL for the main package.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->