### PR TITLE
feat: batch remote action lookups and blob uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,7 @@ dependencies = [
  "async-compression",
  "base64 0.23.1",
  "blake3",
+ "bytes",
  "eyre",
  "fslock",
  "futures-util",

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 
 [dependencies]
 base64 = "0.23"
+bytes = "1"
 blake3 = "1"
 eyre = "0.6"
 fslock = "0.2"

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -25,6 +25,9 @@ const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
 const MAX_REMOTE_TRANSFERS: usize = 64;
 const MAX_PREFETCH_TRANSFERS: usize = 48;
 const MAX_PREFETCH_ACTION_BATCH: usize = 256;
+/// Batched action lookups issued at once, well inside the transfer budget: each
+/// asks about hundreds of actions, so a handful covers a large workspace.
+const MAX_PREFETCH_BATCH_LOOKUPS: usize = 4;
 const PREFETCH_ACTION_BATCH_DELAY: Duration = Duration::from_millis(5);
 const MAX_PREFETCH_DIRECTORY_OBJECTS: usize = 100_000;
 const MAX_PREFETCH_OBJECTS_PER_WAVE: usize = 100_000;
@@ -331,6 +334,10 @@ pub struct AgentStats {
     /// Queued uploads that did not publish, having been reported and recovered
     /// from.
     pub background_upload_failures: u64,
+    /// Framed requests that published several blobs at once.
+    pub remote_blob_pack_uploads: u64,
+    /// Blobs published through those framed requests.
+    pub remote_blob_pack_upload_blobs: u64,
     /// Time the session spent waiting for queued uploads once the build ended.
     pub upload_drain_duration_ns: u64,
     /// Complete actions staged before an adapter requested them.
@@ -426,6 +433,8 @@ struct AtomicAgentStats {
     uploaded_bytes: AtomicU64,
     background_uploads: AtomicU64,
     background_upload_failures: AtomicU64,
+    remote_blob_pack_uploads: AtomicU64,
+    remote_blob_pack_upload_blobs: AtomicU64,
     upload_drain_duration_ns: AtomicU64,
     prefetched_actions: AtomicU64,
     remote_failures: AtomicU64,
@@ -571,6 +580,15 @@ impl UploadSink for AgentUploadSink {
         self.stats
             .background_uploads
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_blob_pack_uploaded(&self, blobs: u64) {
+        self.stats
+            .remote_blob_pack_uploads
+            .fetch_add(1, Ordering::Relaxed);
+        self.stats
+            .remote_blob_pack_upload_blobs
+            .fetch_add(blobs, Ordering::Relaxed);
     }
 
     fn record_upload_failure(&self) {
@@ -1151,6 +1169,11 @@ impl CacheAgent {
                 .stats
                 .background_upload_failures
                 .load(Ordering::Relaxed),
+            remote_blob_pack_uploads: self.stats.remote_blob_pack_uploads.load(Ordering::Relaxed),
+            remote_blob_pack_upload_blobs: self
+                .stats
+                .remote_blob_pack_upload_blobs
+                .load(Ordering::Relaxed),
             upload_drain_duration_ns: self.stats.upload_drain_duration_ns.load(Ordering::Relaxed),
             prefetched_actions: self.stats.prefetched_actions.load(Ordering::Relaxed),
             bypasses: self.stats.bypasses.lock().unwrap().clone(),
@@ -1263,6 +1286,16 @@ impl CacheAgent {
                 .entry(prediction.action.clone())
                 .or_insert_with(|| prediction.adapter.clone());
         }
+        // One request per predicted action is the bulk of a prefetch's latency on
+        // a large workspace, so ask for them together where the server allows it.
+        match self.prefetch_action_batches(&actions).await {
+            Ok(true) => return,
+            Ok(false) => {}
+            Err(error) => {
+                self.note_remote_failure();
+                warn!("remote action batch lookup failed: {error}");
+            }
+        }
         let mut actions = actions.into_iter();
         let mut tasks = tokio::task::JoinSet::new();
         for _ in 0..MAX_PREFETCH_TRANSFERS {
@@ -1313,6 +1346,101 @@ impl CacheAgent {
         if !resolved.is_empty() {
             self.prefetch_resolved_actions(resolved).await;
         }
+    }
+
+    /// Resolve predicted actions in batched lookups, staging what comes back.
+    ///
+    /// Returns whether the batch extension answered. A server without it, or one
+    /// that stops answering part way through, leaves the per-action path to
+    /// resolve whatever is left -- the results already staged here are memoized,
+    /// so nothing is looked up twice.
+    async fn prefetch_action_batches(
+        &self,
+        actions: &BTreeMap<CacheDigest, String>,
+    ) -> Result<bool> {
+        let Some(remote) = self.remote.as_deref() else {
+            return Ok(false);
+        };
+        let Some(limit) = remote.action_batch_limit().await? else {
+            return Ok(false);
+        };
+        let wanted: Vec<CacheDigest> = actions
+            .keys()
+            .filter(|action| !self.action_is_staged(action))
+            .cloned()
+            .collect();
+        if wanted.is_empty() {
+            return Ok(true);
+        }
+        let mut chunks: Vec<Vec<CacheDigest>> = Vec::new();
+        for chunk in wanted.chunks(limit) {
+            chunks.push(chunk.to_vec());
+        }
+        let mut lookups = stream::iter(chunks)
+            .map(|chunk| async move {
+                let _prefetch_permit = self.prefetch_transfers.acquire().await?;
+                let _permit = self.remote_transfers.acquire().await?;
+                self.stats
+                    .remote_action_lookups
+                    .fetch_add(1, Ordering::Relaxed);
+                let _timer =
+                    AtomicDurationTimer::start(&self.stats.remote_action_lookup_duration_ns);
+                remote.get_action_results(&chunk).await
+            })
+            .buffer_unordered(MAX_PREFETCH_BATCH_LOOKUPS);
+        let mut answered = true;
+        while let Some(lookup) = lookups.next().await {
+            let results = match lookup {
+                Ok(Some(results)) => results,
+                // Advertised but unavailable. What is left falls back.
+                Ok(None) => {
+                    answered = false;
+                    continue;
+                }
+                Err(error) => {
+                    self.note_remote_failure();
+                    warn!("remote action batch lookup failed: {error}");
+                    answered = false;
+                    continue;
+                }
+            };
+            let mut resolved = Vec::with_capacity(results.len());
+            for result in results {
+                let Some(adapter) = actions.get(&result.action).cloned() else {
+                    continue;
+                };
+                let lock = self.action_lock(&result.action);
+                let _guard = lock.lock().await;
+                if self.actions.find(&result.action)?.is_some() {
+                    continue;
+                }
+                self.pending_remote_actions
+                    .lock()
+                    .unwrap()
+                    .insert(result.action.clone(), result.clone());
+                resolved.push(PrefetchedAction { adapter, result });
+            }
+            while !resolved.is_empty() {
+                let wave = resolved
+                    .drain(..resolved.len().min(MAX_PREFETCH_ACTION_BATCH))
+                    .collect();
+                self.prefetch_resolved_actions(wave).await;
+            }
+        }
+        Ok(answered)
+    }
+
+    /// Whether an action's result is already local or already looked up.
+    fn action_is_staged(&self, action: &CacheDigest) -> bool {
+        if self
+            .pending_remote_actions
+            .lock()
+            .unwrap()
+            .contains_key(action)
+        {
+            return true;
+        }
+        self.actions.find(action).is_ok_and(|found| found.is_some())
     }
 
     #[cfg(test)]

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ACTION_RESULT_MEDIA_TYPE;
+use crate::{ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, BLOB_PACK_BLOBS_HEADER};
 use std::time::Duration;
 
 #[test]
@@ -2144,6 +2144,304 @@ async fn a_blob_that_failed_is_uploaded_again_for_a_later_result() {
     retried.assert_async().await;
     second_blob.assert_async().await;
     second_result.assert_async().await;
+}
+
+#[tokio::test]
+async fn prefetch_resolves_predicted_actions_in_one_lookup() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    mock_agent_capabilities(&mut server, serde_json::json!({ "action_batch": true })).await;
+    let task = "7".repeat(64);
+    let mut predictions = Vec::new();
+    let mut results = Vec::new();
+    let mut action_blobs = Vec::new();
+    let mut skipped = Vec::new();
+    for index in 0..3 {
+        let action_bytes = format!("predicted action {index}").into_bytes();
+        let action = CacheDigest::blake3(&action_bytes);
+        predictions.push(ActionPrediction {
+            invocation: CacheDigest::blake3(format!("invocation {index}").as_bytes()),
+            action: action.clone(),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        });
+        results.push(RemoteActionResult {
+            action: action.clone(),
+            metadata: None,
+            output_root: None,
+            version: 1,
+        });
+        action_blobs.push(
+            server
+                .mock("GET", blob_path(&action).as_str())
+                .with_status(200)
+                .with_body(action_bytes)
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        // One batched lookup replaces a request per predicted action.
+        skipped.push(
+            server
+                .mock("GET", action_path(&action).as_str())
+                .expect(0)
+                .create_async()
+                .await,
+        );
+    }
+    let manifest_bytes = canonical_json(&TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.clone(),
+        predictions: predictions.clone(),
+    })
+    .unwrap();
+    let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+    let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+    let manifest = server
+        .mock("GET", action_manifest_path(&selector).as_str())
+        .with_status(200)
+        .with_header("etag", &format!("\"{manifest_etag}\""))
+        .with_body(manifest_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+    let batch = server
+        .mock("POST", "/v1/action-results:batch")
+        .with_status(200)
+        .with_header("content-type", ACTION_RESULT_BATCH_MEDIA_TYPE)
+        .with_body(serde_json::json!({ "results": results }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+
+    agent.begin_task(&task).await.unwrap();
+    agent.wait_for_prefetches().await;
+
+    manifest.assert_async().await;
+    batch.assert_async().await;
+    for mock in action_blobs.into_iter().chain(skipped) {
+        mock.assert_async().await;
+    }
+    for result in &results {
+        assert!(agent.actions.find(&result.action).unwrap().is_some());
+    }
+    assert_eq!(agent.stats().remote_action_lookups, 1);
+}
+
+#[tokio::test]
+async fn prefetch_falls_back_when_batched_lookups_are_unavailable() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    // Advertised, then absent: the client must still resolve the prediction.
+    mock_agent_capabilities(&mut server, serde_json::json!({ "action_batch": true })).await;
+    let task = "6".repeat(64);
+    let action_bytes = b"fallback action".to_vec();
+    let action = CacheDigest::blake3(&action_bytes);
+    let result = RemoteActionResult {
+        action: action.clone(),
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+    let manifest_bytes = canonical_json(&TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.clone(),
+        predictions: vec![ActionPrediction {
+            invocation: CacheDigest::blake3(b"fallback invocation"),
+            action: action.clone(),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        }],
+    })
+    .unwrap();
+    let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+    let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+    let manifest = server
+        .mock("GET", action_manifest_path(&selector).as_str())
+        .with_status(200)
+        .with_header("etag", &format!("\"{manifest_etag}\""))
+        .with_body(manifest_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+    let batch = server
+        .mock("POST", "/v1/action-results:batch")
+        .with_status(404)
+        .expect(1)
+        .create_async()
+        .await;
+    let single = server
+        .mock("GET", action_path(&action).as_str())
+        .with_status(200)
+        .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+        .with_body(serde_json::to_vec(&result).unwrap())
+        .expect(1)
+        .create_async()
+        .await;
+    let action_blob = server
+        .mock("GET", blob_path(&action).as_str())
+        .with_status(200)
+        .with_body(action_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+
+    agent.begin_task(&task).await.unwrap();
+    agent.wait_for_prefetches().await;
+
+    manifest.assert_async().await;
+    batch.assert_async().await;
+    single.assert_async().await;
+    action_blob.assert_async().await;
+    assert!(agent.actions.find(&action).unwrap().is_some());
+}
+
+async fn mock_agent_capabilities(server: &mut mockito::ServerGuard, features: serde_json::Value) {
+    server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":features,
+                "limits":{"max_batch_items":100,"max_pack_bytes":1048576}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+}
+
+#[tokio::test]
+async fn queued_blobs_are_published_in_one_pack() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    mock_agent_capabilities(
+        &mut server,
+        serde_json::json!({ "blob_pack_uploads": true }),
+    )
+    .await;
+    let contents = [
+        b"first output".to_vec(),
+        b"second output".to_vec(),
+        b"third output".to_vec(),
+    ];
+    let digests: Vec<CacheDigest> = contents
+        .iter()
+        .map(|bytes| CacheDigest::blake3(bytes))
+        .collect();
+    let pack = server
+        .mock("POST", "/v1/blobs:pack-upload")
+        .match_header(BLOB_PACK_BLOBS_HEADER, "3")
+        .with_status(200)
+        .with_body(serde_json::json!({"created":3,"existing":0}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    // One request replaces three, so none of the individual endpoints are used.
+    let mut singles = Vec::new();
+    for digest in &digests {
+        singles.push(
+            server
+                .mock("PUT", blob_path(digest).as_str())
+                .expect(0)
+                .create_async()
+                .await,
+        );
+    }
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let mut requests = Vec::new();
+    for (index, (digest, bytes)) in digests.iter().zip(&contents).enumerate() {
+        let source = directory.path().join(format!("source-{index}"));
+        fs::write(&source, bytes).unwrap();
+        requests.push(AgentRequest::StoreBlob {
+            digest: digest.clone(),
+            source,
+        });
+    }
+    agent.handle_requests(requests).await;
+    agent.wait_for_uploads().await;
+
+    pack.assert_async().await;
+    for single in singles {
+        single.assert_async().await;
+    }
+    let stats = agent.stats();
+    assert_eq!(stats.remote_blob_pack_uploads, 1);
+    assert_eq!(stats.remote_blob_pack_upload_blobs, 3);
+    assert_eq!(stats.background_uploads, 3);
+}
+
+#[tokio::test]
+async fn a_rejected_pack_falls_back_to_individual_uploads() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    mock_agent_capabilities(
+        &mut server,
+        serde_json::json!({ "blob_pack_uploads": true }),
+    )
+    .await;
+    let contents = [b"first output".to_vec(), b"second output".to_vec()];
+    let digests: Vec<CacheDigest> = contents
+        .iter()
+        .map(|bytes| CacheDigest::blake3(bytes))
+        .collect();
+    let pack = server
+        .mock("POST", "/v1/blobs:pack-upload")
+        .with_status(500)
+        .expect(1)
+        .create_async()
+        .await;
+    let mut singles = Vec::new();
+    for digest in &digests {
+        singles.push(
+            server
+                .mock("PUT", blob_path(digest).as_str())
+                .with_status(200)
+                .expect(1)
+                .create_async()
+                .await,
+        );
+    }
+    let agent = remote_agent(
+        &server,
+        directory.path().join("writer"),
+        RemoteCacheMode::WriteOnly,
+    );
+    let mut requests = Vec::new();
+    for (index, (digest, bytes)) in digests.iter().zip(&contents).enumerate() {
+        let source = directory.path().join(format!("source-{index}"));
+        fs::write(&source, bytes).unwrap();
+        requests.push(AgentRequest::StoreBlob {
+            digest: digest.clone(),
+            source,
+        });
+    }
+    agent.handle_requests(requests).await;
+    agent.wait_for_uploads().await;
+
+    pack.assert_async().await;
+    for single in singles {
+        single.assert_async().await;
+    }
+    // Everything still published, so nothing downstream is withheld.
+    assert_eq!(agent.stats().background_uploads, 2);
+    assert_eq!(agent.stats().remote_blob_pack_uploads, 0);
 }
 
 #[tokio::test]

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -2396,7 +2396,12 @@ async fn a_rejected_pack_falls_back_to_individual_uploads() {
         serde_json::json!({ "blob_pack_uploads": true }),
     )
     .await;
-    let contents = [b"first output".to_vec(), b"second output".to_vec()];
+    // A pack's worth of members, not a pair: the fallback republishes the whole
+    // group, and doing that one round trip at a time is worst exactly when the
+    // server has just refused a request.
+    let contents: Vec<Vec<u8>> = (0..8)
+        .map(|index| format!("output {index}").into_bytes())
+        .collect();
     let digests: Vec<CacheDigest> = contents
         .iter()
         .map(|bytes| CacheDigest::blake3(bytes))
@@ -2440,7 +2445,7 @@ async fn a_rejected_pack_falls_back_to_individual_uploads() {
         single.assert_async().await;
     }
     // Everything still published, so nothing downstream is withheld.
-    assert_eq!(agent.stats().background_uploads, 2);
+    assert_eq!(agent.stats().background_uploads, digests.len() as u64);
     assert_eq!(agent.stats().remote_blob_pack_uploads, 0);
 }
 

--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -783,6 +783,43 @@ async fn mock_blob_pack_capabilities(server: &mut mockito::ServerGuard) {
         .await;
 }
 
+async fn mock_capabilities(server: &mut mockito::ServerGuard, features: serde_json::Value) {
+    server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":features,
+                "limits":{"max_batch_items":100,"max_pack_bytes":1024}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+}
+
+/// Read a framed pack the way a server would, for asserting what was uploaded.
+fn decode_blob_pack_frames(pack: &[u8]) -> Vec<(String, u64, Vec<u8>)> {
+    assert_eq!(&pack[..BLOB_PACK_MAGIC.len()], BLOB_PACK_MAGIC);
+    let mut frames = Vec::new();
+    let mut rest = &pack[BLOB_PACK_MAGIC.len()..];
+    while !rest.is_empty() {
+        let algorithm = match rest[0] {
+            1 => "blake3",
+            2 => "sha256",
+            other => panic!("unexpected pack algorithm {other}"),
+        };
+        let hash = hex::encode(&rest[1..33]);
+        let size = u64::from_be_bytes(rest[33..41].try_into().unwrap());
+        let end = 41 + size as usize;
+        frames.push((format!("{algorithm}:{hash}"), size, rest[41..end].to_vec()));
+        rest = &rest[end..];
+    }
+    frames
+}
+
 fn encode_blob_pack(entries: &[(&CacheDigest, &[u8])]) -> Vec<u8> {
     let mut pack = BLOB_PACK_MAGIC.to_vec();
     for (digest, contents) in entries {
@@ -797,6 +834,242 @@ fn encode_blob_pack(entries: &[(&CacheDigest, &[u8])]) -> Vec<u8> {
         pack.extend_from_slice(contents);
     }
     pack
+}
+
+#[tokio::test]
+async fn looks_up_negotiated_action_batches() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({ "action_batch": true })).await;
+    let found = CacheDigest::blake3(b"found action");
+    let missing = CacheDigest::blake3(b"missing action");
+    let result = RemoteActionResult {
+        action: found.clone(),
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+    let batch = server
+        .mock("POST", "/v1/action-results:batch")
+        .match_header("content-type", DIGEST_LIST_MEDIA_TYPE)
+        .match_header("accept", ACTION_RESULT_BATCH_MEDIA_TYPE)
+        .match_body(mockito::Matcher::Json(serde_json::json!({
+            "digests": [found, missing],
+        })))
+        .with_status(200)
+        .with_header("content-type", ACTION_RESULT_BATCH_MEDIA_TYPE)
+        // A server answers only for what it holds, and may describe the batch
+        // with fields this client does not know.
+        .with_body(serde_json::json!({"results":[result],"truncated":false}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let results = client
+        .get_action_results(&[found.clone(), missing])
+        .await
+        .unwrap()
+        .expect("the server advertised batched lookups");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, found);
+    batch.assert_async().await;
+}
+
+#[tokio::test]
+async fn action_batches_fall_back_when_not_advertised() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({})).await;
+    let batch = server
+        .mock("POST", "/v1/action-results:batch")
+        .expect(0)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let action = CacheDigest::blake3(b"unbatched action");
+    assert!(
+        client
+            .get_action_results(&[action])
+            .await
+            .unwrap()
+            .is_none()
+    );
+    batch.assert_async().await;
+}
+
+#[tokio::test]
+async fn action_batches_stop_after_the_endpoint_is_missing() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({ "action_batch": true })).await;
+    // Advertised but not served: asking again every wave would cost a round
+    // trip to learn the same thing.
+    let batch = server
+        .mock("POST", "/v1/action-results:batch")
+        .with_status(404)
+        .expect(1)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let action = CacheDigest::blake3(b"absent endpoint");
+    assert!(
+        client
+            .get_action_results(std::slice::from_ref(&action))
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        client
+            .get_action_results(&[action])
+            .await
+            .unwrap()
+            .is_none()
+    );
+    batch.assert_async().await;
+}
+
+#[tokio::test]
+async fn rejects_action_batch_results_that_were_not_requested() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({ "action_batch": true })).await;
+    let requested = CacheDigest::blake3(b"requested action");
+    // Accepting this would key cached outputs under an action this client never
+    // derived.
+    let unrequested = RemoteActionResult {
+        action: CacheDigest::blake3(b"someone else's action"),
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+    server
+        .mock("POST", "/v1/action-results:batch")
+        .with_status(200)
+        .with_header("content-type", ACTION_RESULT_BATCH_MEDIA_TYPE)
+        .with_body(serde_json::json!({ "results": [unrequested] }).to_string())
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let error = client
+        .get_action_results(&[requested])
+        .await
+        .expect_err("an unrequested action result was accepted");
+    assert!(error.to_string().contains("unrequested action"));
+}
+
+#[tokio::test]
+async fn uploads_negotiated_blob_packs() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(
+        &mut server,
+        serde_json::json!({ "blob_pack_uploads": true }),
+    )
+    .await;
+    let first_bytes = b"first packed blob".to_vec();
+    let second_bytes = b"second packed blob".to_vec();
+    let first = CacheDigest::blake3(&first_bytes);
+    let second = CacheDigest::blake3(&second_bytes);
+    let expected = vec![
+        (
+            format!("blake3:{}", first.hash),
+            first.size,
+            first_bytes.clone(),
+        ),
+        (
+            format!("blake3:{}", second.hash),
+            second.size,
+            second_bytes.clone(),
+        ),
+    ];
+    let framed =
+        BLOB_PACK_MAGIC.len() as u64 + first.size + second.size + BLOB_PACK_HEADER_BYTES * 2;
+    let upload = server
+        .mock("POST", "/v1/blobs:pack-upload")
+        .match_header("content-type", BLOB_PACK_MEDIA_TYPE)
+        .match_header(BLOB_PACK_BLOBS_HEADER, "2")
+        .match_header(
+            BLOB_PACK_BYTES_HEADER,
+            (first.size + second.size).to_string().as_str(),
+        )
+        .match_header("content-length", framed.to_string().as_str())
+        .match_request(move |request| decode_blob_pack_frames(request.body().unwrap()) == expected)
+        .with_status(200)
+        .with_header("content-type", BLOB_PACK_RECEIPT_MEDIA_TYPE)
+        .with_body(serde_json::json!({"created":2,"existing":0}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let receipt = client
+        .put_blob_pack(&[
+            BlobUpload {
+                digest: first,
+                source: BlobSource::Bytes(first_bytes),
+            },
+            BlobUpload {
+                digest: second,
+                source: BlobSource::Bytes(second_bytes),
+            },
+        ])
+        .await
+        .unwrap()
+        .expect("the server advertised packed uploads");
+
+    assert_eq!(receipt.created, 2);
+    assert_eq!(receipt.existing, 0);
+    upload.assert_async().await;
+}
+
+#[tokio::test]
+async fn packed_uploads_fall_back_when_not_advertised() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({ "blob_packs": true })).await;
+    let upload = server
+        .mock("POST", "/v1/blobs:pack-upload")
+        .expect(0)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let bytes = b"unpacked blob".to_vec();
+    let digest = CacheDigest::blake3(&bytes);
+    assert!(
+        client
+            .put_blob_pack(&[BlobUpload {
+                digest,
+                source: BlobSource::Bytes(bytes),
+            }])
+            .await
+            .unwrap()
+            .is_none()
+    );
+    upload.assert_async().await;
+}
+
+#[tokio::test]
+async fn refuses_packs_over_the_negotiated_size() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(
+        &mut server,
+        serde_json::json!({ "blob_pack_uploads": true }),
+    )
+    .await;
+    let client = test_client(&server);
+
+    // The advertised ceiling is 1024 bytes.
+    let bytes = vec![0u8; 2048];
+    let digest = CacheDigest::blake3(&bytes);
+    let error = client
+        .put_blob_pack(&[BlobUpload {
+            digest,
+            source: BlobSource::Bytes(bytes),
+        }])
+        .await
+        .expect_err("an oversized pack was sent");
+    assert!(error.to_string().contains("exceeds the negotiated limit"));
 }
 
 #[tokio::test]

--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -959,6 +959,68 @@ async fn rejects_action_batch_results_that_were_not_requested() {
     assert!(error.to_string().contains("unrequested action"));
 }
 
+/// A pack holds as many objects as a build compiles, and each one is opened
+/// only while the stream is on it -- so a large pack neither spends a file
+/// descriptor per member for the length of the request nor nests a frame per
+/// member before the first byte is sent.
+#[tokio::test]
+async fn streams_a_pack_of_many_members_from_files() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":{"blob_pack_uploads":true},
+                "limits":{"max_batch_items":1000,"max_pack_bytes":1048576}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    let directory = tempfile::tempdir().unwrap();
+    let mut uploads = Vec::new();
+    let mut expected = Vec::new();
+    let mut payload_bytes = 0;
+    for index in 0..200 {
+        let bytes = format!("packed member {index}").into_bytes();
+        let digest = CacheDigest::blake3(&bytes);
+        let path = directory.path().join(format!("member-{index}"));
+        fs::write(&path, &bytes).unwrap();
+        payload_bytes += digest.size;
+        expected.push((format!("blake3:{}", digest.hash), digest.size, bytes));
+        uploads.push(BlobUpload {
+            digest,
+            source: BlobSource::Path(path),
+        });
+    }
+    let upload = server
+        .mock("POST", "/v1/blobs:pack-upload")
+        .match_header(BLOB_PACK_BLOBS_HEADER, "200")
+        .match_request(move |request| decode_blob_pack_frames(request.body().unwrap()) == expected)
+        .with_status(200)
+        .with_body(serde_json::json!({"created":200,"existing":0}).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let receipt = client
+        .put_blob_pack(&uploads)
+        .await
+        .unwrap()
+        .expect("the server advertised packed uploads");
+
+    assert_eq!(receipt.created, 200);
+    assert_eq!(
+        payload_bytes,
+        uploads.iter().map(|upload| upload.digest.size).sum::<u64>()
+    );
+    upload.assert_async().await;
+}
+
 #[tokio::test]
 async fn uploads_negotiated_blob_packs() {
     let mut server = mockito::Server::new_async().await;

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -88,6 +88,8 @@ const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
 const BLOB_PACK_TIMEOUT_BYTES_PER_UNIT: u64 = MAX_STAGED_BLOB_PACK_BYTES / 4;
 const BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT: usize = MAX_STAGED_BLOB_PACK_ITEMS / 4;
+/// Bytes read from one pack member before the next chunk is yielded.
+const PACK_STREAM_CHUNK_BYTES: usize = 64 * 1024;
 /// Actions looked up in one batched request.
 ///
 /// A prefetch wants its first results back while the rest are still being
@@ -1022,10 +1024,10 @@ impl RemoteCacheClient {
                 .header(BLOB_PACK_BYTES_HEADER, payload_bytes);
             // Each attempt reads the sources again, so the pack is rebuilt here
             // rather than buffered once and held in memory.
-            let reader = blob_pack_reader(uploads).await?;
+            let stream = blob_pack_stream(blob_pack_members(uploads)?);
             let request = if compress {
                 let encoder = async_compression::tokio::bufread::ZstdEncoder::new(
-                    tokio::io::BufReader::new(reader),
+                    tokio::io::BufReader::new(tokio_util::io::StreamReader::new(stream)),
                 );
                 request
                     .header(CONTENT_ENCODING, "zstd")
@@ -1035,9 +1037,7 @@ impl RemoteCacheClient {
             } else {
                 request
                     .header(CONTENT_LENGTH, framed_bytes)
-                    .body(reqwest::Body::wrap_stream(
-                        tokio_util::io::ReaderStream::new(reader),
-                    ))
+                    .body(reqwest::Body::wrap_stream(stream))
             };
             let response = request.send().await?;
             if matches!(
@@ -1161,23 +1161,116 @@ fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Durati
 ///
 /// The frames mirror what [`decode_blob_pack_reader`] accepts, so both
 /// directions of the extension agree on the format by construction.
-async fn blob_pack_reader(
-    uploads: &[BlobUpload],
-) -> Result<Box<dyn AsyncRead + Send + Sync + Unpin>> {
-    use tokio::io::AsyncReadExt as _;
+/// One member of a pack, described rather than opened.
+///
+/// A pack can hold thousands of objects. Opening them all before the first byte
+/// is sent would spend a file descriptor on each for the length of the request,
+/// so a member is opened only when the stream reaches it and closed when it is
+/// past.
+struct PackMemberSource {
+    header: Vec<u8>,
+    source: PackPayloadSource,
+}
 
-    let mut reader: Box<dyn AsyncRead + Send + Sync + Unpin> =
-        Box::new(std::io::Cursor::new(BLOB_PACK_MAGIC.to_vec()));
-    for upload in uploads {
-        let header = blob_pack_frame_header(&upload.digest)?;
-        let payload: Box<dyn AsyncRead + Send + Sync + Unpin> = match &upload.source {
-            BlobSource::Bytes(bytes) => Box::new(std::io::Cursor::new(bytes.clone())),
-            BlobSource::File(file) => Box::new(tokio::fs::File::open(file.path()).await?),
-            BlobSource::Path(path) => Box::new(tokio::fs::File::open(path).await?),
-        };
-        reader = Box::new(reader.chain(std::io::Cursor::new(header)).chain(payload));
-    }
-    Ok(reader)
+enum PackPayloadSource {
+    Bytes(Vec<u8>),
+    Path(PathBuf),
+}
+
+enum PackStreamState {
+    Magic,
+    Header(usize),
+    Payload(usize, Box<dyn AsyncRead + Send + Sync + Unpin>),
+    Done,
+}
+
+/// Frame blobs into one `MBXPACK1` stream, read on demand rather than buffered.
+///
+/// The frames mirror what [`decode_blob_pack_reader`] accepts, so both
+/// directions of the extension agree on the format by construction.
+fn blob_pack_stream(
+    members: Vec<PackMemberSource>,
+) -> impl futures_util::Stream<Item = std::io::Result<bytes::Bytes>> + Send + 'static {
+    futures_util::stream::unfold(
+        (PackStreamState::Magic, members),
+        |(state, members)| async move {
+            let mut state = state;
+            loop {
+                match state {
+                    PackStreamState::Magic => {
+                        return Some((
+                            Ok(bytes::Bytes::from_static(BLOB_PACK_MAGIC)),
+                            (PackStreamState::Header(0), members),
+                        ));
+                    }
+                    PackStreamState::Header(index) => {
+                        let Some(member) = members.get(index) else {
+                            state = PackStreamState::Done;
+                            continue;
+                        };
+                        let payload: Box<dyn AsyncRead + Send + Sync + Unpin> = match &member.source
+                        {
+                            PackPayloadSource::Bytes(bytes) => {
+                                Box::new(std::io::Cursor::new(bytes.clone()))
+                            }
+                            PackPayloadSource::Path(path) => {
+                                match tokio::fs::File::open(path).await {
+                                    Ok(file) => Box::new(file),
+                                    Err(error) => {
+                                        return Some((
+                                            Err(error),
+                                            (PackStreamState::Done, members),
+                                        ));
+                                    }
+                                }
+                            }
+                        };
+                        return Some((
+                            Ok(bytes::Bytes::from(member.header.clone())),
+                            (PackStreamState::Payload(index, payload), members),
+                        ));
+                    }
+                    PackStreamState::Payload(index, mut payload) => {
+                        let mut chunk = vec![0; PACK_STREAM_CHUNK_BYTES];
+                        match payload.read(&mut chunk).await {
+                            // The member is finished, so its handle is dropped
+                            // here rather than held for the whole request.
+                            Ok(0) => {
+                                state = PackStreamState::Header(index + 1);
+                            }
+                            Ok(read) => {
+                                chunk.truncate(read);
+                                return Some((
+                                    Ok(bytes::Bytes::from(chunk)),
+                                    (PackStreamState::Payload(index, payload), members),
+                                ));
+                            }
+                            Err(error) => {
+                                return Some((Err(error), (PackStreamState::Done, members)));
+                            }
+                        }
+                    }
+                    PackStreamState::Done => return None,
+                }
+            }
+        },
+    )
+}
+
+fn blob_pack_members(uploads: &[BlobUpload]) -> Result<Vec<PackMemberSource>> {
+    uploads
+        .iter()
+        .map(|upload| {
+            Ok(PackMemberSource {
+                header: blob_pack_frame_header(&upload.digest)?,
+                source: match &upload.source {
+                    BlobSource::Bytes(bytes) => PackPayloadSource::Bytes(bytes.clone()),
+                    BlobSource::File(file) => PackPayloadSource::Path(file.path().to_path_buf()),
+                    BlobSource::Path(path) => PackPayloadSource::Path(path.clone()),
+                },
+            })
+        })
+        .collect()
 }
 
 fn blob_pack_frame_header(digest: &CacheDigest) -> Result<Vec<u8>> {

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -59,11 +59,12 @@ pub use agent::{
 };
 pub use local::{LocalActionCache, LocalCas};
 pub use mbx_cache_protocol::{
-    ACTION_RESULT_MEDIA_TYPE, ActionPrediction, ActionResult as RemoteActionResult,
-    BLOB_MEDIA_TYPE, BLOB_PACK_BLOBS_HEADER, BLOB_PACK_BYTES_HEADER, BLOB_PACK_HEADER_BYTES,
-    BLOB_PACK_MAGIC, BLOB_PACK_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, Capabilities,
-    CapabilityFeatures, CapabilityLimits, CapabilityProtocol, DIGEST_LIST_MEDIA_TYPE,
-    DIRECTORY_MEDIA_TYPE, Digest as CacheDigest, DigestAlgorithm, Directory as CacheDirectory,
+    ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, ActionPrediction,
+    ActionResult as RemoteActionResult, BLOB_MEDIA_TYPE, BLOB_PACK_BLOBS_HEADER,
+    BLOB_PACK_BYTES_HEADER, BLOB_PACK_HEADER_BYTES, BLOB_PACK_MAGIC, BLOB_PACK_MEDIA_TYPE,
+    BLOB_PACK_RECEIPT_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, Capabilities, CapabilityFeatures,
+    CapabilityLimits, CapabilityProtocol, DIGEST_LIST_MEDIA_TYPE, DIRECTORY_MEDIA_TYPE,
+    Digest as CacheDigest, DigestAlgorithm, Directory as CacheDirectory,
     DirectoryNode as CacheDirectoryNode, FileNode as CacheFileNode, NAMESPACE_HEADER,
     PROTOCOL_HEADER, PROTOCOL_VERSION, RustcMetadata, SymlinkNode as CacheSymlinkNode,
     TASK_ACTION_MANIFEST_MEDIA_TYPE, TaskActionManifest,
@@ -87,6 +88,14 @@ const MAX_STAGED_BLOB_PACK_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_STAGED_BLOB_PACK_ITEMS: usize = 2 * 1024;
 const BLOB_PACK_TIMEOUT_BYTES_PER_UNIT: u64 = MAX_STAGED_BLOB_PACK_BYTES / 4;
 const BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT: usize = MAX_STAGED_BLOB_PACK_ITEMS / 4;
+/// Actions looked up in one batched request.
+///
+/// A prefetch wants its first results back while the rest are still being
+/// answered, so a batch stays small enough to keep the download pipeline fed
+/// rather than as large as a server would accept.
+const MAX_ACTION_BATCH_ITEMS: usize = 256;
+/// Ceiling on one batched action-result response, scaled by what was asked for.
+const MAX_ACTION_RESULT_BYTES: u64 = 64 * 1024;
 
 /// Serialize a protocol object using the JSON Canonicalization Scheme.
 ///
@@ -292,12 +301,36 @@ struct BlobPackLimits {
 #[derive(Debug, Clone, Copy, Default)]
 struct NegotiatedCapabilities {
     blob_packs: Option<BlobPackLimits>,
+    blob_pack_uploads: Option<BlobPackLimits>,
+    action_batches: Option<usize>,
     zstd_uploads: bool,
 }
 
 #[derive(Serialize)]
 struct DigestList<'a> {
     digests: &'a [CacheDigest],
+}
+
+/// Action results a server holds, in no particular order.
+///
+/// Deliberately tolerant of fields it does not know, so a later protocol minor
+/// can describe more about a batch without this client refusing the response.
+/// The records inside stay canonical and exhaustive.
+#[derive(Deserialize)]
+struct ActionResultBatch {
+    #[serde(default)]
+    results: Vec<RemoteActionResult>,
+}
+
+/// What a server did with the blobs in an uploaded pack.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct BlobPackReceipt {
+    /// Blobs this request added to the remote cache.
+    #[serde(default)]
+    pub created: u64,
+    /// Blobs the remote cache already held.
+    #[serde(default)]
+    pub existing: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -322,6 +355,8 @@ pub struct RemoteCacheClient {
     retries: i64,
     capabilities: tokio::sync::OnceCell<NegotiatedCapabilities>,
     blob_packs_disabled: AtomicBool,
+    blob_pack_uploads_disabled: AtomicBool,
+    action_batches_disabled: AtomicBool,
 }
 
 impl RemoteCacheClient {
@@ -352,6 +387,8 @@ impl RemoteCacheClient {
             retries: config.retries,
             capabilities: tokio::sync::OnceCell::new(),
             blob_packs_disabled: AtomicBool::new(false),
+            blob_pack_uploads_disabled: AtomicBool::new(false),
+            action_batches_disabled: AtomicBool::new(false),
         })
     }
 
@@ -405,6 +442,18 @@ impl RemoteCacheClient {
         Ok(self
             .base_url
             .join(&format!("v{PROTOCOL_VERSION}/blobs:pack"))?)
+    }
+
+    fn blob_pack_upload_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/blobs:pack-upload"))?)
+    }
+
+    fn action_result_batch_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/action-results:batch"))?)
     }
 
     async fn request(
@@ -469,7 +518,10 @@ impl RemoteCacheClient {
             .compressors
             .iter()
             .any(|compressor| compressor == "zstd");
-        let blob_packs = if capabilities.features.blob_packs {
+        let pack_limits = |feature: bool| -> Result<Option<BlobPackLimits>> {
+            if !feature {
+                return Ok(None);
+            }
             let max_items = usize::try_from(capabilities.limits.max_batch_items)
                 .ok()
                 .filter(|limit| *limit > 0)
@@ -479,18 +531,31 @@ impl RemoteCacheClient {
             if capabilities.limits.max_pack_bytes == 0 {
                 bail!("remote cache blob packs require a positive max_pack_bytes limit");
             }
-            Some(BlobPackLimits {
+            Ok(Some(BlobPackLimits {
                 max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
                 max_bytes: capabilities
                     .limits
                     .max_pack_bytes
                     .min(MAX_STAGED_BLOB_PACK_BYTES),
-            })
+            }))
+        };
+        let blob_packs = pack_limits(capabilities.features.blob_packs)?;
+        let blob_pack_uploads = pack_limits(capabilities.features.blob_pack_uploads)?;
+        let action_batches = if capabilities.features.action_batch {
+            let max_items = usize::try_from(capabilities.limits.max_batch_items)
+                .ok()
+                .filter(|limit| *limit > 0)
+                .ok_or_else(|| {
+                    eyre!("remote cache action batches require a positive max_batch_items limit")
+                })?;
+            Some(max_items.min(MAX_ACTION_BATCH_ITEMS))
         } else {
             None
         };
         Ok(NegotiatedCapabilities {
             blob_packs,
+            blob_pack_uploads,
+            action_batches,
             zstd_uploads,
         })
     }
@@ -623,6 +688,99 @@ impl RemoteCacheClient {
             bail!("remote action result does not match requested action");
         }
         Ok(result)
+    }
+
+    /// How many actions one batched lookup may ask about.
+    ///
+    /// `None` means the server does not answer batched lookups.
+    pub(crate) async fn action_batch_limit(&self) -> Result<Option<usize>> {
+        if self.action_batches_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        Ok(self.negotiated_capabilities().await?.action_batches)
+    }
+
+    /// Look up several action results in one request.
+    ///
+    /// `None` means the server does not answer batched lookups, leaving the
+    /// caller to ask for each action individually. The response carries only the
+    /// results the server holds, in no particular order, so each record is bound
+    /// to its request by the action digest it names rather than by position.
+    pub async fn get_action_results(
+        &self,
+        actions: &[CacheDigest],
+    ) -> Result<Option<Vec<RemoteActionResult>>> {
+        if actions.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+        if self.action_batches_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let Some(limit) = self.negotiated_capabilities().await?.action_batches else {
+            return Ok(None);
+        };
+        if actions.len() > limit {
+            bail!(
+                "remote cache action batch of {} exceeds the negotiated limit of {limit}",
+                actions.len()
+            );
+        }
+        let mut requested = BTreeSet::new();
+        for action in actions {
+            action.validate()?;
+            if action.algorithm != "blake3" {
+                bail!("remote cache action keys must use blake3");
+            }
+            requested.insert(action.clone());
+        }
+        let url = self.action_result_batch_endpoint()?;
+        let body = serde_json::to_vec(&DigestList { digests: actions })?;
+        let bound = MAX_ACTION_RESULT_BYTES.saturating_mul(actions.len() as u64);
+        let batch = retry_async("POST", &url, self.retries, || async {
+            let response = self
+                .request(
+                    reqwest::Method::POST,
+                    url.clone(),
+                    ACTION_RESULT_BATCH_MEDIA_TYPE,
+                )
+                .await?
+                .header(CONTENT_TYPE, DIGEST_LIST_MEDIA_TYPE)
+                .body(body.clone())
+                .send()
+                .await?;
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            ) {
+                // Advertised but not served. Asking again every wave would cost
+                // a round trip each time to learn the same thing.
+                self.action_batches_disabled.store(true, Ordering::Relaxed);
+                return Ok(None);
+            }
+            let bytes =
+                read_json_within(response.error_for_status()?, "action result batch", bound)
+                    .await?;
+            Ok(Some(serde_json::from_slice::<ActionResultBatch>(&bytes)?))
+        })
+        .await?;
+        let Some(batch) = batch else {
+            return Ok(None);
+        };
+        // A result for an action that was not asked for would key cached outputs
+        // under a digest this client never derived, so it is refused rather than
+        // ignored.
+        let mut seen = BTreeSet::new();
+        for result in &batch.results {
+            if result.version != 1 || !requested.contains(&result.action) {
+                bail!("remote action result batch contains an unrequested action");
+            }
+            if !seen.insert(result.action.clone()) {
+                bail!("remote action result batch repeats an action");
+            }
+        }
+        Ok(Some(batch.results))
     }
 
     /// Canonically serialize and store an action-result record.
@@ -795,6 +953,110 @@ impl RemoteCacheClient {
             .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
     }
 
+    /// How many blobs, and how many payload bytes, one uploaded pack may carry.
+    ///
+    /// `None` means the server does not accept packed uploads.
+    pub(crate) async fn blob_pack_upload_limits(&self) -> Result<Option<BlobPackLimits>> {
+        if self.blob_pack_uploads_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        Ok(self.negotiated_capabilities().await?.blob_pack_uploads)
+    }
+
+    /// Upload several content-addressed blobs in one framed request.
+    ///
+    /// `None` means the server does not accept packed uploads, leaving the
+    /// caller to send each blob on its own. A rejected pack is reported as an
+    /// error and publishes nothing the caller may rely on: a server verifies
+    /// each frame as it arrives, so an accepted prefix may exist, but every blob
+    /// is content-addressed and storing one twice is not an error.
+    pub async fn put_blob_pack(&self, uploads: &[BlobUpload]) -> Result<Option<BlobPackReceipt>> {
+        if uploads.is_empty() {
+            return Ok(Some(BlobPackReceipt {
+                created: 0,
+                existing: 0,
+            }));
+        }
+        let Some(limits) = self.blob_pack_upload_limits().await? else {
+            return Ok(None);
+        };
+        if uploads.len() > limits.max_items {
+            bail!(
+                "remote cache blob pack of {} blobs exceeds the negotiated limit of {}",
+                uploads.len(),
+                limits.max_items
+            );
+        }
+        let mut payload_bytes = 0u64;
+        for upload in uploads {
+            upload.digest.validate()?;
+            payload_bytes = payload_bytes
+                .checked_add(upload.digest.size)
+                .ok_or_else(|| eyre!("remote cache blob pack payload overflowed"))?;
+        }
+        if payload_bytes > limits.max_bytes {
+            bail!(
+                "remote cache blob pack of {payload_bytes} bytes exceeds the negotiated limit of {}",
+                limits.max_bytes
+            );
+        }
+        let framed_bytes = BLOB_PACK_MAGIC.len() as u64
+            + payload_bytes
+            + BLOB_PACK_HEADER_BYTES * uploads.len() as u64;
+        let compress = self
+            .negotiated_capabilities()
+            .await
+            .map(|capabilities| capabilities.zstd_uploads)
+            .unwrap_or(false);
+        let url = self.blob_pack_upload_endpoint()?;
+        retry_async("POST", &url, self.retries, || async {
+            let request = self
+                .request(
+                    reqwest::Method::POST,
+                    url.clone(),
+                    BLOB_PACK_RECEIPT_MEDIA_TYPE,
+                )
+                .await?
+                .header(CONTENT_TYPE, BLOB_PACK_MEDIA_TYPE)
+                .header(BLOB_PACK_BLOBS_HEADER, uploads.len())
+                .header(BLOB_PACK_BYTES_HEADER, payload_bytes);
+            // Each attempt reads the sources again, so the pack is rebuilt here
+            // rather than buffered once and held in memory.
+            let reader = blob_pack_reader(uploads).await?;
+            let request = if compress {
+                let encoder = async_compression::tokio::bufread::ZstdEncoder::new(
+                    tokio::io::BufReader::new(reader),
+                );
+                request
+                    .header(CONTENT_ENCODING, "zstd")
+                    .body(reqwest::Body::wrap_stream(
+                        tokio_util::io::ReaderStream::new(encoder),
+                    ))
+            } else {
+                request
+                    .header(CONTENT_LENGTH, framed_bytes)
+                    .body(reqwest::Body::wrap_stream(
+                        tokio_util::io::ReaderStream::new(reader),
+                    ))
+            };
+            let response = request.send().await?;
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            ) {
+                self.blob_pack_uploads_disabled
+                    .store(true, Ordering::Relaxed);
+                return Ok(None);
+            }
+            let bytes =
+                read_bounded_json(response.error_for_status()?, "blob pack receipt").await?;
+            Ok(Some(serde_json::from_slice::<BlobPackReceipt>(&bytes)?))
+        })
+        .await
+    }
+
     /// Verify and upload a content-addressed blob.
     pub async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
         let url = self.blob_endpoint(&upload.digest)?;
@@ -895,19 +1157,60 @@ fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Durati
 /// A declared `Content-Length` is rejected up front so an oversized body costs
 /// nothing to refuse; the streaming check then covers servers that understate or
 /// omit it.
+/// Frame blobs into one `MBXPACK1` stream, read on demand rather than buffered.
+///
+/// The frames mirror what [`decode_blob_pack_reader`] accepts, so both
+/// directions of the extension agree on the format by construction.
+async fn blob_pack_reader(
+    uploads: &[BlobUpload],
+) -> Result<Box<dyn AsyncRead + Send + Sync + Unpin>> {
+    use tokio::io::AsyncReadExt as _;
+
+    let mut reader: Box<dyn AsyncRead + Send + Sync + Unpin> =
+        Box::new(std::io::Cursor::new(BLOB_PACK_MAGIC.to_vec()));
+    for upload in uploads {
+        let header = blob_pack_frame_header(&upload.digest)?;
+        let payload: Box<dyn AsyncRead + Send + Sync + Unpin> = match &upload.source {
+            BlobSource::Bytes(bytes) => Box::new(std::io::Cursor::new(bytes.clone())),
+            BlobSource::File(file) => Box::new(tokio::fs::File::open(file.path()).await?),
+            BlobSource::Path(path) => Box::new(tokio::fs::File::open(path).await?),
+        };
+        reader = Box::new(reader.chain(std::io::Cursor::new(header)).chain(payload));
+    }
+    Ok(reader)
+}
+
+fn blob_pack_frame_header(digest: &CacheDigest) -> Result<Vec<u8>> {
+    let algorithm = match digest.algorithm_kind()? {
+        DigestAlgorithm::Blake3 => 1u8,
+        DigestAlgorithm::Sha256 => 2u8,
+    };
+    let hash = hex::decode(&digest.hash)?;
+    if hash.len() != 32 {
+        bail!("remote cache blob pack digests must be 32 bytes");
+    }
+    let mut header = Vec::with_capacity(BLOB_PACK_HEADER_BYTES as usize);
+    header.push(algorithm);
+    header.extend_from_slice(&hash);
+    header.extend_from_slice(&digest.size.to_be_bytes());
+    Ok(header)
+}
+
 async fn read_bounded_json(response: reqwest::Response, what: &str) -> Result<Vec<u8>> {
+    read_json_within(response, what, MAX_REMOTE_JSON_BYTES).await
+}
+
+async fn read_json_within(response: reqwest::Response, what: &str, limit: u64) -> Result<Vec<u8>> {
     if let Some(length) = response.content_length()
-        && length > MAX_REMOTE_JSON_BYTES
+        && length > limit
     {
-        bail!(
-            "remote cache {what} declared {length} bytes, over the {MAX_REMOTE_JSON_BYTES} byte limit"
-        );
+        bail!("remote cache {what} declared {length} bytes, over the {limit} byte limit");
     }
     let mut response = response;
     let mut bytes = Vec::new();
     while let Some(chunk) = response.chunk().await? {
-        if bytes.len() as u64 + chunk.len() as u64 > MAX_REMOTE_JSON_BYTES {
-            bail!("remote cache {what} exceeded the {MAX_REMOTE_JSON_BYTES} byte limit");
+        if bytes.len() as u64 + chunk.len() as u64 > limit {
+            bail!("remote cache {what} exceeded the {limit} byte limit");
         }
         bytes.extend_from_slice(&chunk);
     }

--- a/crates/mbx-cache-core/src/uploads.rs
+++ b/crates/mbx-cache-core/src/uploads.rs
@@ -19,7 +19,9 @@
 //! so an action result carries the tickets of the blobs enqueued before it and
 //! waits for them itself.
 
-use crate::{BlobSource, BlobUpload, CacheDigest, RemoteActionResult, RemoteCacheClient};
+use crate::{
+    BlobPackLimits, BlobSource, BlobUpload, CacheDigest, RemoteActionResult, RemoteCacheClient,
+};
 use futures_util::future::{BoxFuture, Shared};
 use futures_util::{FutureExt, StreamExt, stream};
 use log::warn;
@@ -88,6 +90,8 @@ pub(crate) trait UploadSink: Send + Sync {
     fn record_blob_uploaded(&self, bytes: u64);
     /// Record an action result published.
     fn record_action_uploaded(&self);
+    /// Record one framed request that published `blobs` blobs.
+    fn record_blob_pack_uploaded(&self, blobs: u64);
     /// Record an upload that did not publish, having already been reported.
     fn record_upload_failure(&self);
 }
@@ -108,6 +112,55 @@ enum QueuedUpload {
 impl QueuedUpload {
     fn is_blob(&self) -> bool {
         matches!(self, Self::Blob { .. })
+    }
+}
+
+/// A queued blob considered for packing with others.
+struct PackMember {
+    digest: CacheDigest,
+    path: PathBuf,
+    done: tokio::sync::oneshot::Sender<UploadOutcome>,
+}
+
+/// Split blobs into packs the server will accept, plus the ones to send alone.
+///
+/// A blob too large for any pack, or left over as a group of one, is not worth
+/// framing: a pack of one costs the same round trip as the blob itself.
+fn group_into_packs(
+    members: Vec<PackMember>,
+    limits: BlobPackLimits,
+) -> (Vec<Vec<PackMember>>, Vec<PackMember>) {
+    let mut packs = Vec::new();
+    let mut singles = Vec::new();
+    let mut current: Vec<PackMember> = Vec::new();
+    let mut current_bytes = 0u64;
+    for member in members {
+        if member.digest.size > limits.max_bytes {
+            singles.push(member);
+            continue;
+        }
+        let would_exceed = current.len() >= limits.max_items
+            || current_bytes.saturating_add(member.digest.size) > limits.max_bytes;
+        if would_exceed && !current.is_empty() {
+            close_pack(std::mem::take(&mut current), &mut packs, &mut singles);
+            current_bytes = 0;
+        }
+        current_bytes = current_bytes.saturating_add(member.digest.size);
+        current.push(member);
+    }
+    close_pack(current, &mut packs, &mut singles);
+    (packs, singles)
+}
+
+fn close_pack(
+    pack: Vec<PackMember>,
+    packs: &mut Vec<Vec<PackMember>>,
+    singles: &mut Vec<PackMember>,
+) {
+    if pack.len() < 2 {
+        singles.extend(pack);
+    } else {
+        packs.push(pack);
     }
 }
 
@@ -312,13 +365,123 @@ impl Inner {
     /// this batch's blob phase or in a batch that has already run.
     async fn run_batch(&self, batch: Vec<QueuedUpload>) {
         let (blobs, results): (Vec<_>, Vec<_>) = batch.into_iter().partition(QueuedUpload::is_blob);
-        for phase in [blobs, results] {
-            stream::iter(phase)
-                .map(|upload| self.run_upload(upload))
-                .buffer_unordered(MAX_UPLOAD_TRANSFERS)
-                .collect::<Vec<()>>()
-                .await;
+        self.run_blob_phase(blobs).await;
+        self.run_phase(results).await;
+    }
+
+    async fn run_phase(&self, uploads: Vec<QueuedUpload>) {
+        stream::iter(uploads)
+            .map(|upload| self.run_upload(upload))
+            .buffer_unordered(MAX_UPLOAD_TRANSFERS)
+            .collect::<Vec<()>>()
+            .await;
+    }
+
+    /// Publish this batch's blobs, packing them together where the server takes
+    /// packs.
+    ///
+    /// Rustc output is many small objects, so one request per object spends most
+    /// of its time in round trips rather than in transfer.
+    async fn run_blob_phase(&self, blobs: Vec<QueuedUpload>) {
+        if blobs.len() < 2 {
+            return self.run_phase(blobs).await;
         }
+        // A negotiation this cannot complete is not worth failing the uploads
+        // over; individual requests still publish everything.
+        let limits = self
+            .remote
+            .blob_pack_upload_limits()
+            .await
+            .unwrap_or_default();
+        let Some(limits) = limits else {
+            return self.run_phase(blobs).await;
+        };
+        let mut members = Vec::with_capacity(blobs.len());
+        for upload in blobs {
+            match upload {
+                QueuedUpload::Blob { digest, path, done } => {
+                    members.push(PackMember { digest, path, done });
+                }
+                // The partition in `run_batch` leaves only blobs here.
+                other => self.run_upload(other).await,
+            }
+        }
+        let (packs, singles) = group_into_packs(members, limits);
+        let packed = stream::iter(packs)
+            .map(|pack| self.upload_pack(pack))
+            .buffer_unordered(MAX_UPLOAD_TRANSFERS);
+        let single = stream::iter(singles)
+            .map(|member| self.upload_member(member))
+            .buffer_unordered(MAX_UPLOAD_TRANSFERS);
+        futures_util::future::join(packed.collect::<Vec<()>>(), single.collect::<Vec<()>>()).await;
+    }
+
+    /// Publish one group of blobs in a single framed request.
+    ///
+    /// A pack the server will not take -- because it does not serve the
+    /// extension, or because the request failed -- leaves its members to be sent
+    /// individually, which also reports precisely which blob was the problem.
+    async fn upload_pack(&self, pack: Vec<PackMember>) {
+        let mut present = Vec::with_capacity(pack.len());
+        for member in pack {
+            if tokio::fs::try_exists(&member.path).await.unwrap_or(false) {
+                present.push(member);
+            } else {
+                warn!(
+                    "remote cache blob upload skipped for {}: the local object is gone",
+                    member.digest.hash
+                );
+                self.sink.record_upload_failure();
+                let _ = member.done.send(UploadOutcome::Skipped);
+            }
+        }
+        if present.len() < 2 {
+            for member in present {
+                self.upload_member(member).await;
+            }
+            return;
+        }
+        let uploads: Vec<BlobUpload> = present
+            .iter()
+            .map(|member| BlobUpload {
+                digest: member.digest.clone(),
+                source: BlobSource::Path(member.path.clone()),
+            })
+            .collect();
+        let receipt = {
+            let Ok(_permit) = self.transfers.acquire().await else {
+                return;
+            };
+            let Ok(_transfer) = self.remote_transfers.acquire().await else {
+                return;
+            };
+            self.remote.put_blob_pack(&uploads).await
+        };
+        match receipt {
+            Ok(Some(_)) => {
+                self.sink.record_blob_pack_uploaded(present.len() as u64);
+                for member in present {
+                    self.sink.record_blob_uploaded(member.digest.size);
+                    let _ = member.done.send(UploadOutcome::Uploaded);
+                }
+            }
+            Ok(None) => {
+                for member in present {
+                    self.upload_member(member).await;
+                }
+            }
+            Err(error) => {
+                warn!("remote cache blob pack upload failed: {error}");
+                for member in present {
+                    self.upload_member(member).await;
+                }
+            }
+        }
+    }
+
+    async fn upload_member(&self, member: PackMember) {
+        let outcome = self.upload_blob(&member.digest, &member.path).await;
+        let _ = member.done.send(outcome);
     }
 
     async fn run_upload(&self, upload: QueuedUpload) {

--- a/crates/mbx-cache-core/src/uploads.rs
+++ b/crates/mbx-cache-core/src/uploads.rs
@@ -409,11 +409,9 @@ impl Inner {
         let (packs, singles) = group_into_packs(members, limits);
         let packed = stream::iter(packs)
             .map(|pack| self.upload_pack(pack))
-            .buffer_unordered(MAX_UPLOAD_TRANSFERS);
-        let single = stream::iter(singles)
-            .map(|member| self.upload_member(member))
-            .buffer_unordered(MAX_UPLOAD_TRANSFERS);
-        futures_util::future::join(packed.collect::<Vec<()>>(), single.collect::<Vec<()>>()).await;
+            .buffer_unordered(MAX_UPLOAD_TRANSFERS)
+            .collect::<Vec<()>>();
+        futures_util::future::join(packed, self.upload_members(singles)).await;
     }
 
     /// Publish one group of blobs in a single framed request.
@@ -436,9 +434,7 @@ impl Inner {
             }
         }
         if present.len() < 2 {
-            for member in present {
-                self.upload_member(member).await;
-            }
+            self.upload_members(present).await;
             return;
         }
         let uploads: Vec<BlobUpload> = present
@@ -465,18 +461,25 @@ impl Inner {
                     let _ = member.done.send(UploadOutcome::Uploaded);
                 }
             }
-            Ok(None) => {
-                for member in present {
-                    self.upload_member(member).await;
-                }
-            }
+            Ok(None) => self.upload_members(present).await,
             Err(error) => {
                 warn!("remote cache blob pack upload failed: {error}");
-                for member in present {
-                    self.upload_member(member).await;
-                }
+                self.upload_members(present).await;
             }
         }
+    }
+
+    /// Publish these blobs individually, as concurrently as any other upload.
+    ///
+    /// This is the path a pack falls back to, so it has to match what the
+    /// unpacked path would have done: sending a whole group one round trip at a
+    /// time is worst exactly when the server has just refused a request.
+    async fn upload_members(&self, members: Vec<PackMember>) {
+        stream::iter(members)
+            .map(|member| self.upload_member(member))
+            .buffer_unordered(MAX_UPLOAD_TRANSFERS)
+            .collect::<Vec<()>>()
+            .await;
     }
 
     async fn upload_member(&self, member: PackMember) {

--- a/crates/mbx-cache-core/tests/agent_protocol.rs
+++ b/crates/mbx-cache-core/tests/agent_protocol.rs
@@ -1,8 +1,9 @@
 use mbx_cache_core::{
-    ACTION_RESULT_MEDIA_TYPE, AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRequest,
-    AgentResponse, BLOB_MEDIA_TYPE, BLOB_PACK_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, CacheDigest,
-    CacheDirectory, CacheFileNode, DIRECTORY_MEDIA_TYPE, PROTOCOL_VERSION, RemoteActionResult,
-    RestoreStats, RustcMetadata, TASK_ACTION_MANIFEST_MEDIA_TYPE, canonical_json,
+    ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, AGENT_PROTOCOL_VERSION,
+    ActionPrediction, AgentRequest, AgentResponse, BLOB_MEDIA_TYPE, BLOB_PACK_MEDIA_TYPE,
+    BLOB_PACK_RECEIPT_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, CacheDigest, CacheDirectory,
+    CacheFileNode, DIRECTORY_MEDIA_TYPE, PROTOCOL_VERSION, RemoteActionResult, RestoreStats,
+    RustcMetadata, TASK_ACTION_MANIFEST_MEDIA_TYPE, canonical_json,
 };
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -381,6 +382,14 @@ fn protocol_constants_match_the_contract() {
     assert_eq!(
         BLOB_PACK_MEDIA_TYPE,
         "application/vnd.mbx.cache-blob-pack.v1"
+    );
+    assert_eq!(
+        ACTION_RESULT_BATCH_MEDIA_TYPE,
+        "application/vnd.mbx.cache-action-result-batch.v1+json"
+    );
+    assert_eq!(
+        BLOB_PACK_RECEIPT_MEDIA_TYPE,
+        "application/vnd.mbx.cache-blob-pack-receipt.v1+json"
     );
 }
 

--- a/crates/mbx-cache-protocol/src/lib.rs
+++ b/crates/mbx-cache-protocol/src/lib.rs
@@ -34,6 +34,15 @@ pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
 pub const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mbx.cache-blob-pack.v1";
 /// Media type for a JSON list of digests.
 pub const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mbx.cache-digests.v1+json";
+/// Media type for a JSON batch of [`ActionResult`] records.
+///
+/// Each record names the action it belongs to, so the batch is unordered and
+/// carries only the results a service actually holds.
+pub const ACTION_RESULT_BATCH_MEDIA_TYPE: &str =
+    "application/vnd.mbx.cache-action-result-batch.v1+json";
+/// Media type for the receipt describing an accepted blob-pack upload.
+pub const BLOB_PACK_RECEIPT_MEDIA_TYPE: &str =
+    "application/vnd.mbx.cache-blob-pack-receipt.v1+json";
 /// Header declaring the number of blobs in a blob pack.
 pub const BLOB_PACK_BLOBS_HEADER: &str = "mbx-cache-pack-blobs";
 /// Header declaring the total payload bytes in a blob pack.
@@ -450,9 +459,19 @@ pub struct CapabilityFeatures {
     /// Missing-blob batch queries are available.
     #[serde(default)]
     pub batch: bool,
+    /// Batched action-result lookups are available.
+    ///
+    /// Distinct from [`Self::batch`], which covers missing-blob queries only. A
+    /// service that answered those before this feature existed advertises
+    /// `batch` without implementing the action-result endpoint.
+    #[serde(default)]
+    pub action_batch: bool,
     /// Framed blob-pack downloads are available.
     #[serde(default)]
     pub blob_packs: bool,
+    /// Framed blob-pack uploads are available.
+    #[serde(default)]
+    pub blob_pack_uploads: bool,
     /// Resumable uploads are available.
     #[serde(default)]
     pub resumable_uploads: bool,

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -423,6 +423,8 @@ struct StatsReport {
     uploaded_bytes: u64,
     background_uploads: u64,
     background_upload_failures: u64,
+    remote_blob_pack_uploads: u64,
+    remote_blob_pack_upload_blobs: u64,
     upload_drain_duration_ns: u64,
     stored_bytes: u64,
     restored_output_files: u64,
@@ -497,6 +499,8 @@ impl From<&AgentStats> for StatsReport {
             uploaded_bytes: stats.uploaded_bytes,
             background_uploads: stats.background_uploads,
             background_upload_failures: stats.background_upload_failures,
+            remote_blob_pack_uploads: stats.remote_blob_pack_uploads,
+            remote_blob_pack_upload_blobs: stats.remote_blob_pack_upload_blobs,
             upload_drain_duration_ns: stats.upload_drain_duration_ns,
             stored_bytes: stats.stored_bytes,
             restored_output_files: stats.restored_output_files,
@@ -632,8 +636,16 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
         format_nanos(stats.materialization_duration_ns),
     ));
     if stats.background_uploads > 0 || stats.background_upload_failures > 0 {
+        let packed = if stats.remote_blob_pack_uploads > 0 {
+            format!(
+                " ({} of them in {} packs)",
+                stats.remote_blob_pack_upload_blobs, stats.remote_blob_pack_uploads
+            )
+        } else {
+            String::new()
+        };
         note(&format!(
-            "mbx[cache]: uploads: {} published, {} not published; {} waited for after the build",
+            "mbx[cache]: uploads: {} published{packed}, {} not published; {} waited for after the build",
             stats.background_uploads,
             stats.background_upload_failures,
             format_nanos(stats.upload_drain_duration_ns),

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -41,8 +41,26 @@ uses these resources:
 | capabilities | `GET /v1/capabilities` | JSON capability document |
 | action result | `GET`/`PUT /v1/action-results/{algorithm}/{hash}/{size}` | `application/vnd.mbx.cache-action-result.v1+json` |
 | action manifest | `GET`/`PUT /v1/action-manifests/{algorithm}/{hash}/{size}` | `application/vnd.mbx.cache-task-action-manifest.v1+json` |
+| action result batch | `POST /v1/action-results:batch` | `application/vnd.mbx.cache-action-result-batch.v1+json` |
 | blob | `GET`/`PUT /v1/blobs/{algorithm}/{hash}/{size}` | media type requested by the caller |
 | blob pack | `POST /v1/blobs:pack` | `application/vnd.mbx.cache-blob-pack.v1` |
+| blob pack upload | `POST /v1/blobs:pack-upload` | `application/vnd.mbx.cache-blob-pack-receipt.v1+json` |
+
+Both batched resources are extensions, gated on their own capability
+(`features.action_batch` and `features.blob_pack_uploads`) and bounded by
+`limits.max_batch_items` and `limits.max_pack_bytes`. A client falls back to the
+single-object resources when a feature is not advertised, and also when an
+advertised endpoint answers `404`, `405`, or `501` — after which it stops asking
+for the rest of the session. Neither is required to serve the baseline.
+
+A batched action-result response carries only the records the service holds, in
+no order, so each one is bound to its request by the action digest inside it
+rather than by position: a client refuses a batch naming an action it did not
+ask for. An uploaded pack repeats the `MBXPACK1` framing of a downloaded one and
+declares its contents in the pack headers; because every blob in it is
+content-addressed and immutable, a rejected pack may leave an accepted prefix
+stored, and the client republishes its blobs individually rather than relying on
+that.
 
 The capabilities endpoint is optional: `404`, `405`, or `501` selects the v1
 baseline without extensions. Advertised capabilities must report the same

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -107,6 +107,24 @@ mbx[cache]: uploads: 143 published, 0 not published; 412ms waited for after the 
 `MBX_STATS_REPORT` carries the same figures as `background_uploads`,
 `background_upload_failures`, and `upload_drain_duration_ns`.
 
+Where the server accepts them, queued blobs are published several to a request
+rather than one at a time — rustc output is many small objects, so one request
+each spends most of its time in round trips. The summary says how many went that
+way, and `remote_blob_pack_uploads` and `remote_blob_pack_upload_blobs` report
+it. A pack the server refuses is republished blob by blob, which also says which
+blob was the problem.
+
+## Batched lookups
+
+A prefetch knows every action it wants before it asks for any of them, so where
+the server offers batched lookups it asks for them together instead of once per
+action. `remote_action_lookups` counts requests rather than actions, so the same
+build reports far fewer of them against a server with the extension.
+
+Both extensions are negotiated. A server without them, or one that advertises an
+endpoint it does not serve, gets the single-object requests every version of mbx
+has made; nothing needs configuring either way.
+
 ## Transfer behavior
 
 Remote blobs are compressed with zstd. `MBX_HTTP_DOWNLOAD_TIMEOUT` is separate


### PR DESCRIPTION
> **Stacked on [#126](https://github.com/jdx/mr-boxington/pull/126)** — based on `feat/background-uploads`, so review that one first. Rebase onto `main` when it lands.

## Why

Two remaining asymmetries from the [kache](https://github.com/kunobi-ninja/kache) comparison, both about round trips rather than bytes. A rustc cache moves thousands of small objects, so per-object request latency dominates:

1. **Prefetch asked for one action at a time.** It resolves predicted actions with a `GET /v1/action-results/...` each, 48-wide. It already knows the whole set up front — a large workspace just spends its prefetch latency in round trips.
2. **Uploads were individual `PUT`s.** Downloads have batched into `MBXPACK1` packs for a while; the upload direction never did.

## What changed

Both are capability-gated protocol extensions, and both fall back to exactly what mbx has always sent.

### Batched action lookups — `POST /v1/action-results:batch`

Reuses `DIGEST_LIST_MEDIA_TYPE` for the request (same shape as the pack download) and adds `ACTION_RESULT_BATCH_MEDIA_TYPE` for the response, which carries only the results the server holds, unordered.

Since the requested digest is no longer in the URL, **each record is bound to its request by the action digest inside it**: a batch naming an action the client did not ask for is refused, not ignored. Without that check a buggy or hostile server could key cached outputs under digests this client never derived, straight through the prefetch path.

Gated on a new `features.action_batch` rather than the existing `features.batch` — that one is documented as missing-blob queries and servers already advertise it, so reusing it would guarantee 404s against everything deployed today.

The foreground single lookup is unchanged: it is latency-sensitive and single-key, and its coalescing/memo behaviour stays as is.

### Packed uploads — `POST /v1/blobs:pack-upload`

Same `MBXPACK1` framing as the download direction, streamed from the CAS rather than buffered, zstd when negotiated, declared in the existing pack headers. Its own path (not `PUT /v1/blobs:pack`) because a server has to put this route behind the decompression and body-limit layers that the download `POST` deliberately avoids.

The upload queue from #126 is what makes this possible — it is the one place where several pending blobs are visible at once. Blobs too large for a pack, and leftover groups of one, are sent individually; a pack of one costs the same round trip as the blob.

Failure handling is conservative: any rejected or unsupported pack republishes its members individually, and member tickets only resolve as published on success — so the ordering guarantee for action results in #126 still holds. An accepted prefix left behind by a rejected pack is harmless, since blobs are content-addressed and immutable.

### Advertised-but-absent

Both features latch off for the session on `404`/`405`/`501` from an advertised endpoint, mirroring the existing `blob_packs_disabled` kill switch, so a lying server costs one round trip rather than one per wave.

## Stats

`remote_action_lookups` now counts requests rather than actions, so the same build reports far fewer against a batching server. New `remote_blob_pack_uploads` / `remote_blob_pack_upload_blobs` appear in `MBX_STATS_REPORT` and in the summary:

```text
mbx[cache]: uploads: 143 published (138 of them in 12 packs), 0 not published; 84ms waited for after the build
```

## Tests

11 new tests. Client level (`core_tests.rs`): batch happy path with an unknown envelope field, fallback when unadvertised, latch-off after a 404, refusal of an unrequested result; pack upload asserting the exact framing and headers the server will parse, fallback when unadvertised, refusal over the negotiated size. Agent level (`agent_tests.rs`): a prefetch resolving three predictions in one lookup with the per-action endpoints at `expect(0)`, the same prefetch falling back when the endpoint 404s, three queued blobs published as one pack, and a rejected pack falling back to individual uploads.

Protocol constants asserted in `agent_protocol.rs`; no `AGENT_PROTOCOL_VERSION` bump and no fixture change, since the shim/agent messages are untouched.

## Follow-up

The server side (`jdx/mr-boxington-cache`) needs both endpoints, plus a bulk action-result query and a frame parser, and can only bump to a released `mbx-cache-protocol` after this merges. That is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote cache negotiation, prefetch, and background upload paths with new validation and fallbacks; incorrect batch binding or pack failure handling could affect cache hit rate or upload latency, but design explicitly preserves prior single-request behavior and refuses malformed batch responses.
> 
> **Overview**
> Adds two **capability-gated** remote cache extensions that cut round trips on rustc-scale workloads, with **unchanged single-object behavior** when a server does not advertise them or returns `404`/`405`/`501` (those endpoints are latched off for the rest of the session).
> 
> **Batched action lookups** (`POST /v1/action-results:batch`, `features.action_batch`): `RemoteCacheClient::get_action_results` issues digest-list requests and validates that every returned record matches a requested action. Prefetch tries batched resolution first (`prefetch_action_batches`), then falls back to per-action `GET`s for anything still unstaged.
> 
> **Packed blob uploads** (`POST /v1/blobs:pack-upload`, `features.blob_pack_uploads`): queued background blobs are grouped and streamed as `MBXPACK1` (optional zstd) instead of one `PUT` each; rejected or unsupported packs republish members individually so action-result ordering guarantees stay intact.
> 
> Protocol constants and docs are extended; session stats add `remote_blob_pack_uploads` / `remote_blob_pack_upload_blobs`, and **`remote_action_lookups` counts HTTP requests**, not actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc12841f31918953c531e2f601aa69364e9f5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->