### PR TITLE
chore: version each crate by what it promises

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,10 @@ jobs:
           # anything outside this workspace is meant to build against, which
           # `crates/mbx/src/lib.rs` says outright. Checking it would mean a
           # major bump every time the CLI gains a setting, or contorting
-          # internal types to avoid one. The published API lives in
-          # mbx-cache-core and mbx-cache-rustc, which stay checked.
+          # internal types to avoid one. mbx-cache-protocol is the crate with a
+          # promise to keep; mbx-cache-core and mbx-cache-rustc are internals on
+          # 0.x. All three stay checked, so a bump that breaks one is at least
+          # deliberate -- semver-checks understands 0.x rules.
           UNCHECKED_PACKAGES: mbx
         run: |
           baseline_dir="$(mktemp -d)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,9 @@ members = [
 ]
 
 [workspace.package]
-# One version for every crate in the workspace. release-plz keeps them in step
-# through the `version_group` in release-plz.toml, so a release moves all four
-# together rather than leaving each on a number of its own.
-version = "0.4.0"
+# `version` is deliberately absent: the crates here do not share one number.
+# What each crate's version promises differs, so each carries its own. See the
+# version tiers in release-plz.toml.
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,6 +17,24 @@ hand.
 `release_always = false`, so a push to `main` that merely carries a version
 bump does not release — only merging a release PR does.
 
+## Versions
+
+The crates do not share a version. `mbx` and `mbx-cache-protocol` each have an
+independent one, because each carries a stability promise the other should not
+be able to break: the CLI's surface is its commands and JSON output, and the
+protocol crate's is the remote cache wire contract that `jdx/mbx-cache` depends
+on. `mbx-cache-core` and `mbx-cache-rustc` are internals; they share the
+`mbx-internals` version group, move together, and stay on `0.x` so semver
+itself says a minor bump may break them.
+
+release-plz computes each line from the commits that touched it and updates the
+path dependencies' version requirements, so a release can move one crate and
+leave the rest alone. When `mbx` reaches `1.0`, the internal crates stay on
+`0.x`: the CLI depending on a `0.x` library is normal, and the library target
+inside `mbx` is `#[doc(hidden)]` so none of those types are part of the
+promise. See [protocol compatibility](docs/protocol-compatibility.md) for the
+promise each version line makes.
+
 ## Tags and asset names
 
 The `mbx` crate is tagged `v{version}`; the three library crates are published to

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mbx-cache-core"
-version.workspace = true
-description = "Action cache protocol, CAS, authentication, and transport primitives for mbx"
+version = "0.4.0"
+description = "mbx internals: CAS, authentication, transport, and the cache agent. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version.workspace = true
+version = "0.4.0"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mbx-cache-rustc"
-version.workspace = true
-description = "Conservative rustc action analysis and key construction for mbx"
+version = "0.4.0"
+description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version.workspace = true
+version = "0.4.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -5,24 +5,41 @@
 //! shared further through a remote cache.
 //!
 //! This library target exists so the executable and integration tests can
-//! share application code; it is not a stable embedding API. Applications
-//! should use `mbx-cache-core` or `mbx-cache-rustc` instead.
+//! share application code; it is not an embedding API. The supported
+//! interfaces are the `mbx` command line -- its subcommands and its versioned
+//! JSON output -- and, for anything speaking to a remote cache,
+//! `mbx-cache-protocol`. `mbx-cache-core` and `mbx-cache-rustc` are internals
+//! too, and say so in their own descriptions.
 //!
 //! Nothing here carries a compatibility guarantee, and CI's public-API check
 //! skips this package for that reason -- see `UNCHECKED_PACKAGES` in
 //! `.github/workflows/ci.yml`. Types the CLI alone reads may gain fields in a
 //! patch release. Do not restore the check to "protect" these items: it would
 //! only force a major bump every time the CLI gains a setting.
+//!
+//! The modules below are `#[doc(hidden)]` for the same reason. They have to
+//! stay `pub` for the binary and the integration tests, but a published crate
+//! whose documentation advertises `store` and `session` invites exactly the
+//! dependency the paragraph above rules out.
 
+#[doc(hidden)]
 pub mod cli;
+#[doc(hidden)]
 pub mod config;
+#[doc(hidden)]
 pub mod doctor;
+#[doc(hidden)]
 pub mod explain;
+#[doc(hidden)]
 pub mod policy;
 pub(crate) mod savings;
+#[doc(hidden)]
 pub mod session;
+#[doc(hidden)]
 pub mod store;
+#[doc(hidden)]
 pub mod target;
+#[doc(hidden)]
 pub mod util;
 
 mod rustc;

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -61,3 +61,18 @@ protocols. Pull requests that touch workspace crates run `cargo-semver-checks`
 against the pull request's base commit with all features enabled. An intentional
 breaking API change must include the corresponding major version change; wire
 format changes still require the protocol-version steps above.
+
+The four published crates do not share a version, because they do not promise
+the same things:
+
+| Crate | Version line | What it promises |
+| --- | --- | --- |
+| `mbx` | independent | The command line: subcommands and versioned JSON output. The library target is internal. |
+| `mbx-cache-protocol` | independent | The remote cache wire contract, as described above. Depend on this to speak to an mbx cache. |
+| `mbx-cache-core` | shared `0.x` | Nothing. Internal. |
+| `mbx-cache-rustc` | shared `0.x` | Nothing. Internal. |
+
+`mbx-cache-core` and `mbx-cache-rustc` are published because the `mbx` binary
+is built from them, not because they are meant to be built against. They stay
+on `0.x`, where a minor bump is allowed to break, and they move together. Build
+against them and an upgrade may not compile.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,11 +8,20 @@ git_release_enable = true
 # later. release-plz.yml undrafts it once the upload succeeds.
 git_release_draft = true
 
-# Every crate shares one version: a single group is what makes release-plz
-# bump them together instead of computing a separate number for each.
+# Three version tiers, because the crates promise different things.
+#
+# `mbx` and `mbx-cache-protocol` each carry a stability promise, so each gets an
+# independent version: the CLI's surface is its commands and its JSON output,
+# the protocol crate's is a wire contract with an external consumer (the
+# `jdx/mbx-cache` server depends on it and nothing else). Neither should be
+# forced to a major bump by the other, which is what sharing a number would do.
+#
+# `mbx-cache-core` and `mbx-cache-rustc` are internals with no promise to keep.
+# They share a group so a release moves them together, and they stay on 0.x so
+# semver itself says a minor bump may break them. They cannot hold the CLI's
+# number without making every refactor inside them a major mbx release.
 [[package]]
 name = "mbx"
-version_group = "mbx"
 publish = true
 # release-plz would otherwise tag the binary crate `mbx-vX.Y.Z`. The README's
 # install URLs are written against `v{version}`, and this is the tag people
@@ -21,21 +30,20 @@ git_tag_name = "v{{ version }}"
 git_release_enable = true
 
 [[package]]
-name = "mbx-cache-core"
-version_group = "mbx"
+name = "mbx-cache-protocol"
 publish = true
 # A library: crates.io is its distribution. A GitHub release for it would carry
 # no assets and would sit drafted forever, since only the `mbx` tag is undrafted.
 git_release_enable = false
 
 [[package]]
-name = "mbx-cache-protocol"
-version_group = "mbx"
+name = "mbx-cache-core"
+version_group = "mbx-internals"
 publish = true
 git_release_enable = false
 
 [[package]]
 name = "mbx-cache-rustc"
-version_group = "mbx"
+version_group = "mbx-internals"
 publish = true
 git_release_enable = false


### PR DESCRIPTION
Closes the "decide what 1.0 covers" question from the pre-1.0 audit.

## The problem

All four crates shared one `version_group`, so a 1.0 bump on the CLI would simultaneously declare API stability for `mbx-cache-core` (CAS, agent, transport) and `mbx-cache-rustc`. That promise buys nothing today and costs either honesty or velocity: every internal refactor becomes a workspace-wide major bump, or we break semver on a 1.x crate.

Two facts shaped the fix:

- **Nothing external depends on core or rustc.** `jdx/mbx-cache` pins `mbx-cache-protocol = "0.4.0"` and nothing else. Core and rustc are internal layers of the binary.
- **The `mbx` lib target barely exists.** The integration tests drive the compiled binary via `CARGO_BIN_EXE_mbx` everywhere except one call to `mbx::session::install_shim`. It is plumbing for the binary and one test helper, not an embedding API — which its own doc comment said, while docs.rs advertised `pub mod store`.

## The change

Three tiers, replacing the single group:

| Crate | Version line | Promise |
| --- | --- | --- |
| `mbx` | independent | Commands and versioned JSON output |
| `mbx-cache-protocol` | independent | Remote cache wire contract |
| `mbx-cache-core` | shared `mbx-internals` `0.x` | None |
| `mbx-cache-rustc` | shared `mbx-internals` `0.x` | None |

`mbx` and `mbx-cache-protocol` get independent versions rather than a shared one, so a CLI breaking change cannot force a protocol major bump that lies about the wire contract, or vice versa. Protocol *deserves* 1.0 — small, deliberately frozen, documented evolution rules, a real external consumer. Core and rustc stay on 0.x, where semver already says a minor bump may break, and move together.

Supporting changes:

- Sharing one number required `version.workspace = true`, so each crate carries its own version now. The `[workspace.package]` key is removed rather than left as a number nothing inherits.
- Core and rustc descriptions say they are internals and point at the supported interfaces — that string is what shows on crates.io.
- The `mbx` lib modules become `#[doc(hidden)]`. They stay `pub` for the binary and tests; `#[doc(hidden)]` affects docs only, so nothing breaks.
- The lib doc comment pointed applications at core and rustc, which is now the opposite of the advice. Rewritten to name the CLI and `mbx-cache-protocol`.
- `docs/protocol-compatibility.md` gains the tier table; `RELEASING.md` gains a "Versions" section; the CI `UNCHECKED_PACKAGES` comment no longer calls core and rustc "the published API".

## Why not the alternatives

Going 1.0 in lockstep freezes today's `mbx-cache-core` shape on speculation. This is reversible in the right direction: when mise integrates, *that* is when core gains a real consumer and can graduate to 1.0 with a surface shaped by what mise needs.

The cost is that "which core does mbx 1.2 use" now takes a `Cargo.lock` glance. For crates nobody should depend on, that trade seems easy.

## Verification

`mise run lint`, `test:cargo` (325 tests), `check:docs`, and `build:docs` all pass. All four crates still resolve at `0.4.0` and `Cargo.lock` is unchanged — this PR restructures how versions *can* diverge without moving any of them. The shim/agent handshake compares `mbx`'s own `CARGO_PKG_VERSION` against itself ([session.rs:36](crates/mbx/src/session.rs#L36)), the only runtime version read in the workspace, so diverging crate versions cannot affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and documentation policy only; crate versions stay at 0.4.0 with no runtime or wire-protocol behavior changes.
> 
> **Overview**
> **Replaces a single workspace-wide version with three release tiers** so CLI, wire protocol, and internal libraries can semver independently without lying about what each crate guarantees.
> 
> `release-plz` no longer uses one `version_group` for everything: **`mbx`** and **`mbx-cache-protocol`** each get their own version line; **`mbx-cache-core`** and **`mbx-cache-rustc`** share **`mbx-internals`** on **`0.x`**. The root **`[workspace.package] version`** is removed and each crate pins **`version = "0.4.0"`** locally (numbers unchanged in this PR—only the *machinery* for future divergence).
> 
> Docs and packaging reinforce the policy: **`RELEASING.md`** and **`docs/protocol-compatibility.md`** document the tier table; internal crates’ **crates.io descriptions** steer consumers to the CLI or **`mbx-cache-protocol`**. The **`mbx`** library docs are rewritten and **`pub` modules are `#[doc(hidden)]`** so docs.rs does not advertise embedding APIs. CI’s **`UNCHECKED_PACKAGES`** comment now frames **`mbx-cache-protocol`** as the semver-checked public contract while **`mbx`** stays unchecked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9ea55eded7acfd9a6bf489282789089974ad66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->