### PR TITLE
feat: cache natively linked test binaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# Working in this repository
+
+## Never bump a crate version in a pull request
+
+Versions belong to release-plz alone. It computes each crate's next version
+from the commits that touched it and writes the bump in the release PR, so a
+version edited by hand in a feature PR either collides with that calculation or
+is silently overwritten by it. See [RELEASING.md](RELEASING.md) for the flow.
+
+This holds even when `cargo semver-checks` fails in CI. That check compares the
+branch against its base and reports what the change would require; it is
+telling you the shape of the change, not asking for a bump. A failure means one
+of two things:
+
+- The break is unintended. Fix the API instead. Adding a field to a struct with
+  all-public fields breaks exhaustive literals, so add a method or a
+  constructor rather than a field. Additive methods, new types, and new enum
+  variants on `#[non_exhaustive]` enums are all free.
+- The break is intended and worth it. Say so in the pull request and leave the
+  version alone. Whoever merges decides how it releases; release-plz will pick
+  the right number from the commits.
+
+Chasing the check with a bump is also self-defeating: `main` moves, the bump
+collides on the next rebase, and it has to be raised again.
+
+## Documentation is generated
+
+`docs/cli/` is generated from the `usage` declarations in
+`crates/mbx/src/config.rs` and `crates/mbx/src/cli.rs`. Run `mise run
+render:docs` after changing a setting and commit the result; `mise run
+check:docs` fails otherwise. Never hand-edit a file under `docs/cli/`, and
+resolve a rebase conflict there by regenerating rather than by merging.
+
+## Before pushing
+
+`mise run ci` is the gate: lint, build, generated-docs check, and both test
+suites. `mise run format` fixes what lint complains about.
+
+The bats suites need the git submodules under `test/`, and the wasm end-to-end
+test needs `wasm32-unknown-unknown` installed for the toolchain `mise` pins —
+`rustup target add --toolchain <pinned> wasm32-unknown-unknown`, not just for
+the rustup default.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,6 +31,13 @@ on. `mbx-cache-core` and `mbx-cache-rustc` are internals; they share the
 `mbx-internals` version group, move together, and stay on `0.x` so semver
 itself says a minor bump may break them.
 
+Nobody edits a version in a feature pull request. release-plz owns every
+number, and one written by hand either collides with its calculation or is
+overwritten by it. A failing `cargo semver-checks` reports what a change would
+require; it is not a request for a bump. Either the break is unintended, and
+the API is what to fix, or it is intended, and the pull request should say so
+and leave the version alone.
+
 release-plz computes each line from the commits that touched it and updates the
 path dependencies' version requirements, so a release can move one crate and
 leave the rest alone. When `mbx` reaches `1.0`, the internal crates stay on

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -2486,10 +2486,16 @@ impl CacheAgent {
         executable: PathBuf,
         environment: BTreeMap<String, Option<String>>,
     ) -> Result<ExecutableIdentityKey> {
-        if !environment
-            .keys()
-            .all(|name| matches!(name.as_str(), "RUSTUP_HOME" | "RUSTUP_TOOLCHAIN"))
-        {
+        // Restricted to the variables that actually select what an identity
+        // probe reports: the toolchain rustup resolves, and the SDK a linker
+        // driver builds against. Anything else would let one key stand for two
+        // different compilers.
+        if !environment.keys().all(|name| {
+            matches!(
+                name.as_str(),
+                "RUSTUP_HOME" | "RUSTUP_TOOLCHAIN" | "SDKROOT" | "MACOSX_DEPLOYMENT_TARGET"
+            )
+        }) {
             bail!("executable identity contains an unsupported environment variable");
         }
         Ok(ExecutableIdentityKey {

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -2981,6 +2981,39 @@ async fn memoizes_client_observed_executable_identities() {
     ));
 }
 
+/// A linker driver's identity depends on the SDK it builds against, so those
+/// names key an identity too. Everything else stays refused: a name that does
+/// not select what the probe reports would let one key stand for two answers.
+#[tokio::test]
+async fn identity_keys_admit_only_names_that_select_the_answer() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = CacheAgent::new(directory.path(), "test-version");
+    let executable = directory.path().join("cc");
+
+    for name in ["SDKROOT", "MACOSX_DEPLOYMENT_TARGET"] {
+        let response = agent
+            .respond(AgentRequest::StoreExecutableIdentity {
+                executable: executable.clone(),
+                environment: BTreeMap::from([(name.into(), Some("value".into()))]),
+                stdout: b"cc identity".to_vec(),
+            })
+            .await;
+        assert!(
+            matches!(response, AgentResponse::ExecutableIdentity { .. }),
+            "{name} should key an identity"
+        );
+    }
+
+    let response = agent
+        .respond(AgentRequest::StoreExecutableIdentity {
+            executable,
+            environment: BTreeMap::from([("PATH".into(), Some("/usr/bin".into()))]),
+            stdout: b"cc identity".to_vec(),
+        })
+        .await;
+    assert!(matches!(response, AgentResponse::Error { .. }));
+}
+
 #[test]
 fn bounds_executable_identity_entry_count() {
     let directory = tempfile::tempdir().unwrap();

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -697,7 +697,6 @@ mod tests {
             environment: BTreeMap::new(),
             portable_environment: BTreeSet::new(),
             inputs: Vec::new(),
-            linker: None,
         };
         discovered.clone().apply_to(&mut context).unwrap();
         let action = invocation.action(context).unwrap();

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -697,6 +697,7 @@ mod tests {
             environment: BTreeMap::new(),
             portable_environment: BTreeSet::new(),
             inputs: Vec::new(),
+            linker: None,
         };
         discovered.clone().apply_to(&mut context).unwrap();
         let action = invocation.action(context).unwrap();

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -312,6 +312,15 @@ pub struct ParseOptions {
     pub cache_native_links: bool,
 }
 
+impl ParseOptions {
+    /// Options that admit native links when `enabled`.
+    pub fn caching_native_links(enabled: bool) -> Self {
+        Self {
+            cache_native_links: enabled,
+        }
+    }
+}
+
 /// The cacheable files and dependency manifest produced by a rustc invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustcOutputs {
@@ -750,7 +759,8 @@ pub struct ActionContext {
 /// against. Nothing here is placeholder-mapped -- these paths are host
 /// locations rather than checkout locations, and two hosts that differ should
 /// miss rather than share.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LinkerIdentity {
     /// Resolved absolute path of the linker driver rustc will invoke.
     pub driver: String,

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -1387,6 +1387,11 @@ impl Parser<'_> {
     /// cargo omits it for host builds anyway.
     fn links_a_native_program(&self) -> bool {
         self.target.is_none()
+            // A compilation that emits no linked artifact did not link, so it
+            // needs no linker to describe it. `cargo check --tests` asks for
+            // metadata alone, and reading that as a link would send it looking
+            // for a linker identity and refusing flags no linker ever saw.
+            && self.emits.iter().any(|emit| emit.kind == "link")
             && ((self.test && self.crate_types.is_empty())
                 || matches!(self.crate_types.as_slice(), [kind] if kind == "bin"))
     }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -732,6 +732,41 @@ pub struct ActionContext {
     pub portable_environment: BTreeSet<String>,
     /// Complete set of direct and discovered file inputs.
     pub inputs: Vec<ActionInput>,
+    /// Identity of the linker, for an invocation that links a native program.
+    ///
+    /// Required by [`RustcInvocation::action`] whenever
+    /// [`RustcInvocation::links_natively`] holds: the linker, its CRT objects,
+    /// and the platform SDK are inputs that rustc dep-info does not enumerate,
+    /// so a key without them would claim more than it can support.
+    pub linker: Option<LinkerIdentity>,
+}
+
+/// What produced a linked native program, beyond the compiler itself.
+///
+/// The fields are identity rather than content wherever a compiler's own
+/// identity is: a driver's version output names its toolchain more cheaply than
+/// hashing a hundred megabytes of it, and matches how rustc is identified. The
+/// CRT objects are hashed, because nothing else pins the libc a link resolves
+/// against. Nothing here is placeholder-mapped -- these paths are host
+/// locations rather than checkout locations, and two hosts that differ should
+/// miss rather than share.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LinkerIdentity {
+    /// Resolved absolute path of the linker driver rustc will invoke.
+    pub driver: String,
+    /// Version output of that driver.
+    pub driver_version: String,
+    /// Version of the linker the driver selects.
+    pub linker_version: String,
+    /// Startup objects and libc the driver resolves, by probe name.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub crt_objects: BTreeMap<String, CacheDigest>,
+    /// Platform SDK identity, where the platform has one.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sdk: Option<String>,
+    /// Deployment target the link was made against, where one applies.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub deployment_target: Option<String>,
 }
 
 /// Canonical action descriptor and its content digest.
@@ -829,6 +864,10 @@ struct ActionDescriptor {
     arguments: Vec<String>,
     environment: BTreeMap<String, Option<String>>,
     inputs: Vec<InputDescriptor>,
+    /// Omitted entirely unless the invocation links natively, so every key
+    /// written before this field existed still serializes to the same bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    linker: Option<LinkerIdentity>,
 }
 
 #[derive(Serialize)]
@@ -1440,6 +1479,13 @@ impl<'a> ActionBuilder<'a> {
             .into_iter()
             .map(|(path, digest)| InputDescriptor { path, digest })
             .collect();
+        // A native link without a linker identity would be keyed as though the
+        // host did not matter. Refuse rather than publish that claim.
+        if self.invocation.links_natively() && self.context.linker.is_none() {
+            return Err(BypassReason::UnportableNativeLink(
+                "linker identity is unknown".into(),
+            ));
+        }
         let descriptor = ActionDescriptor {
             version: ACTION_SCHEMA_VERSION,
             kind: "rustc",
@@ -1448,6 +1494,7 @@ impl<'a> ActionBuilder<'a> {
             arguments: invocation.arguments,
             environment,
             inputs,
+            linker: self.context.linker.clone(),
         };
         let bytes = canonical_json(&descriptor)
             .map_err(|error| BypassReason::Serialization(error.to_string()))?;

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -177,6 +177,9 @@ pub enum BypassReason {
     /// Native-library lookup is not modeled as a precise input.
     #[error("native library lookup is not cacheable yet")]
     NativeLibrary,
+    /// An output's name does not say whether it is a program or a library.
+    #[error("rustc output name does not distinguish a program from a library: {0}")]
+    AmbiguousOutputName(PathBuf),
     /// A native link would embed something no other checkout can reproduce.
     #[error("native link is not reproducible across checkouts: {0}")]
     UnportableNativeLink(String),
@@ -494,6 +497,19 @@ impl RustcInvocation {
             }
             if path.parent() != Some(output_directory.as_path()) {
                 return Err(BypassReason::SplitOutputDirectories);
+            }
+            // Whether a restored output is a program is read back off its name,
+            // so a program that answers to a library's name would be restored
+            // without the permission that makes it runnable. Nothing cargo
+            // emits looks like this; a hand-built invocation could.
+            if emit.kind == "link"
+                && !matches!(self.link_output, LinkOutput::Library)
+                && matches!(
+                    path.extension().and_then(|extension| extension.to_str()),
+                    Some("rlib" | "rmeta")
+                )
+            {
+                return Err(BypassReason::AmbiguousOutputName(path));
             }
             files.insert(path);
         }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -1380,38 +1380,52 @@ impl Parser<'_> {
             let Argument::Plain(value) = argument else {
                 continue;
             };
-            let Some((name, value)) = value
-                .strip_prefix("--codegen=")
-                .and_then(|option| option.split_once('='))
-            else {
+            // `-g` is rustc's shorthand for debug info, and arrives as itself
+            // rather than as a codegen option.
+            let (name, value) = if value == "-g" {
+                ("debuginfo", Some("2"))
+            } else if let Some(option) = value.strip_prefix("--codegen=") {
+                match option.split_once('=') {
+                    Some((name, value)) => (name, Some(value)),
+                    // A codegen flag with no value asks for its enabled form,
+                    // which is what cargo passes for `-Crpath`. Reading it as
+                    // "nothing to check" is how these slipped through.
+                    None => (option, None),
+                }
+            } else {
                 continue;
             };
             let unportable = match name {
                 // Packed debug info leaves a .dSYM bundle or .dwp file beside
                 // the binary, and mbx stores neither.
-                "split-debuginfo" => value != "off",
+                "split-debuginfo" => value != Some("off"),
                 // ld64 records absolute object paths and their timestamps in
                 // the binary's debug map, so the same source links to
                 // different bytes in another checkout -- or the same one
                 // twice.
-                "debuginfo" if cfg!(target_os = "macos") => !matches!(value, "0" | "none"),
+                "debuginfo" if cfg!(target_os = "macos") => !matches!(value, Some("0" | "none")),
                 // Both embed this checkout's absolute target directory.
-                "rpath" | "prefer-dynamic" => {
-                    matches!(value, "y" | "yes" | "on" | "true")
-                }
+                "rpath" | "prefer-dynamic" => is_enabled(value),
                 // The CRT objects a self-contained link uses come from
                 // somewhere other than where the driver reports.
                 "link-self-contained" => true,
                 _ => false,
             };
             if unportable {
-                return Err(BypassReason::UnportableNativeLink(format!(
-                    "{name}={value}"
-                )));
+                return Err(BypassReason::UnportableNativeLink(match value {
+                    Some(value) => format!("{name}={value}"),
+                    None => name.to_owned(),
+                }));
             }
         }
         Ok(())
     }
+}
+
+/// Whether a boolean codegen option is asking for its enabled form. Absent a
+/// value, rustc reads the flag itself as the request.
+fn is_enabled(value: Option<&str>) -> bool {
+    matches!(value, None | Some("y" | "yes" | "on" | "true"))
 }
 
 fn compiler_bundled_wasm_target(target: &str) -> bool {

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -328,8 +328,6 @@ pub struct RustcOutputs {
     pub directory: PathBuf,
     /// Cacheable library, metadata, and/or linked program files.
     pub files: Vec<PathBuf>,
-    /// Outputs whose executable permission is part of the declared contract.
-    pub executables: Vec<PathBuf>,
     /// Dep-info file used for precise input discovery.
     pub dep_info: PathBuf,
 }
@@ -449,7 +447,6 @@ impl RustcInvocation {
             return Err(BypassReason::ImplicitEmitWithOutputFile(output.clone()));
         }
         let mut files = BTreeSet::new();
-        let mut executables = BTreeSet::new();
         let mut dep_info = None;
         for emit in &self.emits {
             if emit.kind == "dep-info" {
@@ -498,14 +495,6 @@ impl RustcInvocation {
             if path.parent() != Some(output_directory.as_path()) {
                 return Err(BypassReason::SplitOutputDirectories);
             }
-            if emit.kind == "link"
-                && matches!(
-                    self.link_output,
-                    LinkOutput::WasmExecutable | LinkOutput::NativeExecutable
-                )
-            {
-                executables.insert(path.clone());
-            }
             files.insert(path);
         }
         let dep_info = dep_info.ok_or(BypassReason::NoDepInfo)?;
@@ -515,7 +504,6 @@ impl RustcInvocation {
         Ok(RustcOutputs {
             directory: output_directory,
             files: files.into_iter().collect(),
-            executables: executables.into_iter().collect(),
             dep_info,
         })
     }
@@ -526,7 +514,23 @@ impl RustcInvocation {
     /// every additional source or environment-generated input discovered from
     /// dep-info.
     pub fn action(&self, context: ActionContext) -> Result<RustcAction, BypassReason> {
-        ActionBuilder::new(self, context).build()
+        self.action_linked_by(context, None)
+    }
+
+    /// Build canonical action bytes for an invocation that links a native
+    /// program.
+    ///
+    /// A `linker` is required whenever [`RustcInvocation::links_natively`]
+    /// holds: the linker, its startup objects, and the platform SDK are inputs
+    /// rustc dep-info does not enumerate, so a key without them would claim
+    /// more than it can support. Passing one for anything else is ignored,
+    /// since nothing else depends on a linker.
+    pub fn action_linked_by(
+        &self,
+        context: ActionContext,
+        linker: Option<LinkerIdentity>,
+    ) -> Result<RustcAction, BypassReason> {
+        ActionBuilder::new(self, context).linked_by(linker).build()
     }
 
     /// Fingerprint the modeled invocation before dependency contents are known.
@@ -576,8 +580,17 @@ impl RustcInvocation {
 impl RustcOutputs {
     /// Whether `path` is a linked program whose executable permission is part
     /// of the declared output contract.
+    /// A program is whatever this invocation emitted that is not a library
+    /// artifact. Every tier the adapter admits distinguishes the two by
+    /// extension -- `rlib` and `rmeta` are the compiler's own, and a linked
+    /// program carries either the target's (`wasm`) or none at all -- so the
+    /// name is enough and no separate list has to be carried alongside.
     pub fn is_executable(&self, path: &Path) -> bool {
-        self.executables.iter().any(|output| output == path)
+        self.files.iter().any(|output| output == path)
+            && !matches!(
+                path.extension().and_then(|extension| extension.to_str()),
+                Some("rlib" | "rmeta")
+            )
     }
 }
 
@@ -741,13 +754,6 @@ pub struct ActionContext {
     pub portable_environment: BTreeSet<String>,
     /// Complete set of direct and discovered file inputs.
     pub inputs: Vec<ActionInput>,
-    /// Identity of the linker, for an invocation that links a native program.
-    ///
-    /// Required by [`RustcInvocation::action`] whenever
-    /// [`RustcInvocation::links_natively`] holds: the linker, its CRT objects,
-    /// and the platform SDK are inputs that rustc dep-info does not enumerate,
-    /// so a key without them would claim more than it can support.
-    pub linker: Option<LinkerIdentity>,
 }
 
 /// What produced a linked native program, beyond the compiler itself.
@@ -1451,6 +1457,7 @@ struct ActionBuilder<'a> {
     invocation: &'a RustcInvocation,
     context: ActionContext,
     mappings: Vec<PathMapping>,
+    linker: Option<LinkerIdentity>,
 }
 
 impl<'a> ActionBuilder<'a> {
@@ -1465,10 +1472,16 @@ impl<'a> ActionBuilder<'a> {
             })
             .collect();
         Self {
+            linker: None,
             invocation,
             mappings,
             context,
         }
+    }
+
+    fn linked_by(mut self, linker: Option<LinkerIdentity>) -> Self {
+        self.linker = linker;
+        self
     }
 
     fn build(self) -> Result<RustcAction, BypassReason> {
@@ -1505,7 +1518,7 @@ impl<'a> ActionBuilder<'a> {
             .collect();
         // A native link without a linker identity would be keyed as though the
         // host did not matter. Refuse rather than publish that claim.
-        if self.invocation.links_natively() && self.context.linker.is_none() {
+        if self.invocation.links_natively() && self.linker.is_none() {
             return Err(BypassReason::UnportableNativeLink(
                 "linker identity is unknown".into(),
             ));
@@ -1518,7 +1531,7 @@ impl<'a> ActionBuilder<'a> {
             arguments: invocation.arguments,
             environment,
             inputs,
-            linker: self.context.linker.clone(),
+            linker: self.linker.clone(),
         };
         let bytes = canonical_json(&descriptor)
             .map_err(|error| BypassReason::Serialization(error.to_string()))?;

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -177,6 +177,9 @@ pub enum BypassReason {
     /// Native-library lookup is not modeled as a precise input.
     #[error("native library lookup is not cacheable yet")]
     NativeLibrary,
+    /// A native link would embed something no other checkout can reproduce.
+    #[error("native link is not reproducible across checkouts: {0}")]
+    UnportableNativeLink(String),
     /// A library search-path kind is not modeled.
     #[error("rustc search path kind is not cacheable yet: {0}")]
     UnsupportedSearchPath(String),
@@ -293,6 +296,20 @@ pub struct RustcInvocation {
 enum LinkOutput {
     Library,
     WasmExecutable,
+    NativeExecutable,
+}
+
+/// What the caller is prepared to model beyond the default tier.
+///
+/// The parser itself stays pure: whether the host can describe its linker
+/// precisely enough to key a native link is the caller's question, and the
+/// answer arrives here rather than being read out of the environment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct ParseOptions {
+    /// Admit natively linked test binaries and executables, given a linker
+    /// identity in the action key. Off by default.
+    pub cache_native_links: bool,
 }
 
 /// The cacheable files and dependency manifest produced by a rustc invocation.
@@ -300,8 +317,10 @@ enum LinkOutput {
 pub struct RustcOutputs {
     /// Common directory containing all modeled outputs.
     pub directory: PathBuf,
-    /// Cacheable library, metadata, and/or compiler-linked wasm files.
+    /// Cacheable library, metadata, and/or linked program files.
     pub files: Vec<PathBuf>,
+    /// Outputs whose executable permission is part of the declared contract.
+    pub executables: Vec<PathBuf>,
     /// Dep-info file used for precise input discovery.
     pub dep_info: PathBuf,
 }
@@ -315,8 +334,20 @@ impl RustcInvocation {
     /// rlib/rmeta tier plus binaries linked by compiler-bundled WebAssembly
     /// toolchains.
     pub fn parse(arguments: &[OsString]) -> Result<Self, BypassReason> {
+        Self::parse_with(arguments, ParseOptions::default())
+    }
+
+    /// Parse as [`RustcInvocation::parse`] does, admitting what `options`
+    /// says the caller can model.
+    pub fn parse_with(arguments: &[OsString], options: ParseOptions) -> Result<Self, BypassReason> {
         let expanded = expand_response_files(arguments)?;
-        Parser::new(&expanded.arguments).parse()
+        Parser::new(&expanded.arguments, options).parse()
+    }
+
+    /// Whether this invocation links a native program, whose key must therefore
+    /// describe the linker that produced it.
+    pub fn links_natively(&self) -> bool {
+        self.link_output == LinkOutput::NativeExecutable
     }
 
     /// Return the source input passed to rustc.
@@ -409,6 +440,7 @@ impl RustcInvocation {
             return Err(BypassReason::ImplicitEmitWithOutputFile(output.clone()));
         }
         let mut files = BTreeSet::new();
+        let mut executables = BTreeSet::new();
         let mut dep_info = None;
         for emit in &self.emits {
             if emit.kind == "dep-info" {
@@ -434,6 +466,9 @@ impl RustcInvocation {
                 "link" => match self.link_output {
                     LinkOutput::Library => ("lib", "rlib"),
                     LinkOutput::WasmExecutable => ("", "wasm"),
+                    // A linked native program has no extension of its own on
+                    // the platforms this tier admits.
+                    LinkOutput::NativeExecutable => ("", ""),
                 },
                 "metadata" => ("lib", "rmeta"),
                 _ => continue,
@@ -441,16 +476,26 @@ impl RustcInvocation {
             let path = if let Some(path) = &emit.path {
                 absolute_path(path, working_dir)
             } else {
-                output_directory.join(format!(
-                    "{prefix}{}{}.{}",
-                    self.crate_name, self.extra_filename, extension
-                ))
+                let name = format!("{prefix}{}{}", self.crate_name, self.extra_filename);
+                output_directory.join(if extension.is_empty() {
+                    name
+                } else {
+                    format!("{name}.{extension}")
+                })
             };
             if path.file_name().is_none() {
                 return Err(BypassReason::InvalidOutputPath(path));
             }
             if path.parent() != Some(output_directory.as_path()) {
                 return Err(BypassReason::SplitOutputDirectories);
+            }
+            if emit.kind == "link"
+                && matches!(
+                    self.link_output,
+                    LinkOutput::WasmExecutable | LinkOutput::NativeExecutable
+                )
+            {
+                executables.insert(path.clone());
             }
             files.insert(path);
         }
@@ -461,6 +506,7 @@ impl RustcInvocation {
         Ok(RustcOutputs {
             directory: output_directory,
             files: files.into_iter().collect(),
+            executables: executables.into_iter().collect(),
             dep_info,
         })
     }
@@ -522,10 +568,7 @@ impl RustcOutputs {
     /// Whether `path` is a linked program whose executable permission is part
     /// of the declared output contract.
     pub fn is_executable(&self, path: &Path) -> bool {
-        self.files.iter().any(|output| output == path)
-            && path
-                .extension()
-                .is_some_and(|extension| extension == "wasm")
+        self.executables.iter().any(|output| output == path)
     }
 }
 
@@ -825,6 +868,7 @@ struct Parser<'a> {
     out_dir: Option<PathBuf>,
     explicit_output: Option<PathBuf>,
     target: Option<String>,
+    options: ParseOptions,
 }
 
 struct ExpandedArguments {
@@ -895,9 +939,10 @@ fn expand_response_files(arguments: &[OsString]) -> Result<ExpandedArguments, By
 }
 
 impl<'a> Parser<'a> {
-    fn new(arguments: &'a [OsString]) -> Self {
+    fn new(arguments: &'a [OsString], options: ParseOptions) -> Self {
         Self {
             arguments,
+            options,
             index: 0,
             parsed: Vec::new(),
             source: None,
@@ -1224,6 +1269,9 @@ impl<'a> Parser<'a> {
             // and libc shipped in the Rust toolchain. Unlike native linking,
             // there are no implicit host inputs outside compiler identity.
             LinkOutput::WasmExecutable
+        } else if self.options.cache_native_links && self.links_a_native_program() {
+            self.check_native_link_is_portable()?;
+            LinkOutput::NativeExecutable
         } else if self.test {
             return Err(BypassReason::UnsupportedCrateType("test".into()));
         } else {
@@ -1256,6 +1304,64 @@ impl<'a> Parser<'a> {
             return Err(BypassReason::NoCacheableOutput);
         }
         Ok(link_output)
+    }
+}
+
+impl Parser<'_> {
+    /// Whether this invocation links a program for the host.
+    ///
+    /// An explicit `--target` bypasses even when it spells the host triple:
+    /// rustc without one links for the host by construction, which is the
+    /// cheapest description of "the linker this adapter can identify", and
+    /// cargo omits it for host builds anyway.
+    fn links_a_native_program(&self) -> bool {
+        self.target.is_none()
+            && ((self.test && self.crate_types.is_empty())
+                || matches!(self.crate_types.as_slice(), [kind] if kind == "bin"))
+    }
+
+    /// Reject a native link whose result depends on something the key cannot
+    /// describe, or that leaves artifacts beside the ones mbx would store.
+    ///
+    /// Each check names a value rather than a flag: an option absent from the
+    /// invocation keeps rustc's default, which the compiler identity already
+    /// pins, while any other spelling is refused rather than guessed at.
+    fn check_native_link_is_portable(&self) -> Result<(), BypassReason> {
+        for argument in &self.parsed {
+            let Argument::Plain(value) = argument else {
+                continue;
+            };
+            let Some((name, value)) = value
+                .strip_prefix("--codegen=")
+                .and_then(|option| option.split_once('='))
+            else {
+                continue;
+            };
+            let unportable = match name {
+                // Packed debug info leaves a .dSYM bundle or .dwp file beside
+                // the binary, and mbx stores neither.
+                "split-debuginfo" => value != "off",
+                // ld64 records absolute object paths and their timestamps in
+                // the binary's debug map, so the same source links to
+                // different bytes in another checkout -- or the same one
+                // twice.
+                "debuginfo" if cfg!(target_os = "macos") => !matches!(value, "0" | "none"),
+                // Both embed this checkout's absolute target directory.
+                "rpath" | "prefer-dynamic" => {
+                    matches!(value, "y" | "yes" | "on" | "true")
+                }
+                // The CRT objects a self-contained link uses come from
+                // somewhere other than where the driver reports.
+                "link-self-contained" => true,
+                _ => false,
+            };
+            if unportable {
+                return Err(BypassReason::UnportableNativeLink(format!(
+                    "{name}={value}"
+                )));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -20,6 +20,10 @@ fn bypass_kinds_are_stable_and_field_independent() {
         BypassReason::UnportableNativeLink("rpath=yes".into()).kind(),
         "unportable-native-link"
     );
+    assert_eq!(
+        BypassReason::AmbiguousOutputName(PathBuf::from("a.rlib")).kind(),
+        "ambiguous-output-name"
+    );
     // Two reasons of one kind group together despite differing fields.
     assert_eq!(
         BypassReason::UnmappedAbsolutePath(PathBuf::from("/a")).kind(),
@@ -1217,5 +1221,42 @@ fn the_linker_identity_changes_the_action_key() {
             driver_version: "Apple clang version 18.0.0".into(),
             ..test_linker()
         })
+    );
+}
+
+/// Executability is read back off an output's name, so a program answering to
+/// a library's name would come back without the permission that runs it.
+#[test]
+fn a_program_named_like_a_library_is_not_cacheable() {
+    let arguments = args(&[
+        "--crate-name=widget",
+        "--test",
+        "--emit=dep-info,link",
+        "--out-dir=target/debug/deps",
+        "-Cextra-filename=.rlib",
+        "src/lib.rs",
+    ]);
+    let invocation = RustcInvocation::parse_with(&arguments, native_links()).unwrap();
+
+    assert_eq!(
+        invocation.outputs(&workspace()),
+        Err(BypassReason::AmbiguousOutputName(
+            workspace().join("target/debug/deps/widget.rlib")
+        ))
+    );
+
+    // A library by that name is exactly what it claims to be.
+    let library = args(&[
+        "--crate-name=widget",
+        "--crate-type=lib",
+        "--emit=dep-info,link",
+        "--out-dir=target/debug/deps",
+        "src/lib.rs",
+    ]);
+    assert!(
+        RustcInvocation::parse_with(&library, native_links())
+            .unwrap()
+            .outputs(&workspace())
+            .is_ok()
     );
 }

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -16,6 +16,10 @@ fn bypass_kinds_are_stable_and_field_independent() {
         BypassReason::UnsupportedCrateType("bin".into()).kind(),
         "unsupported-crate-type"
     );
+    assert_eq!(
+        BypassReason::UnportableNativeLink("rpath=yes".into()).kind(),
+        "unportable-native-link"
+    );
     // Two reasons of one kind group together despite differing fields.
     assert_eq!(
         BypassReason::UnmappedAbsolutePath(PathBuf::from("/a")).kind(),
@@ -321,6 +325,7 @@ fn resolves_cargo_library_outputs() {
                 working_dir.join("target/debug/deps/libwidget-abc123.rlib"),
                 working_dir.join("target/debug/deps/libwidget-abc123.rmeta"),
             ],
+            executables: Vec::new(),
             dep_info: working_dir.join("target/debug/deps/widget-abc123.d"),
         }
     );
@@ -346,7 +351,8 @@ fn resolves_a_compiler_linked_wasm_binary() {
         invocation.outputs(&working_dir).unwrap(),
         RustcOutputs {
             directory: working_dir.join("target/wasm32-unknown-unknown/debug/deps"),
-            files: vec![executable],
+            files: vec![executable.clone()],
+            executables: vec![executable],
             dep_info: working_dir.join("target/wasm32-unknown-unknown/debug/deps/widget-abc123.d"),
         }
     );
@@ -517,6 +523,7 @@ fn resolves_an_output_file_when_every_emit_names_its_path() {
                 working_dir.join("target/widget.rlib"),
                 working_dir.join("target/widget.rmeta"),
             ],
+            executables: Vec::new(),
             dep_info: working_dir.join("target/widget.d"),
         }
     );
@@ -945,4 +952,161 @@ fn a_rebuilt_dependency_does_not_move_the_source_fingerprint() {
     // The crate itself changed.
     std::fs::write(working_dir.join("src.rs"), "pub fn value() -> u32 { 1 }\n").unwrap();
     assert_ne!(fingerprint(), before);
+
+fn native_links() -> ParseOptions {
+    ParseOptions {
+        cache_native_links: true,
+    }
+}
+
+/// Off, a native link stays outside the cacheable tier exactly as before: the
+/// option is what admits it, never the invocation alone.
+#[test]
+fn native_links_are_admitted_only_when_the_caller_models_them() {
+    let test_binary = args(&["--test", "--emit=dep-info,link", "src/lib.rs"]);
+    assert_eq!(
+        RustcInvocation::parse(&test_binary),
+        Err(BypassReason::UnsupportedCrateType("test".into()))
+    );
+    assert!(RustcInvocation::parse_with(&test_binary, native_links()).is_ok());
+
+    let binary = args(&["--crate-type=bin", "--emit=dep-info,link", "src/main.rs"]);
+    assert_eq!(
+        RustcInvocation::parse(&binary),
+        Err(BypassReason::UnsupportedCrateType("bin".into()))
+    );
+    assert!(RustcInvocation::parse_with(&binary, native_links()).is_ok());
+}
+
+/// A linked program has no extension, and its executable bit is part of what
+/// the cache promises to restore.
+#[test]
+fn a_native_program_is_named_without_an_extension() {
+    let working_dir = workspace();
+    let invocation = RustcInvocation::parse_with(
+        &args(&[
+            "--crate-name=widget",
+            "--test",
+            "--emit=dep-info,link",
+            "--out-dir=target/debug/deps",
+            "-Cextra-filename=-abc123",
+            "src/lib.rs",
+        ]),
+        native_links(),
+    )
+    .unwrap();
+    let linked = working_dir.join("target/debug/deps/widget-abc123");
+
+    let outputs = invocation.outputs(&working_dir).unwrap();
+
+    assert_eq!(outputs.files, vec![linked.clone()]);
+    assert_eq!(outputs.executables, vec![linked.clone()]);
+    assert!(outputs.is_executable(&linked));
+    assert!(invocation.links_natively());
+}
+
+/// rustc without `--target` links for the host by construction, which is the
+/// only linker this adapter can identify. Naming the host triple explicitly is
+/// not the same statement, so it is not assumed to be one.
+#[test]
+fn an_explicit_target_is_never_a_native_link() {
+    let arguments = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "--target=x86_64-unknown-linux-gnu",
+        "src/lib.rs",
+    ]);
+
+    assert_eq!(
+        RustcInvocation::parse_with(&arguments, native_links()),
+        Err(BypassReason::UnsupportedCrateType("test".into()))
+    );
+}
+
+/// Everything here would either embed a path this checkout owns, depend on a
+/// linker the key does not describe, or leave a file beside the binary that
+/// mbx does not store.
+#[test]
+fn unportable_native_links_still_bypass() {
+    for (flag, expected) in [
+        (
+            "-Csplit-debuginfo=packed",
+            BypassReason::UnportableNativeLink("split-debuginfo=packed".into()),
+        ),
+        (
+            "-Crpath=yes",
+            BypassReason::UnportableNativeLink("rpath=yes".into()),
+        ),
+        (
+            "-Cprefer-dynamic=yes",
+            BypassReason::UnportableNativeLink("prefer-dynamic=yes".into()),
+        ),
+        (
+            "-Clink-self-contained=yes",
+            BypassReason::UnportableNativeLink("link-self-contained=yes".into()),
+        ),
+        // Not modeled at all, so it never reaches the portability question.
+        (
+            "-Clinker=/usr/bin/false",
+            BypassReason::UnknownCodegenOption("linker".into()),
+        ),
+    ] {
+        let arguments = args(&["--test", "--emit=dep-info,link", flag, "src/lib.rs"]);
+        assert_eq!(
+            RustcInvocation::parse_with(&arguments, native_links()),
+            Err(expected),
+            "{flag} should not be cacheable"
+        );
+    }
+
+    // Absent or affirmatively off is the default the compiler identity pins.
+    for flag in ["-Csplit-debuginfo=off", "-Crpath=no"] {
+        let arguments = args(&["--test", "--emit=dep-info,link", flag, "src/lib.rs"]);
+        assert!(
+            RustcInvocation::parse_with(&arguments, native_links()).is_ok(),
+            "{flag} should still be cacheable"
+        );
+    }
+}
+
+/// ld64 writes absolute object paths and their timestamps into the binary's
+/// debug map, so the same source links to different bytes in another checkout.
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_debug_info_makes_a_native_link_unportable() {
+    let arguments = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "-Cdebuginfo=2",
+        "src/lib.rs",
+    ]);
+
+    assert_eq!(
+        RustcInvocation::parse_with(&arguments, native_links()),
+        Err(BypassReason::UnportableNativeLink("debuginfo=2".into()))
+    );
+
+    let none = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "-Cdebuginfo=0",
+        "src/lib.rs",
+    ]);
+    assert!(RustcInvocation::parse_with(&none, native_links()).is_ok());
+}
+
+/// A native library is still not a precise input, whoever is asking.
+#[test]
+fn native_libraries_bypass_even_for_admitted_links() {
+    let arguments = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "-lstatic=fixture",
+        "src/lib.rs",
+    ]);
+
+    assert_eq!(
+        RustcInvocation::parse_with(&arguments, native_links()),
+        Err(BypassReason::NativeLibrary)
+    );
 }

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1046,6 +1046,20 @@ fn unportable_native_links_still_bypass() {
             "-Clink-self-contained=yes",
             BypassReason::UnportableNativeLink("link-self-contained=yes".into()),
         ),
+        // Valueless is how cargo actually spells these, and rustc reads the
+        // flag itself as the request.
+        (
+            "-Crpath",
+            BypassReason::UnportableNativeLink("rpath".into()),
+        ),
+        (
+            "-Cprefer-dynamic",
+            BypassReason::UnportableNativeLink("prefer-dynamic".into()),
+        ),
+        (
+            "-Clink-self-contained",
+            BypassReason::UnportableNativeLink("link-self-contained".into()),
+        ),
         // Not modeled at all, so it never reaches the portability question.
         (
             "-Clinker=/usr/bin/false",
@@ -1061,7 +1075,7 @@ fn unportable_native_links_still_bypass() {
     }
 
     // Absent or affirmatively off is the default the compiler identity pins.
-    for flag in ["-Csplit-debuginfo=off", "-Crpath=no"] {
+    for flag in ["-Csplit-debuginfo=off", "-Crpath=no", "-Cprefer-dynamic=no"] {
         let arguments = args(&["--test", "--emit=dep-info,link", flag, "src/lib.rs"]);
         assert!(
             RustcInvocation::parse_with(&arguments, native_links()).is_ok(),
@@ -1084,6 +1098,13 @@ fn macos_debug_info_makes_a_native_link_unportable() {
 
     assert_eq!(
         RustcInvocation::parse_with(&arguments, native_links()),
+        Err(BypassReason::UnportableNativeLink("debuginfo=2".into()))
+    );
+
+    // `-g` is the same request under another name.
+    let shorthand = args(&["--test", "--emit=dep-info,link", "-g", "src/lib.rs"]);
+    assert_eq!(
+        RustcInvocation::parse_with(&shorthand, native_links()),
         Err(BypassReason::UnportableNativeLink("debuginfo=2".into()))
     );
 

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1260,3 +1260,38 @@ fn a_program_named_like_a_library_is_not_cacheable() {
             .is_ok()
     );
 }
+
+/// `cargo check --tests` asks for metadata and never links. Reading that as a
+/// native link would send it looking for a linker identity and refusing flags
+/// no linker ever saw.
+#[test]
+fn a_compilation_that_never_links_is_not_a_link() {
+    let checked = args(&[
+        "--crate-name=widget",
+        "--test",
+        "--emit=dep-info,metadata",
+        "--out-dir=target/debug/deps",
+        "src/lib.rs",
+    ]);
+
+    // Whatever this is, it is not something a linker has an opinion about, so
+    // the answer is the one it gets with the option off.
+    assert_eq!(
+        RustcInvocation::parse_with(&checked, native_links()),
+        RustcInvocation::parse(&checked)
+    );
+
+    // And a flag that would make a *link* unportable says nothing here.
+    let with_debug = args(&[
+        "--crate-name=widget",
+        "--test",
+        "--emit=dep-info,metadata",
+        "--out-dir=target/debug/deps",
+        "-Cdebuginfo=2",
+        "src/lib.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse_with(&with_debug, native_links()),
+        Err(BypassReason::UnsupportedCrateType("test".into()))
+    );
+}

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -97,6 +97,7 @@ fn context(inputs: &[(&str, &str)]) -> ActionContext {
                 digest: digest(contents),
             })
             .collect(),
+        linker: None,
     }
 }
 
@@ -615,6 +616,7 @@ fn predicts_inputs_without_reusing_stale_contents() {
         environment: BTreeMap::new(),
         portable_environment: BTreeSet::new(),
         inputs: Vec::new(),
+        linker: None,
     };
     let dep_info = RustcDepInfo {
         files: vec!["src/lib.rs".into()],
@@ -1108,5 +1110,102 @@ fn native_libraries_bypass_even_for_admitted_links() {
     assert_eq!(
         RustcInvocation::parse_with(&arguments, native_links()),
         Err(BypassReason::NativeLibrary)
+    );
+}
+
+/// The linker field must be absent, not null, for everything that does not link
+/// natively -- otherwise adding it would invalidate every key already in every
+/// store, for a property those compilations never depended on.
+#[test]
+fn modeling_the_linker_leaves_existing_keys_untouched() {
+    let invocation = common_invocation();
+    let inputs = &[
+        ("src/lib.rs", "source"),
+        ("target/debug/deps/libserde.rlib", "serde"),
+    ];
+
+    let action = invocation.action(context(inputs)).unwrap();
+
+    let json = String::from_utf8(action.bytes).unwrap();
+    assert!(!json.contains("linker"), "{json}");
+    // Verified against the adapter as it shipped in 0.5.1: every key already
+    // in a store still resolves after this change.
+    assert_eq!(
+        action.digest.key(),
+        "blake3/af70e14cc38eccf01eabb89067418e7780883628d051f499ea8acf3ebc925933/865"
+    );
+}
+
+/// A native link keyed without one would claim the host does not matter.
+#[test]
+fn a_native_link_without_a_linker_identity_is_refused() {
+    let invocation = RustcInvocation::parse_with(
+        &args(&[
+            "--crate-name=widget",
+            "--test",
+            "--emit=dep-info,link",
+            "--out-dir=target/debug/deps",
+            "src/lib.rs",
+        ]),
+        native_links(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        invocation.action(context(&[("src/lib.rs", "source")])),
+        Err(BypassReason::UnportableNativeLink(
+            "linker identity is unknown".into()
+        ))
+    );
+
+    let identified = ActionContext {
+        linker: Some(test_linker()),
+        ..context(&[("src/lib.rs", "source")])
+    };
+    let action = invocation.action(identified).unwrap();
+    let json = String::from_utf8(action.bytes).unwrap();
+    assert!(json.contains(r#""linker":{"#), "{json}");
+}
+
+fn test_linker() -> LinkerIdentity {
+    LinkerIdentity {
+        driver: "/usr/bin/cc".into(),
+        driver_version: "Apple clang version 17.0.0".into(),
+        linker_version: "ld64-1200".into(),
+        crt_objects: BTreeMap::new(),
+        sdk: Some("MacOSX15.0.sdk (24A335)".into()),
+        deployment_target: None,
+    }
+}
+
+/// Two hosts whose linkers differ must key differently rather than share.
+#[test]
+fn the_linker_identity_changes_the_action_key() {
+    let invocation = RustcInvocation::parse_with(
+        &args(&[
+            "--crate-name=widget",
+            "--test",
+            "--emit=dep-info,link",
+            "--out-dir=target/debug/deps",
+            "src/lib.rs",
+        ]),
+        native_links(),
+    )
+    .unwrap();
+    let first = ActionContext {
+        linker: Some(test_linker()),
+        ..context(&[("src/lib.rs", "source")])
+    };
+    let second = ActionContext {
+        linker: Some(LinkerIdentity {
+            driver_version: "Apple clang version 18.0.0".into(),
+            ..test_linker()
+        }),
+        ..context(&[("src/lib.rs", "source")])
+    };
+
+    assert_ne!(
+        invocation.action(first).unwrap().digest,
+        invocation.action(second).unwrap().digest
     );
 }

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -954,11 +954,10 @@ fn a_rebuilt_dependency_does_not_move_the_source_fingerprint() {
     // The crate itself changed.
     std::fs::write(working_dir.join("src.rs"), "pub fn value() -> u32 { 1 }\n").unwrap();
     assert_ne!(fingerprint(), before);
+}
 
 fn native_links() -> ParseOptions {
-    ParseOptions {
-        cache_native_links: true,
-    }
+    ParseOptions::caching_native_links(true)
 }
 
 /// Off, a native link stays outside the cacheable tier exactly as before: the

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -97,7 +97,6 @@ fn context(inputs: &[(&str, &str)]) -> ActionContext {
                 digest: digest(contents),
             })
             .collect(),
-        linker: None,
     }
 }
 
@@ -326,7 +325,6 @@ fn resolves_cargo_library_outputs() {
                 working_dir.join("target/debug/deps/libwidget-abc123.rlib"),
                 working_dir.join("target/debug/deps/libwidget-abc123.rmeta"),
             ],
-            executables: Vec::new(),
             dep_info: working_dir.join("target/debug/deps/widget-abc123.d"),
         }
     );
@@ -352,8 +350,7 @@ fn resolves_a_compiler_linked_wasm_binary() {
         invocation.outputs(&working_dir).unwrap(),
         RustcOutputs {
             directory: working_dir.join("target/wasm32-unknown-unknown/debug/deps"),
-            files: vec![executable.clone()],
-            executables: vec![executable],
+            files: vec![executable],
             dep_info: working_dir.join("target/wasm32-unknown-unknown/debug/deps/widget-abc123.d"),
         }
     );
@@ -524,7 +521,6 @@ fn resolves_an_output_file_when_every_emit_names_its_path() {
                 working_dir.join("target/widget.rlib"),
                 working_dir.join("target/widget.rmeta"),
             ],
-            executables: Vec::new(),
             dep_info: working_dir.join("target/widget.d"),
         }
     );
@@ -616,7 +612,6 @@ fn predicts_inputs_without_reusing_stale_contents() {
         environment: BTreeMap::new(),
         portable_environment: BTreeSet::new(),
         inputs: Vec::new(),
-        linker: None,
     };
     let dep_info = RustcDepInfo {
         files: vec!["src/lib.rs".into()],
@@ -1001,7 +996,6 @@ fn a_native_program_is_named_without_an_extension() {
     let outputs = invocation.outputs(&working_dir).unwrap();
 
     assert_eq!(outputs.files, vec![linked.clone()]);
-    assert_eq!(outputs.executables, vec![linked.clone()]);
     assert!(outputs.is_executable(&linked));
     assert!(invocation.links_natively());
 }
@@ -1178,11 +1172,9 @@ fn a_native_link_without_a_linker_identity_is_refused() {
         ))
     );
 
-    let identified = ActionContext {
-        linker: Some(test_linker()),
-        ..context(&[("src/lib.rs", "source")])
-    };
-    let action = invocation.action(identified).unwrap();
+    let action = invocation
+        .action_linked_by(context(&[("src/lib.rs", "source")]), Some(test_linker()))
+        .unwrap();
     let json = String::from_utf8(action.bytes).unwrap();
     assert!(json.contains(r#""linker":{"#), "{json}");
 }
@@ -1212,20 +1204,18 @@ fn the_linker_identity_changes_the_action_key() {
         native_links(),
     )
     .unwrap();
-    let first = ActionContext {
-        linker: Some(test_linker()),
-        ..context(&[("src/lib.rs", "source")])
-    };
-    let second = ActionContext {
-        linker: Some(LinkerIdentity {
-            driver_version: "Apple clang version 18.0.0".into(),
-            ..test_linker()
-        }),
-        ..context(&[("src/lib.rs", "source")])
+    let keyed = |linker| {
+        invocation
+            .action_linked_by(context(&[("src/lib.rs", "source")]), Some(linker))
+            .unwrap()
+            .digest
     };
 
     assert_ne!(
-        invocation.action(first).unwrap().digest,
-        invocation.action(second).unwrap().digest
+        keyed(test_linker()),
+        keyed(LinkerIdentity {
+            driver_version: "Apple clang version 18.0.0".into(),
+            ..test_linker()
+        })
     );
 }

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1146,11 +1146,13 @@ fn modeling_the_linker_leaves_existing_keys_untouched() {
 
     let json = String::from_utf8(action.bytes).unwrap();
     assert!(!json.contains("linker"), "{json}");
-    // Verified against the adapter as it shipped in 0.5.1: every key already
-    // in a store still resolves after this change.
+    // The digest this same invocation has on the branch this one came from.
+    // What it guards is that modeling a linker did not move it; a change on
+    // `main` moves it legitimately, and updating this line is then the point
+    // at which someone confirms whose change it was.
     assert_eq!(
         action.digest.key(),
-        "blake3/af70e14cc38eccf01eabb89067418e7780883628d051f499ea8acf3ebc925933/865"
+        "blake3/943ce7a1474e7e3aeb11e54fd513bfe7ef44fd5367f3a5486197b730c6f1e0d3/865"
     );
 }
 

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -499,6 +499,12 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
         return run_cargo(&cargo, arguments, BTreeMap::new());
     }
 
+    // Experimental, and only where mbx can identify the linker precisely
+    // enough to key what it produced.
+    let cache_links = settings.cache_links && session::cache_links_supported();
+    if settings.cache_links && !cache_links {
+        log::warn!("caching native links is not supported on this platform");
+    }
     let working_dir = std::env::current_dir()?;
     let mut roots = resolve_roots(&cargo, arguments, &working_dir);
     let mut config = config.clone();
@@ -609,10 +615,15 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
             )
             .await;
         // Stated explicitly for the same reason as the session's own keys: an
-        // unset value would let the shim inherit one from the parent.
+        // unset value would let the shim inherit one from the parent, with no
+        // way to turn it off here.
         environment.insert(
             session::LEARNED_INCREMENTAL_ENV.into(),
             if learned_incremental { "1" } else { "0" }.into(),
+        );
+        environment.insert(
+            session::CACHE_LINKS_ENV.into(),
+            if cache_links { "1" } else { "0" }.into(),
         );
 
         let status = run_cargo(&cargo, arguments, environment);

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -126,7 +126,7 @@ pub(crate) struct RawConfig {
         default = false,
         scope = "env"
     )]
-    _cache_links: bool,
+    cache_links: bool,
     /// Append the full reason for every bypassed compilation to this path.
     #[usage(key = "bypass_log", env = "MBX_BYPASS_LOG", scope = "env")]
     _bypass_log: Option<PathBuf>,
@@ -344,6 +344,8 @@ pub(crate) struct CliSettings {
     pub savings: SavingsStyle,
     /// Whether a churning crate may compile with its own incremental state.
     pub learned_incremental: bool,
+    /// Whether natively linked programs may be cached.
+    pub cache_links: bool,
 }
 
 /// Matches the declared defaults: a derived `Default` would silence the savings
@@ -354,6 +356,7 @@ impl Default for CliSettings {
             retention: RetentionSettings::default(),
             savings: SavingsStyle::default(),
             learned_incremental: true,
+            cache_links: false,
         }
     }
 }
@@ -575,6 +578,7 @@ impl Config {
                 retention,
                 savings: raw.savings.parse().wrap_err("invalid savings")?,
                 learned_incremental: raw._learned_incremental,
+                cache_links: raw.cache_links,
             },
         ))
     }

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -118,6 +118,15 @@ pub(crate) struct RawConfig {
         choices("quips", "plain", "off")
     )]
     savings: String,
+    /// Cache natively linked test binaries and executables. Experimental:
+    /// qualify it on your own workload with MBX_VERIFY=1 before relying on it.
+    #[usage(
+        key = "cache_links",
+        env = "MBX_CACHE_LINKS",
+        default = false,
+        scope = "env"
+    )]
+    _cache_links: bool,
     /// Append the full reason for every bypassed compilation to this path.
     #[usage(key = "bypass_log", env = "MBX_BYPASS_LOG", scope = "env")]
     _bypass_log: Option<PathBuf>,

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -164,6 +164,31 @@ mod tests {
         assert!(guidance("incremental").contains("MBX_INCREMENTAL=0"));
     }
 
+    /// A kind with nothing specific to say falls back to a sentence that
+    /// amounts to "look at the reason below", which is what `mbx explain`
+    /// exists to save someone from. Every kind the adapter can report should
+    /// therefore say something of its own.
+    #[test]
+    fn every_reported_kind_says_something_of_its_own() {
+        let generic = guidance("a kind nobody wrote guidance for");
+        for kind in [
+            "compiler-query",
+            "standard-input",
+            "incremental",
+            "response-file",
+            "unsupported-crate-type",
+            "unsupported-search-path",
+            "native-library",
+            "unportable-native-link",
+            "ambiguous-output-name",
+            "unknown-flag",
+            "unknown-codegen-option",
+            "unmapped-absolute-path",
+        ] {
+            assert_ne!(guidance(kind), generic, "{kind} has no guidance of its own");
+        }
+    }
+
     #[test]
     fn rejects_partial_records_instead_of_guessing() {
         let error = parse_records("missing a tab\n").unwrap_err();

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -116,6 +116,9 @@ fn guidance(kind: &str) -> &'static str {
         "unsupported-crate-type" => {
             "This artifact type is outside mbx's current cacheability tier. Dynamic libraries still link normally; `MBX_CACHE_LINKS=1` adds native test binaries and executables."
         }
+        "ambiguous-output-name" => {
+            "This output is named like a library but is a program, so mbx cannot tell which permissions to restore it with."
+        }
         "unportable-native-link" => {
             "This link would embed a path, a timestamp, or a file mbx does not store, so another checkout could not use its result."
         }

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -114,7 +114,10 @@ fn guidance(kind: &str) -> &'static str {
             "The invocation uses an `@response-file`; mbx does not model response-file contents yet."
         }
         "unsupported-crate-type" => {
-            "This artifact type is outside mbx's current cacheability tier. Native binaries and dynamic libraries still link normally."
+            "This artifact type is outside mbx's current cacheability tier. Dynamic libraries still link normally; `MBX_CACHE_LINKS=1` adds native test binaries and executables."
+        }
+        "unportable-native-link" => {
+            "This link would embed a path, a timestamp, or a file mbx does not store, so another checkout could not use its result."
         }
         "unsupported-search-path" | "native-library" => {
             "A native dependency or search path is not a precise compiler input, so mbx cannot safely reuse this action."

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -46,4 +46,5 @@ pub mod tui;
 #[doc(hidden)]
 pub mod util;
 
+mod linker;
 mod rustc;

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -22,22 +22,41 @@ use std::process::Command;
 /// Environment that selects what the probes below report.
 const IDENTITY_ENVIRONMENT: &[&str] = &["SDKROOT", "MACOSX_DEPLOYMENT_TARGET"];
 
-/// The object that starts a program. One of these must resolve, or nothing
-/// pins what the link began with.
-#[cfg(target_os = "linux")]
-const STARTUP_PROBES: &[&str] = &["Scrt1.o", "crt1.o"];
+/// What the driver is asked to place, and which of it a key cannot do without.
+///
+/// The names are platform knowledge; the rule about them is not, so the two are
+/// separated and only the names are chosen by `cfg`. A host this build cannot
+/// run on is still a host whose logic can be tested here.
+struct FileProbes {
+    /// The object that starts a program. One of these must resolve, or nothing
+    /// pins what the link began with.
+    startup: &'static [&'static str],
+    /// Names a libc goes by, across the C libraries and linkage modes this
+    /// tier admits. One must resolve too: libc is the input a statically
+    /// linked program carries inside it, so a key that does not pin it lets
+    /// one distribution's binary restore onto another's.
+    libc: &'static [&'static str],
+    /// Everything else a link pulls in. Individually optional -- a toolchain
+    /// that does not use one is not thereby unidentifiable.
+    rest: &'static [&'static str],
+}
 
-/// Names a libc goes by, across the C libraries and linkage modes this tier
-/// admits. One of these must resolve too: libc is the input a statically
-/// linked program carries inside it, so a key that does not pin it is a key
-/// that lets one distribution's binary restore onto another's.
+/// GNU-style hosts link against loose objects the driver can place.
 #[cfg(target_os = "linux")]
-const LIBC_PROBES: &[&str] = &["libc.so.6", "libc.so", "libc.a", "libc.musl-x86_64.so.1"];
+const FILE_PROBES: FileProbes = FileProbes {
+    startup: &["Scrt1.o", "crt1.o"],
+    libc: &["libc.so.6", "libc.so", "libc.a", "libc.musl-x86_64.so.1"],
+    rest: &["crti.o", "crtn.o", "crtbeginS.o", "crtendS.o"],
+};
 
-/// Everything else a GNU-style link pulls in. Individually optional -- a
-/// toolchain that does not use one is not thereby unidentifiable.
-#[cfg(target_os = "linux")]
-const CRT_PROBES: &[&str] = &["crti.o", "crtn.o", "crtbeginS.o", "crtendS.o"];
+/// macOS links against the SDK rather than loose objects, and the SDK identity
+/// below covers what those would have pinned.
+#[cfg(not(target_os = "linux"))]
+const FILE_PROBES: FileProbes = FileProbes {
+    startup: &[],
+    libc: &[],
+    rest: &[],
+};
 
 /// Describe the linker rustc will use for a native link on this host.
 ///
@@ -141,35 +160,37 @@ fn linker_version(driver: &Path) -> Result<String> {
 /// what that probe stood for. So the inputs a link cannot be described without
 /// -- a startup object and a libc -- have to resolve, and a host where neither
 /// does gets no identity and no cached link.
-#[cfg(target_os = "linux")]
 fn crt_objects(driver: &Path) -> Result<BTreeMap<String, CacheDigest>> {
-    let resolved = STARTUP_PROBES
+    probe_files(&FILE_PROBES, |name| {
+        let resolved = run(driver, &[&format!("-print-file-name={name}")]).ok()?;
+        let path = PathBuf::from(resolved.trim());
+        // The driver echoes the name back when it cannot place it.
+        path.is_absolute().then_some(path)
+    })
+}
+
+/// Resolve each probe, hash what came back, and insist on the ones a key
+/// cannot describe a link without.
+fn probe_files(
+    probes: &FileProbes,
+    place: impl Fn(&str) -> Option<PathBuf>,
+) -> Result<BTreeMap<String, CacheDigest>> {
+    let resolved = probes
+        .startup
         .iter()
-        .chain(LIBC_PROBES)
-        .chain(CRT_PROBES)
+        .chain(probes.libc)
+        .chain(probes.rest)
         .filter_map(|name| {
-            let resolved = run(driver, &[&format!("-print-file-name={name}")]).ok()?;
-            let path = PathBuf::from(resolved.trim());
-            // The driver echoes the name back when it cannot place it.
-            let digest = path
-                .is_absolute()
-                .then(|| CacheDigest::blake3_file(&path))?;
-            Some(((*name).to_owned(), digest.ok()?))
+            let digest = CacheDigest::blake3_file(&place(name)?).ok()?;
+            Some(((*name).to_owned(), digest))
         })
         .collect::<BTreeMap<_, _>>();
-    for (probes, what) in [(STARTUP_PROBES, "startup object"), (LIBC_PROBES, "libc")] {
-        if !probes.iter().any(|name| resolved.contains_key(*name)) {
+    for (required, what) in [(probes.startup, "startup object"), (probes.libc, "libc")] {
+        if !required.is_empty() && !required.iter().any(|name| resolved.contains_key(*name)) {
             bail!("the linker driver resolved no {what}, so its links cannot be identified");
         }
     }
     Ok(resolved)
-}
-
-/// macOS links against the SDK rather than loose startup objects, and the SDK
-/// identity below covers it.
-#[cfg(not(target_os = "linux"))]
-fn crt_objects(_driver: &Path) -> Result<BTreeMap<String, CacheDigest>> {
-    Ok(BTreeMap::new())
 }
 
 /// Identity of the SDK a link builds against, where the platform has one.

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -22,17 +22,22 @@ use std::process::Command;
 /// Environment that selects what the probes below report.
 const IDENTITY_ENVIRONMENT: &[&str] = &["SDKROOT", "MACOSX_DEPLOYMENT_TARGET"];
 
-/// Startup objects and libc a GNU-style link resolves against.
+/// The object that starts a program. One of these must resolve, or nothing
+/// pins what the link began with.
 #[cfg(target_os = "linux")]
-const CRT_PROBES: &[&str] = &[
-    "Scrt1.o",
-    "crt1.o",
-    "crti.o",
-    "crtn.o",
-    "crtbeginS.o",
-    "crtendS.o",
-    "libc.so.6",
-];
+const STARTUP_PROBES: &[&str] = &["Scrt1.o", "crt1.o"];
+
+/// Names a libc goes by, across the C libraries and linkage modes this tier
+/// admits. One of these must resolve too: libc is the input a statically
+/// linked program carries inside it, so a key that does not pin it is a key
+/// that lets one distribution's binary restore onto another's.
+#[cfg(target_os = "linux")]
+const LIBC_PROBES: &[&str] = &["libc.so.6", "libc.so", "libc.a", "libc.musl-x86_64.so.1"];
+
+/// Everything else a GNU-style link pulls in. Individually optional -- a
+/// toolchain that does not use one is not thereby unidentifiable.
+#[cfg(target_os = "linux")]
+const CRT_PROBES: &[&str] = &["crti.o", "crtn.o", "crtbeginS.o", "crtendS.o"];
 
 /// Describe the linker rustc will use for a native link on this host.
 ///
@@ -93,8 +98,8 @@ fn probe(driver: &Path) -> Result<LinkerIdentity> {
             .to_owned(),
         driver_version: run(driver, &["--version"])?,
         linker_version: linker_version(driver)?,
-        crt_objects: crt_objects(driver),
-        sdk: sdk_identity(),
+        crt_objects: crt_objects(driver)?,
+        sdk: sdk_identity()?,
         deployment_target: std::env::var("MACOSX_DEPLOYMENT_TARGET").ok(),
     })
 }
@@ -123,13 +128,18 @@ fn linker_version(driver: &Path) -> Result<String> {
 
 /// Hash the startup objects and libc the driver resolves.
 ///
-/// A probe that does not resolve to a readable file is left out rather than
-/// guessed at: the ones that do resolve already distinguish two hosts, and a
-/// missing entry cannot make two different hosts look alike.
+/// A probe that does not resolve is left out of the map, so a host that
+/// resolves a different set keys differently. That alone is not enough: two
+/// hosts failing the *same* probe would agree on a key without ever pinning
+/// what that probe stood for. So the inputs a link cannot be described without
+/// -- a startup object and a libc -- have to resolve, and a host where neither
+/// does gets no identity and no cached link.
 #[cfg(target_os = "linux")]
-fn crt_objects(driver: &Path) -> BTreeMap<String, CacheDigest> {
-    CRT_PROBES
+fn crt_objects(driver: &Path) -> Result<BTreeMap<String, CacheDigest>> {
+    let resolved = STARTUP_PROBES
         .iter()
+        .chain(LIBC_PROBES)
+        .chain(CRT_PROBES)
         .filter_map(|name| {
             let resolved = run(driver, &[&format!("-print-file-name={name}")]).ok()?;
             let path = PathBuf::from(resolved.trim());
@@ -139,28 +149,42 @@ fn crt_objects(driver: &Path) -> BTreeMap<String, CacheDigest> {
                 .then(|| CacheDigest::blake3_file(&path))?;
             Some(((*name).to_owned(), digest.ok()?))
         })
-        .collect()
+        .collect::<BTreeMap<_, _>>();
+    for (probes, what) in [(STARTUP_PROBES, "startup object"), (LIBC_PROBES, "libc")] {
+        if !probes.iter().any(|name| resolved.contains_key(*name)) {
+            bail!("the linker driver resolved no {what}, so its links cannot be identified");
+        }
+    }
+    Ok(resolved)
 }
 
 /// macOS links against the SDK rather than loose startup objects, and the SDK
 /// identity below covers it.
 #[cfg(not(target_os = "linux"))]
-fn crt_objects(_driver: &Path) -> BTreeMap<String, CacheDigest> {
-    BTreeMap::new()
+fn crt_objects(_driver: &Path) -> Result<BTreeMap<String, CacheDigest>> {
+    Ok(BTreeMap::new())
 }
 
 /// Identity of the SDK a link builds against, where the platform has one.
 ///
 /// The build version is what changes when Apple ships new libraries under an
-/// unchanged SDK version, so it is the half that matters most here.
+/// unchanged SDK version, so it is the half that matters most here. A host that
+/// cannot report it gets no identity rather than one that omits the SDK: two
+/// such hosts would otherwise agree on a key while linking against different
+/// system libraries.
 #[cfg(target_os = "macos")]
-fn sdk_identity() -> Option<String> {
-    let version = xcrun(&["--sdk", "macosx", "--show-sdk-version"])?;
-    let build = xcrun(&["--sdk", "macosx", "--show-sdk-build-version"])?;
-    let path = std::env::var("SDKROOT")
-        .ok()
-        .or_else(|| xcrun(&["--sdk", "macosx", "--show-sdk-path"]))?;
-    Some(format!("{path} {version} ({build})"))
+fn sdk_identity() -> Result<Option<String>> {
+    let describe = || {
+        let version = xcrun(&["--sdk", "macosx", "--show-sdk-version"])?;
+        let build = xcrun(&["--sdk", "macosx", "--show-sdk-build-version"])?;
+        let path = std::env::var("SDKROOT")
+            .ok()
+            .or_else(|| xcrun(&["--sdk", "macosx", "--show-sdk-path"]))?;
+        Some(format!("{path} {version} ({build})"))
+    };
+    describe().map(Some).ok_or_else(|| {
+        eyre::eyre!("the macOS SDK could not be identified, so its links cannot be either")
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -174,8 +198,8 @@ fn xcrun(arguments: &[&str]) -> Option<String> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn sdk_identity() -> Option<String> {
-    None
+fn sdk_identity() -> Result<Option<String>> {
+    Ok(None)
 }
 
 fn run(program: &Path, arguments: &[&str]) -> Result<String> {

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -216,15 +216,27 @@ fn probe_files(
 /// the same reason as the probe tables: code only one platform compiles is
 /// code only that platform's CI can find a mistake in.
 fn sdk_identity() -> Result<Option<String>> {
+    sdk_identity_for(std::env::var("SDKROOT").ok())
+}
+
+/// Split from the environment it usually reads so that a test can ask about an
+/// SDK without setting a variable every other test in the process would see.
+fn sdk_identity_for(root: Option<String>) -> Result<Option<String>> {
     if !cfg!(target_os = "macos") {
         return Ok(None);
     }
     let describe = || {
-        let version = xcrun(&["--sdk", "macosx", "--show-sdk-version"])?;
-        let build = xcrun(&["--sdk", "macosx", "--show-sdk-build-version"])?;
-        let path = std::env::var("SDKROOT")
-            .ok()
-            .or_else(|| xcrun(&["--sdk", "macosx", "--show-sdk-path"]))?;
+        // Every question is asked of the SDK the link will actually use, which
+        // `SDKROOT` names when it is set. Asking for `macosx` regardless would
+        // report the default SDK's version beside another SDK's path, so the
+        // key would describe an SDK no link was made against.
+        let sdk = root.as_deref().unwrap_or("macosx");
+        let version = xcrun(&["--sdk", sdk, "--show-sdk-version"])?;
+        let build = xcrun(&["--sdk", sdk, "--show-sdk-build-version"])?;
+        let path = match &root {
+            Some(root) => root.clone(),
+            None => xcrun(&["--sdk", sdk, "--show-sdk-path"])?,
+        };
         Some(format!("{path} {version} ({build})"))
     };
     describe().map(Some).ok_or_else(|| {

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -110,9 +110,12 @@ fn probe(driver: &Path) -> Result<LinkerIdentity> {
 /// are read; only the first line is kept, since later ones list supported
 /// emulations that say nothing about the version.
 fn linker_version(driver: &Path) -> Result<String> {
-    let linker = run(driver, &["-print-prog-name=ld"])
-        .map(|path| PathBuf::from(path.trim()))
-        .unwrap_or_else(|_| PathBuf::from("ld"));
+    // Asked of the driver rather than resolved from PATH: the `ld` a shell
+    // would find is not necessarily the one this driver invokes, and a key
+    // naming the wrong linker is worse than no key at all.
+    let linker = PathBuf::from(
+        run(driver, &["-print-prog-name=ld"]).wrap_err("the linker driver named no linker")?,
+    );
     let output = Command::new(&linker)
         .arg("-v")
         .output()
@@ -123,7 +126,11 @@ fn linker_version(driver: &Path) -> Result<String> {
         output.stdout
     };
     let text = String::from_utf8_lossy(&combined);
-    Ok(text.lines().next().unwrap_or_default().trim().to_owned())
+    let version = text.lines().next().unwrap_or_default().trim();
+    if version.is_empty() {
+        bail!("{} reported no version", linker.display());
+    }
+    Ok(version.to_owned())
 }
 
 /// Hash the startup objects and libc the driver resolves.
@@ -214,7 +221,14 @@ fn run(program: &Path, arguments: &[&str]) -> Result<String> {
             String::from_utf8_lossy(&output.stderr)
         );
     }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    let reported = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    // A probe that answers with nothing describes nothing. Letting it through
+    // would put an empty string in the key, which every host that failed the
+    // same way would agree on.
+    if reported.is_empty() {
+        bail!("{} {arguments:?} reported nothing", program.display());
+    }
+    Ok(reported)
 }
 
 #[cfg(test)]

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -1,0 +1,198 @@
+//! Identity of the toolchain that links a native program.
+//!
+//! rustc hands a native link to a driver -- `cc` on the platforms this tier
+//! admits -- which chooses the real linker, the startup objects, and on macOS
+//! the SDK. None of that appears in rustc dep-info, so a link is only
+//! cacheable once it does appear in the key.
+//!
+//! What enters the key is identity rather than content wherever a compiler's
+//! own identity is: `cc --version` names a toolchain as precisely as
+//! `rustc -vV` names rustc, and far more cheaply than hashing the binary. The
+//! startup objects are hashed instead, because nothing else pins the libc a
+//! link resolves against.
+
+use crate::session;
+use eyre::{Context, Result, bail};
+use mbx_cache_core::{AgentRequest, AgentResponse, CacheDigest, canonical_json};
+use mbx_cache_rustc::LinkerIdentity;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Environment that selects what the probes below report.
+const IDENTITY_ENVIRONMENT: &[&str] = &["SDKROOT", "MACOSX_DEPLOYMENT_TARGET"];
+
+/// Startup objects and libc a GNU-style link resolves against.
+#[cfg(target_os = "linux")]
+const CRT_PROBES: &[&str] = &[
+    "Scrt1.o",
+    "crt1.o",
+    "crti.o",
+    "crtn.o",
+    "crtbeginS.o",
+    "crtendS.o",
+    "libc.so.6",
+];
+
+/// Describe the linker rustc will use for a native link on this host.
+///
+/// Memoized through the agent for the life of the build, since the answer is
+/// the same for every link in it and the probes are several processes.
+pub(crate) fn identity() -> Result<LinkerIdentity> {
+    let driver = which::which("cc").wrap_err("failed to find the linker driver `cc`")?;
+    let environment = IDENTITY_ENVIRONMENT
+        .iter()
+        .map(|name| ((*name).into(), std::env::var(name).ok()))
+        .collect::<BTreeMap<_, _>>();
+    if let Some(cached) = find_recorded(&driver, &environment)? {
+        return Ok(cached);
+    }
+    let identity = probe(&driver)?;
+    record(&driver, &environment, &identity)?;
+    Ok(identity)
+}
+
+fn find_recorded(
+    driver: &Path,
+    environment: &BTreeMap<String, Option<String>>,
+) -> Result<Option<LinkerIdentity>> {
+    let responses = session::request_agent(&[AgentRequest::FindExecutableIdentity {
+        executable: driver.to_path_buf(),
+        environment: environment.clone(),
+    }])?;
+    let Some(AgentResponse::ExecutableIdentity { stdout }) = responses.into_iter().next() else {
+        bail!("cache agent did not return the linker identity");
+    };
+    stdout
+        .map(|stdout| serde_json::from_slice(&stdout).wrap_err("invalid recorded linker identity"))
+        .transpose()
+}
+
+fn record(
+    driver: &Path,
+    environment: &BTreeMap<String, Option<String>>,
+    identity: &LinkerIdentity,
+) -> Result<()> {
+    let responses = session::request_agent(&[AgentRequest::StoreExecutableIdentity {
+        executable: driver.to_path_buf(),
+        environment: environment.clone(),
+        stdout: canonical_json(identity)?,
+    }])?;
+    match responses.into_iter().next() {
+        Some(AgentResponse::ExecutableIdentity { .. }) => Ok(()),
+        Some(AgentResponse::Error { message }) => bail!(message),
+        _ => bail!("cache agent returned an unexpected linker identity response"),
+    }
+}
+
+fn probe(driver: &Path) -> Result<LinkerIdentity> {
+    Ok(LinkerIdentity {
+        driver: driver
+            .to_str()
+            .ok_or_else(|| eyre::eyre!("the linker driver path is not valid UTF-8"))?
+            .to_owned(),
+        driver_version: run(driver, &["--version"])?,
+        linker_version: linker_version(driver)?,
+        crt_objects: crt_objects(driver),
+        sdk: sdk_identity(),
+        deployment_target: std::env::var("MACOSX_DEPLOYMENT_TARGET").ok(),
+    })
+}
+
+/// Version of the linker the driver selects, as opposed to the driver itself.
+///
+/// ld reports through stderr on some platforms and stdout on others, so both
+/// are read; only the first line is kept, since later ones list supported
+/// emulations that say nothing about the version.
+fn linker_version(driver: &Path) -> Result<String> {
+    let linker = run(driver, &["-print-prog-name=ld"])
+        .map(|path| PathBuf::from(path.trim()))
+        .unwrap_or_else(|_| PathBuf::from("ld"));
+    let output = Command::new(&linker)
+        .arg("-v")
+        .output()
+        .wrap_err_with(|| format!("failed to query the linker {}", linker.display()))?;
+    let combined = if output.stdout.is_empty() {
+        output.stderr
+    } else {
+        output.stdout
+    };
+    let text = String::from_utf8_lossy(&combined);
+    Ok(text.lines().next().unwrap_or_default().trim().to_owned())
+}
+
+/// Hash the startup objects and libc the driver resolves.
+///
+/// A probe that does not resolve to a readable file is left out rather than
+/// guessed at: the ones that do resolve already distinguish two hosts, and a
+/// missing entry cannot make two different hosts look alike.
+#[cfg(target_os = "linux")]
+fn crt_objects(driver: &Path) -> BTreeMap<String, CacheDigest> {
+    CRT_PROBES
+        .iter()
+        .filter_map(|name| {
+            let resolved = run(driver, &[&format!("-print-file-name={name}")]).ok()?;
+            let path = PathBuf::from(resolved.trim());
+            // The driver echoes the name back when it cannot place it.
+            let digest = path
+                .is_absolute()
+                .then(|| CacheDigest::blake3_file(&path))?;
+            Some(((*name).to_owned(), digest.ok()?))
+        })
+        .collect()
+}
+
+/// macOS links against the SDK rather than loose startup objects, and the SDK
+/// identity below covers it.
+#[cfg(not(target_os = "linux"))]
+fn crt_objects(_driver: &Path) -> BTreeMap<String, CacheDigest> {
+    BTreeMap::new()
+}
+
+/// Identity of the SDK a link builds against, where the platform has one.
+///
+/// The build version is what changes when Apple ships new libraries under an
+/// unchanged SDK version, so it is the half that matters most here.
+#[cfg(target_os = "macos")]
+fn sdk_identity() -> Option<String> {
+    let version = xcrun(&["--sdk", "macosx", "--show-sdk-version"])?;
+    let build = xcrun(&["--sdk", "macosx", "--show-sdk-build-version"])?;
+    let path = std::env::var("SDKROOT")
+        .ok()
+        .or_else(|| xcrun(&["--sdk", "macosx", "--show-sdk-path"]))?;
+    Some(format!("{path} {version} ({build})"))
+}
+
+#[cfg(target_os = "macos")]
+fn xcrun(arguments: &[&str]) -> Option<String> {
+    let output = Command::new("xcrun").args(arguments).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn sdk_identity() -> Option<String> {
+    None
+}
+
+fn run(program: &Path, arguments: &[&str]) -> Result<String> {
+    let output = Command::new(program)
+        .args(arguments)
+        .output()
+        .wrap_err_with(|| format!("failed to run {}", program.display()))?;
+    if !output.status.success() {
+        bail!(
+            "{} {arguments:?} failed: {}",
+            program.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+#[cfg(test)]
+#[path = "linker_tests.rs"]
+mod tests;

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -27,6 +27,7 @@ const IDENTITY_ENVIRONMENT: &[&str] = &["SDKROOT", "MACOSX_DEPLOYMENT_TARGET"];
 /// The names are platform knowledge; the rule about them is not, so the two are
 /// separated and only the names are chosen by `cfg`. A host this build cannot
 /// run on is still a host whose logic can be tested here.
+#[derive(Clone, Copy)]
 struct FileProbes {
     /// The object that starts a program. One of these must resolve, or nothing
     /// pins what the link began with.
@@ -42,8 +43,7 @@ struct FileProbes {
 }
 
 /// GNU-style hosts link against loose objects the driver can place.
-#[cfg(target_os = "linux")]
-const FILE_PROBES: FileProbes = FileProbes {
+const GNU_PROBES: FileProbes = FileProbes {
     startup: &["Scrt1.o", "crt1.o"],
     libc: &["libc.so.6", "libc.so", "libc.a", "libc.musl-x86_64.so.1"],
     rest: &["crti.o", "crtn.o", "crtbeginS.o", "crtendS.o"],
@@ -51,12 +51,24 @@ const FILE_PROBES: FileProbes = FileProbes {
 
 /// macOS links against the SDK rather than loose objects, and the SDK identity
 /// below covers what those would have pinned.
-#[cfg(not(target_os = "linux"))]
-const FILE_PROBES: FileProbes = FileProbes {
+const NO_PROBES: FileProbes = FileProbes {
     startup: &[],
     libc: &[],
     rest: &[],
 };
+
+/// What this platform asks the driver to place.
+///
+/// Chosen with `cfg!` rather than `#[cfg]` so that both tables are compiled
+/// wherever this builds. A table only one platform compiles is a table only
+/// that platform's CI can find a mistake in.
+fn file_probes() -> FileProbes {
+    if cfg!(target_os = "linux") {
+        GNU_PROBES
+    } else {
+        NO_PROBES
+    }
+}
 
 /// Describe the linker rustc will use for a native link on this host.
 ///
@@ -161,7 +173,7 @@ fn linker_version(driver: &Path) -> Result<String> {
 /// -- a startup object and a libc -- have to resolve, and a host where neither
 /// does gets no identity and no cached link.
 fn crt_objects(driver: &Path) -> Result<BTreeMap<String, CacheDigest>> {
-    probe_files(&FILE_PROBES, |name| {
+    probe_files(&file_probes(), |name| {
         let resolved = run(driver, &[&format!("-print-file-name={name}")]).ok()?;
         let path = PathBuf::from(resolved.trim());
         // The driver echoes the name back when it cannot place it.
@@ -200,8 +212,13 @@ fn probe_files(
 /// cannot report it gets no identity rather than one that omits the SDK: two
 /// such hosts would otherwise agree on a key while linking against different
 /// system libraries.
-#[cfg(target_os = "macos")]
+/// Written for every platform and gated with `cfg!` rather than `#[cfg]`, for
+/// the same reason as the probe tables: code only one platform compiles is
+/// code only that platform's CI can find a mistake in.
 fn sdk_identity() -> Result<Option<String>> {
+    if !cfg!(target_os = "macos") {
+        return Ok(None);
+    }
     let describe = || {
         let version = xcrun(&["--sdk", "macosx", "--show-sdk-version"])?;
         let build = xcrun(&["--sdk", "macosx", "--show-sdk-build-version"])?;
@@ -215,7 +232,6 @@ fn sdk_identity() -> Result<Option<String>> {
     })
 }
 
-#[cfg(target_os = "macos")]
 fn xcrun(arguments: &[&str]) -> Option<String> {
     let output = Command::new("xcrun").args(arguments).output().ok()?;
     output
@@ -223,11 +239,6 @@ fn xcrun(arguments: &[&str]) -> Option<String> {
         .success()
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
         .filter(|value| !value.is_empty())
-}
-
-#[cfg(not(target_os = "macos"))]
-fn sdk_identity() -> Result<Option<String>> {
-    Ok(None)
 }
 
 fn run(program: &Path, arguments: &[&str]) -> Result<String> {

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -46,7 +46,20 @@ struct FileProbes {
 const GNU_PROBES: FileProbes = FileProbes {
     startup: &["Scrt1.o", "crt1.o"],
     libc: &["libc.so.6", "libc.so", "libc.a", "libc.musl-x86_64.so.1"],
-    rest: &["crti.o", "crtn.o", "crtbeginS.o", "crtendS.o"],
+    // Both spellings of the constructor objects: GNU drivers place the `S`
+    // variants for shared and position-independent links and the plain or `T`
+    // ones for static and non-PIE links. Naming only the first pair would
+    // leave a static link's own CRT out of the key, so changing it would not
+    // change the key.
+    rest: &[
+        "crti.o",
+        "crtn.o",
+        "crtbegin.o",
+        "crtbeginS.o",
+        "crtbeginT.o",
+        "crtend.o",
+        "crtendS.o",
+    ],
 };
 
 /// macOS links against the SDK rather than loose objects, and the SDK identity

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -27,20 +27,19 @@ fn the_probe_describes_this_host() {
     // Whatever the probes could not place is absent from the key, so the
     // inputs a link cannot be described without have to be present -- two
     // hosts failing the same probe would otherwise agree on a key without
-    // either of them having pinned what it stood for.
-    #[cfg(target_os = "linux")]
-    {
+    // either of them having pinned what it stood for. Written against whatever
+    // this platform asks for rather than behind a `cfg`, so that the host this
+    // does not run on still compiles it.
+    for (required, what) in [
+        (file_probes().startup, "what the link starts with"),
+        (file_probes().libc, "the libc"),
+    ] {
         assert!(
-            STARTUP_PROBES
-                .iter()
-                .any(|name| identity.crt_objects.contains_key(*name)),
-            "a resolved identity must pin what the link starts with: {identity:?}"
-        );
-        assert!(
-            LIBC_PROBES
-                .iter()
-                .any(|name| identity.crt_objects.contains_key(*name)),
-            "a resolved identity must pin the libc: {identity:?}"
+            required.is_empty()
+                || required
+                    .iter()
+                    .any(|name| identity.crt_objects.contains_key(*name)),
+            "a resolved identity must pin {what}: {identity:?}"
         );
     }
     if cfg!(target_os = "macos") {

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+/// The probe has to describe the host it actually ran on, because a key that
+/// cannot tell two hosts apart is what would let one restore the other's
+/// binary.
+#[test]
+fn the_probe_describes_this_host() {
+    let Ok(identity) = identity_without_agent() else {
+        // No `cc` on this machine; there is nothing a native link could be
+        // keyed on, which is the bypass the adapter already handles.
+        return;
+    };
+
+    assert!(Path::new(&identity.driver).is_absolute());
+    assert!(!identity.driver_version.is_empty());
+    // One line, not the driver's whole banner: the rest lists emulations and
+    // search paths that say nothing about which linker this is.
+    assert!(!identity.driver_version.contains('\n') || identity.driver_version.lines().count() > 1);
+
+    if cfg!(target_os = "linux") {
+        assert!(
+            identity.crt_objects.contains_key("crt1.o")
+                || identity.crt_objects.contains_key("Scrt1.o"),
+            "a GNU-style host should resolve its startup objects: {identity:?}"
+        );
+    }
+    if cfg!(target_os = "macos") {
+        assert!(
+            identity.sdk.is_some(),
+            "a macOS host should identify its SDK: {identity:?}"
+        );
+    }
+}
+
+/// The identity is recorded as canonical JSON, and read back the same way.
+#[test]
+fn the_identity_round_trips_through_its_recorded_form() {
+    let identity = LinkerIdentity {
+        driver: "/usr/bin/cc".into(),
+        driver_version: "cc version 14".into(),
+        linker_version: "GNU ld 2.42".into(),
+        crt_objects: BTreeMap::from([("crt1.o".into(), CacheDigest::blake3(b"crt"))]),
+        sdk: None,
+        deployment_target: Some("11.0".into()),
+    };
+
+    let recorded = canonical_json(&identity).unwrap();
+
+    assert_eq!(
+        serde_json::from_slice::<LinkerIdentity>(&recorded).unwrap(),
+        identity
+    );
+}
+
+/// Probe this host without the agent round-trip the real path memoizes through.
+fn identity_without_agent() -> Result<LinkerIdentity> {
+    let driver = which::which("cc")?;
+    probe(&driver)
+}

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -161,3 +161,18 @@ fn the_sdk_identity_follows_sdkroot() {
         "an unusable SDKROOT must not report the default SDK: {overridden:?}"
     );
 }
+
+/// A shim installed by `mbx setup` is driven by plain cargo, with no session
+/// to have applied the platform gate, so the shim applies it itself rather
+/// than trusting the variable it was handed.
+#[test]
+fn the_platform_gate_does_not_depend_on_who_set_the_variable() {
+    assert_eq!(
+        crate::session::cache_links_supported(),
+        cfg!(any(target_os = "linux", target_os = "macos"))
+    );
+    // Whatever the environment says, an unsupported host never admits links.
+    if !crate::session::cache_links_supported() {
+        assert!(!crate::session::cache_links_requested());
+    }
+}

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -12,7 +12,14 @@ fn the_probe_describes_this_host() {
     };
 
     assert!(Path::new(&identity.driver).is_absolute());
+    // Nothing in the key may be blank: every host whose probe answered with
+    // nothing would otherwise agree on the same empty value.
     assert!(!identity.driver_version.is_empty());
+    assert!(!identity.linker_version.is_empty());
+    assert!(
+        identity.crt_objects.values().all(|d| !d.key().is_empty()),
+        "{identity:?}"
+    );
     // One line, not the driver's whole banner: the rest lists emulations and
     // search paths that say nothing about which linker this is.
     assert!(!identity.driver_version.contains('\n') || identity.driver_version.lines().count() > 1);

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -76,3 +76,67 @@ fn identity_without_agent() -> Result<LinkerIdentity> {
     let driver = which::which("cc")?;
     probe(&driver)
 }
+
+/// The probe names are platform knowledge, but the rule about them is not:
+/// what a key cannot describe a link without has to be present, whatever host
+/// this test runs on.
+#[test]
+fn a_link_is_only_identified_once_its_essentials_resolve() {
+    let directory = tempfile::tempdir().unwrap();
+    let placed = |name: &str| {
+        let path = directory.path().join(name);
+        std::fs::write(&path, name).unwrap();
+        path
+    };
+    let probes = FileProbes {
+        startup: &["Scrt1.o", "crt1.o"],
+        libc: &["libc.so.6", "libc.a"],
+        rest: &["crti.o"],
+    };
+
+    // One of each essential is enough, and the optional one is not required.
+    let resolved = probe_files(&probes, |name| {
+        matches!(name, "crt1.o" | "libc.a").then(|| placed(name))
+    })
+    .unwrap();
+    assert_eq!(
+        resolved.keys().collect::<Vec<_>>(),
+        ["crt1.o", "libc.a"],
+        "only what resolved belongs in the key"
+    );
+
+    // A host whose libc the driver cannot place is a host whose links cannot
+    // be told apart from another's.
+    assert!(
+        probe_files(&probes, |name| (name == "crt1.o").then(|| placed(name))).is_err(),
+        "no libc should refuse"
+    );
+    assert!(
+        probe_files(&probes, |name| (name == "libc.a").then(|| placed(name))).is_err(),
+        "no startup object should refuse"
+    );
+    assert!(
+        probe_files(&probes, |_| None).is_err(),
+        "nothing should refuse"
+    );
+
+    // Two hosts placing different libcs cannot agree on a key.
+    let glibc = probe_files(&probes, |name| {
+        matches!(name, "crt1.o" | "libc.so.6").then(|| placed(name))
+    })
+    .unwrap();
+    assert_ne!(glibc, resolved);
+}
+
+/// A platform with no loose objects to place -- macOS, whose SDK identity
+/// covers what they would have pinned -- is not thereby unidentifiable.
+#[test]
+fn a_platform_that_places_nothing_is_still_identified() {
+    let probes = FileProbes {
+        startup: &[],
+        libc: &[],
+        rest: &[],
+    };
+
+    assert!(probe_files(&probes, |_| None).unwrap().is_empty());
+}

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -139,3 +139,25 @@ fn a_platform_that_places_nothing_is_still_identified() {
 
     assert!(probe_files(&probes, |_| None).unwrap().is_empty());
 }
+
+/// `SDKROOT` names the SDK a link is made against, so it has to be the SDK
+/// every part of the identity describes. Reporting the default SDK's version
+/// beside another SDK's path would put an SDK nothing was built against in the
+/// key.
+#[cfg(target_os = "macos")]
+#[test]
+fn the_sdk_identity_follows_sdkroot() {
+    let Ok(Some(_)) = sdk_identity_for(None) else {
+        // No usable SDK on this machine; there is nothing to describe.
+        return;
+    };
+
+    // An SDK that is not there cannot be described, so it is refused rather
+    // than quietly reported as the default one.
+    let overridden = sdk_identity_for(Some("/nonexistent.sdk".into()));
+
+    assert!(
+        overridden.is_err(),
+        "an unusable SDKROOT must not report the default SDK: {overridden:?}"
+    );
+}

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -17,11 +17,23 @@ fn the_probe_describes_this_host() {
     // search paths that say nothing about which linker this is.
     assert!(!identity.driver_version.contains('\n') || identity.driver_version.lines().count() > 1);
 
-    if cfg!(target_os = "linux") {
+    // Whatever the probes could not place is absent from the key, so the
+    // inputs a link cannot be described without have to be present -- two
+    // hosts failing the same probe would otherwise agree on a key without
+    // either of them having pinned what it stood for.
+    #[cfg(target_os = "linux")]
+    {
         assert!(
-            identity.crt_objects.contains_key("crt1.o")
-                || identity.crt_objects.contains_key("Scrt1.o"),
-            "a GNU-style host should resolve its startup objects: {identity:?}"
+            STARTUP_PROBES
+                .iter()
+                .any(|name| identity.crt_objects.contains_key(*name)),
+            "a resolved identity must pin what the link starts with: {identity:?}"
+        );
+        assert!(
+            LIBC_PROBES
+                .iter()
+                .any(|name| identity.crt_objects.contains_key(*name)),
+            "a resolved identity must pin the libc: {identity:?}"
         );
     }
     if cfg!(target_os = "macos") {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -678,6 +678,7 @@ fn base_action_context(
         environment: BTreeMap::new(),
         portable_environment: portable.names.clone(),
         inputs: Vec::new(),
+        linker: None,
     })
 }
 

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -5,8 +5,8 @@ use mbx_cache_core::{
     RemoteActionResult, RestoreStats, RustcMetadata, canonical_json,
 };
 use mbx_cache_rustc::{
-    ActionContext, CompilerIdentity, DiscoveredInputs, LinkerIdentity, ParseOptions, PathMapping,
-    RustcAction, RustcDepInfo, RustcInputPrediction, RustcInvocation, RustcOutputs,
+    ActionContext, BypassReason, CompilerIdentity, DiscoveredInputs, LinkerIdentity, ParseOptions,
+    PathMapping, RustcAction, RustcDepInfo, RustcInputPrediction, RustcInvocation, RustcOutputs,
     normalize_mapped_path,
 };
 use serde::de::DeserializeOwned;
@@ -131,6 +131,8 @@ struct Compilation<'a> {
     invocation: &'a RustcInvocation,
     working_dir: &'a Path,
     portable: &'a Portable,
+    /// Identity of the linker, for an invocation whose key must describe it.
+    linker: Option<LinkerIdentity>,
 }
 
 pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
@@ -157,20 +159,20 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     let mut verification = None;
     let mut action_lookup_attempted = false;
     let mut learned = LearnedPlan::default();
+    // Probed once, before anything that would swallow the answer: a host whose
+    // linker cannot be described bypasses here, where the reason is recorded,
+    // rather than deep inside key construction where it becomes a warning
+    // nobody counts.
     let compilation = Compilation {
         rustc,
         invocation: &invocation,
         working_dir: &working_dir,
         portable: &portable,
+        linker: linker_for(&invocation)?,
     };
     if outputs.dep_info.is_file()
-        && let Ok((candidates, discovered)) = action_from_current_dep_info(
-            rustc,
-            &invocation,
-            &outputs.dep_info,
-            &working_dir,
-            &portable,
-        )
+        && let Ok((candidates, discovered)) =
+            action_from_current_dep_info(&compilation, &outputs.dep_info)
     {
         action_lookup_attempted = true;
         match restore_candidates(
@@ -278,13 +280,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     if output.status.success() {
         learned.record_compiled();
         let publication: Result<()> = (|| {
-            let (candidates, discovered) = action_from_dep_info(
-                rustc,
-                &invocation,
-                &outputs.dep_info,
-                &working_dir,
-                &portable,
-            )?;
+            let (candidates, discovered) = action_from_dep_info(&compilation, &outputs.dep_info)?;
             discovered.verify_not_modified_since(compilation_started)?;
             discovered.verify()?;
             // An incremental artifact carries state from this checkout's edit
@@ -529,7 +525,7 @@ fn restore_predicted_result(
     }
     let discovered = input_prediction.discover(working_dir, &context.path_mappings)?;
     discovered.clone().apply_to(&mut context)?;
-    let candidates = ActionCandidates::build(invocation, context)?;
+    let candidates = ActionCandidates::build(invocation, context, compilation.linker.clone())?;
     // From this point onward, every return follows at least one action-result
     // request, including error responses from a corrupt local record.
     *action_lookup_attempted = true;
@@ -570,8 +566,11 @@ struct ActionCandidates {
 }
 
 impl ActionCandidates {
-    fn build(invocation: &RustcInvocation, context: ActionContext) -> Result<Self> {
-        let linker = linker_for(invocation)?;
+    fn build(
+        invocation: &RustcInvocation,
+        context: ActionContext,
+        linker: Option<LinkerIdentity>,
+    ) -> Result<Self> {
         // Only worth a second key if a portable name is actually an input here.
         // Crates that never read one keep the key they always had.
         let applies = context
@@ -634,40 +633,37 @@ fn restore_candidates(
 }
 
 fn action_from_dep_info(
-    rustc: &OsStr,
-    invocation: &RustcInvocation,
+    compilation: &Compilation<'_>,
     dep_info: &Path,
-    working_dir: &Path,
-    portable: &Portable,
 ) -> Result<(ActionCandidates, DiscoveredInputs)> {
     let dep_info = RustcDepInfo::read(dep_info)?;
-    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir, portable)
+    action_from_parsed_dep_info(compilation, &dep_info)
 }
 
 fn action_from_current_dep_info(
-    rustc: &OsStr,
-    invocation: &RustcInvocation,
+    compilation: &Compilation<'_>,
     dep_info: &Path,
-    working_dir: &Path,
-    portable: &Portable,
 ) -> Result<(ActionCandidates, DiscoveredInputs)> {
     let dep_info = RustcDepInfo::read(dep_info)?;
     verify_environment(&dep_info.environment)?;
-    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir, portable)
+    action_from_parsed_dep_info(compilation, &dep_info)
 }
 
 fn action_from_parsed_dep_info(
-    rustc: &OsStr,
-    invocation: &RustcInvocation,
+    compilation: &Compilation<'_>,
     dep_info: &RustcDepInfo,
-    working_dir: &Path,
-    portable: &Portable,
 ) -> Result<(ActionCandidates, DiscoveredInputs)> {
+    let Compilation {
+        invocation,
+        working_dir,
+        portable,
+        ..
+    } = compilation;
     let discovered =
         invocation.discover_inputs_with_mappings(dep_info, working_dir, &portable.mappings)?;
-    let mut context = base_action_context(rustc, working_dir, portable)?;
+    let mut context = base_action_context(compilation.rustc, working_dir, portable)?;
     discovered.clone().apply_to(&mut context)?;
-    let candidates = ActionCandidates::build(invocation, context)?;
+    let candidates = ActionCandidates::build(invocation, context, compilation.linker.clone())?;
     Ok((candidates, discovered))
 }
 
@@ -690,11 +686,22 @@ fn base_action_context(
 ///
 /// Only a native link needs one, and probing costs several processes on the
 /// first one, so nothing else pays for it.
+///
+/// A host that cannot be described is reported as a bypass rather than as a
+/// failure: not knowing the linker is a reason this compilation cannot be
+/// cached, which is what a bypass is, and reporting it as anything else leaves
+/// it out of the summary and out of `mbx explain`.
 fn linker_for(invocation: &RustcInvocation) -> Result<Option<LinkerIdentity>> {
-    invocation
-        .links_natively()
-        .then(crate::linker::identity)
-        .transpose()
+    if !invocation.links_natively() {
+        return Ok(None);
+    }
+    match crate::linker::identity() {
+        Ok(identity) => Ok(Some(identity)),
+        Err(error) => Err(BypassReason::UnportableNativeLink(format!(
+            "the linker could not be identified: {error:#}"
+        ))
+        .into()),
+    }
 }
 
 fn record_prediction(

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -493,8 +493,12 @@ fn restore_predicted_result(
         portable,
         ..
     } = compilation;
-    let mut context =
-        base_action_context(compilation.rustc, compilation.invocation, working_dir, portable)?;
+    let mut context = base_action_context(
+        compilation.rustc,
+        compilation.invocation,
+        working_dir,
+        portable,
+    )?;
     let invocation_digest = invocation.invocation_digest(&context)?;
     let task = prediction_task(&invocation_digest);
     let responses = session::request_agent(&[AgentRequest::FindActionPrediction {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -5,8 +5,8 @@ use mbx_cache_core::{
     RemoteActionResult, RestoreStats, RustcMetadata, canonical_json,
 };
 use mbx_cache_rustc::{
-    ActionContext, CompilerIdentity, DiscoveredInputs, PathMapping, RustcAction, RustcDepInfo,
-    RustcInputPrediction, RustcInvocation, RustcOutputs, normalize_mapped_path,
+    ActionContext, CompilerIdentity, DiscoveredInputs, ParseOptions, PathMapping, RustcAction,
+    RustcDepInfo, RustcInputPrediction, RustcInvocation, RustcOutputs, normalize_mapped_path,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -137,7 +137,8 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     // The orchestrated session supplies the target root. A persistent wrapper
     // has no parent session, so first parse just enough of the invocation to
     // learn its output directory and use that as the stable target mapping.
-    let initial_invocation = RustcInvocation::parse(arguments)?;
+    let options = ParseOptions::caching_native_links(session::cache_links_requested());
+    let initial_invocation = RustcInvocation::parse_with(arguments, options)?;
     let initial_outputs = initial_invocation.outputs(&working_dir)?;
     let portable = Portable::detect(
         &working_dir,
@@ -145,7 +146,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
         initial_invocation.target(),
     );
     let arguments = portable.applied_to(arguments);
-    let invocation = RustcInvocation::parse(&arguments)?;
+    let invocation = RustcInvocation::parse_with(&arguments, options)?;
     let outputs = invocation.outputs(&working_dir)?;
 
     let verify = session::verify_requested();
@@ -416,6 +417,7 @@ fn plan_learned_reuse(
         let sources = compilation.invocation.source_fingerprint(discovered);
         let context = base_action_context(
             compilation.rustc,
+            compilation.invocation,
             compilation.working_dir,
             compilation.portable,
         )?;
@@ -491,7 +493,8 @@ fn restore_predicted_result(
         portable,
         ..
     } = compilation;
-    let mut context = base_action_context(compilation.rustc, working_dir, portable)?;
+    let mut context =
+        base_action_context(compilation.rustc, compilation.invocation, working_dir, portable)?;
     let invocation_digest = invocation.invocation_digest(&context)?;
     let task = prediction_task(&invocation_digest);
     let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
@@ -660,7 +663,7 @@ fn action_from_parsed_dep_info(
 ) -> Result<(ActionCandidates, DiscoveredInputs)> {
     let discovered =
         invocation.discover_inputs_with_mappings(dep_info, working_dir, &portable.mappings)?;
-    let mut context = base_action_context(rustc, working_dir, portable)?;
+    let mut context = base_action_context(rustc, invocation, working_dir, portable)?;
     discovered.clone().apply_to(&mut context)?;
     let candidates = ActionCandidates::build(invocation, context)?;
     Ok((candidates, discovered))
@@ -668,9 +671,16 @@ fn action_from_parsed_dep_info(
 
 fn base_action_context(
     rustc: &OsStr,
+    invocation: &RustcInvocation,
     working_dir: &Path,
     portable: &Portable,
 ) -> Result<ActionContext> {
+    // Only a native link needs it, and probing costs several processes on the
+    // first one, so nothing else pays for it.
+    let linker = invocation
+        .links_natively()
+        .then(crate::linker::identity)
+        .transpose()?;
     Ok(ActionContext {
         compiler: compiler_identity(rustc)?,
         working_dir: working_dir.to_path_buf(),
@@ -678,7 +688,7 @@ fn base_action_context(
         environment: BTreeMap::new(),
         portable_environment: portable.names.clone(),
         inputs: Vec::new(),
-        linker: None,
+        linker,
     })
 }
 
@@ -689,12 +699,13 @@ fn record_prediction(
     timing: &CompileTiming,
 ) {
     let result = (|| {
+        let invocation = compilation.invocation;
         let context = base_action_context(
             compilation.rustc,
+            invocation,
             compilation.working_dir,
             compilation.portable,
         )?;
-        let invocation = compilation.invocation;
         let invocation_digest = invocation.invocation_digest(&context)?;
         let mut prediction = invocation.prediction(&context, discovered)?;
         prediction.version = prediction.version.max(2);
@@ -712,6 +723,7 @@ fn record_prediction(
 fn prediction_timing(compilation: &Compilation<'_>) -> Result<CompileTiming> {
     let context = base_action_context(
         compilation.rustc,
+        compilation.invocation,
         compilation.working_dir,
         compilation.portable,
     )?;

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -5,8 +5,9 @@ use mbx_cache_core::{
     RemoteActionResult, RestoreStats, RustcMetadata, canonical_json,
 };
 use mbx_cache_rustc::{
-    ActionContext, CompilerIdentity, DiscoveredInputs, ParseOptions, PathMapping, RustcAction,
-    RustcDepInfo, RustcInputPrediction, RustcInvocation, RustcOutputs, normalize_mapped_path,
+    ActionContext, CompilerIdentity, DiscoveredInputs, LinkerIdentity, ParseOptions, PathMapping,
+    RustcAction, RustcDepInfo, RustcInputPrediction, RustcInvocation, RustcOutputs,
+    normalize_mapped_path,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -417,7 +418,6 @@ fn plan_learned_reuse(
         let sources = compilation.invocation.source_fingerprint(discovered);
         let context = base_action_context(
             compilation.rustc,
-            compilation.invocation,
             compilation.working_dir,
             compilation.portable,
         )?;
@@ -493,12 +493,7 @@ fn restore_predicted_result(
         portable,
         ..
     } = compilation;
-    let mut context = base_action_context(
-        compilation.rustc,
-        compilation.invocation,
-        working_dir,
-        portable,
-    )?;
+    let mut context = base_action_context(compilation.rustc, working_dir, portable)?;
     let invocation_digest = invocation.invocation_digest(&context)?;
     let task = prediction_task(&invocation_digest);
     let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
@@ -576,6 +571,7 @@ struct ActionCandidates {
 
 impl ActionCandidates {
     fn build(invocation: &RustcInvocation, context: ActionContext) -> Result<Self> {
+        let linker = linker_for(invocation)?;
         // Only worth a second key if a portable name is actually an input here.
         // Crates that never read one keep the key they always had.
         let applies = context
@@ -587,8 +583,10 @@ impl ActionCandidates {
             ..context.clone()
         };
         Ok(Self {
-            portable: applies.then(|| invocation.action(context)).transpose()?,
-            literal: invocation.action(literal_context)?,
+            portable: applies
+                .then(|| invocation.action_linked_by(context, linker.clone()))
+                .transpose()?,
+            literal: invocation.action_linked_by(literal_context, linker)?,
         })
     }
 
@@ -667,7 +665,7 @@ fn action_from_parsed_dep_info(
 ) -> Result<(ActionCandidates, DiscoveredInputs)> {
     let discovered =
         invocation.discover_inputs_with_mappings(dep_info, working_dir, &portable.mappings)?;
-    let mut context = base_action_context(rustc, invocation, working_dir, portable)?;
+    let mut context = base_action_context(rustc, working_dir, portable)?;
     discovered.clone().apply_to(&mut context)?;
     let candidates = ActionCandidates::build(invocation, context)?;
     Ok((candidates, discovered))
@@ -675,16 +673,9 @@ fn action_from_parsed_dep_info(
 
 fn base_action_context(
     rustc: &OsStr,
-    invocation: &RustcInvocation,
     working_dir: &Path,
     portable: &Portable,
 ) -> Result<ActionContext> {
-    // Only a native link needs it, and probing costs several processes on the
-    // first one, so nothing else pays for it.
-    let linker = invocation
-        .links_natively()
-        .then(crate::linker::identity)
-        .transpose()?;
     Ok(ActionContext {
         compiler: compiler_identity(rustc)?,
         working_dir: working_dir.to_path_buf(),
@@ -692,8 +683,18 @@ fn base_action_context(
         environment: BTreeMap::new(),
         portable_environment: portable.names.clone(),
         inputs: Vec::new(),
-        linker,
     })
+}
+
+/// Identify the linker, for the invocations whose key has to describe it.
+///
+/// Only a native link needs one, and probing costs several processes on the
+/// first one, so nothing else pays for it.
+fn linker_for(invocation: &RustcInvocation) -> Result<Option<LinkerIdentity>> {
+    invocation
+        .links_natively()
+        .then(crate::linker::identity)
+        .transpose()
 }
 
 fn record_prediction(
@@ -706,7 +707,6 @@ fn record_prediction(
         let invocation = compilation.invocation;
         let context = base_action_context(
             compilation.rustc,
-            invocation,
             compilation.working_dir,
             compilation.portable,
         )?;
@@ -727,7 +727,6 @@ fn record_prediction(
 fn prediction_timing(compilation: &Compilation<'_>) -> Result<CompileTiming> {
     let context = base_action_context(
         compilation.rustc,
-        compilation.invocation,
         compilation.working_dir,
         compilation.portable,
     )?;

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -169,7 +169,6 @@ fn test_outputs(root: &Path) -> RustcOutputs {
     let directory = root.join("out");
     RustcOutputs {
         files: vec![directory.join("libdemo.rlib")],
-        executables: Vec::new(),
         dep_info: directory.join("demo.d"),
         directory,
     }
@@ -351,9 +350,7 @@ fn rejects_executable_rustc_outputs() {
 fn accepts_wasm_executable_rustc_outputs() {
     let root = tempfile::tempdir().unwrap();
     let mut outputs = test_outputs(root.path());
-    let linked = outputs.directory.join("demo.wasm");
-    outputs.files = vec![linked.clone()];
-    outputs.executables = vec![linked];
+    outputs.files = vec![outputs.directory.join("demo.wasm")];
     let mut file = test_file("demo.wasm");
     file.executable = true;
 
@@ -366,19 +363,17 @@ fn accepts_wasm_executable_rustc_outputs() {
 fn accepts_native_executable_rustc_outputs() {
     let root = tempfile::tempdir().unwrap();
     let mut outputs = test_outputs(root.path());
-    let linked = outputs.directory.join("demo-abc123");
-    outputs.files = vec![linked.clone()];
-    outputs.executables = vec![linked];
+    outputs.files = vec![outputs.directory.join("demo-abc123")];
     let mut file = test_file("demo-abc123");
     file.executable = true;
 
     assert!(validated_outputs(test_output_directory(file), &outputs).is_ok());
 
-    // The same name, undeclared, is still refused.
-    outputs.executables.clear();
-    let mut undeclared = test_file("demo-abc123");
-    undeclared.executable = true;
-    assert!(validated_outputs(test_output_directory(undeclared), &outputs).is_err());
+    // A library artifact under the same roof is still not a program.
+    outputs.files = vec![outputs.directory.join("libdemo.rlib")];
+    let mut library = test_file("libdemo.rlib");
+    library.executable = true;
+    assert!(validated_outputs(test_output_directory(library), &outputs).is_err());
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -169,6 +169,7 @@ fn test_outputs(root: &Path) -> RustcOutputs {
     let directory = root.join("out");
     RustcOutputs {
         files: vec![directory.join("libdemo.rlib")],
+        executables: Vec::new(),
         dep_info: directory.join("demo.d"),
         directory,
     }
@@ -350,11 +351,34 @@ fn rejects_executable_rustc_outputs() {
 fn accepts_wasm_executable_rustc_outputs() {
     let root = tempfile::tempdir().unwrap();
     let mut outputs = test_outputs(root.path());
-    outputs.files = vec![outputs.directory.join("demo.wasm")];
+    let linked = outputs.directory.join("demo.wasm");
+    outputs.files = vec![linked.clone()];
+    outputs.executables = vec![linked];
     let mut file = test_file("demo.wasm");
     file.executable = true;
 
     assert!(validated_outputs(test_output_directory(file), &outputs).is_ok());
+}
+
+/// A native program has no extension to recognize it by, so the contract has to
+/// be what the invocation declared rather than what the name looks like.
+#[test]
+fn accepts_native_executable_rustc_outputs() {
+    let root = tempfile::tempdir().unwrap();
+    let mut outputs = test_outputs(root.path());
+    let linked = outputs.directory.join("demo-abc123");
+    outputs.files = vec![linked.clone()];
+    outputs.executables = vec![linked];
+    let mut file = test_file("demo-abc123");
+    file.executable = true;
+
+    assert!(validated_outputs(test_output_directory(file), &outputs).is_ok());
+
+    // The same name, undeclared, is still refused.
+    outputs.executables.clear();
+    let mut undeclared = test_file("demo-abc123");
+    undeclared.executable = true;
+    assert!(validated_outputs(test_output_directory(undeclared), &outputs).is_err());
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1198,8 +1198,14 @@ pub fn cache_links_supported() -> bool {
 
 /// Whether the shim may cache a natively linked program. Read the same way as
 /// verify mode.
+///
+/// The platform is checked here rather than trusted from whoever set the
+/// variable: a shim installed by `mbx setup` is driven by plain cargo, with no
+/// session to have applied the gate, so the value it reads is whatever the
+/// developer exported.
 pub(crate) fn cache_links_requested() -> bool {
-    std::env::var_os(CACHE_LINKS_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+    cache_links_supported()
+        && std::env::var_os(CACHE_LINKS_ENV).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
 /// Whether the shim may make a compilation independent of its `OUT_DIR` so two

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -31,6 +31,7 @@ pub(crate) const BUILD_ENV: &str = "MBX_BUILD";
 pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
 pub(crate) const SHARE_OUT_DIR_ENV: &str = "MBX_SHARE_OUT_DIR";
 pub(crate) const LEARNED_INCREMENTAL_ENV: &str = "MBX_LEARNED_INCREMENTAL";
+pub const CACHE_LINKS_ENV: &str = "MBX_CACHE_LINKS";
 pub(crate) const WORKSPACE_ROOT_ENV: &str = "MBX_WORKSPACE_ROOT";
 pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
@@ -1184,6 +1185,16 @@ fn crate_name_argument(arguments: &[OsString]) -> Option<String> {
 /// that an explicit disable cannot be mistaken for an enable.
 pub(crate) fn verify_requested() -> bool {
     std::env::var_os(VERIFY_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
+/// Whether the shim may cache a natively linked program.
+///
+/// Restricted to platforms whose linker this build knows how to identify: a
+/// host mbx cannot describe would otherwise key a link as though the linker
+/// did not matter. Read the same way as verify mode.
+pub(crate) fn cache_links_requested() -> bool {
+    cfg!(any(target_os = "linux", target_os = "macos"))
+        && std::env::var_os(CACHE_LINKS_ENV).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
 /// Whether the shim may make a compilation independent of its `OUT_DIR` so two

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1187,14 +1187,19 @@ pub(crate) fn verify_requested() -> bool {
     std::env::var_os(VERIFY_ENV).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
-/// Whether the shim may cache a natively linked program.
+/// Whether this build may cache natively linked programs.
 ///
-/// Restricted to platforms whose linker this build knows how to identify: a
-/// host mbx cannot describe would otherwise key a link as though the linker
-/// did not matter. Read the same way as verify mode.
-pub(crate) fn cache_links_requested() -> bool {
+/// Restricted to platforms whose linker mbx knows how to identify: a host it
+/// cannot describe would otherwise key a link as though the linker did not
+/// matter.
+pub fn cache_links_supported() -> bool {
     cfg!(any(target_os = "linux", target_os = "macos"))
-        && std::env::var_os(CACHE_LINKS_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
+/// Whether the shim may cache a natively linked program. Read the same way as
+/// verify mode.
+pub(crate) fn cache_links_requested() -> bool {
+    std::env::var_os(CACHE_LINKS_ENV).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
 /// Whether the shim may make a compilation independent of its `OUT_DIR` so two

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -24,6 +24,15 @@ Append the full reason for every bypassed compilation to this path.
 
 Cache root.
 
+### `cache_links`
+
+- **Type:** `bool`
+- **Default:** `false`
+- **Scope:** only from the environment or the command line
+- **Set with:** `MBX_CACHE_LINKS`
+
+Cache natively linked test binaries and executables. Experimental: qualify it on your own workload with MBX_VERIFY=1 before relying on it.
+
 ### `events`
 
 - **Type:** `bool`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,21 @@ an unsafe or misspelled workspace setting.
 results. It is deliberately expensive — use it to qualify correctness, not for
 everyday builds.
 
+The build reports what it found:
+
+```text
+mbx[cache]: qualification: 24 verified, 0 diverged
+```
+
+Run it in the checkout that filled the cache, so that what is being measured
+is whether a compilation reproduces itself rather than whether two checkouts
+embed the same paths. Anything above zero divergences is a modeling bug worth
+reporting; `MBX_BYPASS_LOG` and `mbx explain` show what was left out.
+
+This is how to qualify an experimental setting such as
+[`MBX_CACHE_LINKS`](/limits#native-linking-is-not-cached) on your own
+workload before relying on it.
+
 ## The savings line
 
 `savings` controls the one-line report of accumulated savings after a build

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -39,6 +39,14 @@ produce different keys and miss, rather than sharing a binary neither of them
 built. It is experimental — qualify it on your own workload as described in
 [verify mode](/configuration#verify-mode) before relying on it.
 
+Some hosts cannot be described at all. mbx asks the driver to place a startup
+object and a libc, and a host where neither resolves gets no linker identity
+and therefore no cached links — refusing is the only safe answer, because two
+hosts failing the same probe would otherwise agree on a key without either of
+them having pinned what it stood for. The same goes for a driver that names no
+linker or reports no version. Those links appear in `mbx explain` like any
+other bypass.
+
 Even then, a link bypasses if it names a native library, overrides the linker,
 or carries a flag that would embed this checkout's paths (`-Crpath`,
 `-Cprefer-dynamic`), leave a file beside the binary that mbx does not store

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -27,9 +27,25 @@ targets using its compiler-bundled self-contained linker:
 
 mbx caches those links because all explicit artifacts are modeled inputs and
 the linker, CRT objects, and bundled libc are covered by the Rust toolchain
-identity. Native targets, custom target specifications, external WebAssembly
-toolchains, native libraries, custom linkers, disabled WASI CRT bundling, and
+identity. Custom target specifications, external WebAssembly toolchains,
+native libraries, custom linkers, disabled WASI CRT bundling, and
 non-affirmative `link-self-contained` modes remain uncached.
+
+`MBX_CACHE_LINKS=1` adds host test binaries and executables on Linux and
+macOS, by putting the rest of the link into the key: the resolved `cc` driver
+and its version, the linker it selects, the startup objects and libc it
+resolves (hashed), and on macOS the SDK. Two hosts that differ in any of those
+produce different keys and miss, rather than sharing a binary neither of them
+built. It is experimental — qualify it on your own workload as described in
+[verify mode](/configuration#verify-mode) before relying on it.
+
+Even then, a link bypasses if it names a native library, overrides the linker,
+or carries a flag that would embed this checkout's paths (`-Crpath`,
+`-Cprefer-dynamic`), leave a file beside the binary that mbx does not store
+(`-Csplit-debuginfo`), or — on macOS — record absolute object paths and their
+timestamps in the binary's debug map (`-Cdebuginfo` above `0`). An explicit
+`--target` bypasses too, even when it spells the host triple: rustc without one
+links for the host by construction, and that is the only linker mbx identifies.
 
 ## Restored artifacts are equivalent, not always identical
 

--- a/mise.lock
+++ b/mise.lock
@@ -120,6 +120,7 @@ checksum = "sha256:fbd5e2c3366f085cb8ce71362bcdc05fbf549e7787bd401ae085a1dee09bd
 url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283628"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.windows-x64"]
 checksum = "sha256:fd3157419889dc558c87e5779f89d123dc909bfc4f7557c970dcb95d71a97d1b"

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -65,8 +65,14 @@ test_binary() {
     MBX_STATS_REPORT="$warm_report" \
     "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
   assert_success
-  run grep -E '"hits"[[:space:]]*:[[:space:]]*[1-9]' "$warm_report"
+  # Two hits, not merely one: the library and the linked test binary. A host
+  # whose linker mbx cannot identify bypasses the link and still restores the
+  # library, so a laxer assertion would pass while the feature did nothing.
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*[2-9]' "$warm_report"
   assert_success
+  # And it bypassed nothing beyond the probes cargo always makes.
+  run grep -E '"(other|unsupported-crate-type|unportable-native-link)"' "$warm_report"
+  assert_failure
 
   local first second
   first="$(test_binary "$first_target")"

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "test_helper/common_setup"
+  local developer_home="$HOME"
+  export RUSTUP_HOME="${RUSTUP_HOME:-$developer_home/.rustup}"
+  export CARGO_HOME="${CARGO_HOME:-$developer_home/.cargo}"
+  _common_setup
+
+  unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI
+  export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store"
+
+  export PROJECT="$BATS_TEST_TMPDIR/project"
+  mkdir -p "$PROJECT/src"
+  # Debug info is what makes a macOS link unportable, and rustc records it by
+  # default in the test profile. Turning it off is what the predicate asks for,
+  # and keeps this test the same on both platforms.
+  cat >"$PROJECT/Cargo.toml" <<'EOF'
+[package]
+name = "native-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[profile.test]
+debug = false
+EOF
+  cat >"$PROJECT/src/lib.rs" <<'EOF'
+pub fn double(value: u32) -> u32 {
+    value * 2
+}
+
+#[test]
+fn doubles() {
+    assert_eq!(double(21), 42);
+}
+EOF
+
+  run cargo generate-lockfile --offline --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+}
+
+# The test binary in `deps/`, which has no extension to match on.
+test_binary() {
+  find "$1/debug/deps" -type f -name 'native_fixture-*' ! -name '*.d' | head -1
+}
+
+@test "a linked test binary restores into a distinct target directory" {
+  local first_target="$BATS_TEST_TMPDIR/first-target"
+  local second_target="$BATS_TEST_TMPDIR/second-target"
+  local cold_report="$BATS_TEST_TMPDIR/cold.json"
+  local warm_report="$BATS_TEST_TMPDIR/warm.json"
+
+  run env \
+    CARGO_TARGET_DIR="$first_target" \
+    MBX_CACHE_LINKS=1 \
+    MBX_STATS_REPORT="$cold_report" \
+    "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*0' "$cold_report"
+  assert_success
+
+  run env \
+    CARGO_TARGET_DIR="$second_target" \
+    MBX_CACHE_LINKS=1 \
+    MBX_STATS_REPORT="$warm_report" \
+    "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*[1-9]' "$warm_report"
+  assert_success
+
+  local first second
+  first="$(test_binary "$first_target")"
+  second="$(test_binary "$second_target")"
+  assert_file_exists "$first"
+  assert_file_exists "$second"
+
+  # Byte-identical, still executable, and it still runs: a restored program
+  # that cannot be executed would be a cache hit worth nothing.
+  run cmp "$first" "$second"
+  assert_success
+  assert_file_executable "$second"
+  run "$second"
+  assert_success
+}
+
+@test "native links stay outside the cache until asked for" {
+  local target="$BATS_TEST_TMPDIR/unasked-target"
+  local bypasses="$BATS_TEST_TMPDIR/bypasses.tsv"
+
+  run env \
+    CARGO_TARGET_DIR="$target" \
+    MBX_BYPASS_LOG="$bypasses" \
+    "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+
+  run grep -E '^unsupported-crate-type' "$bypasses"
+  assert_success
+}


### PR DESCRIPTION
## The problem

`mbx test` links one executable per test target, and mbx caches none of them. Those links are the serial tail of a warm build: a rebase that touches one crate relinks every test binary from scratch, even when every compilation above them hits.

[Native linking has been outside the cacheable tier](https://mr-boxington.jdx.dev/limits) for a good reason — the linker, its startup objects, and the system libraries it resolves are inputs that rustc dep-info never enumerates, so a key built from dep-info alone would claim more than it could support.

## The change

Rather than caching links and hoping, this puts the rest of the link into the key. With `MBX_CACHE_LINKS=1`, the shim probes the linker rustc will actually use and records:

- the resolved `cc` driver and its version output,
- the linker that driver selects,
- the startup objects and libc it resolves (hashed — nothing else pins the libc a link resolves against),
- on macOS, the SDK path, version, and build version.

Two hosts differing in any of it produce different keys and miss, rather than sharing a binary neither of them built. The probes are memoized through the agent's existing executable-identity cache, so they run once per build rather than once per link.

## Correctness

The admission predicate is deliberately narrow. A link bypasses if it names a native library, overrides the linker, or carries a flag that would embed this checkout's paths (`-Crpath`, `-Cprefer-dynamic`), leave a file beside the binary mbx does not store (`-Csplit-debuginfo`), or — on macOS — record absolute object paths **and their timestamps** in the binary's debug map (`-Cdebuginfo` above `0`; those timestamps would make the link nondeterministic even in place).

An explicit `--target` bypasses too, even spelling the host triple: rustc without one links for the host by construction, and that is the only linker mbx can identify.

An action that links natively but cannot produce a linker identity is **refused**, not keyed weakly.

## Existing caches are provably unaffected

The `linker` field is omitted entirely — not null — for everything that does not link natively, so no existing key changes. This is pinned by a test asserting the exact digest for an ordinary library compilation, which I verified equals what the adapter produced on `main`:

```
blake3/af70e14cc38eccf01eabb89067418e7780883628d051f499ea8acf3ebc925933/865
```

No schema, adapter, metadata, or agent-protocol version changes. The only agent change widens the identity-key allowlist to `SDKROOT` and `MACOSX_DEPLOYMENT_TARGET`; no new request variants, so the protocol conformance fixture is untouched.

## Verified end to end

On macOS ARM64, a test binary linked in one checkout restores into a second: byte-identical, still `0755`, and it still runs its tests. The macOS ad-hoc signature survives because it lives in the Mach-O bytes.

`MBX_VERIFY=1` reports **zero divergences** across three repeated runs. Worth noting for anyone repeating this: run the qualification in the checkout that filled the cache. Comparing across checkouts measures debug-info path embedding, which diverges identically for plain rlibs with no link caching involved — I confirmed that against a library-only build.

## Scope

Off by default and experimental. Linux and macOS only. Test binaries and plain `bin` crates; the first is where the payoff is.

## Testing

- Adapter unit tests for every arm of the predicate, including that the option — never the invocation alone — is what admits a link.
- The digest-stability test above, plus tests that the linker identity changes the key and that a native link without one is refused.
- `test/native_link_cache.bats`: cold/warm across two target directories, `cmp`, executable bit, and executing the restored binary; plus a negative case proving links stay outside the cache until asked for.
- `mise run ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache keying and restore semantics for native binaries (executable bits, linker/SDK inputs); mitigated by default-off flag, strict bypass rules, and backward-compatible action serialization for non-native compilations.
> 
> **Overview**
> Adds **experimental, off-by-default** caching for host-linked test binaries and `bin` crates on Linux and macOS via **`MBX_CACHE_LINKS`** / `cache_links`, so warm builds can restore linked test artifacts instead of always relinking them.
> 
> The rustc adapter gains **`ParseOptions::cache_native_links`**, **`LinkerIdentity`**, and **`action_linked_by`**: when enabled, host `bin` / `--test` links with `emit=link` and no explicit `--target` are modeled as native executables, with portability checks that bypass flags like **rpath**, **split-debuginfo**, and (on macOS) non-zero **debuginfo**. Action keys include an optional **`linker`** field only for native links; library-only keys stay byte-identical (pinned by digest test).
> 
> **mbx** probes and memoizes linker identity (`cc`, `ld`, CRT/libc hashes on Linux, SDK via `xcrun` on macOS) through the cache agent, passes **`MBX_CACHE_LINKS`** into the rustc shim, and maps probe failures to **`unportable-native-link`** bypasses. The agent allowlist for executable identity keys now includes **`SDKROOT`** and **`MACOSX_DEPLOYMENT_TARGET`**.
> 
> Docs add contributor/release guidance (`CLAUDE.md`, `RELEASING.md`), limits and verify-mode notes, CLI config for `cache_links`, and **`mbx explain`** text for new bypass kinds; a **bats** suite exercises cold/warm restore across target dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e74576306df6c6c5c6420d61aaa194246f4e2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in caching for natively linked test binaries and executables on supported Linux and macOS systems.
  * Added `MBX_CACHE_LINKS` configuration and linker-aware cache validation for more reliable restores.
  * Improved cache-agent performance with background uploads and batched prefetching.
* **Bug Fixes**
  * Added safeguards that bypass caching for non-portable or ambiguous native outputs.
  * Improved incremental compilation state handling.
* **Documentation**
  * Documented native-link caching, verification guidance, configuration, and release procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->