### PR TITLE
ci: use Node 24 for action trust updates

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -205,6 +205,11 @@ jobs:
           path: action
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
       - name: Prepare the update
         working-directory: action
         env:


### PR DESCRIPTION
## Summary

- set up Node 24 before generating `mr-boxington-action` trust updates
- match the action package and checked-in bundle's supported Node version
- keep the release workflow cache-free

This removes the unsupported-engine condition observed in the v0.5.1 post-release job. The asset-set correction and verified 0.5.1 digests are in jdx/mr-boxington-action#12.

## Validation

- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/release-plz.yml`
- `mise x zizmor@1.29.0 -- zizmor .github/workflows/release-plz.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application or release artifact logic affected.
> 
> **Overview**
> The **generate action trust update** job in `release-plz.yml` now runs **`actions/setup-node`** with **Node 24** immediately after checking out `jdx/mr-boxington-action`, before `npm ci` and the trust-release/check/test/build steps.
> 
> This aligns the release workflow with the action’s supported Node version so post-release trust generation no longer hits unsupported-engine warnings or failures on the default runner Node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecfc4bd31a691d06388be340708a9425abdff51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->