### PR TITLE
docs: compare mbx to kache

### DIFF
--- a/docs/compared.md
+++ b/docs/compared.md
@@ -35,7 +35,14 @@ compilation, sccache is the right tool. Both wrap rustc through
 [kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx,
 and the comparison comes with a debt: parts of mbx's design were inspired by
 kache. No code is shared between the projects, but the influence is real and
-worth acknowledging. Like mbx, it is a content-addressed `RUSTC_WRAPPER`
+worth acknowledging. mbx has a lineage of its own: it began as the Rust task
+cache inside the [mise](https://github.com/jdx/mise) task runner and was
+later extracted into a standalone CLI, on the theory that a dedicated tool
+could improve the day-to-day experience, be simpler to operate, and be safe
+for public repositories that take fork pull requests. Most of the
+differences below trace back to those three goals.
+
+Like mbx, kache is a content-addressed `RUSTC_WRAPPER`
 cache built for sharing compilations across worktrees, with C/C++ compiler
 shims, S3-compatible remotes, and executable caching on Linux and macOS. It
 also publishes a scheduled benchmark workflow that builds Firefox, LLVM, and
@@ -55,14 +62,21 @@ not offer today. The differences are in the mechanics:
   cache — the two names are the same file. mbx restores by reflink, a
   copy-on-write clone that diverges on first write, and falls back to a
   plain byte copy where the filesystem cannot clone, never to a hardlink.
-- **CI write policy and remote auth.** kache's remotes are S3-compatible
-  buckets reached through the standard AWS credential chain, and its README
-  states no policy on what may publish from pull requests — whatever the
-  credentials allow, any build can write. mbx's client refuses to publish
-  from pull requests and unprotected branches and disables caching entirely
-  on tag builds, and its remote is a namespaced protocol server with
-  deny-by-default token and OIDC grants rather than a bucket the build
-  writes to directly.
+- **CI write policy.** kache's README states no policy on what may publish
+  from pull requests — whatever the credentials allow, any build can write.
+  mbx's client refuses to publish from pull requests and unprotected
+  branches and disables caching entirely on tag builds, before the server
+  enforces anything.
+- **A server, not a bucket.** kache's remotes are S3-compatible buckets
+  reached through the standard AWS credential chain. mbx's remote is a
+  namespaced protocol server with guardrails a bucket cannot express:
+  deny-by-default grants with separate read and write namespace patterns,
+  OIDC rules that pin a repository and its immutable numeric owner ID and
+  can narrow to a `ref` or `environment`, immutable blobs with atomic
+  action commits, and no deletion endpoint — a credentialed writer can add
+  results but never rewrite or remove what an earlier build published. Fork
+  pull requests hold no credentials at all and fall back to a read-only
+  platform cache; see [fork PRs](/cookbook/fork-prs).
 - **C/C++ scope.** kache's shims sit on `PATH`, so C/C++ built outside cargo
   (CMake, for example) is in scope. mbx caches the C and C++ that cargo
   build scripts compile through the `cc` crate — it follows the cargo build
@@ -71,11 +85,11 @@ not offer today. The differences are in the mechanics:
   mbx it is opt-in (`MBX_CACHE_LINKS=1`) and experimental, and the key
   includes the resolved linker, startup objects, libc, and SDK rather than
   dep-info alone.
-- **A store other tools embed.** mbx's cache crates also power Rust task
-  caching in the [mise](https://github.com/jdx/mise) task runner: a task run
-  through mise and a direct mbx build fill and hit the same shared action
-  store and speak the same remote protocol, so each warms the other. kache's
-  integration points are its compiler wrappers and its GitHub Action.
+- **A store other tools embed.** The extraction from mise went both ways:
+  mise now embeds mbx's cache crates, so a task run through mise and a
+  direct mbx build fill and hit the same shared action store and speak the
+  same remote protocol, each warming the other. kache's integration points
+  are its compiler wrappers and its GitHub Action.
 
 If your repository mixes cargo with substantial C/C++ under other build
 systems, or you want published benchmark numbers to check claims against,

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -71,6 +71,11 @@ not offer today. The differences are in the mechanics:
   mbx it is opt-in (`MBX_CACHE_LINKS=1`) and experimental, and the key
   includes the resolved linker, startup objects, libc, and SDK rather than
   dep-info alone.
+- **A store other tools embed.** mbx's cache crates also power Rust task
+  caching in the [mise](https://github.com/jdx/mise) task runner: a task run
+  through mise and a direct mbx build fill and hit the same shared action
+  store and speak the same remote protocol, so each warms the other. kache's
+  integration points are its compiler wrappers and its GitHub Action.
 
 If your repository mixes cargo with substantial C/C++ under other build
 systems, or you want published benchmark numbers to check claims against,

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -4,8 +4,10 @@
 
 [sccache](https://github.com/mozilla/sccache) is the established compiler
 cache, and it aims wider: it caches C, C++, and CUDA alongside Rust and can
-distribute compilation across machines. mbx only caches rustc, and spends that
-narrower scope on problems sccache does not attempt:
+distribute compilation across machines. mbx caches only what a cargo build
+runs — rustc, the C and C++ its build scripts compile, and optionally its
+native links — and spends that narrower scope on problems sccache does not
+attempt:
 
 - **No daemon.** sccache runs a background server that builds talk to. mbx
   starts an in-process agent for each command and exits with it; there is
@@ -24,9 +26,56 @@ narrower scope on problems sccache does not attempt:
   from pull requests, unprotected branches, and tag builds, on top of whatever
   the server enforces.
 
-If you need C/C++ caching or distributed compilation, sccache is the right
-tool. Both wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
-the same build.
+If you need C/C++ caching outside cargo builds, CUDA, or distributed
+compilation, sccache is the right tool. Both wrap rustc through
+`RUSTC_WRAPPER`, so they cannot be combined for the same build.
+
+## kache
+
+[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx,
+and the comparison comes with a debt: parts of mbx's design were inspired by
+kache. No code is shared between the projects, but the influence is real and
+worth acknowledging. Like mbx, it is a content-addressed `RUSTC_WRAPPER`
+cache built for sharing compilations across worktrees, with C/C++ compiler
+shims, S3-compatible remotes, and executable caching on Linux and macOS. It
+also publishes a scheduled benchmark workflow that builds Firefox, LLVM, and
+other large projects cold and warm — a level of public verification mbx does
+not offer today. The differences are in the mechanics:
+
+- **No daemon.** `kache init` installs an OS service by default (there is a
+  `--no-service` opt-out). mbx starts an in-process agent for each command
+  and exits with it; there is nothing to install, restart, or leave running.
+- **Managed `target/` vs. deduplicated `target/`.** kache hardlinks outputs
+  into place, so each checkout's `target/` shares disk with the store but
+  stays where it is, pruned by `kache gc`. mbx owns the directories it
+  creates: outputs live once in the store, appear in each checkout by
+  reflink, and directories whose checkout is gone are collected
+  automatically.
+- **Restores never hardlink.** A hardlinked output shares an inode with the
+  cache — the two names are the same file. mbx restores by reflink, a
+  copy-on-write clone that diverges on first write, and falls back to a
+  plain byte copy where the filesystem cannot clone, never to a hardlink.
+- **CI write policy and remote auth.** kache's remotes are S3-compatible
+  buckets reached through the standard AWS credential chain, and its README
+  states no policy on what may publish from pull requests — whatever the
+  credentials allow, any build can write. mbx's client refuses to publish
+  from pull requests and unprotected branches and disables caching entirely
+  on tag builds, and its remote is a namespaced protocol server with
+  deny-by-default token and OIDC grants rather than a bucket the build
+  writes to directly.
+- **C/C++ scope.** kache's shims sit on `PATH`, so C/C++ built outside cargo
+  (CMake, for example) is in scope. mbx caches the C and C++ that cargo
+  build scripts compile through the `cc` crate — it follows the cargo build
+  rather than the compiler, so a standalone C project is out of scope.
+- **Executable caching.** Both cache linked binaries on Linux and macOS. In
+  mbx it is opt-in (`MBX_CACHE_LINKS=1`) and experimental, and the key
+  includes the resolved linker, startup objects, libc, and SDK rather than
+  dep-info alone.
+
+If your repository mixes cargo with substantial C/C++ under other build
+systems, or you want published benchmark numbers to check claims against,
+kache is worth evaluating. Both tools wrap rustc through `RUSTC_WRAPPER`, so
+they cannot be combined for the same build.
 
 ## Tarball CI caches
 


### PR DESCRIPTION
Adds a [kache](https://github.com/kunobi-ninja/kache) section to `docs/compared.md`, written in the same even-handed style as the existing sccache section. kache is the closest tool to mbx, and the section opens with attribution: parts of mbx's design were inspired by it, though no code is shared.

## Contrasts covered

- **No daemon** vs. kache's default OS service (`kache init --no-service` opts out)
- **Managed, pruned `target/` directories** vs. kache's hardlink dedup that leaves `target/` in place
- **Reflink-then-copy restores, never hardlinks** vs. kache's shared-inode hardlinks
- **Client-side CI write policy** (PRs and unprotected branches never publish, tags disable caching) and the namespaced token/OIDC protocol server vs. kache's direct S3 credential chain with no stated PR write policy
- **cargo-build-script C/C++ scope** vs. kache's PATH shims covering builds outside cargo
- **Opt-in experimental link caching** (`MBX_CACHE_LINKS=1`) vs. kache's Linux/macOS executable caching

kache's claims were verified against its README before writing. Its README does not name blake3, so the section says "content-addressed" without naming the hash, and describes its benchmark workflow as "scheduled" (Firefox, LLVM, Substrate, and others) rather than nightly, matching the README's wording.

## Depends on #132, #129, and jdx/mise#12509

The section describes build-script C/C++ caching and native link caching as shipped, and the sccache section's "mbx only caches rustc" framing is updated to match. It also describes the mise shared-store integration (jdx/mise#12509) as shipped: mise embeds mbx's cache crates, so mise tasks and direct mbx builds share one action store and remote protocol. **This should merge after #132, #129, and jdx/mise#12509 land.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or build behavior impact.
> 
> **Overview**
> **Expands `docs/compared.md`** with a new **kache** section that positions kache as the closest peer, credits design influence, and contrasts mechanics (daemon vs in-process agent, `target/` management and restore strategy, CI write policy, remote model, C/C++ scope, link caching, mise embedding).
> 
> **Updates the sccache section** so mbx is described as caching what a **cargo build** runs (rustc, build-script C/C++, optional native links) rather than rustc alone, and narrows when sccache is recommended to C/C++ **outside** cargo builds, CUDA, and distributed compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b074132a73028114ffaf9d57a8ea0a1d7b04f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

