### PR TITLE
chore: let the agent's statistics grow without breaking

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -235,7 +235,13 @@ pub enum AgentResponse {
 }
 
 /// Aggregate cache activity for one task session.
+///
+/// The agent produces these; nothing outside this crate has cause to build one.
+/// Saying so keeps a new counter from being a breaking change, which is what
+/// this type exists to accumulate -- reach for [`AgentStats::default`] and
+/// assign the fields a test needs.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct AgentStats {
     /// End-to-end lifetime of the task-scoped cache session.
     pub session_duration_ns: u64,

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -150,29 +150,37 @@ fn handshake_rejects_version_skew() {
     assert!(validate_handshake_response(&response).is_err());
 }
 
+/// Build the statistics a test needs without naming every counter.
+///
+/// `AgentStats` is `#[non_exhaustive]` so that the agent can keep adding
+/// counters, which also means no struct literal can be written from here.
+fn agent_stats(fill: impl FnOnce(&mut AgentStats)) -> AgentStats {
+    let mut stats = AgentStats::default();
+    fill(&mut stats);
+    stats
+}
+
 #[test]
 fn qualification_results_are_not_reported_as_misses() {
-    let stats = AgentStats {
-        lookups: 5,
-        hits: 2,
-        verifications: 2,
-        ..AgentStats::default()
-    };
+    let stats = agent_stats(|stats| {
+        stats.lookups = 5;
+        stats.hits = 2;
+        stats.verifications = 2;
+    });
     assert_eq!(cache_misses(&stats), 1);
 }
 
 #[test]
 fn compiler_only_sessions_are_reportable() {
-    let stats = AgentStats {
-        compiler: BTreeMap::from([(
+    let stats = agent_stats(|stats| {
+        stats.compiler = BTreeMap::from([(
             "bypass".into(),
             mbx_cache_core::CompilerStats {
                 invocations: 1,
                 duration_ns: 42,
             },
-        )]),
-        ..AgentStats::default()
-    };
+        )]);
+    });
 
     assert!(should_display_stats(&stats));
 }
@@ -181,34 +189,33 @@ fn compiler_only_sessions_are_reportable() {
 fn writes_versioned_stats_report() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("nested").join("stats.json");
-    let stats = AgentStats {
-        session_duration_ns: 42,
-        lookups: 5,
-        hits: 2,
-        verifications: 1,
-        prefetched_actions: 3,
-        downloaded_bytes: 1024,
-        restored_output_files: 7,
-        restored_output_bytes: 2048,
-        reflinked_output_files: 5,
-        reflinked_output_bytes: 1536,
-        copied_output_files: 2,
-        copied_output_bytes: 512,
-        avoided_compiler_duration_ns: 2_000,
-        compiler: BTreeMap::from([(
+    let stats = agent_stats(|stats| {
+        stats.session_duration_ns = 42;
+        stats.lookups = 5;
+        stats.hits = 2;
+        stats.verifications = 1;
+        stats.prefetched_actions = 3;
+        stats.downloaded_bytes = 1024;
+        stats.restored_output_files = 7;
+        stats.restored_output_bytes = 2048;
+        stats.reflinked_output_files = 5;
+        stats.reflinked_output_bytes = 1536;
+        stats.copied_output_files = 2;
+        stats.copied_output_bytes = 512;
+        stats.avoided_compiler_duration_ns = 2_000;
+        stats.compiler = BTreeMap::from([(
             "miss".into(),
             mbx_cache_core::CompilerStats {
                 invocations: 3,
                 duration_ns: 4_000,
             },
-        )]),
-        slow_compilations: BTreeMap::from([("slow_crate".into(), 3_000)]),
-        remote_blob_requests: 4,
-        remote_blob_pack_requests: 2,
-        remote_blob_pack_blobs: 100,
-        materialization_duration_ns: 9,
-        ..AgentStats::default()
-    };
+        )]);
+        stats.slow_compilations = BTreeMap::from([("slow_crate".into(), 3_000)]);
+        stats.remote_blob_requests = 4;
+        stats.remote_blob_pack_requests = 2;
+        stats.remote_blob_pack_blobs = 100;
+        stats.materialization_duration_ns = 9;
+    });
 
     write_stats_report(&path, &stats).unwrap();
     let report: serde_json::Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();


### PR DESCRIPTION
Found while writing #112: adding a counter to `AgentStats` fails `cargo-semver-checks`, because the struct's fields are all public and downstream code can construct it exhaustively. A purely additive measurement is therefore a breaking change.

`AgentStats` is a counter bag whose entire purpose is to accumulate — hits, bytes, durations, per-reason bypasses, and now remote failures. Every release has reason to add to it. At 1.0 that freezes, and each new measurement becomes either a major bump or a reason not to measure the thing. The fix costs nothing while a break is still cheap, and #100 has already separated the internals version from the CLI's, so taking it here no longer drags `mbx` along.

The agent produces these and nothing outside the crate has cause to build one, so the only construction this removes is in tests, which now fill a `default()` through a small helper instead of naming every field.

`RestoreStats` is deliberately left constructible: the shim builds one on every compilation, so it is an input to this crate rather than an output. That is the line I drew — `#[non_exhaustive]` fits what the library *produces*, not what callers must *construct*.

Full workspace suite passing, clippy `-D warnings` and `cargo fmt --check` clean.

## Worth deciding separately

Two more cases from the same family, both flagged in the pre-1.0 review and both louder than this one:

- `BypassReason` — a ~40-variant public enum whose documented purpose is to *shrink* as link caching and native linking land. Every one of those improvements is a breaking change as written.
- `Capabilities` / `CapabilityFeatures` / `CapabilityLimits` — `docs/protocol-compatibility.md` promises optional response fields may be added compatibly, but the Rust types modelling them cannot gain a field without a major bump. The documented wire-extension path is closed by the type definitions.

I left both out of this PR because each deserves its own decision, and this one had a concrete blocker attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Library API tightening for a stats output type plus test-only construction changes; no runtime behavior change.
> 
> **Overview**
> Marks **`AgentStats`** as **`#[non_exhaustive]`** and documents that only the agent should build these aggregates—callers should start from **`default()`** and set the fields they care about. That way new session counters can be added without **`cargo-semver-checks`** treating every field addition as a breaking change.
> 
> **`mbx`** session tests can no longer use exhaustive struct literals for **`AgentStats`**, so they use a small **`agent_stats`** helper that mutates a **`default()`** instance instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4bd43e614ed746b4725b01a38a961bf2711bb05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->