### PR TITLE
fix: cache libraries with native search paths

### DIFF
--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -1,6 +1,6 @@
 use super::{
     ActionContext, ActionInput, Argument, BypassReason, MAX_NATIVE_INPUT_BYTES,
-    MAX_PREDICTED_INPUTS, RustcInvocation, normalize_components,
+    MAX_PREDICTED_INPUTS, PathMapping, RustcInvocation, normalize_components,
 };
 use mbx_cache_core::CacheDigest;
 use std::collections::{BTreeMap, BTreeSet};
@@ -272,6 +272,17 @@ impl RustcInvocation {
         dep_info: &RustcDepInfo,
         working_dir: &Path,
     ) -> Result<DiscoveredInputs, BypassReason> {
+        self.discover_inputs_with_mappings(dep_info, working_dir, &[])
+    }
+
+    /// Hash dep-info sources plus modeled compiler inputs, allowing native
+    /// search directories beneath the working directory or a mapped root.
+    pub fn discover_inputs_with_mappings(
+        &self,
+        dep_info: &RustcDepInfo,
+        working_dir: &Path,
+        path_mappings: &[PathMapping],
+    ) -> Result<DiscoveredInputs, BypassReason> {
         if !working_dir.is_absolute() {
             return Err(BypassReason::RelativeWorkingDirectory(
                 working_dir.to_path_buf(),
@@ -291,6 +302,8 @@ impl RustcInvocation {
                 normalize_components(&absolute)
             })
             .collect::<BTreeSet<_>>();
+        let admitted_roots = native_input_roots(&working_dir, path_mappings);
+        let mut native_bytes = 0_u64;
         for argument in &self.arguments {
             if let Argument::SearchPath { kind, path } = argument
                 && kind == "native"
@@ -300,26 +313,46 @@ impl RustcInvocation {
                 } else {
                     working_dir.join(path)
                 };
-                collect_native_directory(&directory, &working_dir, &mut paths)?;
+                collect_native_directory(
+                    &directory,
+                    &admitted_roots,
+                    &mut paths,
+                    &mut native_bytes,
+                )?;
             }
         }
         DiscoveredInputs::from_paths(&working_dir, paths, dep_info.environment.clone())
     }
 }
 
+/// Return normalized roots whose native search directories can be tracked.
+pub(super) fn native_input_roots(
+    working_dir: &Path,
+    path_mappings: &[PathMapping],
+) -> Vec<PathBuf> {
+    std::iter::once(working_dir)
+        .chain(path_mappings.iter().map(|mapping| mapping.root.as_path()))
+        .map(normalize_components)
+        .collect()
+}
+
+/// Add regular files beneath an admitted native search directory, enforcing
+/// the prediction input count and the caller's cumulative native byte budget.
 pub(super) fn collect_native_directory(
     directory: &Path,
-    working_dir: &Path,
+    admitted_roots: &[PathBuf],
     paths: &mut BTreeSet<PathBuf>,
+    native_bytes: &mut u64,
 ) -> Result<(), BypassReason> {
     let directory = normalize_components(directory);
-    let working_dir = normalize_components(working_dir);
-    if !directory.starts_with(&working_dir) {
+    if !admitted_roots
+        .iter()
+        .any(|root| directory.starts_with(root))
+    {
         return Err(BypassReason::UnsupportedSearchPath("native".into()));
     }
 
     let mut pending = vec![directory];
-    let mut bytes = 0_u64;
     while let Some(directory) = pending.pop() {
         let entries = match std::fs::read_dir(&directory) {
             Ok(entries) => entries,
@@ -344,7 +377,7 @@ pub(super) fn collect_native_directory(
             if file_type.is_dir() {
                 pending.push(path);
             } else if file_type.is_file() {
-                bytes = bytes
+                *native_bytes = native_bytes
                     .checked_add(
                         entry
                             .metadata()
@@ -359,7 +392,7 @@ pub(super) fn collect_native_directory(
             } else {
                 return Err(BypassReason::UnsupportedSearchPath("native".into()));
             }
-            if paths.len() > MAX_PREDICTED_INPUTS || bytes > MAX_NATIVE_INPUT_BYTES {
+            if paths.len() > MAX_PREDICTED_INPUTS || *native_bytes > MAX_NATIVE_INPUT_BYTES {
                 return Err(BypassReason::UnsupportedSearchPath("native".into()));
             }
         }
@@ -467,6 +500,22 @@ mod tests {
         ] {
             assert!(RustcDepInfo::parse(contents).is_err(), "{contents:?}");
         }
+    }
+
+    #[test]
+    fn native_directory_byte_limit_is_cumulative() {
+        let directory = tempfile::tempdir().unwrap();
+        let native = directory.path().join("native");
+        std::fs::create_dir_all(&native).unwrap();
+        std::fs::write(native.join("input.lib"), b"xx").unwrap();
+        let roots = native_input_roots(directory.path(), &[]);
+        let mut paths = BTreeSet::new();
+        let mut native_bytes = MAX_NATIVE_INPUT_BYTES - 1;
+
+        assert_eq!(
+            collect_native_directory(&native, &roots, &mut paths, &mut native_bytes),
+            Err(BypassReason::UnsupportedSearchPath("native".into()))
+        );
     }
 
     #[test]

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -1,5 +1,6 @@
 use super::{
-    ActionContext, ActionInput, Argument, BypassReason, RustcInvocation, normalize_components,
+    ActionContext, ActionInput, Argument, BypassReason, MAX_NATIVE_INPUT_BYTES,
+    MAX_PREDICTED_INPUTS, RustcInvocation, normalize_components,
 };
 use mbx_cache_core::CacheDigest;
 use std::collections::{BTreeMap, BTreeSet};
@@ -277,7 +278,7 @@ impl RustcInvocation {
             ));
         }
         let working_dir = normalize_components(working_dir);
-        let paths = dep_info
+        let mut paths = dep_info
             .files
             .iter()
             .chain(&self.required_inputs)
@@ -290,8 +291,80 @@ impl RustcInvocation {
                 normalize_components(&absolute)
             })
             .collect::<BTreeSet<_>>();
+        for argument in &self.arguments {
+            if let Argument::SearchPath { kind, path } = argument
+                && kind == "native"
+            {
+                let directory = if path.is_absolute() {
+                    path.clone()
+                } else {
+                    working_dir.join(path)
+                };
+                collect_native_directory(&directory, &working_dir, &mut paths)?;
+            }
+        }
         DiscoveredInputs::from_paths(&working_dir, paths, dep_info.environment.clone())
     }
+}
+
+pub(super) fn collect_native_directory(
+    directory: &Path,
+    working_dir: &Path,
+    paths: &mut BTreeSet<PathBuf>,
+) -> Result<(), BypassReason> {
+    let directory = normalize_components(directory);
+    let working_dir = normalize_components(working_dir);
+    if !directory.starts_with(&working_dir) {
+        return Err(BypassReason::UnsupportedSearchPath("native".into()));
+    }
+
+    let mut pending = vec![directory];
+    let mut bytes = 0_u64;
+    while let Some(directory) = pending.pop() {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(BypassReason::InputRead {
+                    path: directory,
+                    message: error.to_string(),
+                });
+            }
+        };
+        for entry in entries {
+            let entry = entry.map_err(|error| BypassReason::InputRead {
+                path: directory.clone(),
+                message: error.to_string(),
+            })?;
+            let path = entry.path();
+            let file_type = entry.file_type().map_err(|error| BypassReason::InputRead {
+                path: path.clone(),
+                message: error.to_string(),
+            })?;
+            if file_type.is_dir() {
+                pending.push(path);
+            } else if file_type.is_file() {
+                bytes = bytes
+                    .checked_add(
+                        entry
+                            .metadata()
+                            .map_err(|error| BypassReason::InputRead {
+                                path: path.clone(),
+                                message: error.to_string(),
+                            })?
+                            .len(),
+                    )
+                    .ok_or_else(|| BypassReason::UnsupportedSearchPath("native".into()))?;
+                paths.insert(path);
+            } else {
+                return Err(BypassReason::UnsupportedSearchPath("native".into()));
+            }
+            if paths.len() > MAX_PREDICTED_INPUTS || bytes > MAX_NATIVE_INPUT_BYTES {
+                return Err(BypassReason::UnsupportedSearchPath("native".into()));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn render_argument(argument: &Argument) -> Result<OsString, BypassReason> {

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -695,12 +695,19 @@ impl RustcInputPrediction {
             return Err(BypassReason::UnsupportedPrediction);
         }
         let mut paths = BTreeSet::new();
+        let admitted_roots = dep_info::native_input_roots(working_dir, path_mappings);
+        let mut native_bytes = 0_u64;
         for path in &self.inputs {
             if self.version >= 3
                 && let Some(path) = path.strip_prefix(NATIVE_DIRECTORY_PREDICTION_PREFIX)
             {
                 let directory = denormalize_path(path, path_mappings)?;
-                dep_info::collect_native_directory(&directory, working_dir, &mut paths)?;
+                dep_info::collect_native_directory(
+                    &directory,
+                    &admitted_roots,
+                    &mut paths,
+                    &mut native_bytes,
+                )?;
             } else {
                 paths.insert(denormalize_path(path, path_mappings)?);
             }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -87,6 +87,10 @@ const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
     "tls-model",
 ];
 
+const NATIVE_DIRECTORY_PREDICTION_PREFIX: &str = "@native-directory:";
+const MAX_PREDICTED_INPUTS: usize = 16 * 1024;
+const MAX_NATIVE_INPUT_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
 /// Built-in WebAssembly targets whose default linkers and CRT inputs ship in
 /// the Rust toolchain. Custom target specs never enter this list.
 const COMPILER_BUNDLED_WASM_TARGETS: &[&str] = &[
@@ -443,16 +447,26 @@ impl RustcInvocation {
     ) -> Result<RustcInputPrediction, BypassReason> {
         let builder = ActionBuilder::new(self, context.clone());
         builder.validate_mappings()?;
-        let inputs = discovered
+        let mut inputs = discovered
             .inputs
             .iter()
             .map(|input| builder.normalize_path(&input.path))
-            .collect::<Result<BTreeSet<_>, _>>()?
-            .into_iter()
-            .collect();
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        let mut has_native_directory = false;
+        for argument in &self.arguments {
+            if let Argument::SearchPath { kind, path } = argument
+                && kind == "native"
+            {
+                has_native_directory = true;
+                inputs.insert(format!(
+                    "{NATIVE_DIRECTORY_PREDICTION_PREFIX}{}",
+                    builder.normalize_path(path)?
+                ));
+            }
+        }
         Ok(RustcInputPrediction {
-            version: 1,
-            inputs,
+            version: if has_native_directory { 3 } else { 1 },
+            inputs: inputs.into_iter().collect(),
             environment: discovered.environment.keys().cloned().collect(),
             compiler_duration_ns: 0,
             crate_name: String::new(),
@@ -674,17 +688,23 @@ impl RustcInputPrediction {
         working_dir: &Path,
         path_mappings: &[PathMapping],
     ) -> Result<DiscoveredInputs, BypassReason> {
-        if !matches!(self.version, 1 | 2) {
+        if !matches!(self.version, 1..=3) {
             return Err(BypassReason::UnsupportedPrediction);
         }
-        if self.inputs.len() > 16 * 1024 || self.environment.len() > 4 * 1024 {
+        if self.inputs.len() > MAX_PREDICTED_INPUTS || self.environment.len() > 4 * 1024 {
             return Err(BypassReason::UnsupportedPrediction);
         }
-        let paths = self
-            .inputs
-            .iter()
-            .map(|path| denormalize_path(path, path_mappings))
-            .collect::<Result<BTreeSet<_>, _>>()?;
+        let mut paths = BTreeSet::new();
+        for path in &self.inputs {
+            if self.version >= 3
+                && let Some(path) = path.strip_prefix(NATIVE_DIRECTORY_PREDICTION_PREFIX)
+            {
+                let directory = denormalize_path(path, path_mappings)?;
+                dep_info::collect_native_directory(&directory, working_dir, &mut paths)?;
+            } else {
+                paths.insert(denormalize_path(path, path_mappings)?);
+            }
+        }
         let environment = self
             .environment
             .iter()
@@ -1058,7 +1078,7 @@ impl<'a> Parser<'a> {
             let (kind, path) = search
                 .split_once('=')
                 .map_or(("all", search.as_str()), |(kind, path)| (kind, path));
-            if kind != "dependency" {
+            if !matches!(kind, "dependency" | "native") {
                 return Err(BypassReason::UnsupportedSearchPath(kind.into()));
             }
             self.parsed.push(Argument::SearchPath {

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -141,22 +141,29 @@ fn parses_a_cargo_library_invocation() {
 #[test]
 fn tracks_native_search_path_contents_but_still_rejects_native_libraries() {
     let directory = tempfile::tempdir().unwrap();
+    let working_dir = directory.path().join("registry/widget");
     let native = directory.path().join("target/native");
+    std::fs::create_dir_all(&working_dir).unwrap();
     std::fs::create_dir_all(&native).unwrap();
-    std::fs::write(directory.path().join("src.rs"), "pub fn value() {}\n").unwrap();
+    std::fs::write(working_dir.join("src.rs"), "pub fn value() {}\n").unwrap();
     std::fs::write(native.join("fixture.lib"), "first").unwrap();
+    let native_argument = format!("-Lnative={}", native.display());
     let invocation = RustcInvocation::parse(&args(&[
         "--crate-name=widget",
         "--crate-type=lib",
         "--emit=dep-info,metadata,link",
         "--out-dir=target/debug/deps",
-        "-Lnative=target/native",
+        &native_argument,
         "src.rs",
     ]))
     .unwrap();
     let dep_info = RustcDepInfo::parse("target/debug/deps/widget.d: src.rs\n").unwrap();
     let discovered = invocation
-        .discover_inputs(&dep_info, directory.path())
+        .discover_inputs_with_mappings(
+            &dep_info,
+            &working_dir,
+            &[PathMapping::new(directory.path().join("target"), "target")],
+        )
         .unwrap();
     assert!(
         discovered
@@ -166,8 +173,11 @@ fn tracks_native_search_path_contents_but_still_rejects_native_libraries() {
     );
 
     let action_context = ActionContext {
-        working_dir: directory.path().to_path_buf(),
-        path_mappings: vec![PathMapping::new(directory.path(), "workspace")],
+        working_dir: working_dir.clone(),
+        path_mappings: vec![
+            PathMapping::new(&working_dir, "workspace"),
+            PathMapping::new(directory.path().join("target"), "target"),
+        ],
         inputs: discovered.inputs.clone(),
         ..context(&[])
     };
@@ -175,7 +185,7 @@ fn tracks_native_search_path_contents_but_still_rejects_native_libraries() {
     assert_eq!(prediction.version, 3);
     std::fs::write(native.join("added.lib"), "second").unwrap();
     let predicted = prediction
-        .discover(directory.path(), &action_context.path_mappings)
+        .discover(&working_dir, &action_context.path_mappings)
         .unwrap();
     assert!(
         predicted

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -139,6 +139,65 @@ fn parses_a_cargo_library_invocation() {
 }
 
 #[test]
+fn tracks_native_search_path_contents_but_still_rejects_native_libraries() {
+    let directory = tempfile::tempdir().unwrap();
+    let native = directory.path().join("target/native");
+    std::fs::create_dir_all(&native).unwrap();
+    std::fs::write(directory.path().join("src.rs"), "pub fn value() {}\n").unwrap();
+    std::fs::write(native.join("fixture.lib"), "first").unwrap();
+    let invocation = RustcInvocation::parse(&args(&[
+        "--crate-name=widget",
+        "--crate-type=lib",
+        "--emit=dep-info,metadata,link",
+        "--out-dir=target/debug/deps",
+        "-Lnative=target/native",
+        "src.rs",
+    ]))
+    .unwrap();
+    let dep_info = RustcDepInfo::parse("target/debug/deps/widget.d: src.rs\n").unwrap();
+    let discovered = invocation
+        .discover_inputs(&dep_info, directory.path())
+        .unwrap();
+    assert!(
+        discovered
+            .inputs
+            .iter()
+            .any(|input| input.path == native.join("fixture.lib"))
+    );
+
+    let action_context = ActionContext {
+        working_dir: directory.path().to_path_buf(),
+        path_mappings: vec![PathMapping::new(directory.path(), "workspace")],
+        inputs: discovered.inputs.clone(),
+        ..context(&[])
+    };
+    let prediction = invocation.prediction(&action_context, &discovered).unwrap();
+    assert_eq!(prediction.version, 3);
+    std::fs::write(native.join("added.lib"), "second").unwrap();
+    let predicted = prediction
+        .discover(directory.path(), &action_context.path_mappings)
+        .unwrap();
+    assert!(
+        predicted
+            .inputs
+            .iter()
+            .any(|input| input.path == native.join("added.lib"))
+    );
+
+    let linked = args(&[
+        "--crate-type=lib",
+        "--emit=dep-info,metadata,link",
+        "-Lnative=target/native",
+        "-lstatic=fixture",
+        "src/lib.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse(&linked),
+        Err(BypassReason::NativeLibrary)
+    );
+}
+
+#[test]
 fn expands_utf8_response_files_one_argument_per_line() {
     let directory = tempfile::tempdir().unwrap();
     let response = directory.path().join("rustc.args");

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -365,7 +365,8 @@ fn action_from_parsed_dep_info(
     working_dir: &Path,
     portable: &Portable,
 ) -> Result<(ActionCandidates, DiscoveredInputs)> {
-    let discovered = invocation.discover_inputs(dep_info, working_dir)?;
+    let discovered =
+        invocation.discover_inputs_with_mappings(dep_info, working_dir, &portable.mappings)?;
     let mut context = base_action_context(rustc, working_dir, portable)?;
     discovered.clone().apply_to(&mut context)?;
     let candidates = ActionCandidates::build(invocation, context)?;
@@ -449,7 +450,7 @@ fn decode_prediction_timing(
         bail!("cache agent returned an incompatible rustc timing prediction");
     }
     let timing: RustcInputPrediction = serde_json::from_str(&prediction.payload)?;
-    if !matches!(timing.version, 1 | 2)
+    if !matches!(timing.version, 1..=3)
         || timing.crate_name.len() > 256
         || timing.crate_name.contains(['\0', '\n', '\r'])
         || String::from_utf8(canonical_json(&timing)?)? != prediction.payload

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -400,7 +400,7 @@ fn record_prediction(
         let context = base_action_context(rustc, working_dir, portable)?;
         let invocation_digest = invocation.invocation_digest(&context)?;
         let mut prediction = invocation.prediction(&context, discovered)?;
-        prediction.version = 2;
+        prediction.version = prediction.version.max(2);
         prediction.compiler_duration_ns = timing.duration_ns;
         prediction.crate_name.clone_from(&timing.crate_name);
         let payload = String::from_utf8(canonical_json(&prediction)?)?;

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -13,7 +13,7 @@ fn portable_for(values: &[&str]) -> Portable {
 fn compiler_timing_survives_a_changed_action_key() {
     let invocation = CacheDigest::blake3(b"invocation");
     let timing = RustcInputPrediction {
-        version: 2,
+        version: 3,
         inputs: Vec::new(),
         environment: Vec::new(),
         compiler_duration_ns: 42,

--- a/e2e-win/Cache.Tests.ps1
+++ b/e2e-win/Cache.Tests.ps1
@@ -42,7 +42,7 @@ edition = "2024"
 fn main() {
     println!("cargo:rustc-link-search=native={}", std::env::var("OUT_DIR").unwrap());
 }
-        '@ | Set-Content -Encoding utf8 build.rs
+'@ | Set-Content -Encoding utf8 build.rs
         'pub fn value() -> u8 { 1 }' | Set-Content -Encoding utf8 src\lib.rs
 
         $lockfile = & cargo generate-lockfile 2>&1 | Out-String

--- a/e2e-win/Cache.Tests.ps1
+++ b/e2e-win/Cache.Tests.ps1
@@ -42,8 +42,11 @@ edition = "2024"
 fn main() {
     println!("cargo:rustc-link-search=native={}", std::env::var("OUT_DIR").unwrap());
 }
-'@ | Set-Content -Encoding utf8 build.rs
+        '@ | Set-Content -Encoding utf8 build.rs
         'pub fn value() -> u8 { 1 }' | Set-Content -Encoding utf8 src\lib.rs
+
+        $lockfile = & cargo generate-lockfile 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $lockfile
 
         $cold = & mbx build 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0 -Because $cold

--- a/e2e-win/Cache.Tests.ps1
+++ b/e2e-win/Cache.Tests.ps1
@@ -1,0 +1,57 @@
+Describe 'Rust compilation cache' {
+    BeforeEach {
+        $script:OriginalDir = Get-Location
+        $script:OriginalCacheDir = [Environment]::GetEnvironmentVariable('MBX_CACHE_DIR', 'Process')
+        $script:OriginalGcAuto = [Environment]::GetEnvironmentVariable('MBX_GC_AUTO', 'Process')
+        $script:OriginalTargetViews = [Environment]::GetEnvironmentVariable('MBX_TARGET_VIEWS', 'Process')
+        $script:OriginalTargetDir = [Environment]::GetEnvironmentVariable('CARGO_TARGET_DIR', 'Process')
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        Set-Location $script:TestRoot
+        $env:MBX_CACHE_DIR = Join-Path $script:TestRoot 'cache'
+        $env:MBX_GC_AUTO = '0'
+        $env:MBX_TARGET_VIEWS = '0'
+        Remove-Item Env:CARGO_TARGET_DIR -ErrorAction Ignore
+    }
+
+    AfterEach {
+        Set-Location $script:OriginalDir
+        foreach ($item in @(
+            @{ Name = 'MBX_CACHE_DIR'; Value = $script:OriginalCacheDir },
+            @{ Name = 'MBX_GC_AUTO'; Value = $script:OriginalGcAuto },
+            @{ Name = 'MBX_TARGET_VIEWS'; Value = $script:OriginalTargetViews },
+            @{ Name = 'CARGO_TARGET_DIR'; Value = $script:OriginalTargetDir }
+        )) {
+            if ($null -eq $item.Value) {
+                Remove-Item "Env:$($item.Name)" -ErrorAction Ignore
+            } else {
+                [Environment]::SetEnvironmentVariable($item.Name, $item.Value, 'Process')
+            }
+        }
+    }
+
+    It 'caches a library with a native search path' {
+        New-Item -ItemType Directory -Path src | Out-Null
+        @'
+[package]
+name = "native-search-fixture"
+version = "0.1.0"
+edition = "2024"
+'@ | Set-Content -Encoding utf8 Cargo.toml
+        @'
+fn main() {
+    println!("cargo:rustc-link-search=native={}", std::env::var("OUT_DIR").unwrap());
+}
+'@ | Set-Content -Encoding utf8 build.rs
+        'pub fn value() -> u8 { 1 }' | Set-Content -Encoding utf8 src\lib.rs
+
+        $cold = & mbx build 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $cold
+        $cold | Should -Match 'stored locally'
+
+        Remove-Item -Recurse -Force target
+        $warm = & mbx build 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $warm
+        $warm | Should -Match 'mbx\[cache\]: [1-9][0-9]* hits'
+    }
+}


### PR DESCRIPTION
## Summary
- cache Rust library invocations carrying Cargo-provided native search paths
- content-hash bounded workspace-local native search directories and include them in prediction invalidation
- continue bypassing explicit native-library links and unsafe or oversized search trees
- add a Windows cold/warm end-to-end regression test

## Cause
MSVC builds commonly forward `-L native=...` from dependency build scripts. mbx 0.4.0 rejected those invocations before attempting a lookup, producing Windows summaries with 0 hits and 0 misses.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace`

The Windows Pester regression runs in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which compiler inputs feed the action digest and prediction replay; incorrect bounds or root checks could cause stale hits or unnecessary bypasses, though limits and admitted-root checks mitigate that.
> 
> **Overview**
> **Enables rustc cache hits for invocations that only add Cargo-style `-Lnative=...` search paths** (common on MSVC via `build.rs`), instead of treating every native search path as unsupported and bypassing the cache.
> 
> Input discovery now walks **regular files under admitted native directories** (working directory or portable path-mapping roots), hashes them with the rest of the dep-info inputs, and **bypasses** paths outside those roots, non-file entries, or trees that exceed **16k predicted inputs** or a **2 GiB cumulative native byte budget**. Explicit **`-l` native library links** still force a `NativeLibrary` bypass.
> 
> **Cache predictions bump to version 3** when native directories are involved: normalized paths are stored with an `@native-directory:` prefix and expanded on replay via the same bounded walk. The mbx driver passes path mappings into discovery and records `prediction.version = max(2, …)` so v3 is not downgraded. A Windows Pester e2e checks cold store + warm hit for a crate that links via `OUT_DIR` native search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6db0f4e89a523f6470009de26930271c4469cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rust compilation caching now tracks files in native library search paths.
  * Newly added files in native search directories are detected during cache prediction refreshes.
  * Native search paths are supported for compatible `-Lnative` configurations.

* **Bug Fixes**
  * Cache prediction versions are preserved correctly while maintaining compatibility with older versions.

* **Tests**
  * Added coverage for native search paths and Windows end-to-end cache reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->