### PR TITLE
chore(deps): bump tak

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -86,45 +86,45 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools."github:jdx/tak"]]
-version = "0.0.7"
+version = "0.0.8"
 backend = "github:jdx/tak"
-specifiers = ["0.0.7"]
+specifiers = ["0.0.8"]
 
 [tools."github:jdx/tak"."platforms.linux-arm64"]
-checksum = "sha256:60bca32befaa560fc0a48d3afd4409e106366183493ab11090eb4f9c07eecf0b"
-url = "https://github.com/jdx/tak/releases/download/v0.0.7/tak-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/525604008"
+checksum = "sha256:d3b5ee39a9be283586fcc1f40fffbe4003d0fce79905462f9e798ec488e148dd"
+url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283627"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-arm64-musl"]
-checksum = "sha256:bf04a559b2b513878e481eb7de87cb9af52c5f7b05af1e8c4a2460c8f8d266f7"
-url = "https://github.com/jdx/tak/releases/download/v0.0.7/tak-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/525604010"
+checksum = "sha256:a3261a9ffe9fcb2c997687d1d044107ff311429e0d7385ec98e92c6ea1935e2c"
+url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283626"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64"]
-checksum = "sha256:9d75205619266c1b3bc667f3a0c4a49e202e3e91f16b5aac03a8ab80ca76a7b4"
-url = "https://github.com/jdx/tak/releases/download/v0.0.7/tak-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/525604025"
+checksum = "sha256:8def2146c565a331e2de9abebda238c22bb868335dc139db9a76aff1de1339c4"
+url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283644"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.linux-x64-musl"]
-checksum = "sha256:b89e1118e86d2f414a8826e7e32d278e3c147ea7eb0570b7be818f66355e8094"
-url = "https://github.com/jdx/tak/releases/download/v0.0.7/tak-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/525604026"
+checksum = "sha256:442c866a7572936f639c39edb32042a2f60d78a9dd86116a429f6e31cc9840fe"
+url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283646"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.macos-arm64"]
-checksum = "sha256:40365759ed3b2efc604b8a80c65e9027086e1a65fc392f0e82f8f96cf45213cd"
-url = "https://github.com/jdx/tak/releases/download/v0.0.7/tak-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/525604007"
+checksum = "sha256:fbd5e2c3366f085cb8ce71362bcdc05fbf549e7787bd401ae085a1dee09bdb22"
+url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283628"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.windows-x64"]
-checksum = "sha256:06deb7ad00352ab5408594bb214d1d6bd25c820e877053656b9cbfc687f3e881"
-url = "https://github.com/jdx/tak/releases/download/v0.0.7/tak-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/525604024"
+checksum = "sha256:fd3157419889dc558c87e5779f89d123dc909bfc4f7557c970dcb95d71a97d1b"
+url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283641"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -122,7 +122,7 @@ depends = ["perf:prepare"]
 run = "tak run --record"
 
 [tools]
-"github:jdx/tak" = "0.0.7"
+"github:jdx/tak" = "0.0.8"
 aube = "latest"
 communique = "latest"
 node = "24"


### PR DESCRIPTION
## Summary
- bump the benchmark tak version from 0.0.7 to 0.0.8

## Testing
- `mise exec github:jdx/tak@0.0.8 -- tak --version` (0.0.8)
- `mise run lint-fix`
- `MISE_BATS_VERSION=1.14.0 mise run test:e2e`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and lockfile-only update for the benchmark runner; no runtime or security-sensitive logic changes.
> 
> **Overview**
> Bumps the pinned **tak** dev tool from **0.0.7** to **0.0.8** in `mise.toml` and refreshes `mise.lock` with the new release URLs and checksums for every platform.
> 
> That version is what mise installs for **perf** tasks (`tak run` / `tak run --record`) and related CI usage; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49361519f201cc75931b05c4e197533fc69ef61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `tak` tool to version `0.0.8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->