### PR TITLE
chore: move off a yanked chacha20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
`cargo deny` fails the advisories check on `main` and on every open pull request:

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
  chacha20 0.10.1 ... yanked version
  └── rand v0.10.2
      ├── mbx
      └── mbx-cache-core
```

`chacha20 0.10.1` was yanked upstream after the lockfile was written. `rand` reaches it transitively, and 0.10.2 is the same release line, so nothing else has to move with it.

Lockfile only — one dependency, two lines. Afterwards: `advisories ok, bans ok, licenses ok, sources ok`.

Split out of [#129](https://github.com/jdx/mr-boxington/pull/129) rather than fixed there, since it blocks every branch rather than that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch bump for a yanked crate; no code or API changes.
> 
> **Overview**
> Unblocks **`cargo deny`** advisories by replacing the yanked **`chacha20` 0.10.1** entry in **`Cargo.lock`** with **0.10.2** on the same release line.
> 
> No application or manifest changes—only the lockfile checksum/version for that transitive dependency (via **`rand` 0.10.2**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd852de4871d7216da34fd4ce831b220e3945d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->