### PR TITLE
ci: test the musl binaries we actually ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,29 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: windows-latest
             runner: windows-latest
+          # Every Linux binary a release ships is musl, and every job above
+          # builds gnu, so without these the shipped configuration would reach
+          # users having only ever run `--version`. File locks, unix sockets,
+          # and the reflink ioctls are where a musl-only divergence would hide.
+          # Both release architectures have a native runner, so a static musl
+          # binary needs no emulation to build or run its own test suite.
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-24.04-arm
+            runner: namespace-profile-endev-linux-arm64
+            target: aarch64-unknown-linux-musl
     runs-on: ${{ matrix.runner }}
+    env:
+      # Empty for the host-target jobs, which pass no `--target` at all and
+      # keep cargo's default directory layout.
+      TARGET: ${{ matrix.target }}
+      # rustls brings in aws-lc-sys, which compiles C: cc-rs looks for a
+      # target-prefixed compiler, and Debian's musl-tools only ships
+      # `musl-gcc`. Naming it for both musl targets is harmless elsewhere,
+      # since nothing else consults these variables.
+      CC_x86_64_unknown_linux_musl: musl-gcc
+      CC_aarch64_unknown_linux_musl: musl-gcc
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -72,19 +94,36 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: rustup target add wasm32-unknown-unknown
+      - name: Install the musl toolchain
+        if: endsWith(matrix.target, '-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+      - run: rustup target add wasm32-unknown-unknown ${{ matrix.target }}
       - name: Bootstrap mbx
         shell: bash
         run: |
-          cargo build --package mbx --target-dir target/mbx-bootstrap-build
+          target_flags=()
+          [[ -n "$TARGET" ]] && target_flags+=(--target "$TARGET")
+          cargo build --package mbx --target-dir target/mbx-bootstrap-build "${target_flags[@]}"
+          # A `--target` build nests its artifacts one level deeper.
+          build_dir="target/mbx-bootstrap-build${TARGET:+/$TARGET}/debug"
           mkdir -p target/mbx-bootstrap
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp target/mbx-bootstrap-build/debug/mbx.exe target/mbx-bootstrap/mbx.exe
+            cp "$build_dir/mbx.exe" target/mbx-bootstrap/mbx.exe
           else
-            cp target/mbx-bootstrap-build/debug/mbx target/mbx-bootstrap/mbx
+            cp "$build_dir/mbx" target/mbx-bootstrap/mbx
           fi
-      - run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} build --workspace --all-targets
-      - run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} test --workspace
+      - shell: bash
+        run: |
+          target_flags=()
+          [[ -n "$TARGET" ]] && target_flags+=(--target "$TARGET")
+          ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} build --workspace --all-targets "${target_flags[@]}"
+      - shell: bash
+        run: |
+          target_flags=()
+          [[ -n "$TARGET" ]] && target_flags+=(--target "$TARGET")
+          ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} test --workspace "${target_flags[@]}"
       - name: Run Bats behavioral tests
         if: runner.os != 'Windows'
         env:


### PR DESCRIPTION
Every Linux artifact a release ships is musl, and every Linux CI job built gnu. The only validation a shipped Linux binary got was `--version` in `release.yml` — so file locks, unix sockets, and the reflink `ioctl`s, exactly where a musl-only divergence would hide, were never exercised in the configuration users install.

This adds both release architectures to the `test` matrix:

- `x86_64-unknown-linux-musl` on `namespace-profile-endev-linux-amd64`
- `aarch64-unknown-linux-musl` on `namespace-profile-endev-linux-arm64` — also the first arm64 Linux coverage of any kind

Both run natively, so a static musl binary needs no emulation to build or run its own suite. The bootstrapped `mbx` is itself built for the target, so the integration tests resolve `CARGO_BIN_EXE_mbx` to the musl binary and `MBX_BIN` points the bats suite at it too — both halves of the coverage, not just one.

The musl toolchain setup mirrors `release.yml`, since `default = ["rustls"]` pulls in `aws-lc-sys`, which compiles C and needs `musl-gcc`.

## Verification

Run in Docker on arm64/linux, matching the `aarch64-unknown-linux-musl` entry:

- **Build** succeeds, including the `aws-lc-sys` C compile and link.
- **Test suite**: 325 tests, 0 failures — including the 21 integration tests in `build.rs` that do real cargo builds, file locking, unix-socket agent work, and target views.
- **Standalone**: the binary is fully static (`not a dynamic executable`) and runs in a bare `debian:stable-slim` container with no toolchain. `doctor --json`, `cache stats --json`, and `gc --dry-run --json` all emit correct output, correctly probing `HOME` and detecting reflink support.

`actionlint` is clean.

## Notes

- `CARGO_BUILD_TARGET` would have avoided threading a flag through each step, but cargo rejects an empty value with `error: target was empty`, which would break the three host-target jobs. Hence the explicit `--target` arrays, which are also shellcheck-clean.
- This adds two full Linux build-and-test jobs, so expect Linux CI time to roughly double; the nscloud Rust cache should absorb most of it after the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; it increases Linux job count and runtime but does not modify application or release logic.
> 
> **Overview**
> **Adds full build-and-test CI coverage for the static Linux musl targets that releases ship**, which previously only got a `--version` smoke check while regular Linux jobs built gnu.
> 
> The `test` job matrix gains **`x86_64-unknown-linux-musl`** (amd64 runner) and **`aarch64-unknown-linux-musl`** (arm64 runner). Musl jobs install **`musl-tools`**, set **`CC_*_unknown_linux_musl`** to **`musl-gcc`** for **`aws-lc-sys`**, and pass optional **`--target`** through bootstrap **`mbx`**, workspace **build**, and **test** so the bootstrapped binary and Bats **`MBX_BIN`** exercise the same artifact users install.
> 
> Host-target matrix rows are unchanged: **`TARGET`** stays empty so those jobs keep the default cargo layout and no cross-compile flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d103e4dd22393ef3441f1a539cf5d59d1a7a0f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->