### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytesize",
  "demand",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "mbx-cache-core",
  "mbx-cache-rustc",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "blake3",
  "eyre",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-cargo-v0.1.0) - 2026-08-27
+
+### Added
+
+- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
+- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
+- [**breaking**] open the extensible public types to extension ([#103](https://github.com/jdx/mr-boxington/pull/103))
+- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))
+- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
+- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
+- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
+- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
+- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
+- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
+- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
+- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))
+- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
+- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
+- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
+- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
+- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
+- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
+- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
+- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
+
+### Other
+
+- simplify the landing page for 1.0 ([#96](https://github.com/jdx/mr-boxington/pull/96))
+- stop building macOS x64 releases ([#92](https://github.com/jdx/mr-boxington/pull/92))
+- recommend mr-boxington-action ([#54](https://github.com/jdx/mr-boxington/pull/54))
+- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
+- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
+- reword tagline to name target/ ([#36](https://github.com/jdx/mr-boxington/pull/36))
+- *(release)* hand versioning and publishing to release-plz ([#16](https://github.com/jdx/mr-boxington/pull/16))
+- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
+- document usage and the standalone-mode blocker ([#8](https://github.com/jdx/mr-boxington/pull/8))
+- initial placeholder readme

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.1.0...mbx-cache-cc-v0.7.0) - 2026-08-27
+
+### Added
+
+- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
+- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
+- [**breaking**] open the extensible public types to extension ([#103](https://github.com/jdx/mr-boxington/pull/103))
+- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))
+- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
+- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
+- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
+- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
+- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
+- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
+- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
+- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))
+- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
+- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
+- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
+- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
+- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
+- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
+- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
+- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
+
+### Other
+
+- simplify the landing page for 1.0 ([#96](https://github.com/jdx/mr-boxington/pull/96))
+- stop building macOS x64 releases ([#92](https://github.com/jdx/mr-boxington/pull/92))
+- recommend mr-boxington-action ([#54](https://github.com/jdx/mr-boxington/pull/54))
+- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
+- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
+- reword tagline to name target/ ([#36](https://github.com/jdx/mr-boxington/pull/36))
+- *(release)* hand versioning and publishing to release-plz ([#16](https://github.com/jdx/mr-boxington/pull/16))
+- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
+- document usage and the standalone-mode blocker ([#8](https://github.com/jdx/mr-boxington/pull/8))
+- initial placeholder readme

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.1.0"
+version = "0.7.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.5.1...mbx-cache-core-v0.7.0) - 2026-08-27
+
+### Added
+
+- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
+- cache natively linked test binaries ([#129](https://github.com/jdx/mr-boxington/pull/129))
+- cache to an S3-compatible object store ([#140](https://github.com/jdx/mr-boxington/pull/140))
+- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
+- batch remote action lookups and blob uploads ([#131](https://github.com/jdx/mr-boxington/pull/131))
+- publish remote objects after the build asks for them ([#126](https://github.com/jdx/mr-boxington/pull/126))
+- compile churning crates incrementally ([#127](https://github.com/jdx/mr-boxington/pull/127))
+- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
+
+### Fixed
+
+- bound blob pack members to digest sizes ([#136](https://github.com/jdx/mr-boxington/pull/136))
+
+### Other
+
+- define download_timeout as a whole-download deadline ([#142](https://github.com/jdx/mr-boxington/pull/142))
+
 ## [0.5.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.4.0...mbx-cache-core-v0.5.0) - 2026-08-26
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.0" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.1" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.0...mbx-cache-protocol-v0.5.1) - 2026-08-27
+
+### Added
+
+- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
+- batch remote action lookups and blob uploads ([#131](https://github.com/jdx/mr-boxington/pull/131))
+- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
+
 ## [0.5.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.4.0...mbx-cache-protocol-v0.5.0) - 2026-08-26
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.0"
+version = "0.5.1"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.5.1...mbx-cache-rustc-v0.7.0) - 2026-08-27
+
+### Added
+
+- cache natively linked test binaries ([#129](https://github.com/jdx/mr-boxington/pull/129))
+- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
+- compile churning crates incrementally ([#127](https://github.com/jdx/mr-boxington/pull/127))
+- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
+
+### Fixed
+
+- *(rustc)* restore results into the checkout that asked for them ([#141](https://github.com/jdx/mr-boxington/pull/141))
+
 ## [0.5.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.5.0...mbx-cache-rustc-v0.5.1) - 2026-08-26
 
 ### Fixed

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-store-v0.1.0) - 2026-08-27
+
+### Added
+
+- cache standalone C and C++ builds through mbx exec ([#138](https://github.com/jdx/mr-boxington/pull/138))
+- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
+- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
+- [**breaking**] open the extensible public types to extension ([#103](https://github.com/jdx/mr-boxington/pull/103))
+- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))
+- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
+- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
+- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
+- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
+- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
+- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
+- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
+- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))
+- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
+- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
+- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
+- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
+- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
+- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
+- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
+- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))
+
+### Other
+
+- simplify the landing page for 1.0 ([#96](https://github.com/jdx/mr-boxington/pull/96))
+- stop building macOS x64 releases ([#92](https://github.com/jdx/mr-boxington/pull/92))
+- recommend mr-boxington-action ([#54](https://github.com/jdx/mr-boxington/pull/54))
+- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
+- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
+- reword tagline to name target/ ([#36](https://github.com/jdx/mr-boxington/pull/36))
+- *(release)* hand versioning and publishing to release-plz ([#16](https://github.com/jdx/mr-boxington/pull/16))
+- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
+- document usage and the standalone-mode blocker ([#8](https://github.com/jdx/mr-boxington/pull/8))
+- initial placeholder readme

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/jdx/mr-boxington/compare/v0.5.1...v0.5.2) - 2026-08-27
+
+### Added
+
+- cache standalone C and C++ builds through mbx exec ([#138](https://github.com/jdx/mr-boxington/pull/138))
+- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
+- cache natively linked test binaries ([#129](https://github.com/jdx/mr-boxington/pull/129))
+- cache to an S3-compatible object store ([#140](https://github.com/jdx/mr-boxington/pull/140))
+- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
+- batch remote action lookups and blob uploads ([#131](https://github.com/jdx/mr-boxington/pull/131))
+- publish remote objects after the build asks for them ([#126](https://github.com/jdx/mr-boxington/pull/126))
+- compile churning crates incrementally ([#127](https://github.com/jdx/mr-boxington/pull/127))
+- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
+
+### Fixed
+
+- *(rustc)* restore results into the checkout that asked for them ([#141](https://github.com/jdx/mr-boxington/pull/141))
+- symlink the session shim so macOS cannot kill it at exec ([#134](https://github.com/jdx/mr-boxington/pull/134))
+
+### Other
+
+- define download_timeout as a whole-download deadline ([#142](https://github.com/jdx/mr-boxington/pull/142))
+
 ## [0.5.1](https://github.com/jdx/mr-boxington/compare/v0.5.0...v0.5.1) - 2026-08-26
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "0.5.1"
+version = "0.5.2"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -25,7 +25,7 @@ fslock = "0.2"
 log = "0.4"
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.0", default-features = false }
 mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.0", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.1.0", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.7.0", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.7.0", default-features = false }
 mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.0", default-features = false }
 rand = "0.10"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx <SUBCOMMAND>`
 
-**Version:** 0.5.1
+**Version:** 0.5.2
 
 - **Usage:** `mbx <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `mbx-cache-core`: 0.5.1 -> 0.7.0
* `mbx-cache-cargo`: 0.1.0
* `mbx-cache-rustc`: 0.5.1 -> 0.7.0
* `mbx-cache-cc`: 0.1.0 -> 0.7.0
* `mbx-cache-store`: 0.1.0
* `mbx`: 0.5.1 -> 0.5.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.0...mbx-cache-protocol-v0.5.1) - 2026-08-27

### Added

- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
- batch remote action lookups and blob uploads ([#131](https://github.com/jdx/mr-boxington/pull/131))
- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.5.1...mbx-cache-core-v0.7.0) - 2026-08-27

### Added

- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
- cache natively linked test binaries ([#129](https://github.com/jdx/mr-boxington/pull/129))
- cache to an S3-compatible object store ([#140](https://github.com/jdx/mr-boxington/pull/140))
- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
- batch remote action lookups and blob uploads ([#131](https://github.com/jdx/mr-boxington/pull/131))
- publish remote objects after the build asks for them ([#126](https://github.com/jdx/mr-boxington/pull/126))
- compile churning crates incrementally ([#127](https://github.com/jdx/mr-boxington/pull/127))
- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))

### Fixed

- bound blob pack members to digest sizes ([#136](https://github.com/jdx/mr-boxington/pull/136))

### Other

- define download_timeout as a whole-download deadline ([#142](https://github.com/jdx/mr-boxington/pull/142))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-cargo-v0.1.0) - 2026-08-27

### Added

- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
- [**breaking**] open the extensible public types to extension ([#103](https://github.com/jdx/mr-boxington/pull/103))
- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))
- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))
- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))

### Other

- simplify the landing page for 1.0 ([#96](https://github.com/jdx/mr-boxington/pull/96))
- stop building macOS x64 releases ([#92](https://github.com/jdx/mr-boxington/pull/92))
- recommend mr-boxington-action ([#54](https://github.com/jdx/mr-boxington/pull/54))
- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
- reword tagline to name target/ ([#36](https://github.com/jdx/mr-boxington/pull/36))
- *(release)* hand versioning and publishing to release-plz ([#16](https://github.com/jdx/mr-boxington/pull/16))
- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
- document usage and the standalone-mode blocker ([#8](https://github.com/jdx/mr-boxington/pull/8))
- initial placeholder readme
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.5.1...mbx-cache-rustc-v0.7.0) - 2026-08-27

### Added

- cache natively linked test binaries ([#129](https://github.com/jdx/mr-boxington/pull/129))
- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
- compile churning crates incrementally ([#127](https://github.com/jdx/mr-boxington/pull/127))
- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))

### Fixed

- *(rustc)* restore results into the checkout that asked for them ([#141](https://github.com/jdx/mr-boxington/pull/141))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.1.0...mbx-cache-cc-v0.7.0) - 2026-08-27

### Added

- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
- [**breaking**] open the extensible public types to extension ([#103](https://github.com/jdx/mr-boxington/pull/103))
- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))
- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))
- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))

### Other

- simplify the landing page for 1.0 ([#96](https://github.com/jdx/mr-boxington/pull/96))
- stop building macOS x64 releases ([#92](https://github.com/jdx/mr-boxington/pull/92))
- recommend mr-boxington-action ([#54](https://github.com/jdx/mr-boxington/pull/54))
- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
- reword tagline to name target/ ([#36](https://github.com/jdx/mr-boxington/pull/36))
- *(release)* hand versioning and publishing to release-plz ([#16](https://github.com/jdx/mr-boxington/pull/16))
- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
- document usage and the standalone-mode blocker ([#8](https://github.com/jdx/mr-boxington/pull/8))
- initial placeholder readme
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-store-v0.1.0) - 2026-08-27

### Added

- cache standalone C and C++ builds through mbx exec ([#138](https://github.com/jdx/mr-boxington/pull/138))
- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))
- [**breaking**] open the extensible public types to extension ([#103](https://github.com/jdx/mr-boxington/pull/103))
- make landing demo interactive and tag output ([#94](https://github.com/jdx/mr-boxington/pull/94))
- make mbx build the golden path and hide setup ([#75](https://github.com/jdx/mr-boxington/pull/75))
- add cache inspection commands ([#63](https://github.com/jdx/mr-boxington/pull/63))
- add managed target retention policies ([#62](https://github.com/jdx/mr-boxington/pull/62))
- cache compiler-bundled WebAssembly links ([#66](https://github.com/jdx/mr-boxington/pull/66))
- add explicit remote prefetch ([#64](https://github.com/jdx/mr-boxington/pull/64))
- cache compiler-linked wasm outputs ([#45](https://github.com/jdx/mr-boxington/pull/45))
- cache plain cargo commands after setup ([#40](https://github.com/jdx/mr-boxington/pull/40))
- add direct cargo wrapper and docs website ([#28](https://github.com/jdx/mr-boxington/pull/28))
- *(target)* place target directories so a deleted checkout frees them ([#24](https://github.com/jdx/mr-boxington/pull/24))
- *(store)* collect automatically, and release deleted checkouts first ([#23](https://github.com/jdx/mr-boxington/pull/23))
- *(session)* share compilations that read OUT_DIR across checkouts ([#21](https://github.com/jdx/mr-boxington/pull/21))
- *(session)* let a build opt into incremental compilation ([#20](https://github.com/jdx/mr-boxington/pull/20))
- *(session)* count the compilations the cache was never asked about ([#18](https://github.com/jdx/mr-boxington/pull/18))
- *(release)* publish prebuilt binaries on a tag ([#14](https://github.com/jdx/mr-boxington/pull/14))
- *(session)* log why each compilation was not cached ([#11](https://github.com/jdx/mr-boxington/pull/11))
- *(session)* count compilations the cache declined ([#10](https://github.com/jdx/mr-boxington/pull/10))

### Other

- simplify the landing page for 1.0 ([#96](https://github.com/jdx/mr-boxington/pull/96))
- stop building macOS x64 releases ([#92](https://github.com/jdx/mr-boxington/pull/92))
- recommend mr-boxington-action ([#54](https://github.com/jdx/mr-boxington/pull/54))
- enforce protocol and API compatibility ([#43](https://github.com/jdx/mr-boxington/pull/43))
- establish compatibility and security policy ([#37](https://github.com/jdx/mr-boxington/pull/37))
- reword tagline to name target/ ([#36](https://github.com/jdx/mr-boxington/pull/36))
- *(release)* hand versioning and publishing to release-plz ([#16](https://github.com/jdx/mr-boxington/pull/16))
- qualify cross-checkout sharing, and test the boundary ([#12](https://github.com/jdx/mr-boxington/pull/12))
- document usage and the standalone-mode blocker ([#8](https://github.com/jdx/mr-boxington/pull/8))
- initial placeholder readme
</blockquote>

## `mbx`

<blockquote>

## [0.5.2](https://github.com/jdx/mr-boxington/compare/v0.5.1...v0.5.2) - 2026-08-27

### Added

- cache standalone C and C++ builds through mbx exec ([#138](https://github.com/jdx/mr-boxington/pull/138))
- cache C and C++ compiles from build scripts ([#132](https://github.com/jdx/mr-boxington/pull/132))
- cache natively linked test binaries ([#129](https://github.com/jdx/mr-boxington/pull/129))
- cache to an S3-compatible object store ([#140](https://github.com/jdx/mr-boxington/pull/140))
- *(cache)* expose shared Cargo cache integration ([#130](https://github.com/jdx/mr-boxington/pull/130))
- batch remote action lookups and blob uploads ([#131](https://github.com/jdx/mr-boxington/pull/131))
- publish remote objects after the build asks for them ([#126](https://github.com/jdx/mr-boxington/pull/126))
- compile churning crates incrementally ([#127](https://github.com/jdx/mr-boxington/pull/127))
- mbx tui, a live view of every build's cache activity ([#128](https://github.com/jdx/mr-boxington/pull/128))

### Fixed

- *(rustc)* restore results into the checkout that asked for them ([#141](https://github.com/jdx/mr-boxington/pull/141))
- symlink the session shim so macOS cannot kill it at exec ([#134](https://github.com/jdx/mr-boxington/pull/134))

### Other

- define download_timeout as a whole-download deadline ([#142](https://github.com/jdx/mr-boxington/pull/142))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump with changelog and lockfile updates; no runtime or logic changes in the diff.
> 
> **Overview**
> **Release-plz** cut for 2026-08-27: bumps crate versions in `Cargo.toml`, `Cargo.lock`, and the generated CLI docs version string (`0.5.1` → `0.5.2`).
> 
> **`mbx`** goes to **0.5.2**; **`mbx-cache-core`**, **`mbx-cache-rustc`**, and **`mbx-cache-cc`** align at **0.7.0** ( **`mbx-cache-cc`** jumps from **0.1.0**). **`mbx-cache-protocol`** is **0.5.1**; **`mbx-cache-cargo`** and **`mbx-cache-store`** get initial **0.1.0** changelog entries. **`mbx`**’s path dependency on **`mbx-cache-cc`** is updated to **0.7.0**; **`mbx-cache-core`** pins **`mbx-cache-protocol`** at **0.5.1**.
> 
> Each touched crate gets a new **CHANGELOG** section summarizing already-merged work (C/C++ caching, S3 remote store, TUI, rustc restore fix, etc.)—no new behavior lands in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad3bffa318148d515f3d1f05298903b141734e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->