### PR TITLE
feat: publish remote objects after the build asks for them

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -9,7 +9,7 @@ use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
 use log::warn;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -921,7 +921,7 @@ impl CacheAgent {
         }
         let task = state.manifest;
         validate_task_identity(&task)?;
-        let manifest = {
+        let (manifest, introduced) = {
             let _write_guard = self.manifest_write_lock.lock().unwrap();
             let _file_guard = self.lock_task_manifest(&task)?;
             let mut predictions = self
@@ -934,6 +934,16 @@ impl CacheAgent {
                         .collect::<BTreeMap<_, _>>()
                 })
                 .unwrap_or_default();
+            // Which predictions this run adds, as opposed to inherits. Only a
+            // new one may be withheld for a failed upload: retracting an
+            // inherited one would un-advertise a result that is plausibly still
+            // on the server from whichever session put it there.
+            let introduced: BTreeSet<CacheDigest> = state
+                .pending_predictions
+                .keys()
+                .filter(|invocation| !predictions.contains_key(*invocation))
+                .cloned()
+                .collect();
             // Only publish predictions recorded by this run. `predictions`
             // also contains the baseline loaded by `begin_task`; extending
             // with that snapshot would overwrite newer entries committed by
@@ -946,7 +956,7 @@ impl CacheAgent {
             };
             validate_task_manifest(&manifest, &task)?;
             self.persist_task_manifest(&manifest)?;
-            manifest
+            (manifest, introduced)
         };
         self.task_actions.lock().unwrap().remove(run);
         if self.remote_mode.writes() {
@@ -961,17 +971,25 @@ impl CacheAgent {
                     .map(|prediction| prediction.action.clone())
                     .collect();
                 let unpublished = uploads.wait_for_actions(&actions).await;
-                if !unpublished.is_empty() {
+                let withheld = manifest
+                    .predictions
+                    .iter()
+                    .filter(|prediction| {
+                        introduced.contains(&prediction.invocation)
+                            && unpublished.contains(&prediction.action)
+                    })
+                    .count();
+                if withheld > 0 {
                     // The local manifest keeps them: this checkout can still use
                     // what it built, and a later session can publish it.
                     warn!(
-                        "{} of {} predicted actions were not published, so the remote task action manifest omits them",
-                        unpublished.len(),
+                        "{withheld} of {} predicted actions were not published, so the remote task action manifest omits them",
                         manifest.predictions.len()
                     );
-                    manifest
-                        .predictions
-                        .retain(|prediction| !unpublished.contains(&prediction.action));
+                    manifest.predictions.retain(|prediction| {
+                        !(introduced.contains(&prediction.invocation)
+                            && unpublished.contains(&prediction.action))
+                    });
                 }
             }
             match self

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1,8 +1,9 @@
+use crate::uploads::{ConnectionUploads, UploadQueue, UploadSink};
 use crate::{
-    ActionPrediction, BlobPackLimits, BlobSource, BlobUpload, CacheDigest, CacheDirectory,
-    LocalActionCache, LocalCas, MAX_STAGED_BLOB_PACK_BYTES, MAX_STAGED_BLOB_PACK_ITEMS,
-    ManifestPutOutcome, RemoteActionResult, RemoteCacheClient, RemoteCacheMode, RustcMetadata,
-    TaskActionManifest, blob_pack_chunk, canonical_json,
+    ActionPrediction, BlobPackLimits, CacheDigest, CacheDirectory, LocalActionCache, LocalCas,
+    MAX_STAGED_BLOB_PACK_BYTES, MAX_STAGED_BLOB_PACK_ITEMS, ManifestPutOutcome, RemoteActionResult,
+    RemoteCacheClient, RemoteCacheMode, RustcMetadata, TaskActionManifest, blob_pack_chunk,
+    canonical_json,
 };
 use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
@@ -319,6 +320,17 @@ pub struct AgentStats {
     pub downloaded_bytes: u64,
     /// CAS payload bytes uploaded to the remote cache.
     pub uploaded_bytes: u64,
+    /// Objects published to the remote cache after the build asked for them.
+    ///
+    /// A store request returns once the object is in the local CAS, so the
+    /// upload it implies happens off the build's critical path. This counts the
+    /// blobs and action results that publication actually completed for.
+    pub background_uploads: u64,
+    /// Queued uploads that did not publish, having been reported and recovered
+    /// from.
+    pub background_upload_failures: u64,
+    /// Time the session spent waiting for queued uploads once the build ended.
+    pub upload_drain_duration_ns: u64,
     /// Complete actions staged before an adapter requested them.
     pub prefetched_actions: u64,
     /// Compilations that were not cacheable, counted by reason.
@@ -410,6 +422,9 @@ struct AtomicAgentStats {
     divergences: AtomicU64,
     downloaded_bytes: AtomicU64,
     uploaded_bytes: AtomicU64,
+    background_uploads: AtomicU64,
+    background_upload_failures: AtomicU64,
+    upload_drain_duration_ns: AtomicU64,
     prefetched_actions: AtomicU64,
     remote_failures: AtomicU64,
     remote_manifest_lookups: AtomicU64,
@@ -531,6 +546,37 @@ pub struct CacheAgent {
     remote_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    /// Deferred remote publication, present only when the session may write.
+    uploads: Option<UploadQueue>,
+}
+
+/// Records background upload activity against a session's statistics.
+struct AgentUploadSink {
+    stats: Arc<AtomicAgentStats>,
+}
+
+impl UploadSink for AgentUploadSink {
+    fn record_blob_uploaded(&self, bytes: u64) {
+        self.stats
+            .background_uploads
+            .fetch_add(1, Ordering::Relaxed);
+        self.stats
+            .uploaded_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    fn record_action_uploaded(&self) {
+        self.stats
+            .background_uploads
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_upload_failure(&self) {
+        self.stats
+            .background_upload_failures
+            .fetch_add(1, Ordering::Relaxed);
+        self.stats.remote_failures.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -629,6 +675,22 @@ impl CacheAgent {
             |remote| remote.staging_dir.clone(),
         );
         let remote = remote.map(|remote| Arc::new(remote.client));
+        let stats = Arc::new(AtomicAgentStats::default());
+        let remote_transfers = Arc::new(tokio::sync::Semaphore::new(MAX_REMOTE_TRANSFERS));
+        // A session that cannot publish never queues an upload, so it does not
+        // need somewhere to queue one.
+        let uploads = remote
+            .clone()
+            .filter(|_| remote_mode.writes())
+            .map(|client| {
+                UploadQueue::new(
+                    client,
+                    Arc::new(AgentUploadSink {
+                        stats: stats.clone(),
+                    }),
+                    remote_transfers.clone(),
+                )
+            });
         Self {
             cas: LocalCas::new(cache_dir.clone()),
             actions: LocalActionCache::new(cache_dir.clone()),
@@ -636,7 +698,7 @@ impl CacheAgent {
             version,
             write_locks: Arc::new(Mutex::new(BTreeMap::new())),
             action_locks: Arc::new(Mutex::new(BTreeMap::new())),
-            stats: Arc::new(AtomicAgentStats::default()),
+            stats,
             observer: None,
             executable_identities: Arc::new(Mutex::new(BTreeMap::new())),
             manifest_dir: Arc::new(task_manifest_dir(&cache_dir)),
@@ -649,9 +711,10 @@ impl CacheAgent {
             remote_download_limit,
             remote_download_bytes: Arc::new(AtomicU64::new(0)),
             pending_remote_actions: Arc::new(Mutex::new(BTreeMap::new())),
-            remote_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_REMOTE_TRANSFERS)),
+            remote_transfers,
             prefetch_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_PREFETCH_TRANSFERS)),
             prefetch_tasks: Arc::new(Mutex::new(Vec::new())),
+            uploads,
         }
     }
 
@@ -820,6 +883,20 @@ impl CacheAgent {
         }
     }
 
+    /// Publish everything a build queued, before the session stops.
+    ///
+    /// Store requests return once an object is durable locally, so at this point
+    /// the remote cache may still be behind the local one. Uploads run on the
+    /// session's runtime and are abandoned if it goes away, so a session that
+    /// wants them published has to wait here.
+    pub async fn wait_for_uploads(&self) {
+        let Some(uploads) = &self.uploads else {
+            return;
+        };
+        let _timer = AtomicDurationTimer::start(&self.stats.upload_drain_duration_ns);
+        uploads.drain().await;
+    }
+
     async fn wait_for_prefetches(&self) {
         let tasks = std::mem::take(&mut *self.prefetch_tasks.lock().unwrap());
         for task in tasks {
@@ -873,6 +950,17 @@ impl CacheAgent {
         };
         self.task_actions.lock().unwrap().remove(run);
         if self.remote_mode.writes() {
+            // A manifest advertises the actions it predicts, so it must not
+            // reach the remote cache before the results a reader would then go
+            // looking for.
+            if let Some(uploads) = &self.uploads {
+                let actions: Vec<CacheDigest> = manifest
+                    .predictions
+                    .iter()
+                    .map(|prediction| prediction.action.clone())
+                    .collect();
+                uploads.wait_for_actions(&actions).await;
+            }
             match self
                 .put_remote_task_manifest(&task, manifest, state.remote_etag)
                 .await
@@ -1025,6 +1113,12 @@ impl CacheAgent {
             divergences: self.stats.divergences.load(Ordering::Relaxed),
             downloaded_bytes: self.stats.downloaded_bytes.load(Ordering::Relaxed),
             uploaded_bytes: self.stats.uploaded_bytes.load(Ordering::Relaxed),
+            background_uploads: self.stats.background_uploads.load(Ordering::Relaxed),
+            background_upload_failures: self
+                .stats
+                .background_upload_failures
+                .load(Ordering::Relaxed),
+            upload_drain_duration_ns: self.stats.upload_drain_duration_ns.load(Ordering::Relaxed),
             prefetched_actions: self.stats.prefetched_actions.load(Ordering::Relaxed),
             bypasses: self.stats.bypasses.lock().unwrap().clone(),
             avoided_compiler_duration_ns: self
@@ -1080,9 +1174,10 @@ impl CacheAgent {
         &self,
         requests: impl IntoIterator<Item = AgentRequest>,
     ) -> Vec<AgentResponse> {
+        let mut connection = ConnectionUploads::default();
         let mut responses = Vec::new();
         for request in requests {
-            responses.push(self.respond(request).await);
+            responses.push(self.respond_on(request, &mut connection).await);
         }
         responses
     }
@@ -1808,11 +1903,27 @@ impl CacheAgent {
         Ok(path)
     }
 
+    /// Answer one request outside any connection.
+    ///
+    /// An upload queued this way has no sibling requests to order against, so
+    /// the queue falls back to treating every blob it holds as a prerequisite.
+    #[cfg(test)]
     async fn respond(&self, request: AgentRequest) -> AgentResponse {
+        self.respond_on(request, &mut ConnectionUploads::default())
+            .await
+    }
+
+    async fn respond_on(
+        &self,
+        request: AgentRequest,
+        connection: &mut ConnectionUploads,
+    ) -> AgentResponse {
         let result = match request {
             AgentRequest::FindBlob { digest } => self.find_blob(&digest).await,
             AgentRequest::FindBlobs { digests } => self.find_blobs(digests).await,
-            AgentRequest::StoreBlob { digest, source } => self.store_blob(&digest, &source).await,
+            AgentRequest::StoreBlob { digest, source } => {
+                self.store_blob(&digest, &source, connection).await
+            }
             AgentRequest::FindActionResult { action } => {
                 self.stats.lookups.fetch_add(1, Ordering::Relaxed);
                 self.find_action_result(&action).await
@@ -1852,7 +1963,9 @@ impl CacheAgent {
                 self.emit(|| AgentEvent::Verification { matched, restore });
                 Ok(AgentResponse::ActionVerificationRecorded)
             }
-            AgentRequest::StoreActionResult { result } => self.store_action_result(&result).await,
+            AgentRequest::StoreActionResult { result } => {
+                self.store_action_result(&result, connection).await
+            }
             AgentRequest::FindActionPrediction { task, invocation } => {
                 self.find_action_prediction(&task, &invocation)
             }
@@ -1928,12 +2041,12 @@ impl CacheAgent {
         })
     }
 
-    async fn store_blob(&self, digest: &CacheDigest, source: &Path) -> Result<AgentResponse> {
-        let remote = if self.remote_mode.writes() {
-            self.remote.as_deref()
-        } else {
-            None
-        };
+    async fn store_blob(
+        &self,
+        digest: &CacheDigest,
+        source: &Path,
+        connection: &mut ConnectionUploads,
+    ) -> Result<AgentResponse> {
         let path = {
             let lock = self.write_lock(digest);
             let _guard = lock.lock().await;
@@ -1949,25 +2062,10 @@ impl CacheAgent {
                 path
             }
         };
-        if let Some(remote) = remote {
-            let _permit = self.remote_transfers.acquire().await?;
-            if let Err(error) = remote
-                .put_blob(&BlobUpload {
-                    digest: digest.clone(),
-                    source: BlobSource::Path(path.clone()),
-                })
-                .await
-            {
-                self.note_remote_failure();
-                warn!(
-                    "remote cache blob upload failed for {}: {error}",
-                    digest.hash
-                );
-            } else {
-                self.stats
-                    .uploaded_bytes
-                    .fetch_add(digest.size, Ordering::Relaxed);
-            }
+        // The object is durable locally, so the build has what it needs and the
+        // remote publication can happen after this request returns.
+        if let Some(uploads) = &self.uploads {
+            uploads.queue_blob(digest, path.clone(), connection);
         }
         Ok(AgentResponse::Stored { path })
     }
@@ -2047,19 +2145,14 @@ impl CacheAgent {
         }
     }
 
-    async fn store_action_result(&self, result: &RemoteActionResult) -> Result<AgentResponse> {
+    async fn store_action_result(
+        &self,
+        result: &RemoteActionResult,
+        connection: &ConnectionUploads,
+    ) -> Result<AgentResponse> {
         let path = self.actions.store(result)?;
-        if self.remote_mode.writes()
-            && let Some(remote) = &self.remote
-        {
-            let _permit = self.remote_transfers.acquire().await?;
-            if let Err(error) = remote.put_action_result(result).await {
-                self.note_remote_failure();
-                warn!(
-                    "remote cache action upload failed for {}: {error}",
-                    result.action.hash
-                );
-            }
+        if let Some(uploads) = &self.uploads {
+            uploads.queue_action_result(result, connection);
         }
         Ok(AgentResponse::ActionStored { path })
     }
@@ -2309,9 +2402,13 @@ impl CacheAgent {
         )
         .await?;
 
+        // Tickets accumulate for the life of the connection because a shim
+        // publishes a compilation's blobs and the action result naming them over
+        // one connection, in that order.
+        let mut connection = ConnectionUploads::default();
         while let Some(line) = read_request(&mut reader).await? {
             let response = match serde_json::from_str(&line) {
-                Ok(request) => self.respond(request).await,
+                Ok(request) => self.respond_on(request, &mut connection).await,
                 Err(error) => AgentResponse::Error {
                     message: format!("invalid agent request: {error}"),
                 },

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -952,14 +952,27 @@ impl CacheAgent {
         if self.remote_mode.writes() {
             // A manifest advertises the actions it predicts, so it must not
             // reach the remote cache before the results a reader would then go
-            // looking for.
+            // looking for -- nor name a result that never got there at all.
+            let mut manifest = manifest;
             if let Some(uploads) = &self.uploads {
                 let actions: Vec<CacheDigest> = manifest
                     .predictions
                     .iter()
                     .map(|prediction| prediction.action.clone())
                     .collect();
-                uploads.wait_for_actions(&actions).await;
+                let unpublished = uploads.wait_for_actions(&actions).await;
+                if !unpublished.is_empty() {
+                    // The local manifest keeps them: this checkout can still use
+                    // what it built, and a later session can publish it.
+                    warn!(
+                        "{} of {} predicted actions were not published, so the remote task action manifest omits them",
+                        unpublished.len(),
+                        manifest.predictions.len()
+                    );
+                    manifest
+                        .predictions
+                        .retain(|prediction| !unpublished.contains(&prediction.action));
+                }
             }
             match self
                 .put_remote_task_manifest(&task, manifest, state.remote_etag)

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1717,30 +1717,38 @@ async fn an_action_result_is_published_after_the_blobs_it_references() {
         output_root: None,
         version: 1,
     };
-    // Recording the order the server saw is the assertion: an action result the
-    // server accepts before its blobs is one a reader could not restore.
-    let order = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let blob_order = order.clone();
+    // Recorded as each request arrives rather than as each response is written:
+    // an upload finishes without reading the response body, so the body is no
+    // signal for when the client moved on. Each matcher guards on its own path,
+    // because mockito may consult a matcher for a request another mock answers.
+    let arrivals = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let blob_arrivals = arrivals.clone();
+    let blob_route = blob_path(&action);
+    let matched_blob_route = blob_route.clone();
     let blob = server
-        .mock("PUT", blob_path(&action).as_str())
-        .with_status(200)
-        .with_chunked_body(move |writer| {
-            // Held long enough that an unordered upload would finish first.
-            std::thread::sleep(Duration::from_millis(200));
-            blob_order.lock().unwrap().push("blob");
-            std::io::Write::write_all(writer, b"")
+        .mock("PUT", blob_route.as_str())
+        .match_request(move |request| {
+            if request.path() == matched_blob_route {
+                blob_arrivals.lock().unwrap().push("blob");
+            }
+            true
         })
+        .with_status(200)
         .expect(1)
         .create_async()
         .await;
-    let result_order = order.clone();
+    let result_arrivals = arrivals.clone();
+    let action_route = action_path(&action);
+    let matched_action_route = action_route.clone();
     let action_result = server
-        .mock("PUT", action_path(&action).as_str())
-        .with_status(200)
-        .with_chunked_body(move |writer| {
-            result_order.lock().unwrap().push("action result");
-            std::io::Write::write_all(writer, b"")
+        .mock("PUT", action_route.as_str())
+        .match_request(move |request| {
+            if request.path() == matched_action_route {
+                result_arrivals.lock().unwrap().push("action result");
+            }
+            true
         })
+        .with_status(200)
         .expect(1)
         .create_async()
         .await;
@@ -1769,7 +1777,11 @@ async fn an_action_result_is_published_after_the_blobs_it_references() {
 
     blob.assert_async().await;
     action_result.assert_async().await;
-    assert_eq!(*order.lock().unwrap(), vec!["blob", "action result"]);
+    assert_eq!(
+        *arrivals.lock().unwrap(),
+        vec!["blob", "action result"],
+        "an action result reached the server before a blob it references"
+    );
 }
 
 #[tokio::test]

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -2017,6 +2017,101 @@ async fn a_blob_that_fails_to_upload_withholds_its_action_result() {
     assert!(stats.remote_failures > 0);
 }
 
+/// A blob that failed once must not withhold everything that follows.
+///
+/// Compilations share blobs -- every empty stdout is the same object -- so a
+/// settled failure reused for the rest of the session would let one transient
+/// error suppress every action result after it.
+#[tokio::test]
+async fn a_blob_that_failed_is_uploaded_again_for_a_later_result() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let shared_bytes = b"shared across compilations".to_vec();
+    let shared = CacheDigest::blake3(&shared_bytes);
+    let second_action = CacheDigest::blake3(b"the compilation after the failure");
+    let failed = server
+        .mock("PUT", blob_path(&shared).as_str())
+        .with_status(500)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let store_shared = |index: usize| {
+        let source = directory.path().join(format!("source-{index}"));
+        fs::write(&source, &shared_bytes).unwrap();
+        AgentRequest::StoreBlob {
+            digest: shared.clone(),
+            source,
+        }
+    };
+
+    // The first compilation's upload of the shared blob fails, so its result is
+    // withheld.
+    agent
+        .handle_requests([
+            store_shared(0),
+            AgentRequest::StoreActionResult {
+                result: RemoteActionResult {
+                    action: shared.clone(),
+                    metadata: None,
+                    output_root: None,
+                    version: 1,
+                },
+            },
+        ])
+        .await;
+    agent.wait_for_uploads().await;
+    failed.assert_async().await;
+
+    // A later compilation stores the same bytes and must get its own attempt.
+    let retried = server
+        .mock("PUT", blob_path(&shared).as_str())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let second_blob = server
+        .mock("PUT", blob_path(&second_action).as_str())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let second_result = server
+        .mock("PUT", action_path(&second_action).as_str())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let source = directory.path().join("second-action");
+    fs::write(&source, b"the compilation after the failure").unwrap();
+    agent
+        .handle_requests([
+            store_shared(1),
+            AgentRequest::StoreBlob {
+                digest: second_action.clone(),
+                source,
+            },
+            AgentRequest::StoreActionResult {
+                result: RemoteActionResult {
+                    action: second_action.clone(),
+                    metadata: None,
+                    output_root: None,
+                    version: 1,
+                },
+            },
+        ])
+        .await;
+    agent.wait_for_uploads().await;
+
+    retried.assert_async().await;
+    second_blob.assert_async().await;
+    second_result.assert_async().await;
+}
+
 #[tokio::test]
 async fn a_repeated_blob_is_uploaded_once() {
     let directory = tempfile::tempdir().unwrap();

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1785,6 +1785,98 @@ async fn an_action_result_is_published_after_the_blobs_it_references() {
 }
 
 #[tokio::test]
+async fn a_task_manifest_omits_predictions_that_were_not_published() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let task = "5".repeat(64);
+    let published_bytes = b"published action".to_vec();
+    let withheld_bytes = b"withheld action".to_vec();
+    let published = CacheDigest::blake3(&published_bytes);
+    let withheld = CacheDigest::blake3(&withheld_bytes);
+    let predictions: Vec<ActionPrediction> = [&published, &withheld]
+        .into_iter()
+        .enumerate()
+        .map(|(index, action)| ActionPrediction {
+            invocation: CacheDigest::blake3(format!("invocation {index}").as_bytes()),
+            action: action.clone(),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        })
+        .collect();
+    server
+        .mock("PUT", blob_path(&published).as_str())
+        .with_status(200)
+        .create_async()
+        .await;
+    // This blob never lands, so the action result naming it is withheld, and a
+    // manifest advertising that action would send readers after nothing.
+    server
+        .mock("PUT", blob_path(&withheld).as_str())
+        .with_status(500)
+        .create_async()
+        .await;
+    server
+        .mock("PUT", action_path(&published).as_str())
+        .with_status(200)
+        .create_async()
+        .await;
+    let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+    let expected = canonical_json(&TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.clone(),
+        predictions: vec![predictions[0].clone()],
+    })
+    .unwrap();
+    let manifest = server
+        .mock("PUT", action_manifest_path(&selector).as_str())
+        .match_body(expected)
+        .with_status(201)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let run = agent.begin_task(&task).await.unwrap();
+    for (index, (action, bytes)) in [(&published, &published_bytes), (&withheld, &withheld_bytes)]
+        .into_iter()
+        .enumerate()
+    {
+        let source = directory.path().join(format!("source-{index}"));
+        fs::write(&source, bytes).unwrap();
+        agent
+            .handle_requests([
+                AgentRequest::StoreBlob {
+                    digest: action.clone(),
+                    source,
+                },
+                AgentRequest::StoreActionResult {
+                    result: RemoteActionResult {
+                        action: action.clone(),
+                        metadata: None,
+                        output_root: None,
+                        version: 1,
+                    },
+                },
+                AgentRequest::RecordActionPrediction {
+                    task: run.clone(),
+                    prediction: predictions[index].clone(),
+                },
+            ])
+            .await;
+    }
+    agent.commit_task(&run).await.unwrap();
+    agent.wait_for_uploads().await;
+
+    manifest.assert_async().await;
+    // The local manifest keeps both: this checkout can still use what it built.
+    let local = agent.load_task_manifest(&task).unwrap().unwrap();
+    assert_eq!(local.predictions.len(), 2);
+}
+
+#[tokio::test]
 async fn a_blob_that_fails_to_upload_withholds_its_action_result() {
     let directory = tempfile::tempdir().unwrap();
     let mut server = mockito::Server::new_async().await;

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1649,6 +1649,281 @@ async fn session_completion_cancels_outstanding_prefetches() {
     assert!(agent.prefetch_tasks.lock().unwrap().is_empty());
 }
 
+/// A blocking response is what makes this deterministic: were the store waiting
+/// for its upload, it could not return while the server is still holding the
+/// response open.
+#[tokio::test]
+async fn storing_a_blob_returns_before_its_remote_upload() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let bytes = b"deferred blob".to_vec();
+    let digest = CacheDigest::blake3(&bytes);
+    let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+    let response_release = release.clone();
+    let upload = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(200)
+        .with_chunked_body(move |writer| {
+            let (released, condition) = &*response_release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = condition.wait(released).unwrap();
+            }
+            std::io::Write::write_all(writer, b"")
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let source = directory.path().join("source");
+    fs::write(&source, &bytes).unwrap();
+
+    let stored = tokio::time::timeout(
+        Duration::from_secs(2),
+        agent.respond(AgentRequest::StoreBlob {
+            digest: digest.clone(),
+            source,
+        }),
+    )
+    .await
+    .expect("storing a blob waited for its remote upload");
+    assert!(matches!(stored, AgentResponse::Stored { .. }));
+    assert!(agent.cas.find(&digest).unwrap().is_some());
+
+    let (released, condition) = &*release;
+    *released.lock().unwrap() = true;
+    condition.notify_all();
+    agent.wait_for_uploads().await;
+    upload.assert_async().await;
+    let stats = agent.stats();
+    assert_eq!(stats.background_uploads, 1);
+    assert_eq!(stats.background_upload_failures, 0);
+    assert_eq!(stats.uploaded_bytes, digest.size);
+}
+
+#[tokio::test]
+async fn an_action_result_is_published_after_the_blobs_it_references() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let action_bytes = b"ordered action".to_vec();
+    let action = CacheDigest::blake3(&action_bytes);
+    let result = RemoteActionResult {
+        action: action.clone(),
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+    // Recording the order the server saw is the assertion: an action result the
+    // server accepts before its blobs is one a reader could not restore.
+    let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let blob_order = order.clone();
+    let blob = server
+        .mock("PUT", blob_path(&action).as_str())
+        .with_status(200)
+        .with_chunked_body(move |writer| {
+            // Held long enough that an unordered upload would finish first.
+            std::thread::sleep(Duration::from_millis(200));
+            blob_order.lock().unwrap().push("blob");
+            std::io::Write::write_all(writer, b"")
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let result_order = order.clone();
+    let action_result = server
+        .mock("PUT", action_path(&action).as_str())
+        .with_status(200)
+        .with_chunked_body(move |writer| {
+            result_order.lock().unwrap().push("action result");
+            std::io::Write::write_all(writer, b"")
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let source = directory.path().join("source");
+    fs::write(&source, &action_bytes).unwrap();
+
+    let responses = agent
+        .handle_requests([
+            AgentRequest::StoreBlob {
+                digest: action.clone(),
+                source,
+            },
+            AgentRequest::StoreActionResult {
+                result: result.clone(),
+            },
+        ])
+        .await;
+    assert!(matches!(responses[0], AgentResponse::Stored { .. }));
+    assert!(matches!(responses[1], AgentResponse::ActionStored { .. }));
+    agent.wait_for_uploads().await;
+
+    blob.assert_async().await;
+    action_result.assert_async().await;
+    assert_eq!(*order.lock().unwrap(), vec!["blob", "action result"]);
+}
+
+#[tokio::test]
+async fn a_blob_that_fails_to_upload_withholds_its_action_result() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let action_bytes = b"unpublishable action".to_vec();
+    let action = CacheDigest::blake3(&action_bytes);
+    let result = RemoteActionResult {
+        action: action.clone(),
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+    let blob = server
+        .mock("PUT", blob_path(&action).as_str())
+        .with_status(500)
+        .expect(1)
+        .create_async()
+        .await;
+    // A server validates an action result against the blobs it references, so
+    // sending this one would be rejected anyway.
+    let action_result = server
+        .mock("PUT", action_path(&action).as_str())
+        .with_status(200)
+        .expect(0)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let source = directory.path().join("source");
+    fs::write(&source, &action_bytes).unwrap();
+
+    agent
+        .handle_requests([
+            AgentRequest::StoreBlob {
+                digest: action.clone(),
+                source,
+            },
+            AgentRequest::StoreActionResult { result },
+        ])
+        .await;
+    agent.wait_for_uploads().await;
+
+    blob.assert_async().await;
+    action_result.assert_async().await;
+    // The build keeps its local result: a failed upload costs hit rate, not
+    // correctness.
+    assert!(agent.actions.find(&action).unwrap().is_some());
+    let stats = agent.stats();
+    assert_eq!(stats.background_uploads, 0);
+    assert!(stats.remote_failures > 0);
+}
+
+#[tokio::test]
+async fn a_repeated_blob_is_uploaded_once() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let bytes = b"shared blob".to_vec();
+    let digest = CacheDigest::blake3(&bytes);
+    let upload = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    for index in 0..3 {
+        let source = directory.path().join(format!("source-{index}"));
+        fs::write(&source, &bytes).unwrap();
+        agent
+            .respond(AgentRequest::StoreBlob {
+                digest: digest.clone(),
+                source,
+            })
+            .await;
+    }
+    agent.wait_for_uploads().await;
+
+    upload.assert_async().await;
+    assert_eq!(agent.stats().background_uploads, 1);
+}
+
+#[tokio::test]
+async fn a_session_that_cannot_write_queues_nothing() {
+    let directory = tempfile::tempdir().unwrap();
+    let server = mockito::Server::new_async().await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+    assert!(agent.uploads.is_none());
+
+    let bytes = b"local only".to_vec();
+    let digest = CacheDigest::blake3(&bytes);
+    let source = directory.path().join("source");
+    fs::write(&source, &bytes).unwrap();
+    agent
+        .respond(AgentRequest::StoreBlob {
+            digest: digest.clone(),
+            source,
+        })
+        .await;
+    // No mock is registered, so an upload attempt would fail the request.
+    tokio::time::timeout(Duration::from_secs(2), agent.wait_for_uploads())
+        .await
+        .expect("draining a read-only session blocked");
+    assert_eq!(agent.stats().background_uploads, 0);
+    assert_eq!(agent.stats().remote_failures, 0);
+}
+
+#[tokio::test]
+async fn a_collected_blob_is_skipped_rather_than_retried() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let bytes = b"collected blob".to_vec();
+    let digest = CacheDigest::blake3(&bytes);
+    let upload = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(200)
+        .expect(0)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let source = directory.path().join("source");
+    fs::write(&source, &bytes).unwrap();
+    agent
+        .respond(AgentRequest::StoreBlob {
+            digest: digest.clone(),
+            source,
+        })
+        .await;
+    // Stand in for a collection between the store and the upload.
+    fs::remove_file(agent.cas.find(&digest).unwrap().unwrap()).unwrap();
+    agent.wait_for_uploads().await;
+
+    upload.assert_async().await;
+    let stats = agent.stats();
+    assert_eq!(stats.background_uploads, 0);
+    assert_eq!(stats.background_upload_failures, 1);
+}
+
 #[tokio::test]
 async fn prefetch_reserves_capacity_for_foreground_transfers() {
     let transfers = tokio::sync::Semaphore::new(MAX_REMOTE_TRANSFERS);

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1784,6 +1784,92 @@ async fn an_action_result_is_published_after_the_blobs_it_references() {
     );
 }
 
+/// A failed re-upload must not retract what an earlier session advertised.
+///
+/// The conditional manifest write replaces the remote manifest when its entity
+/// tag still matches, so dropping an inherited prediction would un-advertise a
+/// result that is plausibly still on the server.
+#[tokio::test]
+async fn a_task_manifest_keeps_inherited_predictions_whose_upload_fails() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let task = "4".repeat(64);
+    let action_bytes = b"inherited action".to_vec();
+    let action = CacheDigest::blake3(&action_bytes);
+    let prediction = ActionPrediction {
+        invocation: CacheDigest::blake3(b"inherited invocation"),
+        action: action.clone(),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let manifest_bytes = canonical_json(&TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.clone(),
+        predictions: vec![prediction.clone()],
+    })
+    .unwrap();
+    let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+    let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+    // The prediction is already advertised remotely when this session starts.
+    server
+        .mock("GET", action_manifest_path(&selector).as_str())
+        .with_status(200)
+        .with_header("etag", &format!("\"{manifest_etag}\""))
+        .with_body(manifest_bytes.clone())
+        .create_async()
+        .await;
+    server
+        .mock("GET", action_path(&action).as_str())
+        .with_status(404)
+        .create_async()
+        .await;
+    server
+        .mock("PUT", blob_path(&action).as_str())
+        .with_status(500)
+        .create_async()
+        .await;
+    let manifest = server
+        .mock("PUT", action_manifest_path(&selector).as_str())
+        .match_body(manifest_bytes)
+        .with_status(201)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::ReadWrite,
+    );
+    let run = agent.begin_task(&task).await.unwrap();
+    agent.wait_for_prefetches().await;
+    let source = directory.path().join("source");
+    fs::write(&source, &action_bytes).unwrap();
+    agent
+        .handle_requests([
+            AgentRequest::StoreBlob {
+                digest: action.clone(),
+                source,
+            },
+            AgentRequest::StoreActionResult {
+                result: RemoteActionResult {
+                    action: action.clone(),
+                    metadata: None,
+                    output_root: None,
+                    version: 1,
+                },
+            },
+            AgentRequest::RecordActionPrediction {
+                task: run.clone(),
+                prediction,
+            },
+        ])
+        .await;
+    agent.commit_task(&run).await.unwrap();
+    agent.wait_for_uploads().await;
+
+    manifest.assert_async().await;
+}
+
 #[tokio::test]
 async fn a_task_manifest_omits_predictions_that_were_not_published() {
     let directory = tempfile::tempdir().unwrap();

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -50,6 +50,7 @@ use url::{Host, Url};
 
 mod agent;
 mod local;
+mod uploads;
 
 pub use agent::{
     AGENT_PROTOCOL_VERSION, AgentEvent, AgentEventObserver, AgentRemoteCache, AgentRequest,

--- a/crates/mbx-cache-core/src/uploads.rs
+++ b/crates/mbx-cache-core/src/uploads.rs
@@ -23,7 +23,7 @@ use crate::{BlobSource, BlobUpload, CacheDigest, RemoteActionResult, RemoteCache
 use futures_util::future::{BoxFuture, Shared};
 use futures_util::{FutureExt, StreamExt, stream};
 use log::warn;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -233,21 +233,32 @@ impl UploadQueue {
         *worker = Some(tokio::spawn(async move { inner.run().await }));
     }
 
-    /// Wait for the action results covering `actions` to be published.
+    /// Wait for the action results covering `actions`, reporting the ones that
+    /// did not publish.
     ///
     /// A task manifest names the actions it predicts, so publishing it before
-    /// those results exist would advertise work a reader cannot fetch.
-    pub(crate) async fn wait_for_actions(&self, actions: &[CacheDigest]) {
-        let tickets: Vec<UploadTicket> = {
+    /// those results exist would advertise work a reader cannot fetch. An action
+    /// this queue never held is not reported: it was published by an earlier
+    /// session, which is what a manifest baseline is made of.
+    pub(crate) async fn wait_for_actions(&self, actions: &[CacheDigest]) -> BTreeSet<CacheDigest> {
+        let tickets: Vec<(CacheDigest, UploadTicket)> = {
             let queued = self.inner.action_tickets.lock().unwrap();
             actions
                 .iter()
-                .filter_map(|action| queued.get(action).cloned())
+                .filter_map(|action| {
+                    queued
+                        .get(action)
+                        .map(|ticket| (action.clone(), ticket.clone()))
+                })
                 .collect()
         };
-        for ticket in tickets {
-            ticket.await;
+        let mut unpublished = BTreeSet::new();
+        for (action, ticket) in tickets {
+            if !ticket.await.published() {
+                unpublished.insert(action);
+            }
         }
+        unpublished
     }
 
     /// Publish everything queued, then stop the worker.

--- a/crates/mbx-cache-core/src/uploads.rs
+++ b/crates/mbx-cache-core/src/uploads.rs
@@ -1,0 +1,430 @@
+//! Deferred remote publication for a build session.
+//!
+//! Publishing a compilation result is not on the critical path of the build that
+//! produced it: the local CAS already holds every object before the shim is told
+//! the result was stored. Uploading inside that request would make every miss
+//! wait for a round trip that only later builds benefit from, and Cargo cannot
+//! schedule a dependent crate until the wrapper it is waiting on exits.
+//!
+//! This module accepts uploads into a queue instead, hands each caller a ticket
+//! it can await, and drains the queue before the session exits. The queue also
+//! gives the client one place where several pending blobs are visible at once,
+//! which is what lets them be coalesced into a single request.
+//!
+//! # Ordering
+//!
+//! A remote action result may only be published once every blob it references is
+//! visible remotely; a server validates the output tree before committing one.
+//! Deferring uploads removes the transport ordering that used to guarantee that,
+//! so an action result carries the tickets of the blobs enqueued before it and
+//! waits for them itself.
+
+use crate::{BlobSource, BlobUpload, CacheDigest, RemoteActionResult, RemoteCacheClient};
+use futures_util::future::{BoxFuture, Shared};
+use futures_util::{FutureExt, StreamExt, stream};
+use log::warn;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Uploads performed concurrently by the background queue.
+///
+/// Deliberately below the agent's overall remote transfer budget: a queue
+/// working through a large build's output must not crowd out the foreground
+/// downloads a later compilation is waiting on.
+const MAX_UPLOAD_TRANSFERS: usize = 32;
+
+/// How one queued upload finished.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UploadOutcome {
+    /// The object is now visible to the remote cache.
+    Uploaded,
+    /// There was nothing to upload, so nothing depends on this having happened.
+    ///
+    /// A local object collected between its store and its upload produces this:
+    /// the blob it would have published no longer exists to read.
+    Skipped,
+    /// The upload was attempted and did not succeed.
+    Failed,
+}
+
+impl UploadOutcome {
+    fn published(self) -> bool {
+        matches!(self, Self::Uploaded)
+    }
+}
+
+/// A handle for awaiting one queued upload, shared by everything that depends on
+/// it.
+pub(crate) type UploadTicket = Shared<BoxFuture<'static, UploadOutcome>>;
+
+/// Tickets for the uploads a single agent connection has queued so far.
+///
+/// A shim publishes every blob of a compilation before the action result that
+/// references them, over one connection, so this is exactly the set an action
+/// result must wait for -- including the directory objects that name the rest.
+#[derive(Default)]
+pub(crate) struct ConnectionUploads {
+    tickets: Vec<UploadTicket>,
+}
+
+impl ConnectionUploads {
+    fn record(&mut self, ticket: UploadTicket) {
+        self.tickets.push(ticket);
+    }
+
+    fn prerequisites(&self) -> Vec<UploadTicket> {
+        self.tickets.clone()
+    }
+}
+
+/// Statistics recorded for background uploads.
+///
+/// The queue reports through this rather than owning counters so that a session's
+/// figures stay in one place.
+pub(crate) trait UploadSink: Send + Sync {
+    /// Record a blob published with the given payload size.
+    fn record_blob_uploaded(&self, bytes: u64);
+    /// Record an action result published.
+    fn record_action_uploaded(&self);
+    /// Record an upload that did not publish, having already been reported.
+    fn record_upload_failure(&self);
+}
+
+enum QueuedUpload {
+    Blob {
+        digest: CacheDigest,
+        path: PathBuf,
+        done: tokio::sync::oneshot::Sender<UploadOutcome>,
+    },
+    ActionResult {
+        result: RemoteActionResult,
+        prerequisites: Vec<UploadTicket>,
+        done: tokio::sync::oneshot::Sender<UploadOutcome>,
+    },
+}
+
+impl QueuedUpload {
+    fn is_blob(&self) -> bool {
+        matches!(self, Self::Blob { .. })
+    }
+}
+
+/// A queue of remote publications that outlives the requests that asked for them.
+#[derive(Clone)]
+pub(crate) struct UploadQueue {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    remote: Arc<RemoteCacheClient>,
+    sink: Arc<dyn UploadSink>,
+    transfers: Arc<tokio::sync::Semaphore>,
+    remote_transfers: Arc<tokio::sync::Semaphore>,
+    pending: Mutex<Vec<QueuedUpload>>,
+    /// Tickets for blobs already queued, so the same object is uploaded once.
+    blob_tickets: Mutex<BTreeMap<CacheDigest, UploadTicket>>,
+    /// Tickets for action results, so a task manifest can wait for the results
+    /// it names without waiting for the whole queue.
+    action_tickets: Mutex<BTreeMap<CacheDigest, UploadTicket>>,
+    work: tokio::sync::Notify,
+    draining: AtomicBool,
+    worker: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl UploadQueue {
+    /// Create a queue that publishes through `remote`.
+    pub(crate) fn new(
+        remote: Arc<RemoteCacheClient>,
+        sink: Arc<dyn UploadSink>,
+        remote_transfers: Arc<tokio::sync::Semaphore>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                remote,
+                sink,
+                transfers: Arc::new(tokio::sync::Semaphore::new(MAX_UPLOAD_TRANSFERS)),
+                remote_transfers,
+                pending: Mutex::new(Vec::new()),
+                blob_tickets: Mutex::new(BTreeMap::new()),
+                action_tickets: Mutex::new(BTreeMap::new()),
+                work: tokio::sync::Notify::new(),
+                draining: AtomicBool::new(false),
+                worker: Mutex::new(None),
+            }),
+        }
+    }
+
+    /// Queue a blob held in the local CAS, returning the ticket for its upload.
+    ///
+    /// A digest already queued in this session returns the existing ticket
+    /// instead of uploading the same bytes again.
+    pub(crate) fn queue_blob(
+        &self,
+        digest: &CacheDigest,
+        path: PathBuf,
+        connection: &mut ConnectionUploads,
+    ) {
+        let ticket = {
+            let mut tickets = self.inner.blob_tickets.lock().unwrap();
+            if let Some(ticket) = tickets.get(digest) {
+                ticket.clone()
+            } else {
+                let (done, ticket) = ticket_channel();
+                tickets.insert(digest.clone(), ticket.clone());
+                self.push(QueuedUpload::Blob {
+                    digest: digest.clone(),
+                    path,
+                    done,
+                });
+                ticket
+            }
+        };
+        connection.record(ticket);
+    }
+
+    /// Queue an action result, to be published once this connection's blobs are.
+    pub(crate) fn queue_action_result(
+        &self,
+        result: &RemoteActionResult,
+        connection: &ConnectionUploads,
+    ) {
+        let mut prerequisites = connection.prerequisites();
+        if prerequisites.is_empty() {
+            // A caller with no connection of its own cannot say which blobs this
+            // result references, so every blob the session has queued is treated
+            // as one. A shim always stores a result's blobs first, over the same
+            // connection, so this only covers requests made outside that path.
+            prerequisites = self
+                .inner
+                .blob_tickets
+                .lock()
+                .unwrap()
+                .values()
+                .cloned()
+                .collect();
+        }
+        let (done, ticket) = ticket_channel();
+        self.inner
+            .action_tickets
+            .lock()
+            .unwrap()
+            .insert(result.action.clone(), ticket);
+        self.push(QueuedUpload::ActionResult {
+            result: result.clone(),
+            prerequisites,
+            done,
+        });
+    }
+
+    fn push(&self, upload: QueuedUpload) {
+        self.inner.pending.lock().unwrap().push(upload);
+        self.ensure_worker();
+        self.inner.work.notify_one();
+    }
+
+    fn ensure_worker(&self) {
+        let mut worker = self.inner.worker.lock().unwrap();
+        if worker.is_some() {
+            return;
+        }
+        let inner = self.inner.clone();
+        *worker = Some(tokio::spawn(async move { inner.run().await }));
+    }
+
+    /// Wait for the action results covering `actions` to be published.
+    ///
+    /// A task manifest names the actions it predicts, so publishing it before
+    /// those results exist would advertise work a reader cannot fetch.
+    pub(crate) async fn wait_for_actions(&self, actions: &[CacheDigest]) {
+        let tickets: Vec<UploadTicket> = {
+            let queued = self.inner.action_tickets.lock().unwrap();
+            actions
+                .iter()
+                .filter_map(|action| queued.get(action).cloned())
+                .collect()
+        };
+        for ticket in tickets {
+            ticket.await;
+        }
+    }
+
+    /// Publish everything queued, then stop the worker.
+    ///
+    /// Called once the session can no longer accept requests. Uploads run on the
+    /// session's runtime, so this has to finish before that runtime goes away.
+    pub(crate) async fn drain(&self) {
+        self.inner.draining.store(true, Ordering::Release);
+        let worker = self.inner.worker.lock().unwrap().take();
+        match worker {
+            Some(worker) => {
+                self.inner.work.notify_one();
+                if let Err(error) = worker.await {
+                    warn!("remote cache upload queue failed: {error}");
+                }
+            }
+            // Nothing was ever queued, so there is no worker to wind down.
+            None => self.inner.run().await,
+        }
+    }
+}
+
+impl Inner {
+    async fn run(&self) {
+        loop {
+            let batch = std::mem::take(&mut *self.pending.lock().unwrap());
+            if batch.is_empty() {
+                if self.draining.load(Ordering::Acquire) {
+                    return;
+                }
+                self.work.notified().await;
+                continue;
+            }
+            self.run_batch(batch).await;
+        }
+    }
+
+    /// Run one batch of queued uploads, blobs first.
+    ///
+    /// The two phases are what keeps an action result from occupying a transfer
+    /// slot while the blobs it is waiting for sit unstarted behind it. Every
+    /// prerequisite of an action result was queued before it, so it is either in
+    /// this batch's blob phase or in a batch that has already run.
+    async fn run_batch(&self, batch: Vec<QueuedUpload>) {
+        let (blobs, results): (Vec<_>, Vec<_>) = batch.into_iter().partition(QueuedUpload::is_blob);
+        for phase in [blobs, results] {
+            stream::iter(phase)
+                .map(|upload| self.run_upload(upload))
+                .buffer_unordered(MAX_UPLOAD_TRANSFERS)
+                .collect::<Vec<()>>()
+                .await;
+        }
+    }
+
+    async fn run_upload(&self, upload: QueuedUpload) {
+        match upload {
+            QueuedUpload::Blob { digest, path, done } => {
+                let outcome = self.upload_blob(&digest, &path).await;
+                let _ = done.send(outcome);
+            }
+            QueuedUpload::ActionResult {
+                result,
+                prerequisites,
+                done,
+            } => {
+                let outcome = self.upload_action_result(&result, prerequisites).await;
+                let _ = done.send(outcome);
+            }
+        }
+    }
+
+    async fn upload_blob(&self, digest: &CacheDigest, path: &PathBuf) -> UploadOutcome {
+        // Reading the object confirms it survived long enough to publish. A
+        // collection between the store and this upload is a lost upload, not a
+        // failed one -- there is no longer anything to send.
+        if !tokio::fs::try_exists(path).await.unwrap_or(false) {
+            warn!(
+                "remote cache blob upload skipped for {}: the local object is gone",
+                digest.hash
+            );
+            self.sink.record_upload_failure();
+            return UploadOutcome::Skipped;
+        }
+        let _permit = match self.transfers.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => return UploadOutcome::Failed,
+        };
+        let _transfer = match self.remote_transfers.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => return UploadOutcome::Failed,
+        };
+        let upload = BlobUpload {
+            digest: digest.clone(),
+            source: BlobSource::Path(path.clone()),
+        };
+        match self.remote.put_blob(&upload).await {
+            Ok(()) => {
+                self.sink.record_blob_uploaded(digest.size);
+                UploadOutcome::Uploaded
+            }
+            Err(error) => {
+                if missing_source(&error) {
+                    warn!(
+                        "remote cache blob upload skipped for {}: the local object is gone",
+                        digest.hash
+                    );
+                    self.sink.record_upload_failure();
+                    return UploadOutcome::Skipped;
+                }
+                warn!(
+                    "remote cache blob upload failed for {}: {error}",
+                    digest.hash
+                );
+                self.sink.record_upload_failure();
+                UploadOutcome::Failed
+            }
+        }
+    }
+
+    async fn upload_action_result(
+        &self,
+        result: &RemoteActionResult,
+        prerequisites: Vec<UploadTicket>,
+    ) -> UploadOutcome {
+        for prerequisite in prerequisites {
+            if !prerequisite.await.published() {
+                // The server validates an action result against the blobs it
+                // references, so publishing this one now would be rejected. The
+                // blob failure has already been reported.
+                warn!(
+                    "remote cache action upload skipped for {}: a referenced blob was not published",
+                    result.action.hash
+                );
+                return UploadOutcome::Skipped;
+            }
+        }
+        let _permit = match self.transfers.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => return UploadOutcome::Failed,
+        };
+        let _transfer = match self.remote_transfers.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => return UploadOutcome::Failed,
+        };
+        match self.remote.put_action_result(result).await {
+            Ok(()) => {
+                self.sink.record_action_uploaded();
+                UploadOutcome::Uploaded
+            }
+            Err(error) => {
+                warn!(
+                    "remote cache action upload failed for {}: {error}",
+                    result.action.hash
+                );
+                self.sink.record_upload_failure();
+                UploadOutcome::Failed
+            }
+        }
+    }
+}
+
+fn ticket_channel() -> (tokio::sync::oneshot::Sender<UploadOutcome>, UploadTicket) {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let ticket = receiver
+        // A dropped sender means the upload never reported an outcome, which
+        // nothing may treat as a successful publication.
+        .map(|outcome| outcome.unwrap_or(UploadOutcome::Failed))
+        .boxed()
+        .shared();
+    (sender, ticket)
+}
+
+/// Whether a failed upload failed because its local source had been collected.
+fn missing_source(error: &eyre::Report) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+    })
+}

--- a/crates/mbx-cache-core/src/uploads.rs
+++ b/crates/mbx-cache-core/src/uploads.rs
@@ -158,8 +158,12 @@ impl UploadQueue {
 
     /// Queue a blob held in the local CAS, returning the ticket for its upload.
     ///
-    /// A digest already queued in this session returns the existing ticket
-    /// instead of uploading the same bytes again.
+    /// A digest still in flight, or already published, returns the existing
+    /// ticket rather than sending the same bytes twice. One that finished
+    /// without publishing is queued again: many compilations share a blob --
+    /// every empty stdout is the same object -- so handing a settled failure to
+    /// later requests would let one transient error withhold every action result
+    /// after it.
     pub(crate) fn queue_blob(
         &self,
         digest: &CacheDigest,
@@ -168,17 +172,21 @@ impl UploadQueue {
     ) {
         let ticket = {
             let mut tickets = self.inner.blob_tickets.lock().unwrap();
-            if let Some(ticket) = tickets.get(digest) {
-                ticket.clone()
-            } else {
-                let (done, ticket) = ticket_channel();
-                tickets.insert(digest.clone(), ticket.clone());
-                self.push(QueuedUpload::Blob {
-                    digest: digest.clone(),
-                    path,
-                    done,
-                });
-                ticket
+            match tickets
+                .get(digest)
+                .map(|ticket| (ticket.clone(), ticket.peek().copied()))
+            {
+                Some((ticket, None | Some(UploadOutcome::Uploaded))) => ticket,
+                _ => {
+                    let (done, ticket) = ticket_channel();
+                    tickets.insert(digest.clone(), ticket.clone());
+                    self.push(QueuedUpload::Blob {
+                        digest: digest.clone(),
+                        path,
+                        done,
+                    });
+                    ticket
+                }
             }
         };
         connection.record(ticket);

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -211,6 +211,9 @@ impl CacheSession {
             server.await??;
         }
         self.agent.cancel_prefetches().await;
+        // Cancelling first hands the queue the transfer budget the abandoned
+        // downloads were holding.
+        self.agent.wait_for_uploads().await;
         let mut stats = self.agent.stats();
         stats.session_duration_ns = duration_ns(self.started.elapsed());
         // The same totals the summary reports, so a reader of a finished stream
@@ -409,6 +412,9 @@ struct StatsReport {
     bypasses: BTreeMap<String, u64>,
     downloaded_bytes: u64,
     uploaded_bytes: u64,
+    background_uploads: u64,
+    background_upload_failures: u64,
+    upload_drain_duration_ns: u64,
     stored_bytes: u64,
     restored_output_files: u64,
     restored_output_bytes: u64,
@@ -480,6 +486,9 @@ impl From<&AgentStats> for StatsReport {
             bypasses: stats.bypasses.clone(),
             downloaded_bytes: stats.downloaded_bytes,
             uploaded_bytes: stats.uploaded_bytes,
+            background_uploads: stats.background_uploads,
+            background_upload_failures: stats.background_upload_failures,
+            upload_drain_duration_ns: stats.upload_drain_duration_ns,
             stored_bytes: stats.stored_bytes,
             restored_output_files: stats.restored_output_files,
             restored_output_bytes: stats.restored_output_bytes,
@@ -605,6 +614,14 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         format_nanos(stats.local_cas_write_duration_ns),
         format_nanos(stats.materialization_duration_ns),
     ));
+    if stats.background_uploads > 0 || stats.background_upload_failures > 0 {
+        note(&format!(
+            "mbx[cache]: uploads: {} published, {} not published; {} waited for after the build",
+            stats.background_uploads,
+            stats.background_upload_failures,
+            format_nanos(stats.upload_drain_duration_ns),
+        ));
+    }
     if stats.restored_output_files > 0 {
         note(&format!(
             "mbx[cache]: materialization: {} outputs ({}) reflinked, {} outputs ({}) copied",

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -207,13 +207,21 @@ impl CacheSession {
             let _ = shutdown.send(());
         }
         let server = self.server.lock().unwrap().take();
-        if let Some(server) = server {
-            server.await??;
-        }
+        // Held rather than raised: the shims have already been told their objects
+        // were stored, so a listener that failed is no reason to abandon the
+        // uploads that promise implies.
+        let served = match server {
+            Some(server) => server
+                .await
+                .map_err(eyre::Report::from)
+                .and_then(|served| served),
+            None => Ok(()),
+        };
         self.agent.cancel_prefetches().await;
         // Cancelling first hands the queue the transfer budget the abandoned
         // downloads were holding.
         self.agent.wait_for_uploads().await;
+        served?;
         let mut stats = self.agent.stats();
         stats.session_duration_ns = duration_ns(self.started.elapsed());
         // The same totals the summary reports, so a reader of a finished stream
@@ -655,6 +663,9 @@ fn should_display_stats(stats: &AgentStats) -> bool {
         || stats.verifications > 0
         || stats.downloaded_bytes > 0
         || stats.uploaded_bytes > 0
+        // An action result published on its own moves no payload bytes, and is
+        // still the whole of what a session did.
+        || stats.background_uploads > 0
         || !stats.bypasses.is_empty()
         || !stats.compiler.is_empty()
         || stats.avoided_compiler_duration_ns > 0
@@ -743,20 +754,31 @@ async fn spawn_server(
     let endpoint = socket.to_string_lossy().into_owned();
     let server = tokio::spawn(async move {
         let _cleanup = SocketCleanup(socket);
-        loop {
+        let mut connections = tokio::task::JoinSet::new();
+        let outcome = loop {
             tokio::select! {
                 accepted = listener.accept() => {
-                    let (stream, _) = accepted?;
+                    let (stream, _) = match accepted {
+                        Ok(accepted) => accepted,
+                        Err(error) => break Err(eyre::Report::from(error)),
+                    };
                     let agent = agent.clone();
-                    tokio::spawn(async move {
+                    connections.spawn(async move {
                         if let Err(error) = agent.handle_connection(stream).await {
                             debug!("cache agent connection failed: {error}");
                         }
                     });
+                    // A build makes one connection per compilation, so finished
+                    // ones are reaped as they go rather than held until shutdown.
+                    while connections.try_join_next().is_some() {}
                 }
-                _ = &mut shutdown => return Ok(()),
+                _ = &mut shutdown => break Ok(()),
             }
-        }
+        };
+        // A connection answers requests, and a store request queues an upload,
+        // so the session has not stopped accepting work until these are done.
+        while connections.join_next().await.is_some() {}
+        outcome
     });
     Ok((endpoint, server))
 }
@@ -786,24 +808,37 @@ async fn spawn_server(
     let server_endpoint = endpoint.clone();
     let server = tokio::spawn(async move {
         let mut next_server = Some(first_server);
-        loop {
+        let mut connections = tokio::task::JoinSet::new();
+        let outcome = loop {
             let pipe = next_server
                 .take()
                 .expect("the next named-pipe server is always prepared");
             tokio::select! {
                 connected = pipe.connect() => {
-                    connected?;
-                    next_server = Some(create_named_pipe(&server_endpoint, false)?);
+                    if let Err(error) = connected {
+                        break Err(eyre::Report::from(error));
+                    }
+                    match create_named_pipe(&server_endpoint, false) {
+                        Ok(prepared) => next_server = Some(prepared),
+                        Err(error) => break Err(error),
+                    }
                     let agent = agent.clone();
-                    tokio::spawn(async move {
+                    connections.spawn(async move {
                         if let Err(error) = agent.handle_connection(pipe).await {
                             debug!("cache agent connection failed: {error}");
                         }
                     });
+                    // A build makes one connection per compilation, so finished
+                    // ones are reaped as they go rather than held until shutdown.
+                    while connections.try_join_next().is_some() {}
                 }
-                _ = &mut shutdown => return Ok(()),
+                _ = &mut shutdown => break Ok(()),
             }
-        }
+        };
+        // A connection answers requests, and a store request queues an upload,
+        // so the session has not stopped accepting work until these are done.
+        while connections.join_next().await.is_some() {}
+        outcome
     });
     Ok((endpoint, server))
 }

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -9,7 +9,8 @@ subcommand.
 3. Cargo runs normally with the shim set as `RUSTC_WRAPPER`.
 4. The shim analyzes each rustc invocation and derives a content-addressed action key.
 5. A hit restores the action's outputs; a miss runs the real compiler and publishes the result.
-6. The agent exits with the build. There is no persistent daemon.
+6. The agent exits with the build, draining any remote uploads it still owes.
+   There is no persistent daemon.
 
 Every mbx command works this way; there is no separate mode to turn on and no
 component to keep up to date.

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -78,6 +78,35 @@ manifest as a normal mbx build. Prefetch requires a configured remote in
 `read-only` or `read-write` mode, waits for every predicted action, and returns
 an error when the manifest lookup fails.
 
+## Deferred publication
+
+An upload is not on the critical path of the build that produced it. A store
+request returns once the object is durable in the local content-addressed store,
+and the upload it implies is queued and performed while the build continues, so a
+compilation never waits for a round trip that only later builds benefit from.
+
+Two rules follow from that:
+
+- An action result is published only after every blob it references. A server
+  validates an action result's output tree before committing it, so publishing
+  one early would be rejected — and a reader that fetched it would find outputs
+  it cannot restore. A blob that fails to upload therefore withholds the action
+  result naming it, and a task manifest waits for the results it predicts.
+- The session drains its queue before exiting. Uploads belong to the build's
+  process, so a command killed part way through publishes less than it stored.
+  Nothing is lost but hit rate: the next build recomputes what never landed.
+
+A failed upload is reported, counted in `remote_failures`, and recovered from.
+The build keeps its local result either way. The session summary reports what was
+published and what the drain cost:
+
+```text
+mbx[cache]: uploads: 143 published, 0 not published; 412ms waited for after the build
+```
+
+`MBX_STATS_REPORT` carries the same figures as `background_uploads`,
+`background_upload_failures`, and `upload_drain_duration_ns`.
+
 ## Transfer behavior
 
 Remote blobs are compressed with zstd. `MBX_HTTP_DOWNLOAD_TIMEOUT` is separate


### PR DESCRIPTION
## Why

Comparing mbx's remote path to [kache](https://github.com/kunobi-ninja/kache) turned up one clear asymmetry: our read side is competitive (prediction-driven prefetch, blob-pack downloads, zstd), but **uploads sit on the build's critical path**.

`store_blob` and `store_action_result` awaited their remote `PUT` before answering the shim. The shim blocks per request, Cargo won't schedule a dependent crate until the wrapper exits, so on write-enabled CI every compiled crate paid a serial round trip that only *later* builds benefit from. kache hides this with a background daemon; mbx doesn't need one — the agent already lives for the whole build.

## What changed

The object is durable in the local CAS before the shim is told it was stored, so the upload it implies is queued instead of awaited. New `crates/mbx-cache-core/src/uploads.rs` holds the queue; `CacheSession::finish` drains it once no further requests can arrive.

**Ordering.** Deferring uploads removes the transport ordering that used to keep a result's blobs ahead of the result — and that ordering is load-bearing, because a server validates an action result's output tree against visible blobs before committing it. So:

- an action result carries the tickets of the blobs queued before it on the same connection and waits for them (a shim publishes a compilation's blobs, then the result naming them, over one connection);
- a blob that fails to upload withholds the action result referencing it, rather than sending one the server would reject;
- `commit_task` waits for the results its manifest predicts before publishing the manifest.

**Failure handling is unchanged in kind:** reported, counted in `remote_failures`, recovered from. A collected object is skipped rather than retried. The build keeps its local result either way.

**Uploads never crowd out foreground work:** the queue's own 32-permit budget nests inside the agent's existing `remote_transfers` budget, and prefetches are cancelled before the drain so the queue inherits their permits.

## Stats

New `background_uploads`, `background_upload_failures`, and `upload_drain_duration_ns`, in `MBX_STATS_REPORT` and in the summary:

```text
mbx[cache]: uploads: 143 published, 0 not published; 412ms waited for after the build
```

## Tests

Six new tests in `agent_tests.rs`: a store returning while the server still holds the upload response open, blob-before-result ordering observed server-side, a failed blob withholding its result, per-digest upload dedup, a read-only session queueing nothing, and a collected object being skipped. The existing `round_trips_task_actions_between_fresh_local_caches` passes unchanged — the manifest barrier already enforces what it asserts.

No shim/agent protocol change: `Stored`/`ActionStored` keep their shape, so `AGENT_PROTOCOL_VERSION` and the conformance fixture are untouched.

## Follow-ups

This is the first of three; the other two need protocol additions and matching server work in `jdx/mr-boxington-cache`:

1. **batched action-result lookups** — prefetch currently issues one `GET` per predicted action;
2. **upload-direction blob packs** — downloads batch into `MBXPACK1` packs, uploads are still individual `PUT`s. The queue in this PR is where that coalescing will happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote cache write timing, upload ordering, and task-manifest publication gates—areas where mistakes could hurt cache hit rate or advertise unreachable actions—but local build correctness is preserved and behavior is heavily covered by new integration tests.
> 
> **Overview**
> **Remote cache writes no longer block store responses.** After blobs and action results are durable locally, publication is queued in a new `uploads` module and runs in the background; `CacheSession::finish` drains the queue (after cancelling prefetches) so uploads still complete before the session exits.
> 
> **Ordering and manifest safety are preserved without synchronous PUTs.** Per-connection upload tickets ensure action results publish only after their blobs; failed blob uploads skip the dependent action result. On `commit_task`, the agent waits for predicted action uploads and **drops only newly introduced predictions** from the remote task manifest when upload failed—inherited predictions stay advertised.
> 
> **Observability and lifecycle:** `background_uploads`, `background_upload_failures`, and `upload_drain_duration_ns` feed session stats and stderr summaries. The cache agent socket server now joins in-flight connections on shutdown so queued uploads are not cut off mid-connection.
> 
> Agent/shim protocol is unchanged (`Stored` / `ActionStored` semantics the same). Docs describe deferred publication behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278d7a8857639e7547624cdf5e083af75275433d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote cache uploads now run asynchronously, allowing local store operations to return sooner.
  * Uploads are deduplicated and ordered so referenced blobs are published before action results.
  * Session summaries and statistics report completed uploads, failures, and upload drain time.
  * Sessions finish by draining pending uploads before exiting.

* **Bug Fixes**
  * Prevented action results from being published when required blob uploads fail.
  * Improved handling of missing local objects and read-only sessions.

* **Documentation**
  * Added guidance on deferred publication, upload ordering, failures, and session shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->