### PR TITLE
feat: count remote cache failures in the summary

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -277,6 +277,14 @@ pub struct AgentStats {
     pub compiler: BTreeMap<String, CompilerStats>,
     /// Cumulative real compiler time by crate name.
     pub slow_compilations: BTreeMap<String, u64>,
+    /// Remote cache operations that failed and were degraded to a local result.
+    ///
+    /// A remote cache that cannot be reached, or that answers in a way this
+    /// client refuses, costs hit rate rather than correctness, so every one of
+    /// these is recovered from rather than raised. Counting them is what keeps a
+    /// remote that is failing every request from reading as one that merely had
+    /// nothing to offer.
+    pub remote_failures: u64,
     /// Number of task manifest requests made to the remote cache.
     pub remote_manifest_lookups: u64,
     /// Cumulative time spent requesting remote task manifests.
@@ -335,6 +343,7 @@ struct AtomicAgentStats {
     downloaded_bytes: AtomicU64,
     uploaded_bytes: AtomicU64,
     prefetched_actions: AtomicU64,
+    remote_failures: AtomicU64,
     remote_manifest_lookups: AtomicU64,
     remote_manifest_lookup_duration_ns: AtomicU64,
     remote_action_lookups: AtomicU64,
@@ -535,6 +544,7 @@ impl CacheAgent {
                             format!("remote task action manifest lookup failed for {task}")
                         });
                     }
+                    self.note_remote_failure();
                     warn!("remote task action manifest lookup failed for {task}: {error}");
                     (None, None)
                 }
@@ -683,6 +693,7 @@ impl CacheAgent {
                     }
                 }
                 Err(error) => {
+                    self.note_remote_failure();
                     warn!("remote task action manifest upload failed for {task}: {error}");
                 }
             }
@@ -819,6 +830,7 @@ impl CacheAgent {
                 .load(Ordering::Relaxed),
             compiler: self.stats.compiler.lock().unwrap().clone(),
             slow_compilations: self.stats.slow_compilations.lock().unwrap().clone(),
+            remote_failures: self.stats.remote_failures.load(Ordering::Relaxed),
             remote_manifest_lookups: self.stats.remote_manifest_lookups.load(Ordering::Relaxed),
             remote_manifest_lookup_duration_ns: self
                 .stats
@@ -949,8 +961,14 @@ impl CacheAgent {
             match result {
                 Ok(Ok(Some(action))) => resolved.push(action),
                 Ok(Ok(None)) => {}
-                Ok(Err(error)) => warn!("remote action prefetch failed: {error}"),
-                Err(error) => warn!("remote action prefetch task failed: {error}"),
+                Ok(Err(error)) => {
+                    self.note_remote_failure();
+                    warn!("remote action prefetch failed: {error}");
+                }
+                Err(error) => {
+                    self.note_remote_failure();
+                    warn!("remote action prefetch task failed: {error}");
+                }
             }
             if let Some((action, adapter)) = actions.next() {
                 let agent = self.clone();
@@ -1653,6 +1671,7 @@ impl CacheAgent {
                 })
                 .await
             {
+                self.note_remote_failure();
                 warn!(
                     "remote cache blob upload failed for {}: {error}",
                     digest.hash
@@ -1731,6 +1750,7 @@ impl CacheAgent {
             }
             Ok(None) => Ok(AgentResponse::ActionResult { result: None }),
             Err(error) => {
+                self.note_remote_failure();
                 warn!(
                     "remote cache action lookup failed for {}: {error}",
                     action.hash
@@ -1747,6 +1767,7 @@ impl CacheAgent {
         {
             let _permit = self.remote_transfers.acquire().await?;
             if let Err(error) = remote.put_action_result(result).await {
+                self.note_remote_failure();
                 warn!(
                     "remote cache action upload failed for {}: {error}",
                     result.action.hash
@@ -1754,6 +1775,11 @@ impl CacheAgent {
             }
         }
         Ok(AgentResponse::ActionStored { path })
+    }
+
+    /// Record that a remote operation failed and the build carried on without it.
+    fn note_remote_failure(&self) {
+        self.stats.remote_failures.fetch_add(1, Ordering::Relaxed);
     }
 
     async fn get_remote_action_result(

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -318,6 +318,7 @@ struct StatsReport {
     reflinked_output_bytes: u64,
     copied_output_files: u64,
     copied_output_bytes: u64,
+    remote_failures: u64,
     remote_manifest_lookups: u64,
     remote_action_lookups: u64,
     remote_blob_requests: u64,
@@ -388,6 +389,7 @@ impl From<&AgentStats> for StatsReport {
             reflinked_output_bytes: stats.reflinked_output_bytes,
             copied_output_files: stats.copied_output_files,
             copied_output_bytes: stats.copied_output_bytes,
+            remote_failures: stats.remote_failures,
             remote_manifest_lookups: stats.remote_manifest_lookups,
             remote_action_lookups: stats.remote_action_lookups,
             remote_blob_requests: stats.remote_blob_requests,
@@ -425,6 +427,17 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         ByteSize::b(stats.uploaded_bytes).display().iec(),
         ByteSize::b(stats.stored_bytes).display().iec(),
     ));
+    if stats.remote_failures > 0 {
+        // A remote cache that fails every request reports the same hits, misses
+        // and bytes as one that was simply empty, and the warnings explaining
+        // why scroll past hundreds of lines earlier. Without this line the
+        // summary reads as "the remote had nothing for us" no matter which it
+        // was, and a cache that has stopped working looks like a cold one.
+        note(&format!(
+            "mbx[cache]: the remote cache failed {} of its requests; this build ran without what it could not reach, and the warnings above say why",
+            stats.remote_failures,
+        ));
+    }
     if stats.unconsulted > 0 {
         // A cold target directory hits this for everything it compiles, and
         // reporting only hits and misses there says "0 hits, 0 misses" -- which
@@ -530,6 +543,9 @@ fn should_display_stats(stats: &AgentStats) -> bool {
         || !stats.bypasses.is_empty()
         || !stats.compiler.is_empty()
         || stats.avoided_compiler_duration_ns > 0
+        // A session that reached a remote cache and got nothing but failures has
+        // nothing else to report, and is the session most worth reporting.
+        || stats.remote_failures > 0
 }
 
 /// Write to stderr without failing the build when the pipe is closed.

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -186,6 +186,16 @@ fn compiler_only_sessions_are_reportable() {
 }
 
 #[test]
+fn a_session_that_only_failed_its_remote_is_reportable() {
+    // Nothing was looked up, stored or compiled, so every other signal this
+    // gate reads is zero -- and a remote cache that answered nothing but
+    // failures is the one thing the build most needs to be told about.
+    let stats = agent_stats(|stats| stats.remote_failures = 3);
+
+    assert!(should_display_stats(&stats));
+}
+
+#[test]
 fn writes_versioned_stats_report() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("nested").join("stats.json");

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -33,6 +33,22 @@ mbx explain build --workspace
 
 The command preserves Cargo's exit status after printing the explanation.
 
+## Remote failure
+
+A remote cache request failed and the build carried on without it: unreachable
+host, refused credentials, or a response this client would not accept. mbx never
+fails a build over a remote cache, so these only ever cost hit rate — but a
+remote that is failing every request reports the same hits, misses, and bytes as
+one that was merely empty, which is why the summary counts them:
+
+```text
+mbx[cache]: the remote cache failed 4 of its requests; this build ran without what it could not reach, and the warnings above say why
+```
+
+The individual warnings, printed as the build runs, say what failed. The count
+also appears as `remote_failures` in the JSON statistics report, so CI can alert
+on a cache that has quietly stopped serving.
+
 ## Reading the hit rate
 
 A build can report a high hit rate among attempted lookups while spending most
@@ -73,7 +89,9 @@ The usual causes, roughly in the order they show up:
   it; see [limits](/limits#out_dir-sharing-is-opt-in).
 - **CI restored nothing.** On GitHub Actions, check that the cache step
   actually restored an entry — a changed `cache-generation` or a fresh
-  repository starts empty by design.
+  repository starts empty by design. With a remote cache configured, check the
+  [remote failure](#remote-failure) count too: a remote that is failing every
+  request reports the same zeros as one that is merely empty.
 
 ## Compiler time
 


### PR DESCRIPTION
Stacked on #110 — review that one first.

## Why

While diagnosing #110 I found `jdx/hk` had been uploading ~600 MiB per CI job to a remote cache that was serving nothing back, on every push, for a week. The information was all there:

```
[WARN] remote task action manifest lookup failed for 2ead6f24…: remote action manifest ETag does not match its body
[WARN] remote task action manifest upload failed for 2ead6f24…: remote action manifest ETag does not match its body
cache: 0 hits, 0 misses, 0 prefetched; 0 B downloaded, 628.5 MiB uploaded, 628.5 MiB stored locally
```

But those warnings scroll past hundreds of lines before the summary, and the summary — the part anyone actually reads — is identical to what a healthy-but-empty cache prints. A remote cache that has stopped working is indistinguishable from a cold one at a glance, which is precisely why nobody looked.

## What this does

Counts remote operations that failed and were degraded to a local result, at the six places where such an error is already recovered from: manifest lookup and upload, action-result lookup and upload, blob upload, and prefetch. mbx never fails a build over a remote cache and this does not change that — the count just makes the recovery visible:

```text
mbx[cache]: the remote cache failed 4 of its requests; this build ran without what it could not reach, and the warnings above say why
```

The total also lands in the JSON statistics report as `remote_failures`, so CI can alert on a cache that has quietly stopped serving instead of waiting for someone to notice the bill. The field is additive, so the report stays at version 2.

One gate change: a session whose *only* event was a failing remote used to print nothing at all, because every signal `should_display_stats` reads was zero. That session is now reportable — it is the one most worth reporting.

## Tests

- `a_session_that_only_failed_its_remote_is_reportable` covers the gate.
- Full workspace suite: 327 passing, clippy `-D warnings` clean, `cargo fmt --check` clean.

`docs/cache-results.md` documents the new result category alongside hit/miss/bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: no change to remote degradation semantics or build failure behavior; additive stats field and summary output.
> 
> **Overview**
> Adds a **`remote_failures`** counter for remote cache operations that error out and are **degraded to local behavior** (build still succeeds). The cache agent increments it via **`note_remote_failure()`** at existing recovery points: task manifest lookup (non-strict), manifest upload, action lookup/upload, blob upload, and remote action prefetch.
> 
> When **`remote_failures > 0`**, the stderr cache summary prints an extra line so a broken remote is distinguishable from an empty one. The same field is exposed in the version 2 JSON stats report as **`remote_failures`**. **`should_display_stats`** now treats remote-only failure sessions as reportable, and docs add a **Remote failure** section plus CI troubleshooting guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc99b3bdf07f9e3cf637203fcb03255abae62c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->