### PR TITLE
fix: symlink the session shim so macOS cannot kill it at exec

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -422,7 +422,11 @@ fn setup_at_action(
     if let Some(configured) = configured {
         if owns_configuration {
             std::fs::create_dir_all(install_dir)?;
-            crate::session::install_shim(executable, install_dir)?;
+            crate::session::install_shim(
+                executable,
+                install_dir,
+                crate::session::ShimLink::Pinned,
+            )?;
             let verb = if action == SetupAction::Update {
                 "updated"
             } else {
@@ -440,7 +444,8 @@ fn setup_at_action(
     }
 
     std::fs::create_dir_all(install_dir)?;
-    let shim = crate::session::install_shim(executable, install_dir)?;
+    let shim =
+        crate::session::install_shim(executable, install_dir, crate::session::ShimLink::Pinned)?;
     document["build"]["rustc-wrapper"] = toml_edit::value(shim.to_string_lossy().into_owned());
     let parent = config_path
         .parent()

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -757,9 +757,19 @@ pub fn install_shim(executable: &Path, directory: &Path, link: ShimLink) -> Resu
 /// A failure is not an error: the hard link the caller falls back to is what
 /// every shim was before, so the only thing lost is the race described on
 /// [`install_shim`].
+///
+/// Declined for a target a symlink would name differently than a hard link
+/// would. `link(2)` and `copy` read a relative target from the caller's working
+/// directory and refuse one that is not there; a symlink stores the string and
+/// resolves it from the shim's own directory, so either input would install a
+/// wrapper pointing at nothing and leave cargo to discover it. Handing those
+/// back to the hard link keeps one answer for what the argument means, and the
+/// missing case fails where it happened instead of inside the build.
 #[cfg(unix)]
 fn symlink_shim(executable: &Path, shim: &Path) -> bool {
-    std::os::unix::fs::symlink(executable, shim).is_ok()
+    executable.is_absolute()
+        && executable.exists()
+        && std::os::unix::fs::symlink(executable, shim).is_ok()
 }
 
 /// Windows has no shim symlinks: creating one needs a privilege ordinary

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -758,18 +758,24 @@ pub fn install_shim(executable: &Path, directory: &Path, link: ShimLink) -> Resu
 /// every shim was before, so the only thing lost is the race described on
 /// [`install_shim`].
 ///
-/// Declined for a target a symlink would name differently than a hard link
-/// would. `link(2)` and `copy` read a relative target from the caller's working
-/// directory and refuse one that is not there; a symlink stores the string and
-/// resolves it from the shim's own directory, so either input would install a
-/// wrapper pointing at nothing and leave cargo to discover it. Handing those
-/// back to the hard link keeps one answer for what the argument means, and the
-/// missing case fails where it happened instead of inside the build.
+/// The target is absolutized first, because the two kinds of link do not read a
+/// relative one the same way: `link(2)` and `copy` resolve it from the caller's
+/// working directory, while a symlink resolves it from the shim's own directory
+/// -- a temporary one that shares nothing with the caller's. Resolving it here
+/// gives the argument one meaning. Absolutizing rather than declining, because a
+/// relative target must still get a symlink: `current_exe()` has been absolute
+/// on every platform mbx runs on, but nothing in its contract promises that, and
+/// a shim that quietly stopped tracking would put the kill back.
+///
+/// A target that is not there gets no symlink at all. A hard link and a copy
+/// both refuse one, and a symlink would instead name it and leave cargo to
+/// discover the dangling wrapper mid-build.
 #[cfg(unix)]
 fn symlink_shim(executable: &Path, shim: &Path) -> bool {
-    executable.is_absolute()
-        && executable.exists()
-        && std::os::unix::fs::symlink(executable, shim).is_ok()
+    let Ok(target) = std::path::absolute(executable) else {
+        return false;
+    };
+    target.exists() && std::os::unix::fs::symlink(&target, shim).is_ok()
 }
 
 /// Windows has no shim symlinks: creating one needs a privilege ordinary

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -678,14 +678,51 @@ fn cache_misses(stats: &AgentStats) -> u64 {
 
 fn install_session_shim(session_dir: &Path) -> Result<PathBuf> {
     let executable = std::env::current_exe().wrap_err("failed to locate the running mbx binary")?;
-    install_shim(&executable, session_dir)
+    install_shim(&executable, session_dir, ShimLink::Tracking)
+}
+
+/// How an installed shim refers to the mbx binary behind it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShimLink {
+    /// A symlink: the shim is whatever binary that path holds when it runs.
+    Tracking,
+    /// A hard link, or a copy where the filesystem cannot link: the bytes that
+    /// were there on the day the shim was installed.
+    Pinned,
 }
 
 /// Install a rustc shim into `directory` as a link to `executable`.
 ///
-/// The shim must be the same binary as the agent: the handshake requires an
-/// exact version match, which a hard link guarantees for free.
-pub fn install_shim(executable: &Path, directory: &Path) -> Result<PathBuf> {
+/// The shim must be the same binary as the agent -- the handshake requires an
+/// exact version match -- so it is a link to the running binary rather than an
+/// independently built copy.
+///
+/// Which kind of link matters more than it looks. On macOS, exec of a path that
+/// `link(2)` created moments ago is intermittently killed outright: SIGKILL, no
+/// output, no crash report, nothing in the system log. Measured on macOS 26.6
+/// (Apple silicon) at about one exec in eight hundred under heavy parallel
+/// load, against a binary nothing was writing, and far more readily for a large
+/// image -- the 50 MB debug build of mbx died where a 500 KB one never did,
+/// which is the shape a race in per-page signature validation would have. The
+/// window closes about half a second after the link appears, and the same path
+/// then runs fine forever. Exec of the original path never fails, and neither
+/// does exec of a symlink to it -- the kernel resolves that to a file whose
+/// signature it validated long ago. Reading the new link through first,
+/// fsyncing it and its directory, and taking the first exec ourselves to spend
+/// the race were all tried, and none of them helped.
+///
+/// So [`ShimLink::Tracking`] is for the session shim, which cargo execs a few
+/// milliseconds after it is installed to ask `rustc -vV` what compiler it has.
+/// [`ShimLink::Pinned`] is for the plain-cargo wrapper `mbx setup` installs,
+/// where nothing execs the shim for as long as it takes to type another command
+/// and a hard link keeps working even if the binary it was made from is deleted.
+///
+/// The one thing tracking gives up: replace the mbx binary underneath a running
+/// build and the session shim follows it, so cargo either execs nothing (the
+/// path is gone, and the build stops with a plain error) or execs a version the
+/// agent will not shake hands with, which bypasses the cache for the rest of the
+/// build. Both are loud and self-inflicted, unlike the kill they replace.
+pub fn install_shim(executable: &Path, directory: &Path, link: ShimLink) -> Result<PathBuf> {
     let filename = if cfg!(windows) {
         format!("{RUSTC_SHIM_STEM}.exe")
     } else {
@@ -693,6 +730,9 @@ pub fn install_shim(executable: &Path, directory: &Path) -> Result<PathBuf> {
     };
     let shim = directory.join(filename);
     let _ = std::fs::remove_file(&shim);
+    if link == ShimLink::Tracking && symlink_shim(executable, &shim) {
+        return Ok(shim);
+    }
     if let Err(link_error) = std::fs::hard_link(executable, &shim) {
         std::fs::copy(executable, &shim).wrap_err_with(|| {
             format!("failed to install the rustc shim by hard link ({link_error}) or copy")
@@ -710,6 +750,24 @@ pub fn install_shim(executable: &Path, directory: &Path) -> Result<PathBuf> {
         std::fs::set_permissions(&shim, permissions)?;
     }
     Ok(shim)
+}
+
+/// Point `shim` at `executable` by symlink, reporting whether that worked.
+///
+/// A failure is not an error: the hard link the caller falls back to is what
+/// every shim was before, so the only thing lost is the race described on
+/// [`install_shim`].
+#[cfg(unix)]
+fn symlink_shim(executable: &Path, shim: &Path) -> bool {
+    std::os::unix::fs::symlink(executable, shim).is_ok()
+}
+
+/// Windows has no shim symlinks: creating one needs a privilege ordinary
+/// accounts lack, and the code-signature race they exist to avoid is a macOS
+/// kernel behaviour with no Windows counterpart.
+#[cfg(windows)]
+fn symlink_shim(_executable: &Path, _shim: &Path) -> bool {
+    false
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -323,16 +323,30 @@ fn a_shim_is_never_installed_as_a_link_to_nothing() {
     }
 }
 
-/// A relative target is not a symlink's to interpret.
+/// A relative target is resolved before it is linked, not after.
 ///
-/// It would resolve from the shim's directory rather than the working directory
-/// a hard link reads it from, which is a different file whenever the two differ.
+/// A symlink resolves its target from the shim's own directory, and the session
+/// shim's directory is a temporary one that shares nothing with the caller's, so
+/// the relative target a hard link would have read from the working directory
+/// has to be resolved against that directory here. `Cargo.toml` stands in for
+/// the binary: under test is how the path is read, not what it points at.
 #[cfg(unix)]
 #[test]
-fn a_relative_target_is_left_to_the_hard_link() {
+fn a_relative_target_is_resolved_before_it_is_linked() {
     let directory = tempfile::tempdir().unwrap();
-    assert!(!symlink_shim(
-        Path::new("relative/mbx"),
-        &directory.path().join(RUSTC_SHIM_STEM)
-    ));
+    let shim = directory.path().join(RUSTC_SHIM_STEM);
+    assert!(symlink_shim(Path::new("Cargo.toml"), &shim));
+
+    let target = std::fs::read_link(&shim).unwrap();
+    assert!(
+        target.is_absolute(),
+        "{} should be absolute",
+        target.display()
+    );
+    // Resolves through the link, which it could not if the target had been left
+    // relative: the shim's own directory holds no `Cargo.toml`.
+    assert_eq!(
+        std::fs::canonicalize(&shim).unwrap(),
+        std::fs::canonicalize("Cargo.toml").unwrap()
+    );
 }

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -304,3 +304,35 @@ fn the_installed_wrapper_pins_the_bytes_it_was_made_from() {
         std::fs::metadata(&executable).unwrap().len()
     );
 }
+
+/// No shim is ever installed as a link to nothing.
+///
+/// A symlink can name a target that does not exist, so the tracking path has to
+/// decline one; the hard link it falls back to then fails where the mistake was
+/// made rather than when cargo execs the wrapper.
+#[cfg(unix)]
+#[test]
+fn a_shim_is_never_installed_as_a_link_to_nothing() {
+    let directory = tempfile::tempdir().unwrap();
+    for missing in [directory.path().join("gone"), PathBuf::from("relative/mbx")] {
+        assert!(
+            install_shim(&missing, directory.path(), ShimLink::Tracking).is_err(),
+            "{} should not install a shim",
+            missing.display()
+        );
+    }
+}
+
+/// A relative target is not a symlink's to interpret.
+///
+/// It would resolve from the shim's directory rather than the working directory
+/// a hard link reads it from, which is a different file whenever the two differ.
+#[cfg(unix)]
+#[test]
+fn a_relative_target_is_left_to_the_hard_link() {
+    let directory = tempfile::tempdir().unwrap();
+    assert!(!symlink_shim(
+        Path::new("relative/mbx"),
+        &directory.path().join(RUSTC_SHIM_STEM)
+    ));
+}

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -257,3 +257,50 @@ fn finds_crate_names_in_transparent_invocations() {
     );
     assert_eq!(crate_name_argument(&["--version".into()]), None);
 }
+
+/// The session shim must be a symlink, not a hard link.
+///
+/// Cargo execs it within milliseconds of its creation, and a hard link that new
+/// is not reliably runnable on macOS -- see [`install_shim`]. Asserted on the
+/// kind of link rather than by racing the kernel, which no test can do
+/// dependably.
+#[cfg(unix)]
+#[test]
+fn the_session_shim_tracks_the_binary_it_was_installed_from() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = std::env::current_exe().unwrap();
+    let shim = install_shim(&executable, directory.path(), ShimLink::Tracking).unwrap();
+
+    let metadata = std::fs::symlink_metadata(&shim).unwrap();
+    assert!(
+        metadata.file_type().is_symlink(),
+        "the session shim should be a symlink, found {metadata:?}"
+    );
+    assert_eq!(std::fs::read_link(&shim).unwrap(), executable);
+}
+
+/// The `mbx setup` wrapper keeps the bytes it was installed from.
+///
+/// A symlink there would break the moment the binary it names is deleted, and
+/// nothing execs it soon enough for the race to matter.
+#[cfg(unix)]
+#[test]
+fn the_installed_wrapper_pins_the_bytes_it_was_made_from() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = std::env::current_exe().unwrap();
+    let shim = install_shim(&executable, directory.path(), ShimLink::Pinned).unwrap();
+
+    assert!(
+        !std::fs::symlink_metadata(&shim)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    // Length rather than contents: the point is that the shim is a file of its
+    // own and not a name that can dangle, and reading the binary twice to prove
+    // it costs a hundred megabytes.
+    assert_eq!(
+        std::fs::metadata(&shim).unwrap().len(),
+        std::fs::metadata(&executable).unwrap().len()
+    );
+}

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -79,14 +79,19 @@ fn cargo() -> std::ffi::OsString {
 #[test]
 fn transparent_rustc_replaces_the_shim_process() {
     let directory = tempfile::tempdir().unwrap();
-    let shim =
-        mbx::session::install_shim(Path::new(env!("CARGO_BIN_EXE_mbx")), directory.path()).unwrap();
+    let shim = mbx::session::install_shim(
+        Path::new(env!("CARGO_BIN_EXE_mbx")),
+        directory.path(),
+        mbx::session::ShimLink::Tracking,
+    )
+    .unwrap();
     let pid_file = directory.path().join("compiler.pid");
 
-    // Retried because exec of a just-written executable can transiently fail
-    // with ETXTBSY: a sibling test may fork while its own shim copy is still
-    // open for write, and until that child reaches its exec, the inherited
-    // descriptor (cloexec or not) counts as a writer of this file too.
+    // Retried because exec of the binary behind the shim can transiently fail
+    // with ETXTBSY: anyone holding it open for write blocks the exec, and a
+    // sibling test that forks while cargo is writing it counts, since until
+    // that child reaches its own exec the inherited descriptor (cloexec or not)
+    // is a writer of this file too.
     let mut child = {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
@@ -157,7 +162,8 @@ fn build_with(
     let output = command.output().expect("mbx should run");
     assert!(
         output.status.success(),
-        "build failed: {}",
+        "build failed ({}): {}",
+        output.status,
         String::from_utf8_lossy(&output.stderr)
     );
     let stats = std::fs::read(report).expect("a statistics report should be written");
@@ -176,7 +182,8 @@ fn mbx(store: &Path, arguments: &[&str]) -> String {
         .expect("mbx should run");
     assert!(
         output.status.success(),
-        "{arguments:?} failed: {}",
+        "{arguments:?} failed ({}): {}",
+        output.status,
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8_lossy(&output.stdout).into_owned()


### PR DESCRIPTION
`mbx`'s integration tests intermittently failed on macOS under heavy parallel
load, and not by assertion: the freshly installed shim was killed by the OS.

```
error: process didn't exit successfully: `/var/folders/.../mbx-session-XXXX/mbx-rustc /Users/.../bin/rustc -vV` (signal: 9, SIGKILL: kill)
```

## Root cause

On macOS, **exec of a path that `link(2)` created moments ago** is intermittently
killed outright: SIGKILL, empty stderr, no crash report, nothing in the unified
log (checked for code-signing, AMFI, and jetsam; no `JetsamEvent` report either).
`install_shim` hard-linked the running mbx binary into the session directory, and
cargo's first act is to exec that brand-new link as `mbx-rustc <rustc> -vV` to
identify the compiler — squarely inside the window.

This is not the just-written-executable hazard the neighbouring ETXTBSY retry
documents. On macOS the session directory and the checkout are the same APFS
volume, so `install_shim` always hard-linked; nothing was ever written.

## Evidence

16 workers, two concurrent cargo builds, one frozen binary nothing was writing:

| what is exec'd | killed |
|---|---|
| the binary's own path | 0 / 1680 |
| its own path, while 2742 hard links to it churn | 0 / 720 |
| **a fresh hard link** | **5 / 3840** |
| fresh hard link, opened and closed first | 1 / 960 |
| fresh hard link, whole image read first | 2 / 960 (one retry died too) |
| fresh hard link, file and directory fsynced | 10 / 960 |
| fresh hard link, first exec absorbed by us | 5 / 960 |
| fresh hard link, exec'd half a second later | 0 / 960 |
| **a symlink** | **0 / 2880** |
| a copy, and clonefile then rename | 0 / 864, 0 / 2080 |

It takes a *new hard link*, the window closes in about half a second, and it only
bites a large image — the 50 MB debug build died where a 500 KB one never did,
which is the shape a race in per-page signature validation would have. Retrying,
fsync, and faulting the image in first are all useless.

## The change

`install_shim` now takes a `ShimLink`.

- The **session shim** is `Tracking`: a symlink, which the kernel resolves to a
  file whose signature it validated long ago. Symlink failure falls back to the
  old hard-link path, and Windows keeps hard links — no symlink privilege there,
  and no such race.
- The **`mbx setup` wrapper** stays `Pinned`: nothing execs it for as long as it
  takes to type another command, and a hard link keeps working if the binary it
  was made from is deleted.

Two unit tests pin each choice rather than racing the kernel, which no test can
do dependably.

Both test helpers now print the child's exit status. Without it the failure reads
as `build failed:` with nothing after the colon, which is most of why this went
uncharacterised.

## Not test-only

Every `mbx build` installs a session shim and cargo execs it milliseconds later,
so this fails real builds too, which is why the fix is in the product. The
adjacent path where cargo execs a restored `build-script-build` was checked and
is not exposed: reflink/copy-then-rename saw 0 kills in 2080 execs, including
with a 50 MB image.

## Verification

Same machine, same load, back to back, 45 full-suite rounds each: **2 failures
before, 0 after.** Plus `cargo test --workspace` (346 tests), all 16 bats e2e
tests, clippy `-D warnings`, and fmt — all clean.

One tradeoff taken deliberately, documented at the call site: replace the mbx
binary underneath a running build and a symlinked shim follows it, so cargo
either stops with a plain "no such file" or bypasses the cache on a handshake
mismatch. Both are loud and self-inflicted, unlike the silent kill they replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the rustc shim is installed on every build (session startup path), though Windows behavior is unchanged and symlink failure still falls back to the prior hard-link path.
> 
> **Overview**
> Fixes intermittent **SIGKILL** when Cargo execs a freshly installed `mbx-rustc` shim on macOS by no longer relying on a **brand-new hard link** for the session wrapper.
> 
> `install_shim` now takes a **`ShimLink`** mode: **`Tracking`** installs a **symlink** to the running binary (with absolutized target and hard-link fallback if symlink fails) for the per-build session shim Cargo runs almost immediately; **`Pinned`** keeps **hard link / copy** behavior for **`mbx setup`**’s long-lived Cargo `rustc-wrapper`, which is not exec’d right after install.
> 
> Unix tests assert tracking vs pinned link kinds, missing targets fail install, and relative paths are resolved before symlinking; integration tests pass **`ShimLink::Tracking`** and include child **exit status** in failure messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424e7f69573de5dc0d219251a15c7d7dd5160315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wrapper behavior on macOS by reducing execution conflicts during shim updates.
  * Existing Cargo wrappers now refresh reliably without disrupting active processes.

* **Improvements**
  * Added more consistent handling for tracked and installed command wrappers.
  * Improved validation of wrapper installation behavior across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->