### PR TITLE
ci: notarize the macOS release binary

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -143,6 +143,11 @@ jobs:
     secrets:
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
+      # Optional: absent, the macOS binary ships signed but un-notarized and
+      # the build annotates a warning rather than failing the release.
+      APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
 
   publish-release:
     name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ on:
         required: true
       CERTIFICATES_P12_PASS:
         required: true
+      APPLE_API_KEY_P8:
+        required: false
+      APPLE_API_KEY_ID:
+        required: false
+      APPLE_API_ISSUER_ID:
+        required: false
   workflow_dispatch:
     inputs:
       tag:
@@ -126,6 +132,77 @@ jobs:
           codesign --force --sign "$IDENTITY" --options runtime --timestamp \
             --prefix dev.jdx. "$BINARY"
           codesign --verify --verbose=2 "$BINARY"
+
+      # Signing alone is not enough for an archive a browser downloaded:
+      # quarantine makes Gatekeeper demand a notarization ticket, and without
+      # one it blocks the binary behind a "cannot be verified" dialog that only
+      # a deliberate override gets past. A `curl`-installed tarball is never
+      # quarantined and never consults a ticket either way, so this covers the
+      # release-page download rather than the documented install.
+      #
+      # The ticket stays on Apple's side: `stapler` writes tickets into
+      # bundles, disk images, and installer packages, and a bare Mach-O is none
+      # of those. Gatekeeper resolves it online instead, which is why nothing
+      # here staples and why the shipped archive is byte-identical to the
+      # signed binary above -- touching it after notarization would invalidate
+      # the signature the ticket is keyed to.
+      - name: Notarize macOS binary
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          BINARY: target/${{ matrix.target }}/release/${{ matrix.bin }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
+            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships a signed but un-notarized macOS binary. Gatekeeper will block it for anyone who downloads the archive through a browser. See RELEASING.md."
+            exit 0
+          fi
+
+          # Outside the workspace, so no later step can sweep the key into an
+          # artifact, and removed even when notarization fails.
+          key="$(mktemp -t mbx-notary-key)"
+          submission="$(mktemp -d -t mbx-notary)/mbx.zip"
+          trap 'rm -rf "$key" "$(dirname "$submission")"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$key"
+
+          # notarytool takes a container, never a bare executable. Dropping
+          # resource forks and xattrs keeps the zip to the one entry that
+          # matters; the ticket is keyed to the Mach-O's cdhash, which this
+          # cannot change.
+          ditto -c -k --norsrc --noextattr "$BINARY" "$submission"
+
+          # `--wait` alone is not a gate: parse the reported status rather than
+          # trusting the exit code to distinguish Accepted from Invalid.
+          # plutil reads JSON and ships with macOS, so this needs no jq.
+          result="$(xcrun notarytool submit "$submission" \
+            --key "$key" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --output-format json \
+            --timeout 30m \
+            --wait)"
+          echo "$result"
+
+          status="$(printf '%s' "$result" | plutil -extract status raw -o - -)"
+          id="$(printf '%s' "$result" | plutil -extract id raw -o - -)"
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::notarization returned $status for submission $id"
+            xcrun notarytool log "$id" \
+              --key "$key" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" || true
+            exit 1
+          fi
+          echo "notarized: submission $id"
+
+          # Informational. A ticket takes a moment to reach the service spctl
+          # asks, so a fresh negative here is not evidence of a bad build --
+          # the submission status above is the gate.
+          spctl --assess --type exec -vv "$BINARY" || true
 
       - name: Check the binary runs
         shell: bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,8 +55,10 @@ These settings live outside the repository, and releases fail without them:
   `mbx` as `Developer ID Application: Jeffrey Dickey (4993Y37DX6)` before
   creating the release archives.
 - **`APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID`** — an App
-  Store Connect API key with the Developer ID role, base64-encoded, plus its key
-  and issuer identifiers. The macOS job submits the signed binary to Apple's
+  Store Connect **team** API key with the Developer role, base64-encoded, plus
+  its key and issuer identifiers. It has to be a team key rather than an
+  individual one: `notarytool` takes an issuer only for team keys and rejects it
+  for individual keys. The macOS job submits the signed binary to Apple's
   notary service with them. These three are the one optional entry in this list:
   without them the release still ships, the binary is still signed, and the
   build annotates a warning instead of failing. What it loses is Gatekeeper

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,15 +70,6 @@ These settings live outside the repository, and releases fail without them:
   crates.io yet cannot be created this way — publish its first version by hand
   with a `publish-new` token, then configure its trusted publisher.
 
-## When a release goes wrong
-
-If the tag was created but the binaries failed to build, fix the problem and
-run the `release` workflow manually with that tag. It rebuilds, re-attaches
-with `--clobber`, and undrafts the release itself — dispatching by hand is the
-one path where nothing else would. If the tag exists but its release does not,
-because release-plz failed after tagging or the draft was deleted, that run
-recreates it rather than failing.
-
 ## Notarization
 
 Signing proves who built the binary; notarization is what Gatekeeper asks for
@@ -105,3 +96,12 @@ The build's `spctl` output is informational. Tickets take a moment to propagate
 after a submission is accepted, so a negative assessment in a release log is not
 by itself evidence of a bad build — the accepted submission status is the gate,
 and the job fails when it is anything else.
+
+## When a release goes wrong
+
+If the tag was created but the binaries failed to build, fix the problem and
+run the `release` workflow manually with that tag. It rebuilds, re-attaches
+with `--clobber`, and undrafts the release itself — dispatching by hand is the
+one path where nothing else would. If the tag exists but its release does not,
+because release-plz failed after tagging or the draft was deleted, that run
+recreates it rather than failing.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,6 +54,14 @@ These settings live outside the repository, and releases fail without them:
   jdx.dev CLI release workflows. The macOS jobs import the certificate and sign
   `mbx` as `Developer ID Application: Jeffrey Dickey (4993Y37DX6)` before
   creating the release archives.
+- **`APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID`** — an App
+  Store Connect API key with the Developer ID role, base64-encoded, plus its key
+  and issuer identifiers. The macOS job submits the signed binary to Apple's
+  notary service with them. These three are the one optional entry in this list:
+  without them the release still ships, the binary is still signed, and the
+  build annotates a warning instead of failing. What it loses is Gatekeeper
+  approval for anyone who downloads the archive through a browser — see
+  [Notarization](#notarization).
 - **A crates.io Trusted Publisher for each of `mbx`, `mbx-cache-core`,
   `mbx-cache-protocol`, and `mbx-cache-rustc`**, naming this repository and the
   workflow file `release-plz.yml`. Publishing is OIDC-only; no registry token
@@ -70,3 +78,30 @@ with `--clobber`, and undrafts the release itself — dispatching by hand is the
 one path where nothing else would. If the tag exists but its release does not,
 because release-plz failed after tagging or the draft was deleted, that run
 recreates it rather than failing.
+
+## Notarization
+
+Signing proves who built the binary; notarization is what Gatekeeper asks for
+when the archive carries the quarantine bit, which is to say when someone
+downloaded it from the releases page in a browser rather than with `curl`. An
+un-notarized binary is blocked there behind a "cannot be verified" dialog.
+Getting past it takes a deliberate override — approving the binary under Privacy
+& Security, or stripping `com.apple.quarantine` by hand — which is not something
+to ask of someone installing a build tool.
+
+The ticket lives on Apple's side and is never stapled into the archive.
+`stapler` writes tickets into bundles, disk images, and installer packages, and
+`mbx` is a bare Mach-O executable in a tarball — none of those. Gatekeeper
+resolves the ticket online instead, which is the normal arrangement for a CLI
+distributed this way. Two consequences worth knowing:
+
+- The shipped archive is byte-identical to the signed binary. Nothing may
+  re-sign, strip, or rewrite it after notarization, or the ticket no longer
+  matches what a user runs.
+- A machine with no network reaching Apple cannot confirm the ticket. That is
+  the trade a non-bundle CLI makes; the alternative is shipping a `.pkg`.
+
+The build's `spctl` output is informational. Tickets take a moment to propagate
+after a submission is accepted, so a negative assessment in a release log is not
+by itself evidence of a bad build — the accepted submission status is the gate,
+and the job fails when it is anything else.


### PR DESCRIPTION
The macOS binary is signed but has never been submitted to Apple's notary service. Signing settles *who* built it; notarization is what Gatekeeper demands once the archive carries the quarantine bit — which is to say whenever someone downloads it from the releases page in a browser rather than with `curl`. Without a ticket it is blocked there behind a "cannot be verified" dialog, and getting past that takes a deliberate override (approving it under Privacy & Security, or stripping `com.apple.quarantine` by hand). That is not something to ask of someone installing a build tool, and it is a predictable 1.0 support-ticket source.

## What this does

The macOS build job submits the signed binary to the notary service and gates on the result. Notable choices, all commented in place:

- **The status is parsed, not inferred from the exit code.** `notarytool submit --wait` can return zero on an `Invalid` submission, so the JSON `status` is the gate. A rejection prints `notarytool log` before failing.
- **`plutil` parses the JSON**, not `jq` — it ships with macOS, so this makes no assumption about what the Namespace runner image happens to include.
- **Nothing is stapled.** `stapler` writes tickets into bundles, disk images, and installer packages; `mbx` is a bare Mach-O in a tarball, so the ticket stays on Apple's side and Gatekeeper resolves it online. This is the normal arrangement for a CLI distributed this way, and `RELEASING.md` now records the two consequences (the archive must stay byte-identical after notarization; an offline machine cannot confirm the ticket).
- **It is the last step to touch the binary**, before `Check the binary runs` and the archive steps. Re-signing or rewriting afterwards would leave a ticket keyed to bytes nobody runs.
- **`spctl` output is informational** (`|| true`). Tickets take a moment to propagate after acceptance, so a fresh negative is not evidence of a bad build — an accepted submission is the gate.

## The credentials are optional on purpose

`APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID` are declared `required: false`. Absent them, the release still ships a signed binary and the job emits a `::warning title=Not notarized::` annotation. Making them required would fail the next release on a secret that is not configured yet, which is worse than a visible warning.

**So this PR does nothing until you add an App Store Connect API key** (Developer ID role) as those three repository secrets. `RELEASING.md` documents them as the one optional entry in its setup list and explains what is lost without them.

## Verification

I cannot notarize for real from here, so the step was exercised against a stubbed `xcrun`:

- **Accepted path** — base64 → key file, `ditto -c -k --norsrc --noextattr` produced a single-entry zip (no AppleDouble `._mbx`), every flag reached `notarytool` intact, status parsed as `Accepted`, step exited 0.
- **Invalid path** — the stub deliberately exits **0** while reporting `Invalid`; the step still failed with exit 1 and fetched the notary log, confirming the status check and not the exit code is what gates.
- **No-credentials path** — warned and exited 0.
- The `trap` left no temp key or directory behind in any case.
- `bash -n` and `shellcheck` clean; both workflows still parse and all jobs are intact.
- `plutil -extract status raw` and the `ditto` flags were verified against real macOS locally.

Part of the pre-1.0 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release CI for macOS distribution and secret handling; misconfiguration could block releases when credentials are set but notarization fails, though missing credentials are intentionally non-fatal.
> 
> **Overview**
> Adds **optional** App Store Connect API secrets to the release workflows and a macOS job step that **notarizes** the already-signed `mbx` binary via `notarytool`, so browser downloads can pass Gatekeeper instead of hitting “cannot be verified.”
> 
> When the three secrets are missing, the job **warns** and continues with a signed-but-un-notarized binary; when present, it submits a zip of the Mach-O, **gates on JSON `status` == Accepted** (not `notarytool` exit code), fetches logs on failure, and runs `spctl` only as informational output. The binary is not stapled or modified after notarization so the shipped tarball stays byte-identical to the signed executable.
> 
> `RELEASING.md` documents the optional secrets, team-key requirement, and a new **Notarization** section (quarantine vs `curl`, no stapling, offline ticket checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ee28f2eca03c57247f00835531ddd111ba0995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->