### PR TITLE
ci: keep release PRs open across updates

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -200,5 +200,11 @@ jobs:
           fi
 
           git add docs/cli
-          git commit -m "docs: update generated CLI reference"
+          # release-plz preserves maintainer commits by closing and recreating
+          # its PR instead of force-pushing over them. Mark this generated
+          # commit as automation so the next run can update the existing PR.
+          git \
+            -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "docs: update generated CLI reference"
           git push origin "HEAD:$branch"


### PR DESCRIPTION
## Summary

- author generated CLI documentation commits as `github-actions[bot]`
- allow release-plz to update its existing PR instead of treating the generated commit as maintainer work and closing the PR
- document why the bot identity is required

## Testing

- `git diff --check`
- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/release-plz.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to commit metadata for generated docs; no runtime or publishing logic is affected.
> 
> **Overview**
> **Release PR workflow** now commits regenerated `docs/cli` with the **`github-actions[bot]`** identity instead of the default Actions user.
> 
> That matches how **release-plz** treats automation vs maintainer commits: without the bot author, a docs-only commit on the release branch looks like maintainer work, so release-plz **closes and recreates** the PR rather than updating it. Inline comments in the workflow document that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae7e8688a3c87c4b7098435474c0ead0790021b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->