### PR TITLE
fix: stop timing the runner in the prefetch independence test

### DIFF
--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1353,7 +1353,14 @@ async fn foreground_action_lookup_does_not_wait_for_prefetch_output() {
             .prefetch_action(prefetch_action, "rustc".into())
             .await
     });
-    tokio::time::timeout(Duration::from_secs(1), async {
+    // The prefetch reaches the output blob only after three round trips
+    // against the mock server, and the foreground lookup below makes three of
+    // its own. Both budgets are only ever spent when something hangs, so they
+    // are generous: what this test proves is that the foreground lookup does
+    // not block on the held-open artifact response, not that either side is
+    // fast. A tight bound instead measures the runner, and a contended
+    // windows-latest agent loses that race while behaving correctly.
+    tokio::time::timeout(Duration::from_secs(30), async {
         while !started.load(Ordering::Acquire) {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -1361,11 +1368,8 @@ async fn foreground_action_lookup_does_not_wait_for_prefetch_output() {
     .await
     .expect("prefetch did not request the output blob");
 
-    let foreground = tokio::time::timeout(
-        Duration::from_millis(250),
-        agent.find_action_result(&action),
-    )
-    .await;
+    let foreground =
+        tokio::time::timeout(Duration::from_secs(30), agent.find_action_result(&action)).await;
     release.store(true, Ordering::Release);
     prefetch.await.unwrap().unwrap();
     let foreground = foreground.expect("foreground action lookup waited for output prefetch");


### PR DESCRIPTION
`foreground_action_lookup_does_not_wait_for_prefetch_output` is flaky on Windows CI — it failed on #99, a docs-only PR that cannot affect it, and passed on rerun.

The test blocks a prefetch's output-blob response, then held the foreground `find_action_result` lookup to a hard `Duration::from_millis(250)`. That lookup performs three real HTTP round trips against the mockito server (action result, action blob, output directory), so a slow or contended `windows-latest` runner can exceed 250ms while the lookup is correctly *not* waiting on the prefetch.

The assertion exists to prove independence from the prefetch, and the failure mode it guards against is blocking indefinitely on the held-open response — not slowness. So the budget is now 30 seconds, which is only ever spent when something genuinely hangs. The adjacent wait for the prefetch to reach the output blob had the same shape (three round trips against a 1-second bound) and got the same treatment.

`cargo test --workspace` passes locally, along with `cargo fmt --check` and `cargo clippy --workspace --all-targets`.

Follows 71e1654 ("fix: deflake two tests that race the machine").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout and comment changes; no production cache or agent logic is modified.
> 
> **Overview**
> Deflakes **`foreground_action_lookup_does_not_wait_for_prefetch_output`** by replacing tight `tokio::time::timeout` budgets with **30 seconds** for both the “prefetch reached the held-open output blob” wait and the foreground **`find_action_result`** call.
> 
> The test intentionally blocks the artifact HTTP response while checking that the foreground lookup does **not** wait on prefetch output. Each side needs several mock HTTP round trips, so **250ms / 1s caps were really timing the runner** (notably on contended `windows-latest`) even when behavior was correct. New comments document that generous limits only matter when something actually hangs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd50c144ab0ac151197bacaf62e08c427703cf0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->