### PR TITLE
fix: bound blob pack members to digest sizes

### DIFF
--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -1022,6 +1022,76 @@ async fn streams_a_pack_of_many_members_from_files() {
 }
 
 #[tokio::test]
+async fn pack_stream_stops_each_member_at_its_declared_size() {
+    let directory = tempfile::tempdir().unwrap();
+    let first_bytes = b"first packed blob";
+    let second_bytes = b"second packed blob";
+    let first = CacheDigest::blake3(first_bytes);
+    let second = CacheDigest::blake3(second_bytes);
+    let first_path = directory.path().join("first");
+    let second_path = directory.path().join("second");
+    fs::write(
+        &first_path,
+        [first_bytes.as_slice(), b"trailing bytes"].concat(),
+    )
+    .unwrap();
+    fs::write(&second_path, second_bytes).unwrap();
+    let uploads = [
+        BlobUpload {
+            digest: first.clone(),
+            source: BlobSource::Path(first_path),
+        },
+        BlobUpload {
+            digest: second.clone(),
+            source: BlobSource::Path(second_path),
+        },
+    ];
+
+    let chunks = blob_pack_stream(blob_pack_members(&uploads).unwrap())
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let pack = chunks.concat();
+
+    assert_eq!(
+        decode_blob_pack_frames(&pack),
+        vec![
+            (
+                format!("blake3:{}", first.hash),
+                first.size,
+                first_bytes.to_vec(),
+            ),
+            (
+                format!("blake3:{}", second.hash),
+                second.size,
+                second_bytes.to_vec(),
+            ),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn pack_stream_rejects_members_shorter_than_their_declared_size() {
+    let directory = tempfile::tempdir().unwrap();
+    let complete = b"complete packed blob";
+    let digest = CacheDigest::blake3(complete);
+    let path = directory.path().join("truncated");
+    fs::write(&path, &complete[..complete.len() - 1]).unwrap();
+    let uploads = [BlobUpload {
+        digest,
+        source: BlobSource::Path(path),
+    }];
+
+    let error = blob_pack_stream(blob_pack_members(&uploads).unwrap())
+        .try_collect::<Vec<_>>()
+        .await
+        .expect_err("a short member was accepted");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+    assert!(error.to_string().contains("1 bytes remaining"));
+}
+
+#[tokio::test]
 async fn uploads_negotiated_blob_packs() {
     let mut server = mockito::Server::new_async().await;
     mock_capabilities(

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -1171,6 +1171,7 @@ fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Durati
 /// past.
 struct PackMemberSource {
     header: Vec<u8>,
+    payload_bytes: u64,
     source: PackPayloadSource,
 }
 
@@ -1182,7 +1183,7 @@ enum PackPayloadSource {
 enum PackStreamState {
     Magic,
     Header(usize),
-    Payload(usize, Box<dyn AsyncRead + Send + Sync + Unpin>),
+    Payload(usize, u64, Box<dyn AsyncRead + Send + Sync + Unpin>),
     Done,
 }
 
@@ -1229,22 +1230,44 @@ fn blob_pack_stream(
                         };
                         return Some((
                             Ok(bytes::Bytes::from(member.header.clone())),
-                            (PackStreamState::Payload(index, payload), members),
+                            (
+                                PackStreamState::Payload(index, member.payload_bytes, payload),
+                                members,
+                            ),
                         ));
                     }
-                    PackStreamState::Payload(index, mut payload) => {
-                        let mut chunk = vec![0; PACK_STREAM_CHUNK_BYTES];
+                    PackStreamState::Payload(index, remaining, mut payload) => {
+                        if remaining == 0 {
+                            // The declared frame length, rather than EOF, is the
+                            // boundary between adjacent members.
+                            state = PackStreamState::Header(index + 1);
+                            continue;
+                        }
+                        let chunk_bytes =
+                            usize::try_from(remaining.min(PACK_STREAM_CHUNK_BYTES as u64)).unwrap();
+                        let mut chunk = vec![0; chunk_bytes];
                         match payload.read(&mut chunk).await {
-                            // The member is finished, so its handle is dropped
-                            // here rather than held for the whole request.
                             Ok(0) => {
-                                state = PackStreamState::Header(index + 1);
+                                let error = std::io::Error::new(
+                                    std::io::ErrorKind::UnexpectedEof,
+                                    format!(
+                                        "blob pack member {index} ended with {remaining} bytes remaining"
+                                    ),
+                                );
+                                return Some((Err(error), (PackStreamState::Done, members)));
                             }
                             Ok(read) => {
                                 chunk.truncate(read);
                                 return Some((
                                     Ok(bytes::Bytes::from(chunk)),
-                                    (PackStreamState::Payload(index, payload), members),
+                                    (
+                                        PackStreamState::Payload(
+                                            index,
+                                            remaining - read as u64,
+                                            payload,
+                                        ),
+                                        members,
+                                    ),
                                 ));
                             }
                             Err(error) => {
@@ -1265,6 +1288,7 @@ fn blob_pack_members(uploads: &[BlobUpload]) -> Result<Vec<PackMemberSource>> {
         .map(|upload| {
             Ok(PackMemberSource {
                 header: blob_pack_frame_header(&upload.digest)?,
+                payload_bytes: upload.digest.size,
                 source: match &upload.source {
                     BlobSource::Bytes(bytes) => PackPayloadSource::Bytes(bytes.clone()),
                     BlobSource::File(file) => PackPayloadSource::Path(file.path().to_path_buf()),


### PR DESCRIPTION
Follow-up to #131 addressing https://github.com/jdx/mr-boxington/pull/131#discussion_r3874632727.

- stop each streamed pack member at its declared digest size so extra source bytes cannot corrupt the next frame
- fail explicitly with `UnexpectedEof` when a source is shorter than its frame
- cover oversized and truncated file-backed sources with regression tests

Checks:
- `cargo test -p mbx-cache-core`
- `cargo clippy -p mbx-cache-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote cache pack-upload wire encoding; incorrect bounds could corrupt multi-blob uploads or reject valid uploads, but behavior now aligns with the decoder and existing single-blob size limits.
> 
> **Overview**
> **Blob pack upload streaming** no longer treats source EOF as the end of a frame. Each member now emits exactly `digest.size` bytes, matching how pack **downloads** already decode frames.
> 
> Oversized file-backed sources (extra bytes after the digest length) are truncated so trailing data cannot bleed into the next frame. Sources shorter than the declared size fail with `UnexpectedEof` and a message that includes how many bytes were still expected.
> 
> Regression tests cover both the oversized-file and truncated-file cases for `blob_pack_stream`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb211a8b3523e4c734cb4ee1a960d1b0b4ac866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->