### PR TITLE
ci: drop the protocol crate's crates.io bootstrap

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -61,52 +61,6 @@ jobs:
             --jq '[.[] | select(.merged_at != null) | select(.head.ref | startswith("release-plz-"))][0].number // ""')
           echo "number=$number" >> "$GITHUB_OUTPUT"
 
-      # Trusted publishing cannot create a crate. Bootstrap the protocol crate
-      # with a token restricted to `publish-new`, then wait until crates.io can
-      # see that exact version so release-plz recognizes it as already
-      # published. Once the crate exists this step never reads or uses the
-      # token; later versions use OIDC with the rest of the workspace.
-      - name: Bootstrap mbx-cache-protocol on crates.io
-        if: steps.release-pr.outputs.number != ''
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_PUBLISH_NEW_TOKEN }}
-        run: |
-          crate=mbx-cache-protocol
-          version=$(cargo metadata --no-deps --format-version 1 |
-            jq -r --arg crate "$crate" '.packages[] | select(.name == $crate).version')
-          crate_endpoint="https://crates.io/api/v1/crates/$crate"
-          version_endpoint="$crate_endpoint/$version"
-          user_agent="mr-boxington release workflow (https://github.com/${{ github.repository }})"
-          status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
-            --user-agent "$user_agent" "$crate_endpoint")
-
-          if [ "$status" = 200 ]; then
-            echo "$crate already exists; release-plz will publish version $version with OIDC"
-            exit 0
-          fi
-          if [ "$status" != 404 ]; then
-            echo "::error::crates.io returned HTTP $status while checking $crate $version"
-            exit 1
-          fi
-
-          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
-            echo "::error::CRATES_IO_PUBLISH_NEW_TOKEN is required to publish the first $crate release"
-            exit 1
-          fi
-
-          cargo publish --locked --package "$crate"
-
-          # The publish endpoint can return before the new version is visible
-          # to release-plz through the crates.io API.
-          for _ in $(seq 1 12); do
-            if curl --fail --silent --show-error --user-agent "$user_agent" "$version_endpoint" >/dev/null; then
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "::error::$crate $version did not become visible on crates.io"
-          exit 1
-
       # Exchanges the OIDC token for a short-lived crates.io token. Each crate
       # needs a Trusted Publisher naming this repository and this workflow
       # file, so renaming this file breaks publishing.
@@ -140,9 +94,8 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "mbx tag: ${tag:-<none released>}"
 
-      # An empty result is expected when re-running a completed release, or
-      # when bootstrapping the protocol crate was the only work. Verify the
-      # desired end state instead of rejecting those idempotent cases.
+      # An empty result is expected when re-running a completed release.
+      # Verify the desired end state instead of rejecting that idempotent case.
       - name: Verify an empty release result for a merged release PR
         if: steps.mbx-tag.outputs.tag == '' && steps.release-pr.outputs.number != ''
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,9 +31,6 @@ These settings live outside the repository, and releases fail without them:
 - **`RELEASE_PLZ_TOKEN`** — a PAT with `contents: write` and
   `pull-requests: write`. The default `GITHUB_TOKEN` cannot be used: pushes made
   with it do not trigger workflows, so the release PR would never run CI.
-- **`CRATES_IO_PUBLISH_NEW_TOKEN`** — a crates.io token restricted to the
-  `publish-new` endpoint. It bootstraps `mbx-cache-protocol`, because trusted
-  publishing cannot create a crate. Delete the secret after its first release.
 - **`CERTIFICATES_P12`** and **`CERTIFICATES_P12_PASS`** — the base64-encoded
   Developer ID Application certificate and its password used by the other
   jdx.dev CLI release workflows. The macOS jobs import the certificate and sign
@@ -41,10 +38,11 @@ These settings live outside the repository, and releases fail without them:
   creating the release archives.
 - **A crates.io Trusted Publisher for each of `mbx`, `mbx-cache-core`,
   `mbx-cache-protocol`, and `mbx-cache-rustc`**, naming this repository and the
-  workflow file `release-plz.yml`. Configure the protocol publisher after its
-  bootstrap release; later publishing uses OIDC and does not need a registry
-  token. **Renaming `release-plz.yml` breaks publishing** until the trusted
-  publishers are updated to match.
+  workflow file `release-plz.yml`. Publishing is OIDC-only; no registry token
+  exists anywhere. **Renaming `release-plz.yml` breaks publishing** until the
+  trusted publishers are updated to match. A crate that does not exist on
+  crates.io yet cannot be created this way — publish its first version by hand
+  with a `publish-new` token, then configure its trusted publisher.
 
 ## When a release goes wrong
 


### PR DESCRIPTION
`mbx-cache-protocol` 0.4.0 is published on crates.io (confirmed against the registry API), so the bootstrap step has done its one job and trusted publishing can carry the crate from here.

The step existed only because trusted publishing cannot *create* a crate — but it kept `secrets.CRATES_IO_PUBLISH_NEW_TOKEN` wired into the release path indefinitely, which `RELEASING.md` already flagged for deletion after the first release.

**After merging, delete the `CRATES_IO_PUBLISH_NEW_TOKEN` repository secret.** With this gone, no long-lived crates.io credential reaches the workflow at all: `CARGO_REGISTRY_TOKEN` only ever holds the short-lived token `crates-io-auth-action` exchanges the OIDC token for, which is what the `id-token: write` comment already claims.

`RELEASING.md` keeps the knowledge rather than the procedure — a *future* new crate will still need a hand-publish before its trusted publisher works, so that constraint is now recorded under the trusted-publisher bullet where someone adding a crate would look for it.

Also drops the "or when bootstrapping the protocol crate was the only work" clause from the empty-release-result comment, which no longer describes a reachable case. The `Find the merged release PR` step stays — its output still gates that verification step.

Verified the workflow still parses and all four jobs are intact.

Part of the pre-1.0 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and release docs only; crates.io publishing still goes through the same OIDC path once crates already exist on the registry.
> 
> **Overview**
> Removes the **`Bootstrap mbx-cache-protocol on crates.io`** step from `release-plz.yml`, so releases no longer depend on **`CRATES_IO_PUBLISH_NEW_TOKEN`** or a one-off `cargo publish` before OIDC trusted publishing runs.
> 
> **`RELEASING.md`** drops that secret from the setup list and documents that publishing is **OIDC-only**; any **brand-new** crate still needs a manual first publish with a `publish-new` token before its trusted publisher can take over.
> 
> The empty-release verification comment no longer mentions bootstrap-only runs, since that path is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69eaef9833720b6daa171bd8bafe8cd13cc9ea92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->