### PR TITLE
fix: carry manifest entity tags opaquely

### DIFF
--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -548,6 +548,77 @@ async fn rejects_action_json_larger_than_the_limit() {
 }
 
 #[tokio::test]
+async fn manifest_etags_survive_a_proxy_that_re_encodes_the_response() {
+    // RFC 9110 section 8.8.3.3 obliges an intermediary that compresses a
+    // response to vary the strong ETag with the coding, and Caddy does it by
+    // appending the coding name. Every deployment behind such a proxy serves
+    // tags that cannot be the body's digest, and they still have to reach
+    // If-Match intact or no manifest can ever be updated.
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"manifest");
+    let body = br#"{"predictions":[],"task":"a","version":1}"#;
+    let proxied = format!("{}-zstd", blake3::hash(body).to_hex());
+    let path = format!(
+        "/v{PROTOCOL_VERSION}/action-manifests/{}/{}/{}",
+        key.algorithm, key.hash, key.size
+    );
+    let get = server
+        .mock("GET", path.as_str())
+        .with_status(200)
+        .with_header("etag", &format!("\"{proxied}\""))
+        .with_body(body)
+        .create_async()
+        .await;
+    let put = server
+        .mock("PUT", path.as_str())
+        .match_header("if-match", format!("\"{proxied}\"").as_str())
+        .with_status(204)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let manifest = client.get_action_manifest(&key).await.unwrap().unwrap();
+    assert_eq!(manifest.etag, proxied);
+    assert_eq!(manifest.bytes, body);
+    assert_eq!(
+        client
+            .put_action_manifest(&key, &manifest.bytes, Some(&manifest.etag))
+            .await
+            .unwrap(),
+        ManifestPutOutcome::Stored
+    );
+    get.assert_async().await;
+    put.assert_async().await;
+}
+
+#[test]
+fn entity_tags_are_opaque_but_still_have_to_be_strong() {
+    let hash = blake3::hash(b"manifest").to_hex().to_string();
+    for accepted in [hash.clone(), format!("{hash}-zstd"), "anything".into()] {
+        let header = HeaderValue::from_str(&format!("\"{accepted}\"")).unwrap();
+        assert_eq!(parse_strong_etag(Some(&header)).unwrap(), accepted);
+        assert!(quoted_etag(&accepted).is_ok());
+    }
+    // A weak validator cannot carry a conditional update, and an unquoted or
+    // prematurely terminated tag is not one at all.
+    for rejected in [
+        format!("W/\"{hash}\""),
+        hash.clone(),
+        format!("\"{hash}"),
+        "\"\"".into(),
+        "\"quo\"te\"".into(),
+    ] {
+        let header = HeaderValue::from_str(&rejected).unwrap();
+        assert!(
+            parse_strong_etag(Some(&header)).is_err(),
+            "accepted {rejected}"
+        );
+    }
+    assert!(parse_strong_etag(None).is_err());
+    assert!(quoted_etag(&"x".repeat(MAX_ETAG_BYTES + 1)).is_err());
+}
+
+#[tokio::test]
 async fn uploads_compress_when_the_server_offers_zstd() {
     let mut server = mockito::Server::new_async().await;
     server

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -73,6 +73,11 @@ pub use mbx_cache_protocol::{
 /// `validate_task_manifest` ever sees the payload. The bound matches the agent's
 /// own request ceiling so both ends of the protocol refuse the same magnitude.
 const MAX_REMOTE_JSON_BYTES: u64 = 16 * 1024 * 1024;
+/// Ceiling on the opaque part of an entity tag this client will carry back.
+///
+/// A tag is only ever echoed into `If-Match`, so its length is bounded to keep
+/// a server from choosing how large a request header this client sends.
+const MAX_ETAG_BYTES: usize = 256;
 const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
 const BLOB_PACK_TIMEOUT_BYTES_PER_UNIT: u64 = MAX_STAGED_BLOB_PACK_BYTES / 4;
@@ -644,9 +649,6 @@ impl RemoteCacheClient {
             let response = response.error_for_status()?;
             let etag = parse_strong_etag(response.headers().get(ETAG))?;
             let bytes = read_bounded_json(response, "action manifest").await?;
-            if blake3::hash(&bytes).to_hex().as_str() != etag {
-                bail!("remote action manifest ETag does not match its body");
-            }
             Ok(Some(RemoteActionManifest { bytes, etag }))
         })
         .await
@@ -1024,30 +1026,46 @@ impl BlobPackHasher {
     }
 }
 
+/// Read the entity tag that a later conditional update has to send back.
+///
+/// The tag is carried through opaquely, and nothing may infer content from it.
+/// RFC 9110 section 8.8.3.3 requires an intermediary that re-encodes a response
+/// to vary the strong tag along with it, and proxies do: Caddy appends the
+/// content coding, so a manifest served through compression arrives tagged
+/// `"<hash>-zstd"`. What the body actually is gets established by the caller
+/// comparing it against canonical JSON, not by the shape of this header.
 fn parse_strong_etag(value: Option<&HeaderValue>) -> Result<String> {
     let value = value
         .and_then(|value| value.to_str().ok())
         .ok_or_else(|| eyre!("remote action manifest response is missing an ETag"))?;
+    if value.starts_with("W/") {
+        // If-Match rejects a weak validator, so an update could not tell that it
+        // was overwriting a manifest someone else had published.
+        bail!("remote action manifest response has a weak ETag");
+    }
     let etag = value
         .strip_prefix('"')
         .and_then(|value| value.strip_suffix('"'))
-        .filter(|value| is_lower_hex_digest(value))
+        .filter(|value| is_entity_tag(value))
         .ok_or_else(|| eyre!("remote action manifest response has an invalid ETag"))?;
     Ok(etag.to_owned())
 }
 
 fn quoted_etag(etag: &str) -> Result<HeaderValue> {
-    if !is_lower_hex_digest(etag) {
+    if !is_entity_tag(etag) {
         bail!("invalid remote action manifest ETag");
     }
     Ok(HeaderValue::from_str(&format!("\"{etag}\""))?)
 }
 
-fn is_lower_hex_digest(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+/// Whether this is the opaque body of a strong entity tag (RFC 9110 `etagc`).
+///
+/// `HeaderValue::to_str` has already ruled out anything but visible ASCII, so
+/// the double quote that would end the tag early is all that is left to reject.
+fn is_entity_tag(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_ETAG_BYTES
+        && value.bytes().all(|byte| matches!(byte, 0x21 | 0x23..=0x7e))
 }
 
 #[derive(Clone)]

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -54,6 +54,17 @@ before hashing. The conformance fixture locks their canonical v1 bytes, the
 protocol constants, and the normalized shape of every local-agent message to
 prevent accidental drift.
 
+Action manifests are updated conditionally: a `GET` returns a strong `ETag` that
+the following `PUT` sends back as `If-Match`, and a first write uses
+`If-None-Match: *`. That entity tag is **opaque**. A client must echo it
+unchanged and must not read content from it, because a manifest can reach the
+client through an intermediary — RFC 9110 section 8.8.3.3 requires a proxy that
+compresses a response to vary the strong tag along with the coding, and Caddy
+does so by appending the coding name. What the body is gets established by
+comparing it against its canonical JSON and validating the task identity it
+claims, never by the tag. A server may therefore choose any strong tag; a weak
+one leaves the manifest readable but not updatable.
+
 ## Rust API compatibility
 
 Published Rust APIs follow semantic versioning independently of the wire


### PR DESCRIPTION
## The bug

Every remote cache served through a compressing proxy — which is every real deployment, including `cache.mise.jdx.dev` — has been unable to read or update an action manifest since remote caching shipped.

`get_action_manifest` required the response `ETag` to equal the BLAKE3 of the body. But [RFC 9110 §8.8.3.3](https://www.rfc-editor.org/rfc/rfc9110.html#name-example-entity-tags-varying) obliges an intermediary that re-encodes a response to vary the strong entity tag along with the coding, and [Caddy does exactly that](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/encode/encode.go) by appending the coding name. A manifest served as zstd arrives tagged `"<hash>-zstd"`, so the check could never pass.

## What it cost

From `jdx/hk` CI on `main`, two consecutive pushes with an unchanged `Cargo.lock`:

```
[WARN] remote task action manifest lookup failed for 2ead6f24…: remote action manifest ETag does not match its body
[WARN] remote task action manifest upload failed for 2ead6f24…: remote action manifest ETag does not match its body
cache: 0 hits, 0 misses, 0 prefetched; 0 B downloaded, 628.5 MiB uploaded, 628.5 MiB stored locally
cache could not look up 244 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from
```

The upload fails for the same reason as the lookup: `put_remote_task_manifest` handles `PreconditionFailed` by re-reading the manifest, and that read is the one that dies. With no manifest published, a fresh runner has neither dep-info nor predictions, so it cannot even build an action key — every compilation is unconsulted, and each job re-uploads its whole output. The remote cache was pure upload tax: ~600 MiB per job, per run, restoring nothing.

## The fix

The entity tag was never what established the body. `parse_task_manifest` already requires the bytes to equal their canonical JSON and validates the task identity they claim, which is strictly stronger than a hash the same response supplied. So the tag is now carried through opaquely, the way HTTP defines it:

- `get_action_manifest` no longer hashes the body against the tag.
- `parse_strong_etag` / `quoted_etag` accept any strong `etagc` value rather than a 64-character hex digest, bounded by `MAX_ETAG_BYTES` so a server cannot choose how large a request header we send.
- A weak tag is still refused, because `If-Match` cannot use one — such a manifest stays readable but not updatable.

No security property is lost: manifests only ever supply *candidate* action keys, and every artifact restored through one is independently digest-verified.

## Tests

- `manifest_etags_survive_a_proxy_that_re_encodes_the_response` — serves a manifest tagged `"<hash>-zstd"` and asserts the read succeeds and the tag reaches `If-Match` unchanged. This is the regression test; it fails on `main`.
- `entity_tags_are_opaque_but_still_have_to_be_strong` — covers the accepted and rejected tag shapes directly.
- Full workspace suite: 326 passing, clippy `-D warnings` clean, `cargo fmt --check` clean.

`docs/protocol-compatibility.md` now states the opacity requirement, which was enforced but never specified.

## Note

This is exactly the class of bug that unit tests with mocked HTTP cannot catch — the mock returns whatever the test tells it to. An end-to-end job against a real server behind a real proxy would have caught it on day one, and I'd suggest that as a pre-1.0 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conditional-update semantics for manifests (no ETag-vs-body hash gate), which fixes production proxy deployments but alters client trust boundaries for manifest GET responses.
> 
> **Overview**
> Fixes remote **action manifest** reads and conditional **PUT**s when the cache sits behind a compressing proxy (e.g. Caddy), which serves strong `ETag` values like `"<hash>-zstd"` instead of a raw body digest.
> 
> **`get_action_manifest`** no longer rejects responses whose `ETag` does not equal the BLAKE3 of the JSON body. Manifest integrity stays on canonical JSON parsing elsewhere, not on inferring content from the tag.
> 
> **ETag parsing** now treats tags as **opaque** strong validators: `parse_strong_etag` / `quoted_etag` accept any RFC 9110 `etagc` (bounded by **`MAX_ETAG_BYTES` = 256**), reject weak `W/"..."` tags, and drop the old 64-character hex-only check. The stored tag is echoed unchanged on **`If-Match`**.
> 
> Adds regression tests for proxy-style tags and tag-shape validation; **`docs/protocol-compatibility.md`** documents the opacity rule for manifest updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c46d87bd8d337be6fb41db355f2ff65329d7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->