### PR TITLE
ci: watch for advisories on a schedule

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -1,0 +1,70 @@
+name: advisories
+
+# CI checks advisories on every push and pull request, which leaves a repository
+# with no traffic unaudited: an advisory published against a dependency of a
+# released version would wait for the next PR to surface. This run is the
+# standing watch for that case, so it reports by email rather than only turning
+# a run red where nobody is looking.
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily, away from the top of the hour and clear of the weekly canary in
+    # measure.yml.
+    - cron: "37 7 * * *"
+
+concurrency:
+  group: advisories
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  advisories:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Advisories only. Licenses, bans, and sources are policy over the
+      # manifests, so they cannot change without a commit and CI already gates
+      # them; the advisory database changes on its own.
+      - id: deny
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          command: check advisories
+
+      - name: Email the advisory report
+        if: steps.deny.outcome == 'failure'
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # A missing secret must not masquerade as a clean audit, but it must
+          # not hide the advisory either: warn, and let the failing step below
+          # still turn the run red.
+          if [[ -z "$RESEND_API_KEY" || -z "$NOTIFY_EMAIL" ]]; then
+            echo "::warning::RESEND_API_KEY or NOTIFY_EMAIL is unset; skipping the advisory email."
+            exit 0
+          fi
+          # jq builds the payload so an advisory title can never break the JSON.
+          payload="$(jq -n \
+            --arg from 'mbx advisories <mbx@en.dev>' \
+            --arg to "$NOTIFY_EMAIL" \
+            --arg subject "cargo-deny found an advisory in ${REPOSITORY}" \
+            --arg html "<p><code>cargo deny check advisories</code> failed on <strong>${REPOSITORY}</strong>.</p><p><a href=\"${RUN_URL}\">View the workflow run</a> for the advisory list.</p>" \
+            '{from: $from, to: [$to], subject: $subject, html: $html}')"
+          curl --fail-with-body -sS -X POST 'https://api.resend.com/emails' \
+            -H "Authorization: Bearer ${RESEND_API_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "$payload"
+
+      - name: Report the advisory
+        if: steps.deny.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -42,6 +42,7 @@ jobs:
         if: steps.deny.outcome == 'failure'
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NOTIFY_FROM: ${{ secrets.NOTIFY_FROM }}
           NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
           REPOSITORY: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -49,13 +50,13 @@ jobs:
           # A missing secret must not masquerade as a clean audit, but it must
           # not hide the advisory either: warn, and let the failing step below
           # still turn the run red.
-          if [[ -z "$RESEND_API_KEY" || -z "$NOTIFY_EMAIL" ]]; then
-            echo "::warning::RESEND_API_KEY or NOTIFY_EMAIL is unset; skipping the advisory email."
+          if [[ -z "$RESEND_API_KEY" || -z "$NOTIFY_FROM" || -z "$NOTIFY_EMAIL" ]]; then
+            echo "::warning::a notification secret is unset; skipping the advisory email."
             exit 0
           fi
           # jq builds the payload so an advisory title can never break the JSON.
           payload="$(jq -n \
-            --arg from 'mbx advisories <mbx@en.dev>' \
+            --arg from "$NOTIFY_FROM" \
             --arg to "$NOTIFY_EMAIL" \
             --arg subject "cargo-deny found an advisory in ${REPOSITORY}" \
             --arg html "<p><code>cargo deny check advisories</code> failed on <strong>${REPOSITORY}</strong>.</p><p><a href=\"${RUN_URL}\">View the workflow run</a> for the advisory list.</p>" \


### PR DESCRIPTION
CI checks advisories on every push and pull request, which leaves a quiet repository unaudited: an advisory published against a dependency of a released version waits for the next PR to surface it. This adds a daily `cargo deny check advisories` run that emails on a finding.

Reporting by email rather than only turning a run red follows [`jdx/ruby`](https://github.com/jdx/ruby)'s release notifier, and for the same reason — a red scheduled run nobody looks at is not a notification.

- Advisories only. Licenses, bans, and sources are policy over the manifests, so they cannot change without a commit that `ci.yml` already gates; the advisory database changes on its own.
- A missing `RESEND_API_KEY`/`NOTIFY_EMAIL` warns and skips the mail rather than failing the step, so a secret problem can never masquerade as a clean audit — the run still goes red.
- `jq` builds the mail payload, so advisory text cannot break the JSON.

`cargo deny check advisories` passes on `main` today, so this starts green.

## Follow-up needed

The two secrets do not exist in this repo yet — they are currently only on `jdx/ruby`, and `jdx` is a user account, so there is nothing org-level to inherit. Until they are added the run still reports correctly in the Actions UI, it just does not mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change: scheduled advisory scan and optional email; no application or auth logic changes.
> 
> **Overview**
> Adds a **daily scheduled** GitHub Actions workflow (`advisories.yml`) so new Rust security advisories against locked dependencies are caught even when the repo has no PR/push activity. It runs **`cargo deny check advisories` only** (not licenses/bans/sources, which still change only via commits gated by `ci.yml`’s full `cargo deny check`).
> 
> On failure, the job **emails via Resend** (`RESEND_API_KEY`, `NOTIFY_FROM`, `NOTIFY_EMAIL`) with a link to the run; missing notification secrets **warn and skip mail** but a final step still **fails the workflow** so a red run is not mistaken for a clean audit. Payload is built with **`jq`** to keep advisory text from breaking JSON. Triggers: **cron** `37 7 * * *` and **workflow_dispatch**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e540a62e1a85d7986e07b8fe45540e2741553de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

**Update:** the sender address is no longer hardcoded in the workflow. No email address appears in the repository at all — both ends of the mail come from secrets:

| Secret | Purpose |
| --- | --- |
| `RESEND_API_KEY` | Resend API key |
| `NOTIFY_FROM` | sender address (its domain must be verified in Resend) |
| `NOTIFY_EMAIL` | recipient |

If any of the three is unset the step warns and skips the mail; the run still goes red, so a secret problem can never look like a clean audit.