### PR TITLE
docs: say how a breaking API change is actually declared

### DIFF
--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -69,9 +69,28 @@ one leaves the manifest readable but not updatable.
 
 Published Rust APIs follow semantic versioning independently of the wire
 protocols. Pull requests that touch workspace crates run `cargo-semver-checks`
-against the pull request's base commit with all features enabled. An intentional
-breaking API change must include the corresponding major version change; wire
-format changes still require the protocol-version steps above.
+against the pull request's base commit with all features enabled. Wire format
+changes still require the protocol-version steps above.
+
+A breaking API change is *declared*, not numbered by hand. Mark the commit
+breaking -- `feat!:`, or a `BREAKING CHANGE:` footer -- and release-plz prices
+it into the version when it opens the release PR. Do not edit a crate's version
+in a pull request: release-plz owns those numbers, and it knows that a crate on
+`0.x` needs a minor bump where a `1.x` crate would need a major one.
+
+One consequence is worth knowing before it surprises you. A pull request that
+breaks an API on purpose leaves `public API compatibility` red, because the
+version it compares against cannot move until the release PR exists. The
+breaking marker on the commit is what makes the break deliberate; the red check
+is the expected state of an honest breaking change, not a problem to solve
+inside the pull request.
+
+Read that job's output as a list of what broke, not as an instruction. Its
+summary says "semver requires new major version" whatever the crate's position,
+so for the crates on `0.x` it names a bump Cargo does not want -- there, a break
+is a minor. The lint names above the summary are the useful part: they say which
+items changed shape, which is what a reviewer needs to judge whether the break
+was intended.
 
 The four published crates do not share a version, because they do not promise
 the same things:


### PR DESCRIPTION
The "Rust API compatibility" section told contributors this:

> An intentional breaking API change must include the corresponding major version change

That is wrong in two ways, and it has already cost time on #103.

**It tells you to do the one thing you must not do.** release-plz owns crate versions and computes them when it opens the release PR. Read literally, the sentence sends a contributor to hand-edit `Cargo.toml` versions in pursuit of a green check — which is what happened on #103: three crates were hand-bumped for exactly that reason, then removed again once `RELEASING.md` and #114's precedent settled which way was right.

**"Major" is the wrong bump.** `mbx-cache-core` and `mbx-cache-rustc` are on `0.x`, where a break needs a *minor*. The version table two paragraphs further down already said so ("on `0.x`, where a minor bump is allowed to break"), so the page contradicted itself — on a page whose whole job is stating compatibility rules.

## What this says instead

That a breaking change is **declared, not numbered by hand**: mark the commit `feat!:` or add a `BREAKING CHANGE:` footer, and release-plz prices it in at release time. The new wording deliberately names no version position at all, leaving that to release-plz.

It also states the consequence that made the old wording tempting: a PR that intentionally breaks an API **cannot** turn `public API compatibility` green, because the version it compares against does not move until the release PR exists. Both #114 and #103 merged or ran with that check red. Saying so means the red reads as the expected state of an honest breaking change, rather than an oversight to fix inside the PR.

Third paragraph added after review discussion: **the check's own summary is misleading in the same direction.** It prints "semver requires new major version" regardless of the crate's position, so on a `0.4.0` crate it names the one bump Cargo does not want. A contributor who ignores the doc and follows the tool output lands in the same wrong place, so the page now says to read that job for *which lints fired*, not for a version instruction.

## Context

Surfaced while reviewing #103's failing checks. Two related findings, neither changed by this PR:

- #103's semver failure included a genuine false positive (`struct_pub_field_missing` on `AgentStats::remote_failures`) caused purely by its branch trailing a main that had merged #112. Since rebased away; that check is now red on the two intentional lints only.
- #114's `AgentStats` break landed as `chore:`, so release PR #117 had `mbx-cache-core` queued at `0.4.1` — a patch bump carrying a break on a `0.x` crate, which Cargo treats as compatible. #103's `feat!` touching `agent.rs` is what pulls core to `0.5.0` and makes that bump adequate.

If the preference is to change the *gate* rather than document its behavior — say, letting semver-checks pass when the commit carries a breaking marker — this page needs rewording again to match. Documenting current behavior seemed better than leaving a sentence that actively misleads.

## Verification

`mise run check:docs` and `mise run build:docs` pass. Docs-only; no code or generated CLI reference touched. #103 also touches this file; test-merged against its head with `git merge-tree` — no conflict, and the combined section reads in order without redundancy, so these can land either way round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidance; no runtime, API, or CI behavior is modified.
> 
> **Overview**
> Updates the **Rust API compatibility** section in `protocol-compatibility.md` so it matches how this repo actually ships API breaks.
> 
> It **removes** the misleading rule that contributors must bump crate versions (especially “major”) in the same PR. Instead it documents that breaks are **declared** with `feat!:` or a `BREAKING CHANGE:` footer and that **release-plz** sets versions when it opens the release PR—including that `0.x` crates need a **minor** bump, not a major one.
> 
> It also explains why **`public API compatibility` stays red** on intentional breaking PRs until the release PR lands, and how to read **cargo-semver-checks** output (lint names vs the generic “new major version” summary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6dccd04ce012067eafa427a693570ba63153c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust API compatibility guidance to cover compatibility checks, breaking-change metadata, automated versioning, and interpreting lint results.
  * Clarified semantic versioning expectations for pre-1.0 releases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->