### PR TITLE
security: bound remote downloads and protect release assets

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -158,6 +158,106 @@ jobs:
           TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false
 
+  trust-action-assets:
+    name: Update action trust store
+    needs: [release-plz-release, upload-assets, publish-release]
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: read
+    steps:
+      - name: Download published checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: |
+          mkdir release
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern SHA256SUMS \
+            --dir release
+
+      - name: Check out the action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: jdx/mr-boxington-action
+          path: action
+          persist-credentials: false
+
+      - name: Prepare the update
+        id: update
+        working-directory: action
+        env:
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: |
+          version=${TAG#v}
+          if [[ "v$version" != "$TAG" ]]; then
+            echo "::error::mbx release tag must start with v: $TAG"
+            exit 1
+          fi
+          branch="automation/trust-mbx-$version"
+
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
+            git fetch origin "$branch:refs/remotes/origin/$branch"
+          fi
+          git switch --force-create "$branch" origin/main
+
+          npm ci
+          npm run trust-release -- "$version" ../release/SHA256SUMS
+          npm run check
+          npm test
+          npm run build
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          if git diff --quiet -- src/trusted-release-digests.json dist/index.js; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push the update
+        if: steps.update.outputs.changed == 'true'
+        working-directory: action
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          BRANCH: ${{ steps.update.outputs.branch }}
+          VERSION: ${{ steps.update.outputs.version }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add src/trusted-release-digests.json dist/index.js
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: trust mbx $VERSION release assets"
+          fi
+          gh auth setup-git
+          git push --force-with-lease --set-upstream origin "$BRANCH"
+
+      - name: Open the pull request
+        if: steps.update.outputs.changed == 'true'
+        working-directory: action
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          BRANCH: ${{ steps.update.outputs.branch }}
+          VERSION: ${{ steps.update.outputs.version }}
+        run: |
+          if gh pr list \
+            --repo jdx/mr-boxington-action \
+            --head "jdx:$BRANCH" \
+            --state open \
+            --json number \
+            --jq 'length > 0' | grep -qx true; then
+            echo "A trust-store pull request for mbx $VERSION is already open"
+            exit 0
+          fi
+
+          gh pr create \
+            --repo jdx/mr-boxington-action \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: trust mbx $VERSION release assets" \
+            --body "Pins the SHA-256 digests published with [mbx $VERSION](https://github.com/jdx/mr-boxington/releases/tag/v$VERSION) and rebuilds the checked-in action bundle."
+
   release-plz-pr:
     name: Release PR
     runs-on: namespace-profile-endev-linux-amd64

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -158,14 +158,30 @@ jobs:
           TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false
 
-  trust-action-assets:
-    name: Update action trust store
+  generate-action-assets:
+    name: Generate action trust update
     needs: [release-plz-release, upload-assets, publish-release]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: read
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+      version: ${{ steps.version.outputs.version }}
     steps:
+      - name: Validate the release version
+        id: version
+        env:
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: |
+          version=${TAG#v}
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]] ||
+            [[ "v$version" != "$TAG" ]]; then
+            echo "::error::invalid mbx release tag: $TAG"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Download published checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -185,65 +201,97 @@ jobs:
           persist-credentials: false
 
       - name: Prepare the update
-        id: update
         working-directory: action
         env:
-          TAG: ${{ needs.release-plz-release.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          version=${TAG#v}
-          if [[ "v$version" != "$TAG" ]]; then
-            echo "::error::mbx release tag must start with v: $TAG"
-            exit 1
-          fi
-          branch="automation/trust-mbx-$version"
-
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
-            git fetch origin "$branch:refs/remotes/origin/$branch"
-          fi
-          git switch --force-create "$branch" origin/main
-
           npm ci
-          npm run trust-release -- "$version" ../release/SHA256SUMS
+          npm run trust-release -- "$VERSION" ../release/SHA256SUMS
           npm run check
           npm test
           npm run build
 
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+      - name: Detect generated changes
+        id: changes
+        working-directory: action
+        run: |
           if git diff --quiet -- src/trusted-release-digests.json dist/index.js; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Push the update
-        if: steps.update.outputs.changed == 'true'
+      - name: Upload generated trust files
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trusted-action-assets-${{ steps.version.outputs.version }}
+          path: |
+            action/src/trusted-release-digests.json
+            action/dist/index.js
+          retention-days: 1
+          if-no-files-found: error
+
+  publish-action-assets:
+    name: Propose action trust update
+    needs: [release-plz-release, generate-action-assets]
+    if: ${{ needs.generate-action-assets.outputs.changed == 'true' }}
+    runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: read
+    steps:
+      # No code from the action repository runs in this token-bearing job.
+      - name: Check out a fresh action worktree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: jdx/mr-boxington-action
+          path: action
+          persist-credentials: false
+
+      - name: Download generated trust files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: trusted-action-assets-${{ needs.generate-action-assets.outputs.version }}
+          path: generated
+
+      - name: Commit the update
         working-directory: action
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          BRANCH: ${{ steps.update.outputs.branch }}
-          VERSION: ${{ steps.update.outputs.version }}
+          VERSION: ${{ needs.generate-action-assets.outputs.version }}
         run: |
+          branch="automation/trust-mbx-$VERSION"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
+            git fetch origin "$branch:refs/remotes/origin/$branch"
+          fi
+          git switch --force-create "$branch" origin/main
+          cp ../generated/src/trusted-release-digests.json src/trusted-release-digests.json
+          cp ../generated/dist/index.js dist/index.js
+
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add src/trusted-release-digests.json dist/index.js
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: trust mbx $VERSION release assets"
-          fi
-          gh auth setup-git
-          git push --force-with-lease --set-upstream origin "$BRANCH"
+          git -c core.hooksPath=/dev/null commit -m "chore: trust mbx $VERSION release assets"
 
-      - name: Open the pull request
-        if: steps.update.outputs.changed == 'true'
+      - name: Push the update
         working-directory: action
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          BRANCH: ${{ steps.update.outputs.branch }}
-          VERSION: ${{ steps.update.outputs.version }}
+          VERSION: ${{ needs.generate-action-assets.outputs.version }}
         run: |
+          branch="automation/trust-mbx-$VERSION"
+          gh auth setup-git
+          git -c core.hooksPath=/dev/null push --force-with-lease --set-upstream origin "$branch"
+
+      - name: Open the pull request
+        working-directory: action
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          VERSION: ${{ needs.generate-action-assets.outputs.version }}
+        run: |
+          branch="automation/trust-mbx-$VERSION"
           if gh pr list \
             --repo jdx/mr-boxington-action \
-            --head "jdx:$BRANCH" \
+            --head "jdx:$branch" \
             --state open \
             --json number \
             --jq 'length > 0' | grep -qx true; then
@@ -254,7 +302,7 @@ jobs:
           gh pr create \
             --repo jdx/mr-boxington-action \
             --base main \
-            --head "$BRANCH" \
+            --head "$branch" \
             --title "chore: trust mbx $VERSION release assets" \
             --body "Pins the SHA-256 digests published with [mbx $VERSION](https://github.com/jdx/mr-boxington/releases/tag/v$VERSION) and rebuilds the checked-in action bundle."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,10 @@ jobs:
               --title "$TAG" \
               --verify-tag
           fi
+          if [[ $(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft --jq .isDraft) != true ]]; then
+            echo "::error::refusing to replace assets on published release $TAG"
+            exit 1
+          fi
           gh release upload "$TAG" release-assets/* --repo "${{ github.repository }}" --clobber
 
       # Called from release-plz.yml, undrafting is that workflow's job — it

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,8 +44,13 @@ crates.io but get no GitHub release of their own. Asset names carry no version
 
 ## Setup this depends on
 
-These settings live outside the repository, and releases fail without them:
+These settings live outside the repository and are required for secure,
+successful releases:
 
+- **Immutable releases enabled for the repository** — draft assets remain
+  replaceable while the matrix is being assembled, then GitHub locks the tag
+  and every asset when the draft is published. This also gives consumers a
+  release attestation they can verify independently of `SHA256SUMS`.
 - **`RELEASE_PLZ_TOKEN`** — a PAT with `contents: write` and
   `pull-requests: write`. The default `GITHUB_TOKEN` cannot be used: pushes made
   with it do not trigger workflows, so the release PR would never run CI.
@@ -65,8 +70,10 @@ These settings live outside the repository, and releases fail without them:
 ## When a release goes wrong
 
 If the tag was created but the binaries failed to build, fix the problem and
-run the `release` workflow manually with that tag. It rebuilds, re-attaches
-with `--clobber`, and undrafts the release itself — dispatching by hand is the
-one path where nothing else would. If the tag exists but its release does not,
-because release-plz failed after tagging or the draft was deleted, that run
-recreates it rather than failing.
+run the `release` workflow manually with that tag while the release is still a
+draft. It rebuilds, re-attaches with `--clobber`, and undrafts the release
+itself — dispatching by hand is the one path where nothing else would. If the
+tag exists but its release does not, because release-plz failed after tagging
+or the draft was deleted, that run recreates it rather than failing. The
+workflow refuses to replace assets after publication; release a new version if
+a published artifact is wrong.

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1438,7 +1438,13 @@ impl CacheAgent {
             atomic_saturating_add(&self.stats.remote_blob_pack_blobs, pack.blob_count);
             atomic_saturating_add(&self.stats.downloaded_bytes, pack.payload_bytes);
             if pack.requested.is_empty() {
-                break;
+                // The server's negotiated cap can be smaller than the local
+                // staging cap used to select this locked slice. Fall back for
+                // this slice, but keep packing later candidates that may fit.
+                for digest in &requested {
+                    pack_candidates.remove(digest);
+                }
+                continue;
             }
             for digest in &pack.requested {
                 pack_candidates.remove(digest);

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1,7 +1,8 @@
 use crate::{
-    ActionPrediction, BlobSource, BlobUpload, CacheDigest, CacheDirectory, LocalActionCache,
-    LocalCas, MAX_STAGED_BLOB_PACK_BYTES, ManifestPutOutcome, RemoteActionResult,
-    RemoteCacheClient, RemoteCacheMode, RustcMetadata, TaskActionManifest, canonical_json,
+    ActionPrediction, BlobPackLimits, BlobSource, BlobUpload, CacheDigest, CacheDirectory,
+    LocalActionCache, LocalCas, MAX_STAGED_BLOB_PACK_BYTES, MAX_STAGED_BLOB_PACK_ITEMS,
+    ManifestPutOutcome, RemoteActionResult, RemoteCacheClient, RemoteCacheMode, RustcMetadata,
+    TaskActionManifest, blob_pack_chunk, canonical_json,
 };
 use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
@@ -1329,7 +1330,48 @@ impl CacheAgent {
 
         let mut pack_candidates = missing.clone();
         while !pack_candidates.is_empty() {
-            let requested = pack_candidates.keys().cloned().collect::<Vec<_>>();
+            let candidates = match blob_pack_chunk(
+                &pack_candidates.keys().cloned().collect::<Vec<_>>(),
+                BlobPackLimits {
+                    max_items: MAX_STAGED_BLOB_PACK_ITEMS,
+                    max_bytes: MAX_STAGED_BLOB_PACK_BYTES,
+                },
+            ) {
+                Ok(candidates) if !candidates.is_empty() => candidates,
+                Ok(_) => break,
+                Err(error) => {
+                    warn!("remote cache blob pack skipped: {error}");
+                    break;
+                }
+            };
+            // A pack and an individual fetch share these per-digest locks. Hold
+            // them through ingestion so overlapping prefetch and foreground
+            // requests cannot download or charge the same object twice.
+            let mut pack_guards = BTreeMap::new();
+            for digest in candidates {
+                let guard = self.write_lock(&digest).lock_owned().await;
+                match self.find_verified_blob(&digest) {
+                    Ok(Some(path)) => {
+                        pack_candidates.remove(&digest);
+                        missing.remove(&digest);
+                        verified.insert(digest, path);
+                    }
+                    Ok(None) => {
+                        pack_guards.insert(digest, guard);
+                    }
+                    Err(error) => {
+                        warn!(
+                            "local cache blob lookup failed for {}: {error}",
+                            digest.hash
+                        );
+                        pack_guards.insert(digest, guard);
+                    }
+                }
+            }
+            let requested = pack_guards.keys().cloned().collect::<Vec<_>>();
+            if requested.is_empty() {
+                continue;
+            }
             let requested_bytes = requested
                 .iter()
                 .fold(0_u64, |total, digest| total.saturating_add(digest.size));
@@ -1403,10 +1445,13 @@ impl CacheAgent {
             }
             let mut ingests = stream::iter(pack.blobs.into_iter().map(|(digest, source)| {
                 let digest_for_result = digest.clone();
+                let guard = pack_guards
+                    .remove(&digest)
+                    .expect("requested packed blob has a write lock");
                 async move {
                     (
                         digest_for_result,
-                        self.ingest_packed_blob(digest, source).await,
+                        self.ingest_packed_blob(digest, source, guard).await,
                     )
                 }
             }))
@@ -1450,10 +1495,13 @@ impl CacheAgent {
         verified
     }
 
-    async fn ingest_packed_blob(&self, digest: CacheDigest, source: PathBuf) -> Result<PathBuf> {
+    async fn ingest_packed_blob(
+        &self,
+        digest: CacheDigest,
+        source: PathBuf,
+        _guard: tokio::sync::OwnedMutexGuard<()>,
+    ) -> Result<PathBuf> {
         let digest_size = digest.size;
-        let lock = self.write_lock(&digest);
-        let _guard = lock.lock().await;
         let agent = self.clone();
         let (path, stored, cas_duration_ns) = tokio::task::spawn_blocking(move || {
             if let Some(path) = agent.find_verified_blob(&digest)? {

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1,7 +1,7 @@
 use crate::{
     ActionPrediction, BlobSource, BlobUpload, CacheDigest, CacheDirectory, LocalActionCache,
-    LocalCas, ManifestPutOutcome, RemoteActionResult, RemoteCacheClient, RemoteCacheMode,
-    RustcMetadata, TaskActionManifest, canonical_json,
+    LocalCas, MAX_STAGED_BLOB_PACK_BYTES, ManifestPutOutcome, RemoteActionResult,
+    RemoteCacheClient, RemoteCacheMode, RustcMetadata, TaskActionManifest, canonical_json,
 };
 use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
@@ -26,6 +26,7 @@ const MAX_PREFETCH_ACTION_BATCH: usize = 256;
 const PREFETCH_ACTION_BATCH_DELAY: Duration = Duration::from_millis(5);
 const MAX_PREFETCH_DIRECTORY_OBJECTS: usize = 100_000;
 const MAX_PREFETCH_OBJECTS_PER_WAVE: usize = 100_000;
+const DEFAULT_MAX_REMOTE_DOWNLOAD_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 
 /// Remote action-cache access owned by one task session.
 pub struct AgentRemoteCache {
@@ -438,6 +439,8 @@ pub struct CacheAgent {
     remote: Option<Arc<RemoteCacheClient>>,
     remote_mode: RemoteCacheMode,
     remote_staging_dir: Arc<PathBuf>,
+    remote_download_limit: u64,
+    remote_download_bytes: Arc<AtomicU64>,
     pending_remote_actions: Arc<Mutex<BTreeMap<CacheDigest, RemoteActionResult>>>,
     remote_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_transfers: Arc<tokio::sync::Semaphore>,
@@ -458,6 +461,33 @@ struct PrefetchedAction {
     result: RemoteActionResult,
 }
 
+struct RemoteDownloadReservation {
+    counter: Arc<AtomicU64>,
+    reserved: u64,
+    committed: bool,
+}
+
+impl RemoteDownloadReservation {
+    fn bytes(&self) -> u64 {
+        self.reserved
+    }
+
+    fn commit(mut self, bytes: u64) {
+        debug_assert!(bytes <= self.reserved);
+        self.counter
+            .fetch_sub(self.reserved.saturating_sub(bytes), Ordering::AcqRel);
+        self.committed = true;
+    }
+}
+
+impl Drop for RemoteDownloadReservation {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.counter.fetch_sub(self.reserved, Ordering::AcqRel);
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct ExecutableIdentityKey {
     executable: PathBuf,
@@ -467,7 +497,7 @@ struct ExecutableIdentityKey {
 impl CacheAgent {
     /// Create an agent backed by the cache rooted at `cache_dir`.
     pub fn new(cache_dir: impl Into<PathBuf>, version: impl Into<Arc<str>>) -> Self {
-        Self::build(cache_dir.into(), version.into(), None)
+        Self::build(cache_dir.into(), version.into(), None, 0)
     }
 
     /// Create an agent with local-first access to a remote action cache.
@@ -476,10 +506,35 @@ impl CacheAgent {
         version: impl Into<Arc<str>>,
         remote: AgentRemoteCache,
     ) -> Self {
-        Self::build(cache_dir.into(), version.into(), Some(remote))
+        Self::build(
+            cache_dir.into(),
+            version.into(),
+            Some(remote),
+            DEFAULT_MAX_REMOTE_DOWNLOAD_BYTES,
+        )
     }
 
-    fn build(cache_dir: PathBuf, version: Arc<str>, remote: Option<AgentRemoteCache>) -> Self {
+    /// Create a remote agent with a cumulative download budget for the session.
+    pub fn new_remote_with_download_limit(
+        cache_dir: impl Into<PathBuf>,
+        version: impl Into<Arc<str>>,
+        remote: AgentRemoteCache,
+        max_remote_download_bytes: u64,
+    ) -> Self {
+        Self::build(
+            cache_dir.into(),
+            version.into(),
+            Some(remote),
+            max_remote_download_bytes,
+        )
+    }
+
+    fn build(
+        cache_dir: PathBuf,
+        version: Arc<str>,
+        remote: Option<AgentRemoteCache>,
+        remote_download_limit: u64,
+    ) -> Self {
         let remote_mode = remote
             .as_ref()
             .map_or(RemoteCacheMode::ReadOnly, |remote| remote.mode);
@@ -504,11 +559,51 @@ impl CacheAgent {
             remote,
             remote_mode,
             remote_staging_dir: Arc::new(remote_staging_dir),
+            remote_download_limit,
+            remote_download_bytes: Arc::new(AtomicU64::new(0)),
             pending_remote_actions: Arc::new(Mutex::new(BTreeMap::new())),
             remote_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_REMOTE_TRANSFERS)),
             prefetch_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_PREFETCH_TRANSFERS)),
             prefetch_tasks: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    fn reserve_remote_download(&self, bytes: u64) -> Result<RemoteDownloadReservation> {
+        let mut current = self.remote_download_bytes.load(Ordering::Acquire);
+        loop {
+            let next = current
+                .checked_add(bytes)
+                .ok_or_else(|| eyre::eyre!("remote cache download budget overflowed"))?;
+            if next > self.remote_download_limit {
+                bail!(
+                    "remote cache download budget exceeded: {} bytes requested with {} of {} bytes already used",
+                    bytes,
+                    current,
+                    self.remote_download_limit
+                );
+            }
+            match self.remote_download_bytes.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(RemoteDownloadReservation {
+                        counter: self.remote_download_bytes.clone(),
+                        reserved: bytes,
+                        committed: false,
+                    });
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn reserve_remote_download_up_to(&self, requested: u64) -> Result<RemoteDownloadReservation> {
+        let used = self.remote_download_bytes.load(Ordering::Acquire);
+        let available = self.remote_download_limit.saturating_sub(used);
+        self.reserve_remote_download(requested.min(available))
     }
 
     /// Load the last committed action manifest for a task into this session.
@@ -1218,6 +1313,19 @@ impl CacheAgent {
         let mut pack_candidates = missing.clone();
         while !pack_candidates.is_empty() {
             let requested = pack_candidates.keys().cloned().collect::<Vec<_>>();
+            let requested_bytes = requested
+                .iter()
+                .fold(0_u64, |total, digest| total.saturating_add(digest.size));
+            let pack_reservation = match self
+                .reserve_remote_download_up_to(requested_bytes.min(MAX_STAGED_BLOB_PACK_BYTES))
+            {
+                Ok(reservation) if reservation.bytes() > 0 => reservation,
+                Ok(_) => break,
+                Err(error) => {
+                    warn!("remote cache blob pack skipped: {error}");
+                    break;
+                }
+            };
             let (pack, transfer_duration_ns) = {
                 let _prefetch_permit = match prefetch_limit {
                     Some(limit) => match limit.acquire().await {
@@ -1240,7 +1348,11 @@ impl CacheAgent {
                 };
                 let transfer_started = Instant::now();
                 let pack = remote
-                    .get_blob_pack(&requested, self.remote_staging_dir.as_path())
+                    .get_blob_pack_with_limit(
+                        &requested,
+                        self.remote_staging_dir.as_path(),
+                        pack_reservation.bytes(),
+                    )
                     .await;
                 (pack, duration_ns(transfer_started))
             };
@@ -1258,6 +1370,7 @@ impl CacheAgent {
                     break;
                 }
             };
+            pack_reservation.commit(pack.payload_bytes);
             atomic_saturating_add(
                 &self.stats.remote_blob_transfer_duration_ns,
                 transfer_duration_ns,
@@ -1492,6 +1605,7 @@ impl CacheAgent {
             None => None,
         };
         let _permit = self.remote_transfers.acquire().await?;
+        let reservation = self.reserve_remote_download(digest.size)?;
         self.stats
             .remote_blob_requests
             .fetch_add(1, Ordering::Relaxed);
@@ -1503,6 +1617,7 @@ impl CacheAgent {
         drop(transfer_timer);
         let _cas_timer = AtomicDurationTimer::start(&self.stats.local_cas_write_duration_ns);
         let path = self.cas.store_verified_file(digest, temporary.path())?;
+        reservation.commit(digest.size);
         self.remember_verified_blob(digest, &path);
         self.stats.stores.fetch_add(1, Ordering::Relaxed);
         self.stats

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -601,9 +601,26 @@ impl CacheAgent {
     }
 
     fn reserve_remote_download_up_to(&self, requested: u64) -> Result<RemoteDownloadReservation> {
-        let used = self.remote_download_bytes.load(Ordering::Acquire);
-        let available = self.remote_download_limit.saturating_sub(used);
-        self.reserve_remote_download(requested.min(available))
+        let mut current = self.remote_download_bytes.load(Ordering::Acquire);
+        loop {
+            let reserved = requested.min(self.remote_download_limit.saturating_sub(current));
+            let next = current + reserved;
+            match self.remote_download_bytes.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(RemoteDownloadReservation {
+                        counter: self.remote_download_bytes.clone(),
+                        reserved,
+                        committed: false,
+                    });
+                }
+                Err(observed) => current = observed,
+            }
+        }
     }
 
     /// Load the last committed action manifest for a task into this session.

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1591,6 +1591,15 @@ fn remote_agent(
 }
 
 fn remote_agent_url(base_url: url::Url, cache_dir: PathBuf, mode: RemoteCacheMode) -> CacheAgent {
+    remote_agent_url_with_limit(base_url, cache_dir, mode, DEFAULT_MAX_REMOTE_DOWNLOAD_BYTES)
+}
+
+fn remote_agent_url_with_limit(
+    base_url: url::Url,
+    cache_dir: PathBuf,
+    mode: RemoteCacheMode,
+    max_remote_download_bytes: u64,
+) -> CacheAgent {
     let client = RemoteCacheClient::new(crate::RemoteCacheConfig {
         base_url,
         namespace: "test".into(),
@@ -1603,7 +1612,7 @@ fn remote_agent_url(base_url: url::Url, cache_dir: PathBuf, mode: RemoteCacheMod
         retries: 0,
     })
     .unwrap();
-    CacheAgent::new_remote(
+    CacheAgent::new_remote_with_download_limit(
         &cache_dir,
         "test-version",
         AgentRemoteCache {
@@ -1611,6 +1620,7 @@ fn remote_agent_url(base_url: url::Url, cache_dir: PathBuf, mode: RemoteCacheMod
             mode,
             staging_dir: cache_dir.join("remote"),
         },
+        max_remote_download_bytes,
     )
 }
 
@@ -1633,6 +1643,55 @@ fn action_manifest_path(digest: &CacheDigest) -> String {
         "/v1/action-manifests/{}/{}/{}",
         digest.algorithm, digest.hash, digest.size
     )
+}
+
+#[tokio::test]
+async fn bounds_cumulative_remote_downloads_for_a_session() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let first = CacheDigest::blake3(b"first");
+    let second = CacheDigest::blake3(b"second");
+    let first_download = server
+        .mock("GET", blob_path(&first).as_str())
+        .with_status(200)
+        .with_body("first")
+        .expect(1)
+        .create_async()
+        .await;
+    let second_download = server
+        .mock("GET", blob_path(&second).as_str())
+        .with_status(200)
+        .with_body("second")
+        .expect(0)
+        .create_async()
+        .await;
+    let agent = remote_agent_url_with_limit(
+        server.url().parse().unwrap(),
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+        first.size,
+    );
+
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::FindBlob {
+                digest: first.clone()
+            })
+            .await,
+        AgentResponse::Blob { path: Some(_) }
+    ));
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::FindBlob { digest: second })
+            .await,
+        AgentResponse::Blob { path: None }
+    ));
+    assert_eq!(
+        agent.remote_download_bytes.load(Ordering::Relaxed),
+        first.size
+    );
+    first_download.assert_async().await;
+    second_download.assert_async().await;
 }
 
 #[tokio::test]

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1230,6 +1230,67 @@ async fn pack_and_individual_fetches_share_a_digest_lock() {
 }
 
 #[tokio::test]
+async fn a_smaller_server_pack_cap_does_not_block_later_candidates() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let oversized = CacheDigest {
+        algorithm: "blake3".into(),
+        hash: "00".repeat(32),
+        size: MAX_STAGED_BLOB_PACK_BYTES,
+    };
+    let packed_bytes = b"fit";
+    let packed = CacheDigest::blake3(packed_bytes);
+    let capabilities = server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":{"blob_packs":true},
+                "limits":{"max_batch_items":100,"max_pack_bytes":4}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let pack = server
+        .mock("POST", "/v1/blobs:pack")
+        .match_body(mockito::Matcher::Json(serde_json::json!({
+            "digests": [&packed]
+        })))
+        .with_status(200)
+        .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+        .with_body(blob_pack_body(&[(packed.clone(), packed_bytes.as_slice())]))
+        .expect(1)
+        .create_async()
+        .await;
+    let fallback = server
+        .mock("GET", blob_path(&oversized).as_str())
+        .with_status(404)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+    let remote = agent.remote.as_deref().unwrap();
+
+    let verified = agent
+        .fetch_remote_blobs(remote, vec![oversized, packed.clone()], None)
+        .await;
+
+    assert_eq!(verified.len(), 1);
+    assert_eq!(fs::read(&verified[&packed]).unwrap(), packed_bytes);
+    capabilities.assert_async().await;
+    pack.assert_async().await;
+    fallback.assert_async().await;
+}
+
+#[tokio::test]
 async fn preserves_successful_pack_metrics_when_a_later_chunk_falls_back() {
     let directory = tempfile::tempdir().unwrap();
     let mut server = mockito::Server::new_async().await;

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1138,6 +1138,98 @@ async fn foreground_blob_batches_use_blob_packs() {
 }
 
 #[tokio::test]
+async fn pack_and_individual_fetches_share_a_digest_lock() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let bytes = b"one remote transfer";
+    let digest = CacheDigest::blake3(bytes);
+    let capabilities = server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":{"blob_packs":true},
+                "limits":{"max_batch_items":100,"max_pack_bytes":1048576}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let release = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let response_started = started.clone();
+    let response_release = release.clone();
+    let pack_body = blob_pack_body(&[(digest.clone(), bytes.as_slice())]);
+    let pack = server
+        .mock("POST", "/v1/blobs:pack")
+        .with_status(200)
+        .with_header("content-type", crate::BLOB_PACK_MEDIA_TYPE)
+        .with_chunked_body(move |writer| {
+            response_started.store(true, Ordering::Release);
+            while !response_release.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            std::io::Write::write_all(writer, &pack_body)
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let individual = server
+        .mock("GET", blob_path(&digest).as_str())
+        .with_status(200)
+        .with_body(bytes)
+        .expect(0)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+
+    let pack_agent = agent.clone();
+    let pack_digest = digest.clone();
+    let pack_fetch = tokio::spawn(async move {
+        let remote = pack_agent.remote.as_deref().unwrap();
+        pack_agent
+            .fetch_remote_blobs(remote, vec![pack_digest], None)
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while !started.load(Ordering::Acquire) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("pack request did not start");
+
+    let foreground_agent = agent.clone();
+    let foreground_digest = digest.clone();
+    let foreground_fetch = tokio::spawn(async move {
+        let remote = foreground_agent.remote.as_deref().unwrap();
+        foreground_agent
+            .fetch_remote_blob(remote, &foreground_digest)
+            .await
+    });
+    release.store(true, Ordering::Release);
+
+    let packed = pack_fetch.await.unwrap();
+    let foreground = foreground_fetch.await.unwrap().unwrap();
+    assert_eq!(fs::read(&packed[&digest]).unwrap(), bytes);
+    assert_eq!(fs::read(foreground).unwrap(), bytes);
+    assert_eq!(
+        agent.remote_download_bytes.load(Ordering::Relaxed),
+        digest.size
+    );
+    capabilities.assert_async().await;
+    pack.assert_async().await;
+    individual.assert_async().await;
+}
+
+#[tokio::test]
 async fn preserves_successful_pack_metrics_when_a_later_chunk_falls_back() {
     let directory = tempfile::tempdir().unwrap();
     let mut server = mockito::Server::new_async().await;

--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -486,6 +486,40 @@ async fn rejects_blob_larger_than_its_digest() {
 }
 
 #[tokio::test]
+async fn rejects_remote_blobs_over_client_limits_before_downloading() {
+    let server = mockito::Server::new_async().await;
+    let client = test_client(&server);
+    let staging = tempfile::tempdir().unwrap();
+    let buffered = CacheDigest {
+        algorithm: "blake3".into(),
+        hash: "0".repeat(64),
+        size: MAX_REMOTE_JSON_BYTES + 1,
+    };
+    let streamed = CacheDigest {
+        algorithm: "blake3".into(),
+        hash: "0".repeat(64),
+        size: MAX_REMOTE_BLOB_BYTES + 1,
+    };
+
+    assert!(
+        client
+            .get_blob(&buffered, BLOB_MEDIA_TYPE)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("in-memory blob declared")
+    );
+    assert!(
+        client
+            .get_blob_file(&streamed, staging.path())
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("remote cache blob declared")
+    );
+}
+
+#[tokio::test]
 async fn rejects_oversized_capabilities() {
     let mut server = mockito::Server::new_async().await;
     server

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -78,6 +78,9 @@ const MAX_REMOTE_JSON_BYTES: u64 = 16 * 1024 * 1024;
 /// A tag is only ever echoed into `If-Match`, so its length is bounded to keep
 /// a server from choosing how large a request header this client sends.
 const MAX_ETAG_BYTES: usize = 256;
+// Match the server's default maximum while retaining a client-side ceiling
+// when the remote advertises or names something larger.
+const MAX_REMOTE_BLOB_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
 const BLOB_PACK_TIMEOUT_BYTES_PER_UNIT: u64 = MAX_STAGED_BLOB_PACK_BYTES / 4;
@@ -500,12 +503,26 @@ impl RemoteCacheClient {
         digests: &[CacheDigest],
         staging_dir: &Path,
     ) -> Result<Option<RemoteBlobPack>> {
+        self.get_blob_pack_with_limit(digests, staging_dir, MAX_STAGED_BLOB_PACK_BYTES)
+            .await
+    }
+
+    pub(crate) async fn get_blob_pack_with_limit(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+        max_bytes: u64,
+    ) -> Result<Option<RemoteBlobPack>> {
         if digests.is_empty() || self.blob_packs_disabled.load(Ordering::Relaxed) {
             return Ok(None);
         }
-        let Some(limits) = self.blob_pack_limits().await? else {
+        let Some(mut limits) = self.blob_pack_limits().await? else {
             return Ok(None);
         };
+        limits.max_bytes = limits.max_bytes.min(max_bytes);
+        if limits.max_bytes == 0 {
+            bail!("remote cache download budget is exhausted");
+        }
         fs::create_dir_all(staging_dir)?;
         let chunk = blob_pack_chunk(digests, limits)?;
         if chunk.is_empty() {
@@ -696,6 +713,13 @@ impl RemoteCacheClient {
         media_type: &'static str,
     ) -> Result<Vec<u8>> {
         digest.validate()?;
+        if digest.size > MAX_REMOTE_JSON_BYTES {
+            bail!(
+                "remote cache in-memory blob declared {} bytes, over the {} byte limit",
+                digest.size,
+                MAX_REMOTE_JSON_BYTES
+            );
+        }
         let url = self.blob_endpoint(digest)?;
         retry_async("GET", &url, self.retries, || async {
             let mut response = self
@@ -728,6 +752,14 @@ impl RemoteCacheClient {
         digest: &CacheDigest,
         staging_dir: &Path,
     ) -> Result<tempfile::NamedTempFile> {
+        digest.validate()?;
+        if digest.size > MAX_REMOTE_BLOB_BYTES {
+            bail!(
+                "remote cache blob declared {} bytes, over the {} byte limit",
+                digest.size,
+                MAX_REMOTE_BLOB_BYTES
+            );
+        }
         let url = self.blob_endpoint(digest)?;
         let download = retry_async("GET", &url, self.retries, || async {
             let mut response = self

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -173,7 +173,7 @@ struct RawGc {
     /// Sweep after a build when collection is due.
     #[usage(env = "MBX_GC_AUTO", default = true)]
     auto: bool,
-    /// Action-store budget.
+    /// Action-store and per-session remote-download budget.
     #[usage(
         env = "MBX_GC_MAX_SIZE",
         default_note = "5% of the cache disk, from 5GiB to 100GiB"

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -62,7 +62,12 @@ impl CacheSession {
         std::fs::create_dir(&staging)?;
         let store = config.store_dir();
         let agent = if let Some(remote) = action_remote_cache(config, &store)? {
-            CacheAgent::new_remote(store.clone(), VERSION, remote)
+            CacheAgent::new_remote_with_download_limit(
+                store.clone(),
+                VERSION,
+                remote,
+                config.gc.max_bytes,
+            )
         } else {
             CacheAgent::new(store.clone(), VERSION)
         };

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -47,7 +47,7 @@ Minimum interval between automatic sweeps.
 - **Default:** 5% of the cache disk, from 5GiB to 100GiB
 - **Set with:** `MBX_GC_MAX_SIZE`
 
-Action-store budget.
+Action-store and per-session remote-download budget.
 
 ## `gc.max_total_size`
 


### PR DESCRIPTION
## Summary

- reject in-memory remote blobs over 16 MiB and streamed blobs over 5 GiB before starting a request
- enforce a cumulative per-session remote download budget, including blob packs, using the configured action-store budget
- refuse to replace assets on a published GitHub release and document immutable-release setup and recovery
- after publishing mbx, open or refresh a ready PR in `jdx/mr-boxington-action` that pins the release checksums and rebuilds `dist`

## Security impact

A malicious or compromised remote cache can no longer use attacker-declared digest sizes or concurrent prefetches to grow client disk usage without a session bound. Published release assets are no longer replaceable through the recovery workflow, and new release digests enter the action through a reviewable PR rather than an automatically trusted write.

The post-release job requires `RELEASE_PLZ_TOKEN` to have contents and pull-request write access to `jdx/mr-boxington-action`.

## Validation

- cargo test --workspace --locked
- cargo clippy --workspace --all-features --all-targets --locked -- -D warnings
- mise run check:docs
- cargo audit
- release updater validated against the published v0.4.0 `SHA256SUMS`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable limits for cumulative remote cache downloads, with a 5 GiB default.
  - Added safeguards that reject oversized downloads before transfer and cap in-memory retrievals.
  - Remote downloads now honor configured budgets across packed and individual blobs.

- **Bug Fixes**
  - Prevented release assets from being replaced after publication.

- **Documentation**
  - Updated cache-size and release guidance to explain download budgets, immutable releases, and artifact verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches security-sensitive remote-cache download accounting and release/asset immutability plus cross-repo automation that depends on `RELEASE_PLZ_TOKEN` permissions to `mr-boxington-action`.
> 
> **Overview**
> Adds **defense-in-depth limits** on remote cache clients and **tighter release supply-chain automation**.
> 
> Remote downloads now fail fast when a digest claims more than **16 MiB** for in-memory blobs or **5 GiB** for streamed blobs, before any HTTP body is read. Each build session also tracks a **cumulative download budget** (reservations for single blobs and blob packs, with commit/adjust on actual bytes); `mbx` sessions wire that cap to **`gc.max_size`**. Blob-pack fetching respects both the budget and per-digest locks so overlapping prefetch and foreground work cannot double-fetch or double-charge the same object; smaller server pack caps no longer stall later pack candidates.
> 
> **Release workflow** changes: manual `release` refuses to **clobber assets** once a GitHub release is no longer a draft; docs call out **immutable releases** and draft-only recovery. After a successful `release-plz` publish, CI validates the tag, runs the action repo’s **`trust-release`** against published `SHA256SUMS`, and opens a **review PR** in `jdx/mr-boxington-action` updating trusted digests and `dist/index.js` (split jobs so untrusted action code does not run in the token-bearing push step).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8c6b47dc8b3688c5e6a1e139f54fb47981fedc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->