### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake3",
  "eyre",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "mbx-cache-core",
  "serde",

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.4.0...mbx-cache-core-v0.4.1) - 2026-08-26
+
+### Fixed
+
+- stop timing the runner in the prefetch independence test ([#105](https://github.com/jdx/mr-boxington/pull/105))
+
+### Other
+
+- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
+- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
+
 ## [0.4.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.3.0...mbx-cache-core-v0.4.0) - 2026-08-25
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "mbx internals: CAS, authentication, transport, and the cache agent. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -22,7 +22,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.4.0" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.4.1" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.4.0...mbx-cache-protocol-v0.4.1) - 2026-08-26
+
+### Other
+
+- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
+- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
+
 ## [0.4.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-protocol-v0.4.0) - 2026-08-25
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.4.0"
+version = "0.4.1"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.4.0...mbx-cache-rustc-v0.4.1) - 2026-08-26
+
+### Other
+
+- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
+- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
+
 ## [0.4.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.3.0...mbx-cache-rustc-v0.4.0) - 2026-08-25
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.4.0"
+version = "0.4.1"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/jdx/mr-boxington/compare/v0.4.0...v0.5.0) - 2026-08-26
+
+### Added
+
+- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))
+
+### Other
+
+- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
+- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
+
 ## [0.4.0](https://github.com/jdx/mr-boxington/compare/v0.3.0...v0.4.0) - 2026-08-25
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "0.4.0"
+version = "0.5.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,8 +23,8 @@ dirs = "6"
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.4.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.4.1", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.4.1", default-features = false }
 rand = "0.10"
 reflink-copy = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx <SUBCOMMAND>`
 
-**Version:** 0.4.0
+**Version:** 0.5.0
 
 - **Usage:** `mbx <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `mbx-cache-core`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `mbx`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `mbx` breaking changes

```text
--- failure function_now_doc_hidden: pub function is now #[doc(hidden)] ---

Description:
A pub function is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_now_doc_hidden.ron

Failed in:
  function run in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/cli.rs:177
  function gc in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:315
  function install_shim in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:574
  function sweep_if_due in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:404
  function incremental_allowed in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/policy.rs:41
  function is_rustc_shim in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:854
  function format_span in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:64
  function stats in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:111
  function touch_managed in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:515
  function disk_total_bytes in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:116
  function verify in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:216
  function migrate_existing in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:122
  function reflinks_work in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:210
  function effective_remote_cache_mode in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/policy.rs:13
  function format_duration in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:46
  function release_context in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/policy.rs:31
  function write_atomic in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:26
  function duration_ns in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:104
  function largest in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:188
  function prune in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:553
  function run in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/explain.rs:10
  function can_remove_existing in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:105
  function record_checkout in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:272
  function place in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:226
  function gc_dry_run in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:320
  function workspace_root in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:11
  function build_identity in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:232
  function run_rustc_shim in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:869
  function display_stats in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:407
  function parse_duration in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:82
  function run in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/doctor.rs:53
  function projects in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:130
  function stats in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:538
  function remove_workspace in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:73
  function remove_project in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:248
  function random_string in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/util.rs:229

--- failure pub_module_level_const_now_doc_hidden: pub module-level const is now #[doc(hidden)] ---

Description:
A public const is now marked #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_now_doc_hidden.ron

Failed in:
  RUSTC_SHIM_STEM in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:26

--- failure struct_now_doc_hidden: pub struct is now #[doc(hidden)] ---

Description:
A pub struct is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_now_doc_hidden.ron

Failed in:
  struct GcSettings in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/config.rs:250
  struct VerifyOutcome in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:84
  struct PruneOutcome in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:51
  struct ViewStats in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:45
  struct RemoteSettings in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/config.rs:225
  struct RemoveProjectOutcome in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:91
  struct MigrationOutcome in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/target.rs:66
  struct CacheSession in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:40
  struct TargetSettings in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/config.rs:243
  struct ActionRun in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/session.rs:209
  struct ProjectUsage in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:68
  struct GcOutcome in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:59
  struct HttpSettings in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/config.rs:235
  struct Config in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/config.rs:205
  struct LargestEntry in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:77
  struct StoreStats in file /tmp/.tmpMvBdtT/mr-boxington/crates/mbx/src/store.rs:39
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.4.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.4.0...mbx-cache-protocol-v0.4.1) - 2026-08-26

### Other

- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.4.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.4.0...mbx-cache-core-v0.4.1) - 2026-08-26

### Fixed

- stop timing the runner in the prefetch independence test ([#105](https://github.com/jdx/mr-boxington/pull/105))

### Other

- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.4.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.4.0...mbx-cache-rustc-v0.4.1) - 2026-08-26

### Other

- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
</blockquote>

## `mbx`

<blockquote>

## [0.5.0](https://github.com/jdx/mr-boxington/compare/v0.4.0...v0.5.0) - 2026-08-26

### Added

- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))

### Other

- give every published crate its crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97))
- version each crate by what it promises ([#100](https://github.com/jdx/mr-boxington/pull/100))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only publishes version and changelog updates; risk is mainly for Rust library consumers of the `mbx` crate API surface tightened in prior releases, not for typical CLI usage.
> 
> **Overview**
> **Release-only PR** (release-plz) that bumps crate versions, refreshes per-crate **CHANGELOG** entries, updates **path dependency version pins** and **Cargo.lock**, and sets the generated CLI docs version to **0.5.0**.
> 
> **`mbx`** goes **0.4.0 → 0.5.0**; **`mbx-cache-protocol`**, **`mbx-cache-core`**, and **`mbx-cache-rustc`** go **0.4.0 → 0.4.1**. Documented user-facing work in this release includes an interactive landing demo ([#94](https://github.com/jdx/mr-boxington/pull/94)), crates.io metadata ([#97](https://github.com/jdx/mr-boxington/pull/97)), per-crate versioning policy ([#100](https://github.com/jdx/mr-boxington/pull/100)), and a **prefetch independence test** fix in **mbx-cache-core** ([#105](https://github.com/jdx/mr-boxington/pull/105)).
> 
> The **0.5.0** bump for **`mbx`** reflects **semver-breaking library API** changes (many previously public items marked **`#[doc(hidden)]`**), not new runtime logic in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5dae011f1fdbd7dcb858034c5942afd2d6bb57a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->