### PR TITLE
feat: cache to an S3-compatible object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "tokio",
  "toml",
  "toml_edit",
+ "url",
  "usage-config",
  "usage-rs",
  "which",

--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::*;
 
 #[test]
 fn protocol_json_uses_jcs_key_and_number_encoding() {
@@ -55,7 +56,7 @@ fn cache_digest_verifies_its_declared_algorithm() {
 
 #[test]
 fn action_result_keys_require_blake3() {
-    let client = RemoteCacheClient::new(RemoteCacheConfig {
+    let client = HttpRemoteCache::new(RemoteCacheConfig {
         base_url: "http://127.0.0.1:1".parse().unwrap(),
         namespace: "test".into(),
         token: None,
@@ -751,8 +752,8 @@ async fn downloads_decompress_zstd_responses() {
     assert_eq!(bytes, payload);
 }
 
-fn test_client(server: &mockito::ServerGuard) -> RemoteCacheClient {
-    RemoteCacheClient::new(RemoteCacheConfig {
+fn test_client(server: &mockito::ServerGuard) -> HttpRemoteCache {
+    HttpRemoteCache::new(RemoteCacheConfig {
         base_url: server.url().parse().unwrap(),
         namespace: "test".into(),
         token: Some("test-token".into()),

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -28,29 +28,18 @@
 //! ```
 #![deny(missing_docs)]
 
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use eyre::{Result, bail, eyre};
-use futures_util::TryStreamExt as _;
 use log::warn;
-use reqwest::StatusCode;
-use reqwest::header::{
-    ACCEPT, AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, ETAG, HeaderMap,
-    HeaderValue, IF_MATCH, IF_NONE_MATCH,
-};
+use reqwest::header::HeaderValue;
 use serde::{Deserialize, Serialize};
-use sha2::Digest as _;
-use std::collections::BTreeSet;
-use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
-use url::{Host, Url};
+use std::time::{Duration, Instant};
+use url::Url;
 
 mod agent;
 mod client;
 mod local;
+mod remote_http;
 mod uploads;
 
 pub use agent::{
@@ -71,6 +60,11 @@ pub use mbx_cache_protocol::{
     PROTOCOL_HEADER, PROTOCOL_VERSION, RustcMetadata, SymlinkNode as CacheSymlinkNode,
     TASK_ACTION_MANIFEST_MEDIA_TYPE, TaskActionManifest,
 };
+use remote_http::HttpRemoteCache;
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub use remote_http::fuzz_decode_blob_pack;
+pub(crate) use remote_http::{BlobPackLimits, blob_pack_chunk};
 /// Cap the JSON bodies a remote cache can hand back. Blob downloads are bounded
 /// by the size their digest promises, but action results and manifests carry no
 /// such claim, so without an explicit ceiling a hostile or broken server can
@@ -211,121 +205,6 @@ pub struct RemoteBlobPack {
     pub framed_bytes: u64,
 }
 
-struct DownloadedBlobPack {
-    directory: tempfile::TempDir,
-    blobs: Vec<(CacheDigest, PathBuf)>,
-    metadata: BlobPackResponseStats,
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-struct BlobPackResponseMetadata {
-    content_length: Option<u64>,
-    blob_count: Option<u64>,
-    payload_bytes: Option<u64>,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct BlobPackResponseStats {
-    blob_count: u64,
-    payload_bytes: u64,
-    framed_bytes: u64,
-}
-
-impl BlobPackResponseMetadata {
-    fn from_headers(headers: &HeaderMap) -> Result<Self> {
-        Ok(Self {
-            content_length: optional_u64_header(headers, CONTENT_LENGTH.as_str())?,
-            blob_count: optional_u64_header(headers, BLOB_PACK_BLOBS_HEADER)?,
-            payload_bytes: optional_u64_header(headers, BLOB_PACK_BYTES_HEADER)?,
-        })
-    }
-
-    fn validate(self, decoded: BlobPackResponseStats) -> Result<BlobPackResponseStats> {
-        if let Some(content_length) = self.content_length
-            && content_length != decoded.framed_bytes
-        {
-            bail!(
-                "remote cache blob pack content length metadata mismatch: expected {}, decoded {}",
-                content_length,
-                decoded.framed_bytes
-            );
-        }
-        if let Some(blob_count) = self.blob_count
-            && blob_count != decoded.blob_count
-        {
-            bail!(
-                "remote cache blob pack blob count metadata mismatch: expected {}, decoded {}",
-                blob_count,
-                decoded.blob_count
-            );
-        }
-        if let Some(payload_bytes) = self.payload_bytes
-            && payload_bytes != decoded.payload_bytes
-        {
-            bail!(
-                "remote cache blob pack payload byte metadata mismatch: expected {}, decoded {}",
-                payload_bytes,
-                decoded.payload_bytes
-            );
-        }
-        Ok(BlobPackResponseStats {
-            blob_count: self.blob_count.unwrap_or(decoded.blob_count),
-            payload_bytes: self.payload_bytes.unwrap_or(decoded.payload_bytes),
-            framed_bytes: self.content_length.unwrap_or(decoded.framed_bytes),
-        })
-    }
-}
-
-fn optional_u64_header(headers: &HeaderMap, name: &str) -> Result<Option<u64>> {
-    let Some(value) = headers.get(name) else {
-        return Ok(None);
-    };
-    let value = value
-        .to_str()
-        .map_err(|_| eyre!("remote cache blob pack {name} header is not valid UTF-8"))?;
-    let value = value
-        .parse::<u64>()
-        .map_err(|_| eyre!("remote cache blob pack {name} header is not an unsigned integer"))?;
-    Ok(Some(value))
-}
-
-type RemoteCacheCapabilities = Capabilities;
-
-#[derive(Debug, Clone, Copy)]
-struct BlobPackLimits {
-    max_items: usize,
-    max_bytes: u64,
-}
-
-/// What one capabilities exchange settled, cached for the session.
-///
-/// `Default` is also the answer for a server with no capabilities endpoint:
-/// no blob packs and no compression, which is exactly how every request
-/// behaved before either feature existed.
-#[derive(Debug, Clone, Copy, Default)]
-struct NegotiatedCapabilities {
-    blob_packs: Option<BlobPackLimits>,
-    blob_pack_uploads: Option<BlobPackLimits>,
-    action_batches: Option<usize>,
-    zstd_uploads: bool,
-}
-
-#[derive(Serialize)]
-struct DigestList<'a> {
-    digests: &'a [CacheDigest],
-}
-
-/// Action results a server holds, in no particular order.
-///
-/// Deliberately tolerant of fields it does not know, so a later protocol minor
-/// can describe more about a batch without this client refusing the response.
-/// The records inside stay canonical and exhaustive.
-#[derive(Deserialize)]
-struct ActionResultBatch {
-    #[serde(default)]
-    results: Vec<RemoteActionResult>,
-}
-
 /// What a server did with the blobs in an uploaded pack.
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct BlobPackReceipt {
@@ -346,227 +225,50 @@ pub enum ManifestPutOutcome {
     PreconditionFailed,
 }
 
-/// HTTP client for the mbx remote cache protocol.
+/// A client for a remote mbx cache.
 ///
 /// The client validates digests, response sizes, media types, and redirects at
 /// the protocol boundary. It is safe to share between asynchronous tasks.
+///
+/// Which service is on the other end is not part of this type's contract. A
+/// cache server speaks the full protocol; an object store answers the same
+/// lookups without the extensions built on top of it, and reports that by
+/// declining them rather than by failing.
 pub struct RemoteCacheClient {
-    base_url: Url,
-    namespace: String,
-    client: reqwest::Client,
-    credential: RemoteCacheCredential,
-    download_timeout: Duration,
-    retries: i64,
-    capabilities: tokio::sync::OnceCell<NegotiatedCapabilities>,
-    blob_packs_disabled: AtomicBool,
-    blob_pack_uploads_disabled: AtomicBool,
-    action_batches_disabled: AtomicBool,
+    backend: Backend,
+}
+
+/// The service a [`RemoteCacheClient`] talks to.
+///
+/// Backends are a closed set, so they dispatch through an enum rather than a
+/// trait: an `async fn` in a trait is not object-safe, and boxing every call to
+/// work around that would buy nothing here.
+enum Backend {
+    Http(HttpRemoteCache),
 }
 
 impl RemoteCacheClient {
     /// Construct a client and validate its URL and authentication settings.
     pub fn new(config: RemoteCacheConfig) -> Result<Self> {
-        let authenticated = config
-            .token
-            .as_deref()
-            .is_some_and(|token| !token.trim().is_empty())
-            || config.token_file.is_some()
-            || config
-                .oidc_audience
-                .as_deref()
-                .is_some_and(|audience| !audience.trim().is_empty());
-        validate_remote_url(&config.base_url, authenticated)?;
-        let client = reqwest::Client::builder()
-            .connect_timeout(config.connect_timeout)
-            .read_timeout(config.read_timeout)
-            .redirect(reqwest::redirect::Policy::none())
-            .build()?;
-        let credential = remote_credential(&config, client.clone())?;
         Ok(Self {
-            base_url: normalized_base_url(config.base_url),
-            namespace: config.namespace,
-            client,
-            credential,
-            download_timeout: config.download_timeout,
-            retries: config.retries,
-            capabilities: tokio::sync::OnceCell::new(),
-            blob_packs_disabled: AtomicBool::new(false),
-            blob_pack_uploads_disabled: AtomicBool::new(false),
-            action_batches_disabled: AtomicBool::new(false),
+            backend: Backend::Http(HttpRemoteCache::new(config)?),
         })
     }
 
-    /// Connect to the server, authenticate, and negotiate protocol capabilities.
+    /// Connect to the service, authenticate, and negotiate protocol capabilities.
     ///
     /// This performs no cache reads or writes. It is intended for diagnostics
     /// that need to distinguish a valid client configuration from a reachable,
     /// compatible remote cache.
     pub async fn check_connection(&self) -> Result<()> {
-        self.fetch_capabilities(false).await?;
-        Ok(())
-    }
-
-    fn action_result_endpoint(&self, action: &CacheDigest) -> Result<Url> {
-        action.validate()?;
-        if action.algorithm != "blake3" {
-            bail!("remote cache action keys must use blake3");
+        match &self.backend {
+            Backend::Http(client) => client.check_connection().await,
         }
-        Ok(self.base_url.join(&format!(
-            "v{PROTOCOL_VERSION}/action-results/{}/{}/{}",
-            action.algorithm, action.hash, action.size
-        ))?)
-    }
-
-    fn blob_endpoint(&self, digest: &CacheDigest) -> Result<Url> {
-        digest.validate()?;
-        Ok(self.base_url.join(&format!(
-            "v{PROTOCOL_VERSION}/blobs/{}/{}/{}",
-            digest.algorithm, digest.hash, digest.size
-        ))?)
-    }
-
-    fn action_manifest_endpoint(&self, key: &CacheDigest) -> Result<Url> {
-        key.validate()?;
-        if key.algorithm != "blake3" {
-            bail!("remote action manifest keys must use blake3");
-        }
-        Ok(self.base_url.join(&format!(
-            "v{PROTOCOL_VERSION}/action-manifests/{}/{}/{}",
-            key.algorithm, key.hash, key.size
-        ))?)
-    }
-
-    fn capabilities_endpoint(&self) -> Result<Url> {
-        Ok(self
-            .base_url
-            .join(&format!("v{PROTOCOL_VERSION}/capabilities"))?)
-    }
-
-    fn blob_pack_endpoint(&self) -> Result<Url> {
-        Ok(self
-            .base_url
-            .join(&format!("v{PROTOCOL_VERSION}/blobs:pack"))?)
-    }
-
-    fn blob_pack_upload_endpoint(&self) -> Result<Url> {
-        Ok(self
-            .base_url
-            .join(&format!("v{PROTOCOL_VERSION}/blobs:pack-upload"))?)
-    }
-
-    fn action_result_batch_endpoint(&self) -> Result<Url> {
-        Ok(self
-            .base_url
-            .join(&format!("v{PROTOCOL_VERSION}/action-results:batch"))?)
-    }
-
-    async fn request(
-        &self,
-        method: reqwest::Method,
-        url: Url,
-        media_type: &'static str,
-    ) -> Result<reqwest::RequestBuilder> {
-        let request = self
-            .client
-            .request(method, url)
-            .header(PROTOCOL_HEADER, u16::from(PROTOCOL_VERSION))
-            .header(NAMESPACE_HEADER, &self.namespace)
-            .header(ACCEPT, media_type);
-        if let Some(authorization) = self.credential.authorization().await? {
-            Ok(request.header(AUTHORIZATION, authorization))
-        } else {
-            Ok(request)
-        }
-    }
-
-    async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
-        Ok(self.negotiated_capabilities().await?.blob_packs)
-    }
-
-    async fn negotiated_capabilities(&self) -> Result<NegotiatedCapabilities> {
-        self.capabilities
-            .get_or_try_init(|| self.fetch_capabilities(true))
-            .await
-            .copied()
-    }
-
-    async fn fetch_capabilities(&self, allow_missing: bool) -> Result<NegotiatedCapabilities> {
-        let url = self.capabilities_endpoint()?;
-        let response = self
-            .request(reqwest::Method::GET, url, "application/json")
-            .await?
-            .send()
-            .await?;
-        if allow_missing
-            && matches!(
-                response.status(),
-                StatusCode::NOT_FOUND
-                    | StatusCode::METHOD_NOT_ALLOWED
-                    | StatusCode::NOT_IMPLEMENTED
-            )
-        {
-            return Ok(NegotiatedCapabilities::default());
-        }
-        let bytes = read_bounded_json(response.error_for_status()?, "capabilities").await?;
-        let capabilities: RemoteCacheCapabilities = serde_json::from_slice(&bytes)?;
-        if capabilities.protocol.major != PROTOCOL_VERSION {
-            bail!(
-                "remote cache capability protocol {} is incompatible with client protocol {PROTOCOL_VERSION}",
-                capabilities.protocol.major
-            );
-        }
-        // Compression is negotiated, never assumed: a body sent with a
-        // coding the server did not offer would be stored corrupt or
-        // rejected, so absence of the advertisement means identity.
-        let zstd_uploads = capabilities
-            .compressors
-            .iter()
-            .any(|compressor| compressor == "zstd");
-        let pack_limits = |feature: bool| -> Result<Option<BlobPackLimits>> {
-            if !feature {
-                return Ok(None);
-            }
-            let max_items = usize::try_from(capabilities.limits.max_batch_items)
-                .ok()
-                .filter(|limit| *limit > 0)
-                .ok_or_else(|| {
-                    eyre!("remote cache blob packs require a positive max_batch_items limit")
-                })?;
-            if capabilities.limits.max_pack_bytes == 0 {
-                bail!("remote cache blob packs require a positive max_pack_bytes limit");
-            }
-            Ok(Some(BlobPackLimits {
-                max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
-                max_bytes: capabilities
-                    .limits
-                    .max_pack_bytes
-                    .min(MAX_STAGED_BLOB_PACK_BYTES),
-            }))
-        };
-        let blob_packs = pack_limits(capabilities.features.blob_packs)?;
-        let blob_pack_uploads = pack_limits(capabilities.features.blob_pack_uploads)?;
-        let action_batches = if capabilities.features.action_batch {
-            let max_items = usize::try_from(capabilities.limits.max_batch_items)
-                .ok()
-                .filter(|limit| *limit > 0)
-                .ok_or_else(|| {
-                    eyre!("remote cache action batches require a positive max_batch_items limit")
-                })?;
-            Some(max_items.min(MAX_ACTION_BATCH_ITEMS))
-        } else {
-            None
-        };
-        Ok(NegotiatedCapabilities {
-            blob_packs,
-            blob_pack_uploads,
-            action_batches,
-            zstd_uploads,
-        })
     }
 
     /// Download verified CAS objects using the server's negotiated blob-pack extension.
     ///
-    /// `None` means the server does not support blob packs. Objects omitted by a
+    /// `None` means the service does not support blob packs. Objects omitted by a
     /// supported server are absent from `blobs`, so callers can retry them through
     /// the ordinary single-blob endpoint.
     pub async fn get_blob_pack(
@@ -574,8 +276,9 @@ impl RemoteCacheClient {
         digests: &[CacheDigest],
         staging_dir: &Path,
     ) -> Result<Option<RemoteBlobPack>> {
-        self.get_blob_pack_with_limit(digests, staging_dir, MAX_STAGED_BLOB_PACK_BYTES)
-            .await
+        match &self.backend {
+            Backend::Http(client) => client.get_blob_pack(digests, staging_dir).await,
+        }
     }
 
     pub(crate) async fn get_blob_pack_with_limit(
@@ -584,87 +287,13 @@ impl RemoteCacheClient {
         staging_dir: &Path,
         max_bytes: u64,
     ) -> Result<Option<RemoteBlobPack>> {
-        if digests.is_empty() || self.blob_packs_disabled.load(Ordering::Relaxed) {
-            return Ok(None);
-        }
-        let Some(mut limits) = self.blob_pack_limits().await? else {
-            return Ok(None);
-        };
-        limits.max_bytes = limits.max_bytes.min(max_bytes);
-        if limits.max_bytes == 0 {
-            bail!("remote cache download budget is exhausted");
-        }
-        fs::create_dir_all(staging_dir)?;
-        let chunk = blob_pack_chunk(digests, limits)?;
-        if chunk.is_empty() {
-            return Ok(Some(RemoteBlobPack {
-                _directory: tempfile::tempdir_in(staging_dir)?,
-                blobs: Vec::new(),
-                requests: 0,
-                requested: Vec::new(),
-                blob_count: 0,
-                payload_bytes: 0,
-                framed_bytes: BLOB_PACK_MAGIC.len() as u64,
-            }));
-        }
-        match self.download_blob_pack_chunk(&chunk, staging_dir).await? {
-            Some(pack) => Ok(Some(RemoteBlobPack {
-                _directory: pack.directory,
-                blobs: pack.blobs,
-                requests: 1,
-                requested: chunk,
-                blob_count: pack.metadata.blob_count,
-                payload_bytes: pack.metadata.payload_bytes,
-                framed_bytes: pack.metadata.framed_bytes,
-            })),
-            None => {
-                self.blob_packs_disabled.store(true, Ordering::Relaxed);
-                Ok(None)
+        match &self.backend {
+            Backend::Http(client) => {
+                client
+                    .get_blob_pack_with_limit(digests, staging_dir, max_bytes)
+                    .await
             }
         }
-    }
-
-    async fn download_blob_pack_chunk(
-        &self,
-        digests: &[CacheDigest],
-        staging_dir: &Path,
-    ) -> Result<Option<DownloadedBlobPack>> {
-        let url = self.blob_pack_endpoint()?;
-        let body = serde_json::to_vec(&DigestList { digests })?;
-        let download_timeout = blob_pack_download_timeout(self.download_timeout, digests);
-        let download = retry_async("POST", &url, self.retries, || async {
-            let response = self
-                .request(reqwest::Method::POST, url.clone(), BLOB_PACK_MEDIA_TYPE)
-                .await?
-                .header(CONTENT_TYPE, DIGEST_LIST_MEDIA_TYPE)
-                .body(body.clone())
-                .send()
-                .await?;
-            if matches!(
-                response.status(),
-                StatusCode::NOT_FOUND
-                    | StatusCode::METHOD_NOT_ALLOWED
-                    | StatusCode::NOT_IMPLEMENTED
-            ) {
-                return Ok(None);
-            }
-            let response = response.error_for_status()?;
-            let media_type = response
-                .headers()
-                .get(CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok())
-                .and_then(|value| value.split(';').next())
-                .map(str::trim);
-            if media_type != Some(BLOB_PACK_MEDIA_TYPE) {
-                bail!("remote cache blob pack has an invalid content type");
-            }
-            Ok(Some(
-                decode_blob_pack(response, digests, staging_dir).await?,
-            ))
-        });
-        tokio::time::timeout(download_timeout, download)
-            .await
-            .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
     }
 
     /// Fetch and validate an action-result record, returning `None` on a miss.
@@ -672,140 +301,40 @@ impl RemoteCacheClient {
         &self,
         action: &CacheDigest,
     ) -> Result<Option<RemoteActionResult>> {
-        let url = self.action_result_endpoint(action)?;
-        let result = retry_async("GET", &url, self.retries, || async {
-            let response = self
-                .request(reqwest::Method::GET, url.clone(), ACTION_RESULT_MEDIA_TYPE)
-                .await?
-                .send()
-                .await?;
-            if response.status() == StatusCode::NOT_FOUND {
-                return Ok(None);
-            }
-            let bytes = read_bounded_json(response.error_for_status()?, "action result").await?;
-            Ok(Some(serde_json::from_slice::<RemoteActionResult>(&bytes)?))
-        })
-        .await?;
-        if let Some(result) = &result
-            && (result.version != 1 || result.action != *action)
-        {
-            bail!("remote action result does not match requested action");
+        match &self.backend {
+            Backend::Http(client) => client.get_action_result(action).await,
         }
-        Ok(result)
     }
 
     /// How many actions one batched lookup may ask about.
     ///
-    /// `None` means the server does not answer batched lookups.
+    /// `None` means the service does not answer batched lookups.
     pub(crate) async fn action_batch_limit(&self) -> Result<Option<usize>> {
-        if self.action_batches_disabled.load(Ordering::Relaxed) {
-            return Ok(None);
+        match &self.backend {
+            Backend::Http(client) => client.action_batch_limit().await,
         }
-        Ok(self.negotiated_capabilities().await?.action_batches)
     }
 
     /// Look up several action results in one request.
     ///
-    /// `None` means the server does not answer batched lookups, leaving the
+    /// `None` means the service does not answer batched lookups, leaving the
     /// caller to ask for each action individually. The response carries only the
-    /// results the server holds, in no particular order, so each record is bound
+    /// results the service holds, in no particular order, so each record is bound
     /// to its request by the action digest it names rather than by position.
     pub async fn get_action_results(
         &self,
         actions: &[CacheDigest],
     ) -> Result<Option<Vec<RemoteActionResult>>> {
-        if actions.is_empty() {
-            return Ok(Some(Vec::new()));
+        match &self.backend {
+            Backend::Http(client) => client.get_action_results(actions).await,
         }
-        if self.action_batches_disabled.load(Ordering::Relaxed) {
-            return Ok(None);
-        }
-        let Some(limit) = self.negotiated_capabilities().await?.action_batches else {
-            return Ok(None);
-        };
-        if actions.len() > limit {
-            bail!(
-                "remote cache action batch of {} exceeds the negotiated limit of {limit}",
-                actions.len()
-            );
-        }
-        let mut requested = BTreeSet::new();
-        for action in actions {
-            action.validate()?;
-            if action.algorithm != "blake3" {
-                bail!("remote cache action keys must use blake3");
-            }
-            requested.insert(action.clone());
-        }
-        let url = self.action_result_batch_endpoint()?;
-        let body = serde_json::to_vec(&DigestList { digests: actions })?;
-        let bound = MAX_ACTION_RESULT_BYTES.saturating_mul(actions.len() as u64);
-        let batch = retry_async("POST", &url, self.retries, || async {
-            let response = self
-                .request(
-                    reqwest::Method::POST,
-                    url.clone(),
-                    ACTION_RESULT_BATCH_MEDIA_TYPE,
-                )
-                .await?
-                .header(CONTENT_TYPE, DIGEST_LIST_MEDIA_TYPE)
-                .body(body.clone())
-                .send()
-                .await?;
-            if matches!(
-                response.status(),
-                StatusCode::NOT_FOUND
-                    | StatusCode::METHOD_NOT_ALLOWED
-                    | StatusCode::NOT_IMPLEMENTED
-            ) {
-                // Advertised but not served. Asking again every wave would cost
-                // a round trip each time to learn the same thing.
-                self.action_batches_disabled.store(true, Ordering::Relaxed);
-                return Ok(None);
-            }
-            let bytes =
-                read_json_within(response.error_for_status()?, "action result batch", bound)
-                    .await?;
-            Ok(Some(serde_json::from_slice::<ActionResultBatch>(&bytes)?))
-        })
-        .await?;
-        let Some(batch) = batch else {
-            return Ok(None);
-        };
-        // A result for an action that was not asked for would key cached outputs
-        // under a digest this client never derived, so it is refused rather than
-        // ignored.
-        let mut seen = BTreeSet::new();
-        for result in &batch.results {
-            if result.version != 1 || !requested.contains(&result.action) {
-                bail!("remote action result batch contains an unrequested action");
-            }
-            if !seen.insert(result.action.clone()) {
-                bail!("remote action result batch repeats an action");
-            }
-        }
-        Ok(Some(batch.results))
     }
 
     /// Canonically serialize and store an action-result record.
     pub async fn put_action_result(&self, result: &RemoteActionResult) -> Result<()> {
-        let url = self.action_result_endpoint(&result.action)?;
-        let body = serde_json::to_vec(result)?;
-        retry_async("PUT", &url, self.retries, || async {
-            let response = self
-                .request(reqwest::Method::PUT, url.clone(), ACTION_RESULT_MEDIA_TYPE)
-                .await?
-                .header(CONTENT_TYPE, ACTION_RESULT_MEDIA_TYPE)
-                .header(IF_NONE_MATCH, "*")
-                .body(body.clone())
-                .send()
-                .await?;
-            if response.status() != StatusCode::PRECONDITION_FAILED {
-                response.error_for_status()?;
-            }
-            Ok(())
-        })
-        .await
+        match &self.backend {
+            Backend::Http(client) => client.put_action_result(result).await,
+        }
     }
 
     /// Fetch a task action manifest and the entity tag needed to update it.
@@ -813,26 +342,9 @@ impl RemoteCacheClient {
         &self,
         key: &CacheDigest,
     ) -> Result<Option<RemoteActionManifest>> {
-        let url = self.action_manifest_endpoint(key)?;
-        retry_async("GET", &url, self.retries, || async {
-            let response = self
-                .request(
-                    reqwest::Method::GET,
-                    url.clone(),
-                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
-                )
-                .await?
-                .send()
-                .await?;
-            if response.status() == StatusCode::NOT_FOUND {
-                return Ok(None);
-            }
-            let response = response.error_for_status()?;
-            let etag = parse_strong_etag(response.headers().get(ETAG))?;
-            let bytes = read_bounded_json(response, "action manifest").await?;
-            Ok(Some(RemoteActionManifest { bytes, etag }))
-        })
-        .await
+        match &self.backend {
+            Backend::Http(client) => client.get_action_manifest(key).await,
+        }
     }
 
     /// Store a task action manifest, optionally requiring an entity-tag match.
@@ -842,32 +354,9 @@ impl RemoteCacheClient {
         bytes: &[u8],
         expected_etag: Option<&str>,
     ) -> Result<ManifestPutOutcome> {
-        let url = self.action_manifest_endpoint(key)?;
-        let body = bytes.to_vec();
-        let expected_etag = expected_etag.map(quoted_etag).transpose()?;
-        retry_async("PUT", &url, self.retries, || async {
-            let mut request = self
-                .request(
-                    reqwest::Method::PUT,
-                    url.clone(),
-                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
-                )
-                .await?
-                .header(CONTENT_TYPE, TASK_ACTION_MANIFEST_MEDIA_TYPE)
-                .body(body.clone());
-            request = if let Some(etag) = &expected_etag {
-                request.header(IF_MATCH, etag)
-            } else {
-                request.header(IF_NONE_MATCH, "*")
-            };
-            let response = request.send().await?;
-            if response.status() == StatusCode::PRECONDITION_FAILED {
-                return Ok(ManifestPutOutcome::PreconditionFailed);
-            }
-            response.error_for_status()?;
-            Ok(ManifestPutOutcome::Stored)
-        })
-        .await
+        match &self.backend {
+            Backend::Http(client) => client.put_action_manifest(key, bytes, expected_etag).await,
+        }
     }
 
     /// Download a small blob into memory and verify its digest.
@@ -876,38 +365,9 @@ impl RemoteCacheClient {
         digest: &CacheDigest,
         media_type: &'static str,
     ) -> Result<Vec<u8>> {
-        digest.validate()?;
-        if digest.size > MAX_REMOTE_JSON_BYTES {
-            bail!(
-                "remote cache in-memory blob declared {} bytes, over the {} byte limit",
-                digest.size,
-                MAX_REMOTE_JSON_BYTES
-            );
+        match &self.backend {
+            Backend::Http(client) => client.get_blob(digest, media_type).await,
         }
-        let url = self.blob_endpoint(digest)?;
-        retry_async("GET", &url, self.retries, || async {
-            let mut response = self
-                .request(reqwest::Method::GET, url.clone(), media_type)
-                .await?
-                .send()
-                .await?
-                .error_for_status()?;
-            // Stop reading as soon as the response outgrows the digest it claims
-            // to satisfy. A server that streams more than it promised must not be
-            // able to exhaust this process before verification rejects it.
-            let mut bytes = Vec::new();
-            while let Some(chunk) = response.chunk().await? {
-                if bytes.len() as u64 + chunk.len() as u64 > digest.size {
-                    bail!("remote cache blob exceeded the size of its digest");
-                }
-                bytes.extend_from_slice(&chunk);
-            }
-            if !digest.matches_bytes(&bytes)? {
-                bail!("remote cache blob failed digest verification");
-            }
-            Ok(bytes)
-        })
-        .await
     }
 
     /// Download a blob to a temporary file and verify its digest.
@@ -916,405 +376,46 @@ impl RemoteCacheClient {
         digest: &CacheDigest,
         staging_dir: &Path,
     ) -> Result<tempfile::NamedTempFile> {
-        digest.validate()?;
-        if digest.size > MAX_REMOTE_BLOB_BYTES {
-            bail!(
-                "remote cache blob declared {} bytes, over the {} byte limit",
-                digest.size,
-                MAX_REMOTE_BLOB_BYTES
-            );
+        match &self.backend {
+            Backend::Http(client) => client.get_blob_file(digest, staging_dir).await,
         }
-        let url = self.blob_endpoint(digest)?;
-        let download = retry_async("GET", &url, self.retries, || async {
-            let mut response = self
-                .request(reqwest::Method::GET, url.clone(), BLOB_MEDIA_TYPE)
-                .await?
-                .send()
-                .await?;
-            response.error_for_status_ref()?;
-            fs::create_dir_all(staging_dir)?;
-            let temporary = tempfile::NamedTempFile::new_in(staging_dir)?;
-            let mut output = tokio::fs::File::from_std(temporary.reopen()?);
-            // Bound the download by the digest's own size so an oversized
-            // response cannot fill the disk before verification rejects it.
-            let mut written = 0u64;
-            while let Some(chunk) = response.chunk().await? {
-                written += chunk.len() as u64;
-                if written > digest.size {
-                    bail!("remote cache blob exceeded the size of its digest");
-                }
-                output.write_all(&chunk).await?;
-            }
-            output.flush().await?;
-            drop(output);
-            if !digest.matches_file(temporary.path())? {
-                bail!("remote cache blob failed digest verification");
-            }
-            Ok(temporary)
-        });
-        tokio::time::timeout(self.download_timeout, download)
-            .await
-            .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
     }
 
     /// How many blobs, and how many payload bytes, one uploaded pack may carry.
     ///
-    /// `None` means the server does not accept packed uploads.
+    /// `None` means the service does not accept packed uploads.
     pub(crate) async fn blob_pack_upload_limits(&self) -> Result<Option<BlobPackLimits>> {
-        if self.blob_pack_uploads_disabled.load(Ordering::Relaxed) {
-            return Ok(None);
+        match &self.backend {
+            Backend::Http(client) => client.blob_pack_upload_limits().await,
         }
-        Ok(self.negotiated_capabilities().await?.blob_pack_uploads)
     }
 
     /// Upload several content-addressed blobs in one framed request.
     ///
-    /// `None` means the server does not accept packed uploads, leaving the
+    /// `None` means the service does not accept packed uploads, leaving the
     /// caller to send each blob on its own. A rejected pack is reported as an
     /// error and publishes nothing the caller may rely on: a server verifies
     /// each frame as it arrives, so an accepted prefix may exist, but every blob
     /// is content-addressed and storing one twice is not an error.
     pub async fn put_blob_pack(&self, uploads: &[BlobUpload]) -> Result<Option<BlobPackReceipt>> {
-        if uploads.is_empty() {
-            return Ok(Some(BlobPackReceipt {
-                created: 0,
-                existing: 0,
-            }));
+        match &self.backend {
+            Backend::Http(client) => client.put_blob_pack(uploads).await,
         }
-        let Some(limits) = self.blob_pack_upload_limits().await? else {
-            return Ok(None);
-        };
-        if uploads.len() > limits.max_items {
-            bail!(
-                "remote cache blob pack of {} blobs exceeds the negotiated limit of {}",
-                uploads.len(),
-                limits.max_items
-            );
-        }
-        let mut payload_bytes = 0u64;
-        for upload in uploads {
-            upload.digest.validate()?;
-            payload_bytes = payload_bytes
-                .checked_add(upload.digest.size)
-                .ok_or_else(|| eyre!("remote cache blob pack payload overflowed"))?;
-        }
-        if payload_bytes > limits.max_bytes {
-            bail!(
-                "remote cache blob pack of {payload_bytes} bytes exceeds the negotiated limit of {}",
-                limits.max_bytes
-            );
-        }
-        let framed_bytes = BLOB_PACK_MAGIC.len() as u64
-            + payload_bytes
-            + BLOB_PACK_HEADER_BYTES * uploads.len() as u64;
-        let compress = self
-            .negotiated_capabilities()
-            .await
-            .map(|capabilities| capabilities.zstd_uploads)
-            .unwrap_or(false);
-        let url = self.blob_pack_upload_endpoint()?;
-        retry_async("POST", &url, self.retries, || async {
-            let request = self
-                .request(
-                    reqwest::Method::POST,
-                    url.clone(),
-                    BLOB_PACK_RECEIPT_MEDIA_TYPE,
-                )
-                .await?
-                .header(CONTENT_TYPE, BLOB_PACK_MEDIA_TYPE)
-                .header(BLOB_PACK_BLOBS_HEADER, uploads.len())
-                .header(BLOB_PACK_BYTES_HEADER, payload_bytes);
-            // Each attempt reads the sources again, so the pack is rebuilt here
-            // rather than buffered once and held in memory.
-            let stream = blob_pack_stream(blob_pack_members(uploads)?);
-            let request = if compress {
-                let encoder = async_compression::tokio::bufread::ZstdEncoder::new(
-                    tokio::io::BufReader::new(tokio_util::io::StreamReader::new(stream)),
-                );
-                request
-                    .header(CONTENT_ENCODING, "zstd")
-                    .body(reqwest::Body::wrap_stream(
-                        tokio_util::io::ReaderStream::new(encoder),
-                    ))
-            } else {
-                request
-                    .header(CONTENT_LENGTH, framed_bytes)
-                    .body(reqwest::Body::wrap_stream(stream))
-            };
-            let response = request.send().await?;
-            if matches!(
-                response.status(),
-                StatusCode::NOT_FOUND
-                    | StatusCode::METHOD_NOT_ALLOWED
-                    | StatusCode::NOT_IMPLEMENTED
-            ) {
-                self.blob_pack_uploads_disabled
-                    .store(true, Ordering::Relaxed);
-                return Ok(None);
-            }
-            let bytes =
-                read_bounded_json(response.error_for_status()?, "blob pack receipt").await?;
-            Ok(Some(serde_json::from_slice::<BlobPackReceipt>(&bytes)?))
-        })
-        .await
     }
 
     /// Verify and upload a content-addressed blob.
     pub async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
-        let url = self.blob_endpoint(&upload.digest)?;
-        // A failed negotiation downgrades to identity rather than failing the
-        // upload: compression is an economy, not a requirement.
-        let compress = self
-            .negotiated_capabilities()
-            .await
-            .map(|capabilities| capabilities.zstd_uploads)
-            .unwrap_or(false);
-        retry_async("PUT", &url, self.retries, || async {
-            let request = self
-                .request(reqwest::Method::PUT, url.clone(), BLOB_MEDIA_TYPE)
-                .await?
-                .header(CONTENT_TYPE, BLOB_MEDIA_TYPE)
-                .header(IF_NONE_MATCH, "*");
-            let request = if compress {
-                // Compressed and therefore chunked: the length of the encoded
-                // stream is not known up front, and the digest already tells
-                // the server the decompressed size it must enforce.
-                let reader: Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin> = match &upload
-                    .source
-                {
-                    BlobSource::Bytes(bytes) => Box::new(std::io::Cursor::new(bytes.clone())),
-                    BlobSource::File(file) => Box::new(tokio::fs::File::open(file.path()).await?),
-                    BlobSource::Path(path) => Box::new(tokio::fs::File::open(path).await?),
-                };
-                let encoder = async_compression::tokio::bufread::ZstdEncoder::new(
-                    tokio::io::BufReader::new(reader),
-                );
-                request
-                    .header(CONTENT_ENCODING, "zstd")
-                    .body(reqwest::Body::wrap_stream(
-                        tokio_util::io::ReaderStream::new(encoder),
-                    ))
-            } else {
-                let (length, body) = match &upload.source {
-                    BlobSource::Bytes(bytes) => {
-                        (bytes.len() as u64, reqwest::Body::from(bytes.clone()))
-                    }
-                    BlobSource::File(file) => {
-                        let file = tokio::fs::File::open(file.path()).await?;
-                        let length = file.metadata().await?.len();
-                        let stream = tokio_util::io::ReaderStream::new(file);
-                        (length, reqwest::Body::wrap_stream(stream))
-                    }
-                    BlobSource::Path(path) => {
-                        let file = tokio::fs::File::open(path).await?;
-                        let length = file.metadata().await?.len();
-                        let stream = tokio_util::io::ReaderStream::new(file);
-                        (length, reqwest::Body::wrap_stream(stream))
-                    }
-                };
-                request.header(CONTENT_LENGTH, length).body(body)
-            };
-            let response = request.send().await?;
-            if response.status() != StatusCode::PRECONDITION_FAILED {
-                response.error_for_status()?;
-            }
-            Ok(())
-        })
-        .await
-    }
-}
-
-fn blob_pack_chunk(digests: &[CacheDigest], limits: BlobPackLimits) -> Result<Vec<CacheDigest>> {
-    let mut seen = BTreeSet::new();
-    let mut chunk = Vec::new();
-    let mut chunk_bytes = 0_u64;
-    for digest in digests {
-        digest.validate()?;
-        if !seen.insert(digest.clone()) || digest.size > limits.max_bytes {
-            continue;
+        match &self.backend {
+            Backend::Http(client) => client.put_blob(upload).await,
         }
-        if chunk.len() == limits.max_items
-            || chunk_bytes.saturating_add(digest.size) > limits.max_bytes
-        {
-            break;
-        }
-        chunk_bytes = chunk_bytes.saturating_add(digest.size);
-        chunk.push(digest.clone());
     }
-    Ok(chunk)
-}
-
-fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Duration {
-    let bytes = digests
-        .iter()
-        .fold(0_u64, |total, digest| total.saturating_add(digest.size));
-    let byte_units = bytes.div_ceil(BLOB_PACK_TIMEOUT_BYTES_PER_UNIT);
-    let item_units = digests.len().div_ceil(BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT);
-    let item_units = u64::try_from(item_units).unwrap_or(u64::MAX);
-    let multiplier = byte_units.max(item_units).max(1);
-    base.saturating_mul(u32::try_from(multiplier).unwrap_or(u32::MAX))
 }
 
 /// Buffer a JSON response body, refusing to grow past [`MAX_REMOTE_JSON_BYTES`].
+///
 /// A declared `Content-Length` is rejected up front so an oversized body costs
 /// nothing to refuse; the streaming check then covers servers that understate or
 /// omit it.
-/// Frame blobs into one `MBXPACK1` stream, read on demand rather than buffered.
-///
-/// The frames mirror what [`decode_blob_pack_reader`] accepts, so both
-/// directions of the extension agree on the format by construction.
-/// One member of a pack, described rather than opened.
-///
-/// A pack can hold thousands of objects. Opening them all before the first byte
-/// is sent would spend a file descriptor on each for the length of the request,
-/// so a member is opened only when the stream reaches it and closed when it is
-/// past.
-struct PackMemberSource {
-    header: Vec<u8>,
-    payload_bytes: u64,
-    source: PackPayloadSource,
-}
-
-enum PackPayloadSource {
-    Bytes(Vec<u8>),
-    Path(PathBuf),
-}
-
-enum PackStreamState {
-    Magic,
-    Header(usize),
-    Payload(usize, u64, Box<dyn AsyncRead + Send + Sync + Unpin>),
-    Done,
-}
-
-/// Frame blobs into one `MBXPACK1` stream, read on demand rather than buffered.
-///
-/// The frames mirror what [`decode_blob_pack_reader`] accepts, so both
-/// directions of the extension agree on the format by construction.
-fn blob_pack_stream(
-    members: Vec<PackMemberSource>,
-) -> impl futures_util::Stream<Item = std::io::Result<bytes::Bytes>> + Send + 'static {
-    futures_util::stream::unfold(
-        (PackStreamState::Magic, members),
-        |(state, members)| async move {
-            let mut state = state;
-            loop {
-                match state {
-                    PackStreamState::Magic => {
-                        return Some((
-                            Ok(bytes::Bytes::from_static(BLOB_PACK_MAGIC)),
-                            (PackStreamState::Header(0), members),
-                        ));
-                    }
-                    PackStreamState::Header(index) => {
-                        let Some(member) = members.get(index) else {
-                            state = PackStreamState::Done;
-                            continue;
-                        };
-                        let payload: Box<dyn AsyncRead + Send + Sync + Unpin> = match &member.source
-                        {
-                            PackPayloadSource::Bytes(bytes) => {
-                                Box::new(std::io::Cursor::new(bytes.clone()))
-                            }
-                            PackPayloadSource::Path(path) => {
-                                match tokio::fs::File::open(path).await {
-                                    Ok(file) => Box::new(file),
-                                    Err(error) => {
-                                        return Some((
-                                            Err(error),
-                                            (PackStreamState::Done, members),
-                                        ));
-                                    }
-                                }
-                            }
-                        };
-                        return Some((
-                            Ok(bytes::Bytes::from(member.header.clone())),
-                            (
-                                PackStreamState::Payload(index, member.payload_bytes, payload),
-                                members,
-                            ),
-                        ));
-                    }
-                    PackStreamState::Payload(index, remaining, mut payload) => {
-                        if remaining == 0 {
-                            // The declared frame length, rather than EOF, is the
-                            // boundary between adjacent members.
-                            state = PackStreamState::Header(index + 1);
-                            continue;
-                        }
-                        let chunk_bytes =
-                            usize::try_from(remaining.min(PACK_STREAM_CHUNK_BYTES as u64)).unwrap();
-                        let mut chunk = vec![0; chunk_bytes];
-                        match payload.read(&mut chunk).await {
-                            Ok(0) => {
-                                let error = std::io::Error::new(
-                                    std::io::ErrorKind::UnexpectedEof,
-                                    format!(
-                                        "blob pack member {index} ended with {remaining} bytes remaining"
-                                    ),
-                                );
-                                return Some((Err(error), (PackStreamState::Done, members)));
-                            }
-                            Ok(read) => {
-                                chunk.truncate(read);
-                                return Some((
-                                    Ok(bytes::Bytes::from(chunk)),
-                                    (
-                                        PackStreamState::Payload(
-                                            index,
-                                            remaining - read as u64,
-                                            payload,
-                                        ),
-                                        members,
-                                    ),
-                                ));
-                            }
-                            Err(error) => {
-                                return Some((Err(error), (PackStreamState::Done, members)));
-                            }
-                        }
-                    }
-                    PackStreamState::Done => return None,
-                }
-            }
-        },
-    )
-}
-
-fn blob_pack_members(uploads: &[BlobUpload]) -> Result<Vec<PackMemberSource>> {
-    uploads
-        .iter()
-        .map(|upload| {
-            Ok(PackMemberSource {
-                header: blob_pack_frame_header(&upload.digest)?,
-                payload_bytes: upload.digest.size,
-                source: match &upload.source {
-                    BlobSource::Bytes(bytes) => PackPayloadSource::Bytes(bytes.clone()),
-                    BlobSource::File(file) => PackPayloadSource::Path(file.path().to_path_buf()),
-                    BlobSource::Path(path) => PackPayloadSource::Path(path.clone()),
-                },
-            })
-        })
-        .collect()
-}
-
-fn blob_pack_frame_header(digest: &CacheDigest) -> Result<Vec<u8>> {
-    let algorithm = match digest.algorithm_kind()? {
-        DigestAlgorithm::Blake3 => 1u8,
-        DigestAlgorithm::Sha256 => 2u8,
-    };
-    let hash = hex::decode(&digest.hash)?;
-    if hash.len() != 32 {
-        bail!("remote cache blob pack digests must be 32 bytes");
-    }
-    let mut header = Vec::with_capacity(BLOB_PACK_HEADER_BYTES as usize);
-    header.push(algorithm);
-    header.extend_from_slice(&hash);
-    header.extend_from_slice(&digest.size.to_be_bytes());
-    Ok(header)
-}
-
 async fn read_bounded_json(response: reqwest::Response, what: &str) -> Result<Vec<u8>> {
     read_json_within(response, what, MAX_REMOTE_JSON_BYTES).await
 }
@@ -1335,153 +436,6 @@ async fn read_json_within(response: reqwest::Response, what: &str, limit: u64) -
     }
     Ok(bytes)
 }
-
-async fn decode_blob_pack(
-    response: reqwest::Response,
-    requested: &[CacheDigest],
-    staging_dir: &Path,
-) -> Result<DownloadedBlobPack> {
-    let metadata = BlobPackResponseMetadata::from_headers(response.headers())?;
-    let stream = response.bytes_stream().map_err(std::io::Error::other);
-    let reader = tokio_util::io::StreamReader::new(stream);
-    decode_blob_pack_reader(reader, metadata, requested, staging_dir).await
-}
-
-async fn decode_blob_pack_reader<R>(
-    mut reader: R,
-    metadata: BlobPackResponseMetadata,
-    requested: &[CacheDigest],
-    staging_dir: &Path,
-) -> Result<DownloadedBlobPack>
-where
-    R: AsyncRead + Unpin,
-{
-    let requested = requested.iter().cloned().collect::<BTreeSet<_>>();
-    let mut magic = [0_u8; BLOB_PACK_MAGIC.len()];
-    reader.read_exact(&mut magic).await?;
-    if &magic != BLOB_PACK_MAGIC {
-        bail!("remote cache blob pack has invalid magic");
-    }
-
-    let directory = tempfile::tempdir_in(staging_dir)?;
-    let mut seen = BTreeSet::new();
-    let mut blobs = Vec::new();
-    let mut payload_bytes = 0_u64;
-    let mut framed_bytes = BLOB_PACK_MAGIC.len() as u64;
-    loop {
-        let mut algorithm = [0_u8; 1];
-        if reader.read(&mut algorithm).await? == 0 {
-            break;
-        }
-        let (algorithm, mut hasher) = match algorithm[0] {
-            1 => (
-                "blake3",
-                BlobPackHasher::Blake3(Box::new(blake3::Hasher::new())),
-            ),
-            2 => ("sha256", BlobPackHasher::Sha256(sha2::Sha256::new())),
-            _ => bail!("remote cache blob pack has an invalid digest algorithm"),
-        };
-        let mut hash = [0_u8; 32];
-        reader.read_exact(&mut hash).await?;
-        let mut size = [0_u8; 8];
-        reader.read_exact(&mut size).await?;
-        let digest = CacheDigest {
-            algorithm: algorithm.into(),
-            hash: hex::encode(hash),
-            size: u64::from_be_bytes(size),
-        };
-        if !requested.contains(&digest) {
-            bail!("remote cache blob pack returned an unrequested digest");
-        }
-        if !seen.insert(digest.clone()) {
-            bail!("remote cache blob pack returned a duplicate digest");
-        }
-        framed_bytes = framed_bytes
-            .checked_add(BLOB_PACK_HEADER_BYTES)
-            .and_then(|bytes| bytes.checked_add(digest.size))
-            .ok_or_else(|| eyre!("remote cache blob pack is too large"))?;
-        payload_bytes = payload_bytes
-            .checked_add(digest.size)
-            .ok_or_else(|| eyre!("remote cache blob pack payload is too large"))?;
-
-        let path = directory.path().join(blobs.len().to_string());
-        let mut output = tokio::fs::File::create(&path).await?;
-        let mut remaining = digest.size;
-        let mut buffer = [0_u8; 64 * 1024];
-        while remaining > 0 {
-            let limit = usize::try_from(remaining.min(buffer.len() as u64)).unwrap();
-            let count = reader.read(&mut buffer[..limit]).await?;
-            if count == 0 {
-                bail!("remote cache blob pack ended before a blob was complete");
-            }
-            output.write_all(&buffer[..count]).await?;
-            hasher.update(&buffer[..count]);
-            remaining -= count as u64;
-        }
-        output.flush().await?;
-        drop(output);
-        if !hasher.matches(&digest.hash) {
-            bail!("remote cache blob pack failed digest verification");
-        }
-        blobs.push((digest, path));
-    }
-    let blob_count = blobs.len().try_into().unwrap_or(u64::MAX);
-    let metadata = metadata.validate(BlobPackResponseStats {
-        blob_count,
-        payload_bytes,
-        framed_bytes,
-    })?;
-    Ok(DownloadedBlobPack {
-        directory,
-        blobs,
-        metadata,
-    })
-}
-
-/// Exercise the production blob-pack decoder without constructing an HTTP
-/// response. This narrow entry point exists for the workspace's fuzz target.
-#[cfg(feature = "fuzzing")]
-#[doc(hidden)]
-pub async fn fuzz_decode_blob_pack(
-    bytes: &[u8],
-    requested: &[CacheDigest],
-    staging_dir: &Path,
-) -> Result<()> {
-    decode_blob_pack_reader(
-        bytes,
-        BlobPackResponseMetadata::default(),
-        requested,
-        staging_dir,
-    )
-    .await
-    .map(drop)
-}
-
-enum BlobPackHasher {
-    Blake3(Box<blake3::Hasher>),
-    Sha256(sha2::Sha256),
-}
-
-impl BlobPackHasher {
-    fn update(&mut self, bytes: &[u8]) {
-        match self {
-            Self::Blake3(hasher) => {
-                hasher.update(bytes);
-            }
-            Self::Sha256(hasher) => {
-                hasher.update(bytes);
-            }
-        }
-    }
-
-    fn matches(self, expected: &str) -> bool {
-        match self {
-            Self::Blake3(hasher) => hasher.finalize().to_hex().as_str() == expected,
-            Self::Sha256(hasher) => hex::encode(hasher.finalize()) == expected,
-        }
-    }
-}
-
 /// Read the entity tag that a later conditional update has to send back.
 ///
 /// The tag is carried through opaquely, and nothing may infer content from it.
@@ -1523,250 +477,6 @@ fn is_entity_tag(value: &str) -> bool {
         && value.len() <= MAX_ETAG_BYTES
         && value.bytes().all(|byte| matches!(byte, 0x21 | 0x23..=0x7e))
 }
-
-#[derive(Clone)]
-enum RemoteCacheCredential {
-    None,
-    Static(HeaderValue),
-    File(PathBuf),
-    GithubActions(Arc<GithubActionsOidcCredential>),
-}
-
-struct GithubActionsOidcCredential {
-    audience: String,
-    request_url: Url,
-    request_token: HeaderValue,
-    client: reqwest::Client,
-    retries: i64,
-    cached: tokio::sync::Mutex<Option<CachedOidcToken>>,
-}
-
-struct CachedOidcToken {
-    authorization: HeaderValue,
-    expires_at: u64,
-}
-
-#[derive(Deserialize)]
-struct GithubActionsOidcResponse {
-    value: String,
-}
-
-#[derive(Deserialize)]
-struct JwtExpiry {
-    exp: u64,
-}
-
-fn remote_credential(
-    config: &RemoteCacheConfig,
-    client: reqwest::Client,
-) -> Result<RemoteCacheCredential> {
-    if let Some(authorization) = authorization_header(config.token.as_deref())? {
-        return Ok(RemoteCacheCredential::Static(authorization));
-    }
-    if let Some(path) = &config.token_file {
-        return Ok(RemoteCacheCredential::File(path.clone()));
-    }
-    let Some(audience) = config
-        .oidc_audience
-        .as_deref()
-        .map(str::trim)
-        .filter(|audience| !audience.is_empty())
-    else {
-        return Ok(RemoteCacheCredential::None);
-    };
-    Ok(RemoteCacheCredential::GithubActions(Arc::new(
-        GithubActionsOidcCredential::from_env(audience, client, config.retries)?,
-    )))
-}
-
-fn authorization_header(token: Option<&str>) -> Result<Option<HeaderValue>> {
-    let Some(token) = token.map(str::trim).filter(|token| !token.is_empty()) else {
-        return Ok(None);
-    };
-    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))?;
-    value.set_sensitive(true);
-    Ok(Some(value))
-}
-
-impl RemoteCacheCredential {
-    async fn authorization(&self) -> Result<Option<HeaderValue>> {
-        match self {
-            Self::None => Ok(None),
-            Self::Static(value) => Ok(Some(value.clone())),
-            Self::File(path) => {
-                let token = tokio::fs::read_to_string(path).await.map_err(|err| {
-                    eyre!(
-                        "failed to read remote cache token file {}: {err}",
-                        path.display()
-                    )
-                })?;
-                authorization_header(Some(&token))?
-                    .ok_or_else(|| eyre!("remote cache token file {} is empty", path.display()))
-                    .map(Some)
-            }
-            Self::GithubActions(credential) => credential.authorization().await.map(Some),
-        }
-    }
-}
-
-impl GithubActionsOidcCredential {
-    fn from_env(audience: &str, client: reqwest::Client, retries: i64) -> Result<Self> {
-        let request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
-            eyre!(
-                "remote cache OIDC audience requires GitHub Actions OIDC; \
-                 grant `id-token: write` or set MBX_REMOTE_TOKEN"
-            )
-        })?;
-        let request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| {
-            eyre!(
-                "remote cache OIDC audience requires GitHub Actions OIDC; \
-                 ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing"
-            )
-        })?;
-        let request_url: Url = request_url
-            .parse()
-            .map_err(|err| eyre!("invalid GitHub Actions OIDC request URL: {err}"))?;
-        Self::new(audience, request_url, &request_token, client, retries)
-    }
-
-    fn new(
-        audience: &str,
-        mut request_url: Url,
-        request_token: &str,
-        client: reqwest::Client,
-        retries: i64,
-    ) -> Result<Self> {
-        validate_oidc_request_url(&request_url)?;
-        let query = request_url
-            .query_pairs()
-            .filter(|(key, _)| key != "audience")
-            .map(|(key, value)| (key.into_owned(), value.into_owned()))
-            .collect::<Vec<_>>();
-        request_url.set_query(None);
-        request_url
-            .query_pairs_mut()
-            .extend_pairs(query)
-            .append_pair("audience", audience);
-        let request_token = authorization_header(Some(request_token))?
-            .ok_or_else(|| eyre!("GitHub Actions OIDC request token is empty"))?;
-        Ok(Self {
-            audience: audience.to_string(),
-            request_url,
-            request_token,
-            client,
-            retries,
-            cached: tokio::sync::Mutex::new(None),
-        })
-    }
-
-    async fn authorization(&self) -> Result<HeaderValue> {
-        const REFRESH_LEEWAY_SECONDS: u64 = 60;
-        let mut cached = self.cached.lock().await;
-        let now = unix_timestamp()?;
-        if let Some(token) = cached.as_ref()
-            && token.expires_at > now.saturating_add(REFRESH_LEEWAY_SECONDS)
-        {
-            return Ok(token.authorization.clone());
-        }
-        let response: GithubActionsOidcResponse =
-            retry_async("GET", &self.request_url, self.retries, || async {
-                Ok(self
-                    .client
-                    .get(self.request_url.clone())
-                    .header(AUTHORIZATION, self.request_token.clone())
-                    .send()
-                    .await?
-                    .error_for_status()?
-                    .json()
-                    .await?)
-            })
-            .await
-            .map_err(|err| {
-                eyre!(
-                    "failed to acquire GitHub Actions OIDC token for audience {:?}: {err}",
-                    self.audience
-                )
-            })?;
-        let expires_at = jwt_expiry(&response.value)?;
-        if expires_at <= now.saturating_add(REFRESH_LEEWAY_SECONDS) {
-            bail!("GitHub Actions OIDC token expires too soon");
-        }
-        let authorization = authorization_header(Some(&response.value))?
-            .ok_or_else(|| eyre!("GitHub Actions returned an empty OIDC token"))?;
-        *cached = Some(CachedOidcToken {
-            authorization: authorization.clone(),
-            expires_at,
-        });
-        Ok(authorization)
-    }
-}
-
-fn jwt_expiry(token: &str) -> Result<u64> {
-    let payload = token
-        .split('.')
-        .nth(1)
-        .ok_or_else(|| eyre!("GitHub Actions returned a malformed OIDC token"))?;
-    let payload = URL_SAFE_NO_PAD
-        .decode(payload)
-        .map_err(|_| eyre!("GitHub Actions returned a malformed OIDC token"))?;
-    let claims: JwtExpiry = serde_json::from_slice(&payload)
-        .map_err(|_| eyre!("GitHub Actions OIDC token is missing a valid expiry"))?;
-    Ok(claims.exp)
-}
-
-fn unix_timestamp() -> Result<u64> {
-    Ok(SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|err| eyre!("system clock is before the Unix epoch: {err}"))?
-        .as_secs())
-}
-
-fn validate_oidc_request_url(url: &Url) -> Result<()> {
-    if url.scheme() == "https"
-        || url.scheme() == "http"
-            && url.host().is_some_and(|host| match host {
-                Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
-                Host::Ipv4(address) => address.is_loopback(),
-                Host::Ipv6(address) => address.is_loopback(),
-            })
-    {
-        Ok(())
-    } else {
-        bail!("GitHub Actions OIDC request URL must use HTTPS")
-    }
-}
-
-fn validate_remote_url(base_url: &Url, authenticated: bool) -> Result<()> {
-    if base_url.scheme() == "https" {
-        return Ok(());
-    }
-    if base_url.scheme() != "http" {
-        bail!("remote cache URL must use HTTPS");
-    }
-    let is_loopback = base_url.host().is_some_and(|host| match host {
-        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
-        Host::Ipv4(address) => address.is_loopback(),
-        Host::Ipv6(address) => address.is_loopback(),
-    });
-    if !is_loopback && authenticated {
-        bail!("remote cache URL must use HTTPS except for loopback development servers");
-    }
-    if !is_loopback {
-        warn!(
-            "using an unauthenticated remote build cache over plain HTTP; cache traffic can be read \
-             or modified in transit"
-        );
-    }
-    Ok(())
-}
-
-fn normalized_base_url(mut url: Url) -> Url {
-    if !url.path().ends_with('/') {
-        url.set_path(&format!("{}/", url.path()));
-    }
-    url
-}
-
 fn retry_delays(retries: i64) -> impl Iterator<Item = Duration> {
     [200u64, 1_000, 4_000, 15_000]
         .into_iter()
@@ -1839,7 +549,3 @@ where
         }
     }
 }
-
-#[cfg(test)]
-#[path = "core_tests.rs"]
-mod tests;

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -40,6 +40,8 @@ mod agent;
 mod client;
 mod local;
 mod remote_http;
+mod remote_s3;
+mod sigv4;
 mod uploads;
 
 pub use agent::{
@@ -65,6 +67,9 @@ use remote_http::HttpRemoteCache;
 #[doc(hidden)]
 pub use remote_http::fuzz_decode_blob_pack;
 pub(crate) use remote_http::{BlobPackLimits, blob_pack_chunk};
+use remote_s3::S3RemoteCache;
+pub use remote_s3::{S3ConditionalWrites, S3RemoteCacheConfig};
+pub use sigv4::S3Credentials;
 /// Cap the JSON bodies a remote cache can hand back. Blob downloads are bounded
 /// by the size their digest promises, but action results and manifests carry no
 /// such claim, so without an explicit ceiling a hostile or broken server can
@@ -245,6 +250,7 @@ pub struct RemoteCacheClient {
 /// work around that would buy nothing here.
 enum Backend {
     Http(HttpRemoteCache),
+    S3(S3RemoteCache),
 }
 
 impl RemoteCacheClient {
@@ -252,6 +258,16 @@ impl RemoteCacheClient {
     pub fn new(config: RemoteCacheConfig) -> Result<Self> {
         Ok(Self {
             backend: Backend::Http(HttpRemoteCache::new(config)?),
+        })
+    }
+
+    /// Construct a client backed directly by an S3-compatible object store.
+    ///
+    /// The store answers the same lookups a cache server does, without the
+    /// extensions built on top of the protocol. See [`S3RemoteCacheConfig`].
+    pub fn new_s3(config: S3RemoteCacheConfig) -> Result<Self> {
+        Ok(Self {
+            backend: Backend::S3(S3RemoteCache::new(config)?),
         })
     }
 
@@ -263,6 +279,7 @@ impl RemoteCacheClient {
     pub async fn check_connection(&self) -> Result<()> {
         match &self.backend {
             Backend::Http(client) => client.check_connection().await,
+            Backend::S3(store) => store.check_connection().await,
         }
     }
 
@@ -278,6 +295,7 @@ impl RemoteCacheClient {
     ) -> Result<Option<RemoteBlobPack>> {
         match &self.backend {
             Backend::Http(client) => client.get_blob_pack(digests, staging_dir).await,
+            Backend::S3(store) => store.get_blob_pack(digests, staging_dir).await,
         }
     }
 
@@ -293,6 +311,11 @@ impl RemoteCacheClient {
                     .get_blob_pack_with_limit(digests, staging_dir, max_bytes)
                     .await
             }
+            Backend::S3(store) => {
+                store
+                    .get_blob_pack_with_limit(digests, staging_dir, max_bytes)
+                    .await
+            }
         }
     }
 
@@ -303,6 +326,7 @@ impl RemoteCacheClient {
     ) -> Result<Option<RemoteActionResult>> {
         match &self.backend {
             Backend::Http(client) => client.get_action_result(action).await,
+            Backend::S3(store) => store.get_action_result(action).await,
         }
     }
 
@@ -312,6 +336,7 @@ impl RemoteCacheClient {
     pub(crate) async fn action_batch_limit(&self) -> Result<Option<usize>> {
         match &self.backend {
             Backend::Http(client) => client.action_batch_limit().await,
+            Backend::S3(store) => store.action_batch_limit().await,
         }
     }
 
@@ -327,6 +352,7 @@ impl RemoteCacheClient {
     ) -> Result<Option<Vec<RemoteActionResult>>> {
         match &self.backend {
             Backend::Http(client) => client.get_action_results(actions).await,
+            Backend::S3(store) => store.get_action_results(actions).await,
         }
     }
 
@@ -334,6 +360,7 @@ impl RemoteCacheClient {
     pub async fn put_action_result(&self, result: &RemoteActionResult) -> Result<()> {
         match &self.backend {
             Backend::Http(client) => client.put_action_result(result).await,
+            Backend::S3(store) => store.put_action_result(result).await,
         }
     }
 
@@ -344,6 +371,7 @@ impl RemoteCacheClient {
     ) -> Result<Option<RemoteActionManifest>> {
         match &self.backend {
             Backend::Http(client) => client.get_action_manifest(key).await,
+            Backend::S3(store) => store.get_action_manifest(key).await,
         }
     }
 
@@ -356,6 +384,7 @@ impl RemoteCacheClient {
     ) -> Result<ManifestPutOutcome> {
         match &self.backend {
             Backend::Http(client) => client.put_action_manifest(key, bytes, expected_etag).await,
+            Backend::S3(store) => store.put_action_manifest(key, bytes, expected_etag).await,
         }
     }
 
@@ -367,6 +396,7 @@ impl RemoteCacheClient {
     ) -> Result<Vec<u8>> {
         match &self.backend {
             Backend::Http(client) => client.get_blob(digest, media_type).await,
+            Backend::S3(store) => store.get_blob(digest, media_type).await,
         }
     }
 
@@ -378,6 +408,7 @@ impl RemoteCacheClient {
     ) -> Result<tempfile::NamedTempFile> {
         match &self.backend {
             Backend::Http(client) => client.get_blob_file(digest, staging_dir).await,
+            Backend::S3(store) => store.get_blob_file(digest, staging_dir).await,
         }
     }
 
@@ -387,6 +418,7 @@ impl RemoteCacheClient {
     pub(crate) async fn blob_pack_upload_limits(&self) -> Result<Option<BlobPackLimits>> {
         match &self.backend {
             Backend::Http(client) => client.blob_pack_upload_limits().await,
+            Backend::S3(store) => store.blob_pack_upload_limits().await,
         }
     }
 
@@ -400,6 +432,7 @@ impl RemoteCacheClient {
     pub async fn put_blob_pack(&self, uploads: &[BlobUpload]) -> Result<Option<BlobPackReceipt>> {
         match &self.backend {
             Backend::Http(client) => client.put_blob_pack(uploads).await,
+            Backend::S3(store) => store.put_blob_pack(uploads).await,
         }
     }
 
@@ -407,6 +440,7 @@ impl RemoteCacheClient {
     pub async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
         match &self.backend {
             Backend::Http(client) => client.put_blob(upload).await,
+            Backend::S3(store) => store.put_blob(upload).await,
         }
     }
 }
@@ -503,6 +537,23 @@ fn is_dns_error(error: &(dyn std::error::Error + 'static)) -> bool {
     false
 }
 
+/// A failure a backend has identified as worth retrying.
+///
+/// [`is_transient`] recognizes the statuses that are transient for any HTTP
+/// service. A backend that knows one of its own -- S3 answers `409` while a
+/// concurrent conditional write to the same key is in flight, and asks that it
+/// be retried -- attaches this instead of teaching that function about it.
+#[derive(Debug)]
+pub(crate) struct TransientRequest(pub(crate) &'static str);
+
+impl std::fmt::Display for TransientRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl std::error::Error for TransientRequest {}
+
 fn is_transient(error: &eyre::Report) -> bool {
     // An unavailable hostname is a deterministic configuration error. reqwest
     // categorizes it as a connect error, but retrying only delays the diagnosis.
@@ -510,6 +561,9 @@ fn is_transient(error: &eyre::Report) -> bool {
         return false;
     }
     error.chain().any(|source| {
+        if source.downcast_ref::<TransientRequest>().is_some() {
+            return true;
+        }
         let Some(error) = source.downcast_ref::<reqwest::Error>() else {
             return false;
         };

--- a/crates/mbx-cache-core/src/remote_http.rs
+++ b/crates/mbx-cache-core/src/remote_http.rs
@@ -1,0 +1,1470 @@
+//! The remote cache protocol as spoken to an mbx cache server over HTTP.
+//!
+//! This is one of the two backends behind [`crate::RemoteCacheClient`]. It
+//! implements the full v1 protocol, including the negotiated blob-pack and
+//! batched-lookup extensions that only a protocol server offers.
+
+use crate::{
+    ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, BLOB_MEDIA_TYPE,
+    BLOB_PACK_BLOBS_HEADER, BLOB_PACK_BYTES_HEADER, BLOB_PACK_HEADER_BYTES, BLOB_PACK_MAGIC,
+    BLOB_PACK_MEDIA_TYPE, BLOB_PACK_RECEIPT_MEDIA_TYPE, BLOB_PACK_TIMEOUT_BYTES_PER_UNIT,
+    BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT, BlobPackReceipt, BlobSource, BlobUpload, CacheDigest,
+    Capabilities, DIGEST_LIST_MEDIA_TYPE, DigestAlgorithm, MAX_ACTION_BATCH_ITEMS,
+    MAX_ACTION_RESULT_BYTES, MAX_REMOTE_BLOB_BYTES, MAX_REMOTE_JSON_BYTES,
+    MAX_STAGED_BLOB_PACK_BYTES, MAX_STAGED_BLOB_PACK_ITEMS, ManifestPutOutcome, NAMESPACE_HEADER,
+    PACK_STREAM_CHUNK_BYTES, PROTOCOL_HEADER, PROTOCOL_VERSION, RemoteActionManifest,
+    RemoteActionResult, RemoteBlobPack, RemoteCacheConfig, TASK_ACTION_MANIFEST_MEDIA_TYPE,
+    parse_strong_etag, quoted_etag, read_bounded_json, read_json_within, retry_async,
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use eyre::{Result, bail, eyre};
+use futures_util::TryStreamExt as _;
+use log::warn;
+use reqwest::StatusCode;
+use reqwest::header::{
+    ACCEPT, AUTHORIZATION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, ETAG, HeaderMap,
+    HeaderValue, IF_MATCH, IF_NONE_MATCH,
+};
+use serde::{Deserialize, Serialize};
+use sha2::Digest as _;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use url::{Host, Url};
+
+struct DownloadedBlobPack {
+    directory: tempfile::TempDir,
+    blobs: Vec<(CacheDigest, PathBuf)>,
+    metadata: BlobPackResponseStats,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct BlobPackResponseMetadata {
+    content_length: Option<u64>,
+    blob_count: Option<u64>,
+    payload_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BlobPackResponseStats {
+    blob_count: u64,
+    payload_bytes: u64,
+    framed_bytes: u64,
+}
+
+impl BlobPackResponseMetadata {
+    fn from_headers(headers: &HeaderMap) -> Result<Self> {
+        Ok(Self {
+            content_length: optional_u64_header(headers, CONTENT_LENGTH.as_str())?,
+            blob_count: optional_u64_header(headers, BLOB_PACK_BLOBS_HEADER)?,
+            payload_bytes: optional_u64_header(headers, BLOB_PACK_BYTES_HEADER)?,
+        })
+    }
+
+    fn validate(self, decoded: BlobPackResponseStats) -> Result<BlobPackResponseStats> {
+        if let Some(content_length) = self.content_length
+            && content_length != decoded.framed_bytes
+        {
+            bail!(
+                "remote cache blob pack content length metadata mismatch: expected {}, decoded {}",
+                content_length,
+                decoded.framed_bytes
+            );
+        }
+        if let Some(blob_count) = self.blob_count
+            && blob_count != decoded.blob_count
+        {
+            bail!(
+                "remote cache blob pack blob count metadata mismatch: expected {}, decoded {}",
+                blob_count,
+                decoded.blob_count
+            );
+        }
+        if let Some(payload_bytes) = self.payload_bytes
+            && payload_bytes != decoded.payload_bytes
+        {
+            bail!(
+                "remote cache blob pack payload byte metadata mismatch: expected {}, decoded {}",
+                payload_bytes,
+                decoded.payload_bytes
+            );
+        }
+        Ok(BlobPackResponseStats {
+            blob_count: self.blob_count.unwrap_or(decoded.blob_count),
+            payload_bytes: self.payload_bytes.unwrap_or(decoded.payload_bytes),
+            framed_bytes: self.content_length.unwrap_or(decoded.framed_bytes),
+        })
+    }
+}
+
+fn optional_u64_header(headers: &HeaderMap, name: &str) -> Result<Option<u64>> {
+    let Some(value) = headers.get(name) else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .map_err(|_| eyre!("remote cache blob pack {name} header is not valid UTF-8"))?;
+    let value = value
+        .parse::<u64>()
+        .map_err(|_| eyre!("remote cache blob pack {name} header is not an unsigned integer"))?;
+    Ok(Some(value))
+}
+
+type RemoteCacheCapabilities = Capabilities;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BlobPackLimits {
+    pub(crate) max_items: usize,
+    pub(crate) max_bytes: u64,
+}
+
+/// What one capabilities exchange settled, cached for the session.
+///
+/// `Default` is also the answer for a server with no capabilities endpoint:
+/// no blob packs and no compression, which is exactly how every request
+/// behaved before either feature existed.
+#[derive(Debug, Clone, Copy, Default)]
+struct NegotiatedCapabilities {
+    blob_packs: Option<BlobPackLimits>,
+    blob_pack_uploads: Option<BlobPackLimits>,
+    action_batches: Option<usize>,
+    zstd_uploads: bool,
+}
+
+#[derive(Serialize)]
+struct DigestList<'a> {
+    digests: &'a [CacheDigest],
+}
+
+/// Action results a server holds, in no particular order.
+///
+/// Deliberately tolerant of fields it does not know, so a later protocol minor
+/// can describe more about a batch without this client refusing the response.
+/// The records inside stay canonical and exhaustive.
+#[derive(Deserialize)]
+struct ActionResultBatch {
+    #[serde(default)]
+    results: Vec<RemoteActionResult>,
+}
+/// The mbx remote cache protocol spoken over HTTP.
+///
+/// The client validates digests, response sizes, media types, and redirects at
+/// the protocol boundary. It is safe to share between asynchronous tasks.
+pub(crate) struct HttpRemoteCache {
+    base_url: Url,
+    namespace: String,
+    client: reqwest::Client,
+    credential: RemoteCacheCredential,
+    download_timeout: Duration,
+    retries: i64,
+    capabilities: tokio::sync::OnceCell<NegotiatedCapabilities>,
+    blob_packs_disabled: AtomicBool,
+    blob_pack_uploads_disabled: AtomicBool,
+    action_batches_disabled: AtomicBool,
+}
+
+impl HttpRemoteCache {
+    pub(crate) fn new(config: RemoteCacheConfig) -> Result<Self> {
+        let authenticated = config
+            .token
+            .as_deref()
+            .is_some_and(|token| !token.trim().is_empty())
+            || config.token_file.is_some()
+            || config
+                .oidc_audience
+                .as_deref()
+                .is_some_and(|audience| !audience.trim().is_empty());
+        validate_remote_url(&config.base_url, authenticated)?;
+        let client = reqwest::Client::builder()
+            .connect_timeout(config.connect_timeout)
+            .read_timeout(config.read_timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        let credential = remote_credential(&config, client.clone())?;
+        Ok(Self {
+            base_url: normalized_base_url(config.base_url),
+            namespace: config.namespace,
+            client,
+            credential,
+            download_timeout: config.download_timeout,
+            retries: config.retries,
+            capabilities: tokio::sync::OnceCell::new(),
+            blob_packs_disabled: AtomicBool::new(false),
+            blob_pack_uploads_disabled: AtomicBool::new(false),
+            action_batches_disabled: AtomicBool::new(false),
+        })
+    }
+
+    pub(crate) async fn check_connection(&self) -> Result<()> {
+        self.fetch_capabilities(false).await?;
+        Ok(())
+    }
+
+    fn action_result_endpoint(&self, action: &CacheDigest) -> Result<Url> {
+        action.validate()?;
+        if action.algorithm != "blake3" {
+            bail!("remote cache action keys must use blake3");
+        }
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        ))?)
+    }
+
+    fn blob_endpoint(&self, digest: &CacheDigest) -> Result<Url> {
+        digest.validate()?;
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        ))?)
+    }
+
+    fn action_manifest_endpoint(&self, key: &CacheDigest) -> Result<Url> {
+        key.validate()?;
+        if key.algorithm != "blake3" {
+            bail!("remote action manifest keys must use blake3");
+        }
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/action-manifests/{}/{}/{}",
+            key.algorithm, key.hash, key.size
+        ))?)
+    }
+
+    fn capabilities_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/capabilities"))?)
+    }
+
+    fn blob_pack_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/blobs:pack"))?)
+    }
+
+    fn blob_pack_upload_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/blobs:pack-upload"))?)
+    }
+
+    fn action_result_batch_endpoint(&self) -> Result<Url> {
+        Ok(self
+            .base_url
+            .join(&format!("v{PROTOCOL_VERSION}/action-results:batch"))?)
+    }
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        url: Url,
+        media_type: &'static str,
+    ) -> Result<reqwest::RequestBuilder> {
+        let request = self
+            .client
+            .request(method, url)
+            .header(PROTOCOL_HEADER, u16::from(PROTOCOL_VERSION))
+            .header(NAMESPACE_HEADER, &self.namespace)
+            .header(ACCEPT, media_type);
+        if let Some(authorization) = self.credential.authorization().await? {
+            Ok(request.header(AUTHORIZATION, authorization))
+        } else {
+            Ok(request)
+        }
+    }
+
+    async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
+        Ok(self.negotiated_capabilities().await?.blob_packs)
+    }
+
+    async fn negotiated_capabilities(&self) -> Result<NegotiatedCapabilities> {
+        self.capabilities
+            .get_or_try_init(|| self.fetch_capabilities(true))
+            .await
+            .copied()
+    }
+
+    async fn fetch_capabilities(&self, allow_missing: bool) -> Result<NegotiatedCapabilities> {
+        let url = self.capabilities_endpoint()?;
+        let response = self
+            .request(reqwest::Method::GET, url, "application/json")
+            .await?
+            .send()
+            .await?;
+        if allow_missing
+            && matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            )
+        {
+            return Ok(NegotiatedCapabilities::default());
+        }
+        let bytes = read_bounded_json(response.error_for_status()?, "capabilities").await?;
+        let capabilities: RemoteCacheCapabilities = serde_json::from_slice(&bytes)?;
+        if capabilities.protocol.major != PROTOCOL_VERSION {
+            bail!(
+                "remote cache capability protocol {} is incompatible with client protocol {PROTOCOL_VERSION}",
+                capabilities.protocol.major
+            );
+        }
+        // Compression is negotiated, never assumed: a body sent with a
+        // coding the server did not offer would be stored corrupt or
+        // rejected, so absence of the advertisement means identity.
+        let zstd_uploads = capabilities
+            .compressors
+            .iter()
+            .any(|compressor| compressor == "zstd");
+        let pack_limits = |feature: bool| -> Result<Option<BlobPackLimits>> {
+            if !feature {
+                return Ok(None);
+            }
+            let max_items = usize::try_from(capabilities.limits.max_batch_items)
+                .ok()
+                .filter(|limit| *limit > 0)
+                .ok_or_else(|| {
+                    eyre!("remote cache blob packs require a positive max_batch_items limit")
+                })?;
+            if capabilities.limits.max_pack_bytes == 0 {
+                bail!("remote cache blob packs require a positive max_pack_bytes limit");
+            }
+            Ok(Some(BlobPackLimits {
+                max_items: max_items.min(MAX_STAGED_BLOB_PACK_ITEMS),
+                max_bytes: capabilities
+                    .limits
+                    .max_pack_bytes
+                    .min(MAX_STAGED_BLOB_PACK_BYTES),
+            }))
+        };
+        let blob_packs = pack_limits(capabilities.features.blob_packs)?;
+        let blob_pack_uploads = pack_limits(capabilities.features.blob_pack_uploads)?;
+        let action_batches = if capabilities.features.action_batch {
+            let max_items = usize::try_from(capabilities.limits.max_batch_items)
+                .ok()
+                .filter(|limit| *limit > 0)
+                .ok_or_else(|| {
+                    eyre!("remote cache action batches require a positive max_batch_items limit")
+                })?;
+            Some(max_items.min(MAX_ACTION_BATCH_ITEMS))
+        } else {
+            None
+        };
+        Ok(NegotiatedCapabilities {
+            blob_packs,
+            blob_pack_uploads,
+            action_batches,
+            zstd_uploads,
+        })
+    }
+
+    pub(crate) async fn get_blob_pack(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+    ) -> Result<Option<RemoteBlobPack>> {
+        self.get_blob_pack_with_limit(digests, staging_dir, MAX_STAGED_BLOB_PACK_BYTES)
+            .await
+    }
+
+    pub(crate) async fn get_blob_pack_with_limit(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+        max_bytes: u64,
+    ) -> Result<Option<RemoteBlobPack>> {
+        if digests.is_empty() || self.blob_packs_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let Some(mut limits) = self.blob_pack_limits().await? else {
+            return Ok(None);
+        };
+        limits.max_bytes = limits.max_bytes.min(max_bytes);
+        if limits.max_bytes == 0 {
+            bail!("remote cache download budget is exhausted");
+        }
+        fs::create_dir_all(staging_dir)?;
+        let chunk = blob_pack_chunk(digests, limits)?;
+        if chunk.is_empty() {
+            return Ok(Some(RemoteBlobPack {
+                _directory: tempfile::tempdir_in(staging_dir)?,
+                blobs: Vec::new(),
+                requests: 0,
+                requested: Vec::new(),
+                blob_count: 0,
+                payload_bytes: 0,
+                framed_bytes: BLOB_PACK_MAGIC.len() as u64,
+            }));
+        }
+        match self.download_blob_pack_chunk(&chunk, staging_dir).await? {
+            Some(pack) => Ok(Some(RemoteBlobPack {
+                _directory: pack.directory,
+                blobs: pack.blobs,
+                requests: 1,
+                requested: chunk,
+                blob_count: pack.metadata.blob_count,
+                payload_bytes: pack.metadata.payload_bytes,
+                framed_bytes: pack.metadata.framed_bytes,
+            })),
+            None => {
+                self.blob_packs_disabled.store(true, Ordering::Relaxed);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn download_blob_pack_chunk(
+        &self,
+        digests: &[CacheDigest],
+        staging_dir: &Path,
+    ) -> Result<Option<DownloadedBlobPack>> {
+        let url = self.blob_pack_endpoint()?;
+        let body = serde_json::to_vec(&DigestList { digests })?;
+        let download_timeout = blob_pack_download_timeout(self.download_timeout, digests);
+        let download = retry_async("POST", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::POST, url.clone(), BLOB_PACK_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, DIGEST_LIST_MEDIA_TYPE)
+                .body(body.clone())
+                .send()
+                .await?;
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            ) {
+                return Ok(None);
+            }
+            let response = response.error_for_status()?;
+            let media_type = response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.split(';').next())
+                .map(str::trim);
+            if media_type != Some(BLOB_PACK_MEDIA_TYPE) {
+                bail!("remote cache blob pack has an invalid content type");
+            }
+            Ok(Some(
+                decode_blob_pack(response, digests, staging_dir).await?,
+            ))
+        });
+        tokio::time::timeout(download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
+    }
+
+    pub(crate) async fn get_action_result(
+        &self,
+        action: &CacheDigest,
+    ) -> Result<Option<RemoteActionResult>> {
+        let url = self.action_result_endpoint(action)?;
+        let result = retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::GET, url.clone(), ACTION_RESULT_MEDIA_TYPE)
+                .await?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            let bytes = read_bounded_json(response.error_for_status()?, "action result").await?;
+            Ok(Some(serde_json::from_slice::<RemoteActionResult>(&bytes)?))
+        })
+        .await?;
+        if let Some(result) = &result
+            && (result.version != 1 || result.action != *action)
+        {
+            bail!("remote action result does not match requested action");
+        }
+        Ok(result)
+    }
+
+    pub(crate) async fn action_batch_limit(&self) -> Result<Option<usize>> {
+        if self.action_batches_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        Ok(self.negotiated_capabilities().await?.action_batches)
+    }
+
+    pub(crate) async fn get_action_results(
+        &self,
+        actions: &[CacheDigest],
+    ) -> Result<Option<Vec<RemoteActionResult>>> {
+        if actions.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+        if self.action_batches_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let Some(limit) = self.negotiated_capabilities().await?.action_batches else {
+            return Ok(None);
+        };
+        if actions.len() > limit {
+            bail!(
+                "remote cache action batch of {} exceeds the negotiated limit of {limit}",
+                actions.len()
+            );
+        }
+        let mut requested = BTreeSet::new();
+        for action in actions {
+            action.validate()?;
+            if action.algorithm != "blake3" {
+                bail!("remote cache action keys must use blake3");
+            }
+            requested.insert(action.clone());
+        }
+        let url = self.action_result_batch_endpoint()?;
+        let body = serde_json::to_vec(&DigestList { digests: actions })?;
+        let bound = MAX_ACTION_RESULT_BYTES.saturating_mul(actions.len() as u64);
+        let batch = retry_async("POST", &url, self.retries, || async {
+            let response = self
+                .request(
+                    reqwest::Method::POST,
+                    url.clone(),
+                    ACTION_RESULT_BATCH_MEDIA_TYPE,
+                )
+                .await?
+                .header(CONTENT_TYPE, DIGEST_LIST_MEDIA_TYPE)
+                .body(body.clone())
+                .send()
+                .await?;
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            ) {
+                // Advertised but not served. Asking again every wave would cost
+                // a round trip each time to learn the same thing.
+                self.action_batches_disabled.store(true, Ordering::Relaxed);
+                return Ok(None);
+            }
+            let bytes =
+                read_json_within(response.error_for_status()?, "action result batch", bound)
+                    .await?;
+            Ok(Some(serde_json::from_slice::<ActionResultBatch>(&bytes)?))
+        })
+        .await?;
+        let Some(batch) = batch else {
+            return Ok(None);
+        };
+        // A result for an action that was not asked for would key cached outputs
+        // under a digest this client never derived, so it is refused rather than
+        // ignored.
+        let mut seen = BTreeSet::new();
+        for result in &batch.results {
+            if result.version != 1 || !requested.contains(&result.action) {
+                bail!("remote action result batch contains an unrequested action");
+            }
+            if !seen.insert(result.action.clone()) {
+                bail!("remote action result batch repeats an action");
+            }
+        }
+        Ok(Some(batch.results))
+    }
+
+    pub(crate) async fn put_action_result(&self, result: &RemoteActionResult) -> Result<()> {
+        let url = self.action_result_endpoint(&result.action)?;
+        let body = serde_json::to_vec(result)?;
+        retry_async("PUT", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::PUT, url.clone(), ACTION_RESULT_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, ACTION_RESULT_MEDIA_TYPE)
+                .header(IF_NONE_MATCH, "*")
+                .body(body.clone())
+                .send()
+                .await?;
+            if response.status() != StatusCode::PRECONDITION_FAILED {
+                response.error_for_status()?;
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    pub(crate) async fn get_action_manifest(
+        &self,
+        key: &CacheDigest,
+    ) -> Result<Option<RemoteActionManifest>> {
+        let url = self.action_manifest_endpoint(key)?;
+        retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(
+                    reqwest::Method::GET,
+                    url.clone(),
+                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
+                )
+                .await?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            let response = response.error_for_status()?;
+            let etag = parse_strong_etag(response.headers().get(ETAG))?;
+            let bytes = read_bounded_json(response, "action manifest").await?;
+            Ok(Some(RemoteActionManifest { bytes, etag }))
+        })
+        .await
+    }
+
+    pub(crate) async fn put_action_manifest(
+        &self,
+        key: &CacheDigest,
+        bytes: &[u8],
+        expected_etag: Option<&str>,
+    ) -> Result<ManifestPutOutcome> {
+        let url = self.action_manifest_endpoint(key)?;
+        let body = bytes.to_vec();
+        let expected_etag = expected_etag.map(quoted_etag).transpose()?;
+        retry_async("PUT", &url, self.retries, || async {
+            let mut request = self
+                .request(
+                    reqwest::Method::PUT,
+                    url.clone(),
+                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
+                )
+                .await?
+                .header(CONTENT_TYPE, TASK_ACTION_MANIFEST_MEDIA_TYPE)
+                .body(body.clone());
+            request = if let Some(etag) = &expected_etag {
+                request.header(IF_MATCH, etag)
+            } else {
+                request.header(IF_NONE_MATCH, "*")
+            };
+            let response = request.send().await?;
+            if response.status() == StatusCode::PRECONDITION_FAILED {
+                return Ok(ManifestPutOutcome::PreconditionFailed);
+            }
+            response.error_for_status()?;
+            Ok(ManifestPutOutcome::Stored)
+        })
+        .await
+    }
+
+    pub(crate) async fn get_blob(
+        &self,
+        digest: &CacheDigest,
+        media_type: &'static str,
+    ) -> Result<Vec<u8>> {
+        digest.validate()?;
+        if digest.size > MAX_REMOTE_JSON_BYTES {
+            bail!(
+                "remote cache in-memory blob declared {} bytes, over the {} byte limit",
+                digest.size,
+                MAX_REMOTE_JSON_BYTES
+            );
+        }
+        let url = self.blob_endpoint(digest)?;
+        retry_async("GET", &url, self.retries, || async {
+            let mut response = self
+                .request(reqwest::Method::GET, url.clone(), media_type)
+                .await?
+                .send()
+                .await?
+                .error_for_status()?;
+            // Stop reading as soon as the response outgrows the digest it claims
+            // to satisfy. A server that streams more than it promised must not be
+            // able to exhaust this process before verification rejects it.
+            let mut bytes = Vec::new();
+            while let Some(chunk) = response.chunk().await? {
+                if bytes.len() as u64 + chunk.len() as u64 > digest.size {
+                    bail!("remote cache blob exceeded the size of its digest");
+                }
+                bytes.extend_from_slice(&chunk);
+            }
+            if !digest.matches_bytes(&bytes)? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(bytes)
+        })
+        .await
+    }
+
+    pub(crate) async fn get_blob_file(
+        &self,
+        digest: &CacheDigest,
+        staging_dir: &Path,
+    ) -> Result<tempfile::NamedTempFile> {
+        digest.validate()?;
+        if digest.size > MAX_REMOTE_BLOB_BYTES {
+            bail!(
+                "remote cache blob declared {} bytes, over the {} byte limit",
+                digest.size,
+                MAX_REMOTE_BLOB_BYTES
+            );
+        }
+        let url = self.blob_endpoint(digest)?;
+        let download = retry_async("GET", &url, self.retries, || async {
+            let mut response = self
+                .request(reqwest::Method::GET, url.clone(), BLOB_MEDIA_TYPE)
+                .await?
+                .send()
+                .await?;
+            response.error_for_status_ref()?;
+            fs::create_dir_all(staging_dir)?;
+            let temporary = tempfile::NamedTempFile::new_in(staging_dir)?;
+            let mut output = tokio::fs::File::from_std(temporary.reopen()?);
+            // Bound the download by the digest's own size so an oversized
+            // response cannot fill the disk before verification rejects it.
+            let mut written = 0u64;
+            while let Some(chunk) = response.chunk().await? {
+                written += chunk.len() as u64;
+                if written > digest.size {
+                    bail!("remote cache blob exceeded the size of its digest");
+                }
+                output.write_all(&chunk).await?;
+            }
+            output.flush().await?;
+            drop(output);
+            if !digest.matches_file(temporary.path())? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(temporary)
+        });
+        tokio::time::timeout(self.download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
+    }
+
+    pub(crate) async fn blob_pack_upload_limits(&self) -> Result<Option<BlobPackLimits>> {
+        if self.blob_pack_uploads_disabled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        Ok(self.negotiated_capabilities().await?.blob_pack_uploads)
+    }
+
+    pub(crate) async fn put_blob_pack(
+        &self,
+        uploads: &[BlobUpload],
+    ) -> Result<Option<BlobPackReceipt>> {
+        if uploads.is_empty() {
+            return Ok(Some(BlobPackReceipt {
+                created: 0,
+                existing: 0,
+            }));
+        }
+        let Some(limits) = self.blob_pack_upload_limits().await? else {
+            return Ok(None);
+        };
+        if uploads.len() > limits.max_items {
+            bail!(
+                "remote cache blob pack of {} blobs exceeds the negotiated limit of {}",
+                uploads.len(),
+                limits.max_items
+            );
+        }
+        let mut payload_bytes = 0u64;
+        for upload in uploads {
+            upload.digest.validate()?;
+            payload_bytes = payload_bytes
+                .checked_add(upload.digest.size)
+                .ok_or_else(|| eyre!("remote cache blob pack payload overflowed"))?;
+        }
+        if payload_bytes > limits.max_bytes {
+            bail!(
+                "remote cache blob pack of {payload_bytes} bytes exceeds the negotiated limit of {}",
+                limits.max_bytes
+            );
+        }
+        let framed_bytes = BLOB_PACK_MAGIC.len() as u64
+            + payload_bytes
+            + BLOB_PACK_HEADER_BYTES * uploads.len() as u64;
+        let compress = self
+            .negotiated_capabilities()
+            .await
+            .map(|capabilities| capabilities.zstd_uploads)
+            .unwrap_or(false);
+        let url = self.blob_pack_upload_endpoint()?;
+        retry_async("POST", &url, self.retries, || async {
+            let request = self
+                .request(
+                    reqwest::Method::POST,
+                    url.clone(),
+                    BLOB_PACK_RECEIPT_MEDIA_TYPE,
+                )
+                .await?
+                .header(CONTENT_TYPE, BLOB_PACK_MEDIA_TYPE)
+                .header(BLOB_PACK_BLOBS_HEADER, uploads.len())
+                .header(BLOB_PACK_BYTES_HEADER, payload_bytes);
+            // Each attempt reads the sources again, so the pack is rebuilt here
+            // rather than buffered once and held in memory.
+            let stream = blob_pack_stream(blob_pack_members(uploads)?);
+            let request = if compress {
+                let encoder = async_compression::tokio::bufread::ZstdEncoder::new(
+                    tokio::io::BufReader::new(tokio_util::io::StreamReader::new(stream)),
+                );
+                request
+                    .header(CONTENT_ENCODING, "zstd")
+                    .body(reqwest::Body::wrap_stream(
+                        tokio_util::io::ReaderStream::new(encoder),
+                    ))
+            } else {
+                request
+                    .header(CONTENT_LENGTH, framed_bytes)
+                    .body(reqwest::Body::wrap_stream(stream))
+            };
+            let response = request.send().await?;
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND
+                    | StatusCode::METHOD_NOT_ALLOWED
+                    | StatusCode::NOT_IMPLEMENTED
+            ) {
+                self.blob_pack_uploads_disabled
+                    .store(true, Ordering::Relaxed);
+                return Ok(None);
+            }
+            let bytes =
+                read_bounded_json(response.error_for_status()?, "blob pack receipt").await?;
+            Ok(Some(serde_json::from_slice::<BlobPackReceipt>(&bytes)?))
+        })
+        .await
+    }
+
+    pub(crate) async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
+        let url = self.blob_endpoint(&upload.digest)?;
+        // A failed negotiation downgrades to identity rather than failing the
+        // upload: compression is an economy, not a requirement.
+        let compress = self
+            .negotiated_capabilities()
+            .await
+            .map(|capabilities| capabilities.zstd_uploads)
+            .unwrap_or(false);
+        retry_async("PUT", &url, self.retries, || async {
+            let request = self
+                .request(reqwest::Method::PUT, url.clone(), BLOB_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, BLOB_MEDIA_TYPE)
+                .header(IF_NONE_MATCH, "*");
+            let request = if compress {
+                // Compressed and therefore chunked: the length of the encoded
+                // stream is not known up front, and the digest already tells
+                // the server the decompressed size it must enforce.
+                let reader: Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin> = match &upload
+                    .source
+                {
+                    BlobSource::Bytes(bytes) => Box::new(std::io::Cursor::new(bytes.clone())),
+                    BlobSource::File(file) => Box::new(tokio::fs::File::open(file.path()).await?),
+                    BlobSource::Path(path) => Box::new(tokio::fs::File::open(path).await?),
+                };
+                let encoder = async_compression::tokio::bufread::ZstdEncoder::new(
+                    tokio::io::BufReader::new(reader),
+                );
+                request
+                    .header(CONTENT_ENCODING, "zstd")
+                    .body(reqwest::Body::wrap_stream(
+                        tokio_util::io::ReaderStream::new(encoder),
+                    ))
+            } else {
+                let (length, body) = match &upload.source {
+                    BlobSource::Bytes(bytes) => {
+                        (bytes.len() as u64, reqwest::Body::from(bytes.clone()))
+                    }
+                    BlobSource::File(file) => {
+                        let file = tokio::fs::File::open(file.path()).await?;
+                        let length = file.metadata().await?.len();
+                        let stream = tokio_util::io::ReaderStream::new(file);
+                        (length, reqwest::Body::wrap_stream(stream))
+                    }
+                    BlobSource::Path(path) => {
+                        let file = tokio::fs::File::open(path).await?;
+                        let length = file.metadata().await?.len();
+                        let stream = tokio_util::io::ReaderStream::new(file);
+                        (length, reqwest::Body::wrap_stream(stream))
+                    }
+                };
+                request.header(CONTENT_LENGTH, length).body(body)
+            };
+            let response = request.send().await?;
+            if response.status() != StatusCode::PRECONDITION_FAILED {
+                response.error_for_status()?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}
+pub(crate) fn blob_pack_chunk(
+    digests: &[CacheDigest],
+    limits: BlobPackLimits,
+) -> Result<Vec<CacheDigest>> {
+    let mut seen = BTreeSet::new();
+    let mut chunk = Vec::new();
+    let mut chunk_bytes = 0_u64;
+    for digest in digests {
+        digest.validate()?;
+        if !seen.insert(digest.clone()) || digest.size > limits.max_bytes {
+            continue;
+        }
+        if chunk.len() == limits.max_items
+            || chunk_bytes.saturating_add(digest.size) > limits.max_bytes
+        {
+            break;
+        }
+        chunk_bytes = chunk_bytes.saturating_add(digest.size);
+        chunk.push(digest.clone());
+    }
+    Ok(chunk)
+}
+
+fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Duration {
+    let bytes = digests
+        .iter()
+        .fold(0_u64, |total, digest| total.saturating_add(digest.size));
+    let byte_units = bytes.div_ceil(BLOB_PACK_TIMEOUT_BYTES_PER_UNIT);
+    let item_units = digests.len().div_ceil(BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT);
+    let item_units = u64::try_from(item_units).unwrap_or(u64::MAX);
+    let multiplier = byte_units.max(item_units).max(1);
+    base.saturating_mul(u32::try_from(multiplier).unwrap_or(u32::MAX))
+}
+/// One member of a pack, described rather than opened.
+///
+/// A pack can hold thousands of objects. Opening them all before the first byte
+/// is sent would spend a file descriptor on each for the length of the request,
+/// so a member is opened only when the stream reaches it and closed when it is
+/// past.
+struct PackMemberSource {
+    header: Vec<u8>,
+    payload_bytes: u64,
+    source: PackPayloadSource,
+}
+
+enum PackPayloadSource {
+    Bytes(Vec<u8>),
+    Path(PathBuf),
+}
+
+enum PackStreamState {
+    Magic,
+    Header(usize),
+    Payload(usize, u64, Box<dyn AsyncRead + Send + Sync + Unpin>),
+    Done,
+}
+
+/// Frame blobs into one `MBXPACK1` stream, read on demand rather than buffered.
+///
+/// The frames mirror what [`decode_blob_pack_reader`] accepts, so both
+/// directions of the extension agree on the format by construction.
+fn blob_pack_stream(
+    members: Vec<PackMemberSource>,
+) -> impl futures_util::Stream<Item = std::io::Result<bytes::Bytes>> + Send + 'static {
+    futures_util::stream::unfold(
+        (PackStreamState::Magic, members),
+        |(state, members)| async move {
+            let mut state = state;
+            loop {
+                match state {
+                    PackStreamState::Magic => {
+                        return Some((
+                            Ok(bytes::Bytes::from_static(BLOB_PACK_MAGIC)),
+                            (PackStreamState::Header(0), members),
+                        ));
+                    }
+                    PackStreamState::Header(index) => {
+                        let Some(member) = members.get(index) else {
+                            state = PackStreamState::Done;
+                            continue;
+                        };
+                        let payload: Box<dyn AsyncRead + Send + Sync + Unpin> = match &member.source
+                        {
+                            PackPayloadSource::Bytes(bytes) => {
+                                Box::new(std::io::Cursor::new(bytes.clone()))
+                            }
+                            PackPayloadSource::Path(path) => {
+                                match tokio::fs::File::open(path).await {
+                                    Ok(file) => Box::new(file),
+                                    Err(error) => {
+                                        return Some((
+                                            Err(error),
+                                            (PackStreamState::Done, members),
+                                        ));
+                                    }
+                                }
+                            }
+                        };
+                        return Some((
+                            Ok(bytes::Bytes::from(member.header.clone())),
+                            (
+                                PackStreamState::Payload(index, member.payload_bytes, payload),
+                                members,
+                            ),
+                        ));
+                    }
+                    PackStreamState::Payload(index, remaining, mut payload) => {
+                        if remaining == 0 {
+                            // The declared frame length, rather than EOF, is the
+                            // boundary between adjacent members.
+                            state = PackStreamState::Header(index + 1);
+                            continue;
+                        }
+                        let chunk_bytes =
+                            usize::try_from(remaining.min(PACK_STREAM_CHUNK_BYTES as u64)).unwrap();
+                        let mut chunk = vec![0; chunk_bytes];
+                        match payload.read(&mut chunk).await {
+                            Ok(0) => {
+                                let error = std::io::Error::new(
+                                    std::io::ErrorKind::UnexpectedEof,
+                                    format!(
+                                        "blob pack member {index} ended with {remaining} bytes remaining"
+                                    ),
+                                );
+                                return Some((Err(error), (PackStreamState::Done, members)));
+                            }
+                            Ok(read) => {
+                                chunk.truncate(read);
+                                return Some((
+                                    Ok(bytes::Bytes::from(chunk)),
+                                    (
+                                        PackStreamState::Payload(
+                                            index,
+                                            remaining - read as u64,
+                                            payload,
+                                        ),
+                                        members,
+                                    ),
+                                ));
+                            }
+                            Err(error) => {
+                                return Some((Err(error), (PackStreamState::Done, members)));
+                            }
+                        }
+                    }
+                    PackStreamState::Done => return None,
+                }
+            }
+        },
+    )
+}
+
+fn blob_pack_members(uploads: &[BlobUpload]) -> Result<Vec<PackMemberSource>> {
+    uploads
+        .iter()
+        .map(|upload| {
+            Ok(PackMemberSource {
+                header: blob_pack_frame_header(&upload.digest)?,
+                payload_bytes: upload.digest.size,
+                source: match &upload.source {
+                    BlobSource::Bytes(bytes) => PackPayloadSource::Bytes(bytes.clone()),
+                    BlobSource::File(file) => PackPayloadSource::Path(file.path().to_path_buf()),
+                    BlobSource::Path(path) => PackPayloadSource::Path(path.clone()),
+                },
+            })
+        })
+        .collect()
+}
+
+fn blob_pack_frame_header(digest: &CacheDigest) -> Result<Vec<u8>> {
+    let algorithm = match digest.algorithm_kind()? {
+        DigestAlgorithm::Blake3 => 1u8,
+        DigestAlgorithm::Sha256 => 2u8,
+    };
+    let hash = hex::decode(&digest.hash)?;
+    if hash.len() != 32 {
+        bail!("remote cache blob pack digests must be 32 bytes");
+    }
+    let mut header = Vec::with_capacity(BLOB_PACK_HEADER_BYTES as usize);
+    header.push(algorithm);
+    header.extend_from_slice(&hash);
+    header.extend_from_slice(&digest.size.to_be_bytes());
+    Ok(header)
+}
+
+async fn decode_blob_pack(
+    response: reqwest::Response,
+    requested: &[CacheDigest],
+    staging_dir: &Path,
+) -> Result<DownloadedBlobPack> {
+    let metadata = BlobPackResponseMetadata::from_headers(response.headers())?;
+    let stream = response.bytes_stream().map_err(std::io::Error::other);
+    let reader = tokio_util::io::StreamReader::new(stream);
+    decode_blob_pack_reader(reader, metadata, requested, staging_dir).await
+}
+
+async fn decode_blob_pack_reader<R>(
+    mut reader: R,
+    metadata: BlobPackResponseMetadata,
+    requested: &[CacheDigest],
+    staging_dir: &Path,
+) -> Result<DownloadedBlobPack>
+where
+    R: AsyncRead + Unpin,
+{
+    let requested = requested.iter().cloned().collect::<BTreeSet<_>>();
+    let mut magic = [0_u8; BLOB_PACK_MAGIC.len()];
+    reader.read_exact(&mut magic).await?;
+    if &magic != BLOB_PACK_MAGIC {
+        bail!("remote cache blob pack has invalid magic");
+    }
+
+    let directory = tempfile::tempdir_in(staging_dir)?;
+    let mut seen = BTreeSet::new();
+    let mut blobs = Vec::new();
+    let mut payload_bytes = 0_u64;
+    let mut framed_bytes = BLOB_PACK_MAGIC.len() as u64;
+    loop {
+        let mut algorithm = [0_u8; 1];
+        if reader.read(&mut algorithm).await? == 0 {
+            break;
+        }
+        let (algorithm, mut hasher) = match algorithm[0] {
+            1 => (
+                "blake3",
+                BlobPackHasher::Blake3(Box::new(blake3::Hasher::new())),
+            ),
+            2 => ("sha256", BlobPackHasher::Sha256(sha2::Sha256::new())),
+            _ => bail!("remote cache blob pack has an invalid digest algorithm"),
+        };
+        let mut hash = [0_u8; 32];
+        reader.read_exact(&mut hash).await?;
+        let mut size = [0_u8; 8];
+        reader.read_exact(&mut size).await?;
+        let digest = CacheDigest {
+            algorithm: algorithm.into(),
+            hash: hex::encode(hash),
+            size: u64::from_be_bytes(size),
+        };
+        if !requested.contains(&digest) {
+            bail!("remote cache blob pack returned an unrequested digest");
+        }
+        if !seen.insert(digest.clone()) {
+            bail!("remote cache blob pack returned a duplicate digest");
+        }
+        framed_bytes = framed_bytes
+            .checked_add(BLOB_PACK_HEADER_BYTES)
+            .and_then(|bytes| bytes.checked_add(digest.size))
+            .ok_or_else(|| eyre!("remote cache blob pack is too large"))?;
+        payload_bytes = payload_bytes
+            .checked_add(digest.size)
+            .ok_or_else(|| eyre!("remote cache blob pack payload is too large"))?;
+
+        let path = directory.path().join(blobs.len().to_string());
+        let mut output = tokio::fs::File::create(&path).await?;
+        let mut remaining = digest.size;
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let limit = usize::try_from(remaining.min(buffer.len() as u64)).unwrap();
+            let count = reader.read(&mut buffer[..limit]).await?;
+            if count == 0 {
+                bail!("remote cache blob pack ended before a blob was complete");
+            }
+            output.write_all(&buffer[..count]).await?;
+            hasher.update(&buffer[..count]);
+            remaining -= count as u64;
+        }
+        output.flush().await?;
+        drop(output);
+        if !hasher.matches(&digest.hash) {
+            bail!("remote cache blob pack failed digest verification");
+        }
+        blobs.push((digest, path));
+    }
+    let blob_count = blobs.len().try_into().unwrap_or(u64::MAX);
+    let metadata = metadata.validate(BlobPackResponseStats {
+        blob_count,
+        payload_bytes,
+        framed_bytes,
+    })?;
+    Ok(DownloadedBlobPack {
+        directory,
+        blobs,
+        metadata,
+    })
+}
+
+/// Exercise the production blob-pack decoder without constructing an HTTP
+/// response. This narrow entry point exists for the workspace's fuzz target.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub async fn fuzz_decode_blob_pack(
+    bytes: &[u8],
+    requested: &[CacheDigest],
+    staging_dir: &Path,
+) -> Result<()> {
+    decode_blob_pack_reader(
+        bytes,
+        BlobPackResponseMetadata::default(),
+        requested,
+        staging_dir,
+    )
+    .await
+    .map(drop)
+}
+
+enum BlobPackHasher {
+    Blake3(Box<blake3::Hasher>),
+    Sha256(sha2::Sha256),
+}
+
+impl BlobPackHasher {
+    fn update(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Blake3(hasher) => {
+                hasher.update(bytes);
+            }
+            Self::Sha256(hasher) => {
+                hasher.update(bytes);
+            }
+        }
+    }
+
+    fn matches(self, expected: &str) -> bool {
+        match self {
+            Self::Blake3(hasher) => hasher.finalize().to_hex().as_str() == expected,
+            Self::Sha256(hasher) => hex::encode(hasher.finalize()) == expected,
+        }
+    }
+}
+#[derive(Clone)]
+enum RemoteCacheCredential {
+    None,
+    Static(HeaderValue),
+    File(PathBuf),
+    GithubActions(Arc<GithubActionsOidcCredential>),
+}
+
+struct GithubActionsOidcCredential {
+    audience: String,
+    request_url: Url,
+    request_token: HeaderValue,
+    client: reqwest::Client,
+    retries: i64,
+    cached: tokio::sync::Mutex<Option<CachedOidcToken>>,
+}
+
+struct CachedOidcToken {
+    authorization: HeaderValue,
+    expires_at: u64,
+}
+
+#[derive(Deserialize)]
+struct GithubActionsOidcResponse {
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct JwtExpiry {
+    exp: u64,
+}
+
+fn remote_credential(
+    config: &RemoteCacheConfig,
+    client: reqwest::Client,
+) -> Result<RemoteCacheCredential> {
+    if let Some(authorization) = authorization_header(config.token.as_deref())? {
+        return Ok(RemoteCacheCredential::Static(authorization));
+    }
+    if let Some(path) = &config.token_file {
+        return Ok(RemoteCacheCredential::File(path.clone()));
+    }
+    let Some(audience) = config
+        .oidc_audience
+        .as_deref()
+        .map(str::trim)
+        .filter(|audience| !audience.is_empty())
+    else {
+        return Ok(RemoteCacheCredential::None);
+    };
+    Ok(RemoteCacheCredential::GithubActions(Arc::new(
+        GithubActionsOidcCredential::from_env(audience, client, config.retries)?,
+    )))
+}
+
+fn authorization_header(token: Option<&str>) -> Result<Option<HeaderValue>> {
+    let Some(token) = token.map(str::trim).filter(|token| !token.is_empty()) else {
+        return Ok(None);
+    };
+    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))?;
+    value.set_sensitive(true);
+    Ok(Some(value))
+}
+
+impl RemoteCacheCredential {
+    async fn authorization(&self) -> Result<Option<HeaderValue>> {
+        match self {
+            Self::None => Ok(None),
+            Self::Static(value) => Ok(Some(value.clone())),
+            Self::File(path) => {
+                let token = tokio::fs::read_to_string(path).await.map_err(|err| {
+                    eyre!(
+                        "failed to read remote cache token file {}: {err}",
+                        path.display()
+                    )
+                })?;
+                authorization_header(Some(&token))?
+                    .ok_or_else(|| eyre!("remote cache token file {} is empty", path.display()))
+                    .map(Some)
+            }
+            Self::GithubActions(credential) => credential.authorization().await.map(Some),
+        }
+    }
+}
+
+impl GithubActionsOidcCredential {
+    fn from_env(audience: &str, client: reqwest::Client, retries: i64) -> Result<Self> {
+        let request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
+            eyre!(
+                "remote cache OIDC audience requires GitHub Actions OIDC; \
+                 grant `id-token: write` or set MBX_REMOTE_TOKEN"
+            )
+        })?;
+        let request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| {
+            eyre!(
+                "remote cache OIDC audience requires GitHub Actions OIDC; \
+                 ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing"
+            )
+        })?;
+        let request_url: Url = request_url
+            .parse()
+            .map_err(|err| eyre!("invalid GitHub Actions OIDC request URL: {err}"))?;
+        Self::new(audience, request_url, &request_token, client, retries)
+    }
+
+    fn new(
+        audience: &str,
+        mut request_url: Url,
+        request_token: &str,
+        client: reqwest::Client,
+        retries: i64,
+    ) -> Result<Self> {
+        validate_oidc_request_url(&request_url)?;
+        let query = request_url
+            .query_pairs()
+            .filter(|(key, _)| key != "audience")
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+        request_url.set_query(None);
+        request_url
+            .query_pairs_mut()
+            .extend_pairs(query)
+            .append_pair("audience", audience);
+        let request_token = authorization_header(Some(request_token))?
+            .ok_or_else(|| eyre!("GitHub Actions OIDC request token is empty"))?;
+        Ok(Self {
+            audience: audience.to_string(),
+            request_url,
+            request_token,
+            client,
+            retries,
+            cached: tokio::sync::Mutex::new(None),
+        })
+    }
+
+    async fn authorization(&self) -> Result<HeaderValue> {
+        const REFRESH_LEEWAY_SECONDS: u64 = 60;
+        let mut cached = self.cached.lock().await;
+        let now = unix_timestamp()?;
+        if let Some(token) = cached.as_ref()
+            && token.expires_at > now.saturating_add(REFRESH_LEEWAY_SECONDS)
+        {
+            return Ok(token.authorization.clone());
+        }
+        let response: GithubActionsOidcResponse =
+            retry_async("GET", &self.request_url, self.retries, || async {
+                Ok(self
+                    .client
+                    .get(self.request_url.clone())
+                    .header(AUTHORIZATION, self.request_token.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json()
+                    .await?)
+            })
+            .await
+            .map_err(|err| {
+                eyre!(
+                    "failed to acquire GitHub Actions OIDC token for audience {:?}: {err}",
+                    self.audience
+                )
+            })?;
+        let expires_at = jwt_expiry(&response.value)?;
+        if expires_at <= now.saturating_add(REFRESH_LEEWAY_SECONDS) {
+            bail!("GitHub Actions OIDC token expires too soon");
+        }
+        let authorization = authorization_header(Some(&response.value))?
+            .ok_or_else(|| eyre!("GitHub Actions returned an empty OIDC token"))?;
+        *cached = Some(CachedOidcToken {
+            authorization: authorization.clone(),
+            expires_at,
+        });
+        Ok(authorization)
+    }
+}
+
+fn jwt_expiry(token: &str) -> Result<u64> {
+    let payload = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| eyre!("GitHub Actions returned a malformed OIDC token"))?;
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| eyre!("GitHub Actions returned a malformed OIDC token"))?;
+    let claims: JwtExpiry = serde_json::from_slice(&payload)
+        .map_err(|_| eyre!("GitHub Actions OIDC token is missing a valid expiry"))?;
+    Ok(claims.exp)
+}
+
+fn unix_timestamp() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| eyre!("system clock is before the Unix epoch: {err}"))?
+        .as_secs())
+}
+
+fn validate_oidc_request_url(url: &Url) -> Result<()> {
+    if url.scheme() == "https"
+        || url.scheme() == "http"
+            && url.host().is_some_and(|host| match host {
+                Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+                Host::Ipv4(address) => address.is_loopback(),
+                Host::Ipv6(address) => address.is_loopback(),
+            })
+    {
+        Ok(())
+    } else {
+        bail!("GitHub Actions OIDC request URL must use HTTPS")
+    }
+}
+fn validate_remote_url(base_url: &Url, authenticated: bool) -> Result<()> {
+    if base_url.scheme() == "https" {
+        return Ok(());
+    }
+    if base_url.scheme() != "http" {
+        bail!("remote cache URL must use HTTPS");
+    }
+    let is_loopback = base_url.host().is_some_and(|host| match host {
+        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+        Host::Ipv4(address) => address.is_loopback(),
+        Host::Ipv6(address) => address.is_loopback(),
+    });
+    if !is_loopback && authenticated {
+        bail!("remote cache URL must use HTTPS except for loopback development servers");
+    }
+    if !is_loopback {
+        warn!(
+            "using an unauthenticated remote build cache over plain HTTP; cache traffic can be read \
+             or modified in transit"
+        );
+    }
+    Ok(())
+}
+
+fn normalized_base_url(mut url: Url) -> Url {
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+    url
+}
+
+#[cfg(test)]
+#[path = "core_tests.rs"]
+mod tests;

--- a/crates/mbx-cache-core/src/remote_s3.rs
+++ b/crates/mbx-cache-core/src/remote_s3.rs
@@ -113,6 +113,9 @@ pub(crate) struct S3RemoteCache {
     /// Latched once a store has told us it does not implement conditional
     /// writes, so the rest of the session stops asking.
     conditionals_disabled: AtomicBool,
+    /// Latched once a read has been refused where an absent object would have
+    /// been, so the explanation is offered once rather than per lookup.
+    absence_is_ambiguous: AtomicBool,
     download_timeout: Duration,
     retries: i64,
 }
@@ -138,6 +141,7 @@ impl S3RemoteCache {
             credentials: config.credentials,
             conditional_writes: config.conditional_writes,
             conditionals_disabled: AtomicBool::new(false),
+            absence_is_ambiguous: AtomicBool::new(false),
             download_timeout: config.download_timeout,
             retries: config.retries,
         })
@@ -221,25 +225,42 @@ impl S3RemoteCache {
 
     pub(crate) async fn check_connection(&self) -> Result<()> {
         let url = self.key_url(CONNECTIVITY_PROBE_KEY)?;
-        retry_async("HEAD", &url, self.retries, || async {
+        // A GET rather than a HEAD, because S3 explains a refusal in the
+        // response body and a HEAD has none. The key is never written, so the
+        // expected answer is a 404 carrying an error document.
+        retry_async("GET", &url, self.retries, || async {
             let response = self
-                .signed(reqwest::Method::HEAD, &url, &PayloadHash::empty())?
+                .signed(reqwest::Method::GET, &url, &PayloadHash::empty())?
                 .send()
                 .await?;
             match response.status() {
                 // The bucket answered and authorized the request. Whether this
                 // one key exists is beside the point.
                 StatusCode::OK | StatusCode::NOT_FOUND => Ok(()),
-                // S3 answers 403 rather than 404 for a key that is not there
-                // when the caller may not list the bucket, so this cannot be
-                // read as proof that the credentials are wrong.
-                StatusCode::FORBIDDEN => bail!(
-                    "the remote object store refused to read {url}. Grant s3:ListBucket on \
-                     the bucket -- without it S3 answers 403 for an absent key rather than \
-                     404, and every cache miss looks like this. Otherwise check \
-                     AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, that the key may read the \
-                     bucket, and that this machine's clock is correct"
-                ),
+                StatusCode::FORBIDDEN => {
+                    let failure = FailedRequest::read(response).await;
+                    if failure.is_credentials_rejected() {
+                        bail!(
+                            "the remote object store rejected these credentials for {url}: {}. \
+                             Check AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, and that this \
+                             machine's clock is correct",
+                            failure.code.as_deref().unwrap_or("forbidden")
+                        );
+                    }
+                    // The signature was accepted; something declined this one
+                    // object. The probe key is never written, so without
+                    // s3:ListBucket that is exactly what a working
+                    // configuration looks like -- and it is also what a
+                    // credential with no access to the prefix looks like.
+                    warn!(
+                        "the remote object store did not confirm access to {url}. That is \
+                         expected without s3:ListBucket on the bucket, where S3 refuses a \
+                         read rather than reporting the object absent; grant it to tell the \
+                         two apart. If the cache never hits, these credentials may not be \
+                         allowed to read the prefix"
+                    );
+                    Ok(())
+                }
                 StatusCode::MOVED_PERMANENTLY | StatusCode::TEMPORARY_REDIRECT => {
                     let region = response
                         .headers()
@@ -342,6 +363,34 @@ impl S3RemoteCache {
         }
     }
 
+    /// Whether a failed read should be treated as the object not being there.
+    ///
+    /// S3 answers `403` rather than `404` for an absent object when the caller
+    /// may not list the bucket, so a miss under a least-privilege policy is
+    /// indistinguishable from a denial by status alone. The error code does
+    /// distinguish the one case that matters: credentials S3 itself rejected.
+    /// Anything else is treated as a miss, since reporting every cold lookup as
+    /// a failure would make such a policy unusable, and a warning explains it
+    /// once.
+    fn reads_as_absent(&self, failure: &FailedRequest) -> bool {
+        if failure.status == StatusCode::NOT_FOUND {
+            return true;
+        }
+        if failure.status != StatusCode::FORBIDDEN || failure.is_credentials_rejected() {
+            return false;
+        }
+        if !self.absence_is_ambiguous.swap(true, Ordering::Relaxed) {
+            warn!(
+                "the remote object store refused a read instead of reporting the object \
+                 absent, which is what S3 does without s3:ListBucket on the bucket. \
+                 Treating it as a cache miss. Grant s3:ListBucket so a miss is a miss; \
+                 if the cache never hits, these credentials may simply not be allowed to \
+                 read it"
+            );
+        }
+        true
+    }
+
     pub(crate) async fn get_action_result(
         &self,
         action: &CacheDigest,
@@ -352,11 +401,13 @@ impl S3RemoteCache {
                 .signed(reqwest::Method::GET, &url, &PayloadHash::empty())?
                 .send()
                 .await?;
-            if response.status() == StatusCode::NOT_FOUND {
-                return Ok(None);
-            }
             if !response.status().is_success() {
-                return Err(FailedRequest::read(response).await.report("read", &url));
+                let failure = FailedRequest::read(response).await;
+                return if self.reads_as_absent(&failure) {
+                    Ok(None)
+                } else {
+                    Err(failure.report("read", &url))
+                };
             }
             let bytes = read_bounded_json(response, "action result").await?;
             Ok(Some(serde_json::from_slice::<RemoteActionResult>(&bytes)?))
@@ -391,11 +442,13 @@ impl S3RemoteCache {
                 .signed(reqwest::Method::GET, &url, &PayloadHash::empty())?
                 .send()
                 .await?;
-            if response.status() == StatusCode::NOT_FOUND {
-                return Ok(None);
-            }
             if !response.status().is_success() {
-                return Err(FailedRequest::read(response).await.report("read", &url));
+                let failure = FailedRequest::read(response).await;
+                return if self.reads_as_absent(&failure) {
+                    Ok(None)
+                } else {
+                    Err(failure.report("read", &url))
+                };
             }
             let etag = parse_strong_etag(response.headers().get(ETAG))?;
             let bytes = read_bounded_json(response, "action manifest").await?;
@@ -672,6 +725,27 @@ impl FailedRequest {
         self.status == StatusCode::NOT_IMPLEMENTED
             || (self.status == StatusCode::BAD_REQUEST
                 && self.code.as_deref() == Some("NotImplemented"))
+    }
+
+    /// Whether S3 rejected the credentials themselves, rather than declining
+    /// this one object.
+    ///
+    /// These codes say the request never authenticated, which no bucket policy
+    /// can explain away. `AccessDenied` deliberately is not among them: it is
+    /// what an absent object looks like without `s3:ListBucket`.
+    fn is_credentials_rejected(&self) -> bool {
+        self.status == StatusCode::FORBIDDEN
+            && matches!(
+                self.code.as_deref(),
+                Some(
+                    "SignatureDoesNotMatch"
+                        | "InvalidAccessKeyId"
+                        | "InvalidSecurity"
+                        | "ExpiredToken"
+                        | "TokenRefreshRequired"
+                        | "RequestTimeTooSkewed"
+                )
+            )
     }
 
     /// Whether the store is asking to be tried again.

--- a/crates/mbx-cache-core/src/remote_s3.rs
+++ b/crates/mbx-cache-core/src/remote_s3.rs
@@ -192,24 +192,31 @@ impl S3RemoteCache {
             && !self.conditionals_disabled.load(Ordering::Relaxed)
     }
 
-    /// Note that a store has refused conditional writes, if that is allowed.
+    /// Whether the same write may be tried again without its condition.
     ///
-    /// Returns whether the caller should try the same write unconditionally.
-    /// Under `required` it never is: a caller that asked for the guarantee gets
+    /// Under `required` it never may: a caller that asked for the guarantee gets
     /// an error rather than a silent downgrade.
-    fn degrade_conditionals(&self, what: &str) -> bool {
-        if self.conditional_writes != S3ConditionalWrites::Auto {
-            return false;
-        }
+    fn may_drop_conditionals(&self) -> bool {
+        self.conditional_writes == S3ConditionalWrites::Auto
+    }
+
+    /// Record that this store does not implement conditional writes.
+    ///
+    /// Called only once an unconditional write has actually succeeded, which is
+    /// what distinguishes a store that refuses conditions from one that refused
+    /// this request for some other reason and would have refused it anyway. A
+    /// `501` from an intermediary is not evidence about the store, and latching
+    /// on it would quietly turn every later manifest update into a
+    /// last-writer-wins one.
+    fn note_conditionals_unsupported(&self) {
         if !self.conditionals_disabled.swap(true, Ordering::Relaxed) {
             warn!(
-                "the remote object store does not implement conditional writes ({what}); \
+                "the remote object store does not implement conditional writes; \
                  continuing without them. Blobs and action results are content-addressed, so \
                  this is safe; concurrent task manifest updates can now lose predictions, \
                  which costs prefetch coverage on later builds"
             );
         }
-        true
     }
 
     pub(crate) async fn check_connection(&self) -> Result<()> {
@@ -223,10 +230,15 @@ impl S3RemoteCache {
                 // The bucket answered and authorized the request. Whether this
                 // one key exists is beside the point.
                 StatusCode::OK | StatusCode::NOT_FOUND => Ok(()),
+                // S3 answers 403 rather than 404 for a key that is not there
+                // when the caller may not list the bucket, so this cannot be
+                // read as proof that the credentials are wrong.
                 StatusCode::FORBIDDEN => bail!(
-                    "the remote object store rejected these credentials for {url}; \
-                     check AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, that the key may \
-                     read the bucket, and that this machine's clock is correct"
+                    "the remote object store refused to read {url}. Grant s3:ListBucket on \
+                     the bucket -- without it S3 answers 403 for an absent key rather than \
+                     404, and every cache miss looks like this. Otherwise check \
+                     AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, that the key may read the \
+                     bucket, and that this machine's clock is correct"
                 ),
                 StatusCode::MOVED_PERMANENTLY | StatusCode::TEMPORARY_REDIRECT => {
                     let region = response
@@ -402,8 +414,11 @@ impl S3RemoteCache {
         let body = bytes.to_vec();
         let expected_etag = expected_etag.map(quoted_etag).transpose()?;
         retry_async("PUT", &url, self.retries, || async {
+            // Set once the store has refused a condition and the same write is
+            // being tried without one, so that success can be attributed.
+            let mut dropped_condition = false;
             let outcome = loop {
-                let conditional = self.conditionals_enabled();
+                let conditional = self.conditionals_enabled() && !dropped_condition;
                 let mut request = self
                     .signed(reqwest::Method::PUT, &url, &PayloadHash::of(&body))?
                     .header(CONTENT_LENGTH, body.len())
@@ -417,9 +432,12 @@ impl S3RemoteCache {
                 let response = request.send().await?;
                 let status = response.status();
                 if status.is_success() {
+                    if dropped_condition {
+                        self.note_conditionals_unsupported();
+                    }
                     break ManifestPutOutcome::Stored;
                 }
-                if status == StatusCode::PRECONDITION_FAILED {
+                if conditional && status == StatusCode::PRECONDITION_FAILED {
                     // Either the manifest moved under us or, for a create, one
                     // already exists. Both mean re-reading and merging.
                     break ManifestPutOutcome::PreconditionFailed;
@@ -432,7 +450,8 @@ impl S3RemoteCache {
                 }
                 let failure = FailedRequest::read(response).await;
                 if conditional && failure.is_not_implemented() {
-                    if self.degrade_conditionals("rejected a conditional write") {
+                    if self.may_drop_conditionals() {
+                        dropped_condition = true;
                         continue;
                     }
                     return Err(failure.report("update", &url).wrap_err(
@@ -464,8 +483,9 @@ impl S3RemoteCache {
     /// Returns whether this request is what created the object; an object that
     /// was already there is success, since its key names these exact bytes.
     async fn put_create(&self, url: &Url, body: &[u8]) -> Result<bool> {
+        let mut dropped_condition = false;
         loop {
-            let conditional = self.conditionals_enabled();
+            let conditional = self.conditionals_enabled() && !dropped_condition;
             let mut request = self
                 .signed(reqwest::Method::PUT, url, &PayloadHash::of(body))?
                 .header(CONTENT_LENGTH, body.len())
@@ -477,8 +497,13 @@ impl S3RemoteCache {
                 .finish_create(url, request.send().await?, conditional)
                 .await?
             {
-                Some(created) => return Ok(created),
-                None => continue,
+                Some(created) => {
+                    if dropped_condition {
+                        self.note_conditionals_unsupported();
+                    }
+                    return Ok(created);
+                }
+                None => dropped_condition = true,
             }
         }
     }
@@ -490,8 +515,9 @@ impl S3RemoteCache {
     /// artifact is not read twice just to compute a hash TLS and the content
     /// address already stand behind.
     async fn put_create_file(&self, url: &Url, path: &Path) -> Result<()> {
+        let mut dropped_condition = false;
         loop {
-            let conditional = self.conditionals_enabled();
+            let conditional = self.conditionals_enabled() && !dropped_condition;
             let file = tokio::fs::File::open(path).await?;
             let length = file.metadata().await?.len();
             let mut request = self
@@ -507,8 +533,13 @@ impl S3RemoteCache {
                 .finish_create(url, request.send().await?, conditional)
                 .await?
             {
-                Some(_) => return Ok(()),
-                None => continue,
+                Some(_) => {
+                    if dropped_condition {
+                        self.note_conditionals_unsupported();
+                    }
+                    return Ok(());
+                }
+                None => dropped_condition = true,
             }
         }
     }
@@ -516,7 +547,7 @@ impl S3RemoteCache {
     /// Interpret the response to a create-only write.
     ///
     /// `None` asks the caller to send the same request again without its
-    /// conditional header, having just learned the store does not support one.
+    /// conditional header, the store having just refused one.
     async fn finish_create(
         &self,
         url: &Url,
@@ -527,7 +558,10 @@ impl S3RemoteCache {
         if status.is_success() {
             return Ok(Some(true));
         }
-        if status == StatusCode::PRECONDITION_FAILED {
+        // Only a condition this request actually carried can have failed. A 412
+        // against an unconditional write means something else refused it, and
+        // reporting that as a stored object would lose the write silently.
+        if conditional && status == StatusCode::PRECONDITION_FAILED {
             return Ok(Some(false));
         }
         if status == StatusCode::CONFLICT {
@@ -535,7 +569,7 @@ impl S3RemoteCache {
         }
         let failure = FailedRequest::read(response).await;
         if conditional && failure.is_not_implemented() {
-            if self.degrade_conditionals("rejected a create-only write") {
+            if self.may_drop_conditionals() {
                 return Ok(None);
             }
             return Err(failure.report("store", url).wrap_err(
@@ -640,11 +674,30 @@ impl FailedRequest {
                 && self.code.as_deref() == Some("NotImplemented"))
     }
 
+    /// Whether the store is asking to be tried again.
+    ///
+    /// `500` and `503` are how S3 reports an internal error and a prefix under
+    /// too much load, and it documents both as the client's to retry. `501` is
+    /// deliberately absent: a store that does not implement something will not
+    /// implement it a moment later.
+    fn is_retryable(&self) -> bool {
+        matches!(self.status.as_u16(), 408 | 429 | 500 | 502 | 503 | 504)
+    }
+
     fn report(&self, verb: &str, url: &Url) -> eyre::Report {
-        match &self.code {
-            Some(code) => eyre!("failed to {verb} {url}: {} ({code})", self.status),
-            None => eyre!("failed to {verb} {url}: {}", self.status),
+        let detail = match &self.code {
+            Some(code) => format!("failed to {verb} {url}: {} ({code})", self.status),
+            None => format!("failed to {verb} {url}: {}", self.status),
+        };
+        if self.is_retryable() {
+            // The protocol client gets this for free: `error_for_status` hands
+            // `is_transient` a `reqwest::Error` carrying the status. Nothing
+            // here produces one, so a retryable status has to say so itself,
+            // or a `503` under load would fail a build that asked for retries.
+            return eyre::Report::new(TransientRequest("the store asked to be retried"))
+                .wrap_err(detail);
         }
+        eyre!(detail)
     }
 }
 
@@ -740,7 +793,10 @@ fn base_url(config: &S3RemoteCacheConfig) -> Result<Url> {
             .host_str()
             .ok_or_else(|| eyre!("an S3 endpoint must have a host"))?;
         url.set_host(Some(&format!("{bucket}.{host}")))?;
-        url.set_path("/");
+        // An endpoint may carry a path, and moving the bucket into the host is
+        // no reason to drop it: a gateway at /s3 still wants to be asked at /s3.
+        let path = url.path().trim_end_matches('/').to_string();
+        url.set_path(&format!("{path}/"));
     }
     Ok(url)
 }

--- a/crates/mbx-cache-core/src/remote_s3.rs
+++ b/crates/mbx-cache-core/src/remote_s3.rs
@@ -1,0 +1,750 @@
+//! The remote cache backed directly by an S3-compatible object store.
+//!
+//! This is the other backend behind [`crate::RemoteCacheClient`]. Where the
+//! protocol server answers lookups, validates uploads, and advertises
+//! extensions, a bucket only stores objects. The v1 protocol is designed for
+//! that: blobs and action results are immutable and content-addressed, so they
+//! are written create-only and re-storing one is not an error, and the single
+//! record that is updated in place -- the task action manifest -- carries an
+//! entity tag that S3's conditional writes can honour.
+//!
+//! What a bucket cannot do it declines rather than approximates. Blob packs,
+//! batched lookups, and negotiated compression all report themselves absent,
+//! which is the same answer the client already handles from a server that does
+//! not implement them.
+
+use crate::sigv4::{PayloadHash, S3Credentials, SigningContext, sign};
+use crate::{
+    BlobPackReceipt, BlobSource, BlobUpload, CacheDigest, MAX_REMOTE_BLOB_BYTES,
+    MAX_REMOTE_JSON_BYTES, ManifestPutOutcome, RemoteActionManifest, RemoteActionResult,
+    RemoteBlobPack, TransientRequest, parse_strong_etag, quoted_etag, read_bounded_json,
+    retry_async,
+};
+use eyre::{Result, bail, eyre};
+use log::warn;
+use reqwest::StatusCode;
+use reqwest::header::{CONTENT_LENGTH, ETAG, IF_MATCH, IF_NONE_MATCH};
+use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime};
+use tokio::io::AsyncWriteExt;
+use url::Url;
+
+/// The object-key layout this client reads and writes.
+///
+/// Independent of the protocol version, which describes a wire format rather
+/// than a bucket layout, though today they are both 1.
+const LAYOUT_VERSION: u8 = 1;
+/// Object read to prove an endpoint answers, credentials work, and the bucket
+/// exists. It is never written, so a diagnostic stays read-only.
+const CONNECTIVITY_PROBE_KEY: &str = "connectivity-probe";
+/// Bytes of an S3 error document read before giving up on a diagnosis.
+const MAX_ERROR_BODY_BYTES: usize = 8 * 1024;
+
+/// Whether conditional writes are required, refused, or tried and given up on.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, strum::EnumString, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
+pub enum S3ConditionalWrites {
+    /// Use conditional writes, and stop using them if the store rejects them.
+    #[default]
+    Auto,
+    /// Require conditional writes, failing if the store does not implement them.
+    Required,
+    /// Never send conditional headers.
+    Off,
+}
+
+/// Connection, addressing, and credential settings for an S3 remote cache.
+pub struct S3RemoteCacheConfig {
+    /// Bucket holding the cache.
+    pub bucket: String,
+    /// Key prefix within the bucket, empty for the bucket root.
+    pub prefix: String,
+    /// Namespace isolating one project's cache, used as a key prefix.
+    pub namespace: String,
+    /// Region used to sign requests.
+    pub region: String,
+    /// Endpoint override for a non-AWS store such as MinIO or R2.
+    pub endpoint: Option<Url>,
+    /// Force bucket-in-path addressing, overriding what the endpoint implies.
+    pub force_path_style: Option<bool>,
+    /// How to treat a store that does not implement conditional writes.
+    pub conditional_writes: S3ConditionalWrites,
+    /// Credentials used to sign requests.
+    pub credentials: S3Credentials,
+    /// Maximum time allowed to establish a connection.
+    pub connect_timeout: Duration,
+    /// Maximum time without response progress for ordinary requests.
+    pub read_timeout: Duration,
+    /// Overall deadline for an individual blob download attempt.
+    pub download_timeout: Duration,
+    /// Number of attempts after the initial request for retryable failures.
+    pub retries: i64,
+}
+
+/// Kinds of object the cache stores, which are also their key prefixes.
+#[derive(Clone, Copy)]
+enum ObjectKind {
+    Blob,
+    ActionResult,
+    ActionManifest,
+}
+
+impl ObjectKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Blob => "blobs",
+            Self::ActionResult => "action-results",
+            Self::ActionManifest => "action-manifests",
+        }
+    }
+}
+
+pub(crate) struct S3RemoteCache {
+    client: reqwest::Client,
+    /// Bucket root, always ending in `/` so keys join onto it.
+    base_url: Url,
+    /// Key prefix covering the configured prefix, namespace, and layout version.
+    root: String,
+    region: String,
+    credentials: S3Credentials,
+    conditional_writes: S3ConditionalWrites,
+    /// Latched once a store has told us it does not implement conditional
+    /// writes, so the rest of the session stops asking.
+    conditionals_disabled: AtomicBool,
+    download_timeout: Duration,
+    retries: i64,
+}
+
+impl S3RemoteCache {
+    pub(crate) fn new(config: S3RemoteCacheConfig) -> Result<Self> {
+        validate_bucket(&config.bucket)?;
+        let prefix = normalize_prefix(&config.prefix)?;
+        validate_key_path(&config.namespace, "remote cache namespace")?;
+        if config.region.trim().is_empty() {
+            bail!("an S3 remote cache needs a region");
+        }
+        let client = reqwest::Client::builder()
+            .connect_timeout(config.connect_timeout)
+            .read_timeout(config.read_timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        Ok(Self {
+            client,
+            base_url: base_url(&config)?,
+            root: format!("{prefix}{}/v{LAYOUT_VERSION}/", config.namespace.trim()),
+            region: config.region.trim().to_string(),
+            credentials: config.credentials,
+            conditional_writes: config.conditional_writes,
+            conditionals_disabled: AtomicBool::new(false),
+            download_timeout: config.download_timeout,
+            retries: config.retries,
+        })
+    }
+
+    fn object_url(&self, kind: ObjectKind, digest: &CacheDigest) -> Result<Url> {
+        digest.validate()?;
+        if matches!(kind, ObjectKind::ActionResult | ObjectKind::ActionManifest)
+            && digest.algorithm != "blake3"
+        {
+            bail!("remote cache action keys must use blake3");
+        }
+        self.key_url(&format!(
+            "{}/{}/{}/{}",
+            kind.as_str(),
+            digest.algorithm,
+            digest.hash,
+            digest.size
+        ))
+    }
+
+    fn key_url(&self, key: &str) -> Result<Url> {
+        Ok(self.base_url.join(&format!("{}{key}", self.root))?)
+    }
+
+    /// Build a request carrying a valid signature for this instant.
+    ///
+    /// Signing happens per attempt rather than once per operation: a retry
+    /// after a long backoff would otherwise present a stale `x-amz-date` and be
+    /// refused for clock skew.
+    fn signed(
+        &self,
+        method: reqwest::Method,
+        url: &Url,
+        payload: &PayloadHash,
+    ) -> Result<reqwest::RequestBuilder> {
+        let context = SigningContext {
+            credentials: &self.credentials,
+            region: &self.region,
+            timestamp: SystemTime::now(),
+        };
+        let mut request = self.client.request(method.clone(), url.clone());
+        for (name, value) in sign(method.as_str(), url, &context, payload)? {
+            request = request.header(name, value);
+        }
+        Ok(request)
+    }
+
+    /// Whether a conditional header should be attached to the next write.
+    fn conditionals_enabled(&self) -> bool {
+        self.conditional_writes != S3ConditionalWrites::Off
+            && !self.conditionals_disabled.load(Ordering::Relaxed)
+    }
+
+    /// Note that a store has refused conditional writes, if that is allowed.
+    ///
+    /// Returns whether the caller should try the same write unconditionally.
+    /// Under `required` it never is: a caller that asked for the guarantee gets
+    /// an error rather than a silent downgrade.
+    fn degrade_conditionals(&self, what: &str) -> bool {
+        if self.conditional_writes != S3ConditionalWrites::Auto {
+            return false;
+        }
+        if !self.conditionals_disabled.swap(true, Ordering::Relaxed) {
+            warn!(
+                "the remote object store does not implement conditional writes ({what}); \
+                 continuing without them. Blobs and action results are content-addressed, so \
+                 this is safe; concurrent task manifest updates can now lose predictions, \
+                 which costs prefetch coverage on later builds"
+            );
+        }
+        true
+    }
+
+    pub(crate) async fn check_connection(&self) -> Result<()> {
+        let url = self.key_url(CONNECTIVITY_PROBE_KEY)?;
+        retry_async("HEAD", &url, self.retries, || async {
+            let response = self
+                .signed(reqwest::Method::HEAD, &url, &PayloadHash::empty())?
+                .send()
+                .await?;
+            match response.status() {
+                // The bucket answered and authorized the request. Whether this
+                // one key exists is beside the point.
+                StatusCode::OK | StatusCode::NOT_FOUND => Ok(()),
+                StatusCode::FORBIDDEN => bail!(
+                    "the remote object store rejected these credentials for {url}; \
+                     check AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, that the key may \
+                     read the bucket, and that this machine's clock is correct"
+                ),
+                StatusCode::MOVED_PERMANENTLY | StatusCode::TEMPORARY_REDIRECT => {
+                    let region = response
+                        .headers()
+                        .get("x-amz-bucket-region")
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or("another region");
+                    bail!(
+                        "the bucket is in {region}, not {}; set the remote region to match",
+                        self.region
+                    )
+                }
+                _ => Err(FailedRequest::read(response)
+                    .await
+                    .report("connect to", &url)),
+            }
+        })
+        .await
+    }
+
+    pub(crate) async fn get_blob(
+        &self,
+        digest: &CacheDigest,
+        _media_type: &'static str,
+    ) -> Result<Vec<u8>> {
+        if digest.size > MAX_REMOTE_JSON_BYTES {
+            bail!(
+                "remote cache in-memory blob declared {} bytes, over the {} byte limit",
+                digest.size,
+                MAX_REMOTE_JSON_BYTES
+            );
+        }
+        let url = self.object_url(ObjectKind::Blob, digest)?;
+        retry_async("GET", &url, self.retries, || async {
+            let mut response = self.get(&url).await?;
+            // Stop reading as soon as the response outgrows the digest it claims
+            // to satisfy, exactly as the protocol client does.
+            let mut bytes = Vec::new();
+            while let Some(chunk) = response.chunk().await? {
+                if bytes.len() as u64 + chunk.len() as u64 > digest.size {
+                    bail!("remote cache blob exceeded the size of its digest");
+                }
+                bytes.extend_from_slice(&chunk);
+            }
+            if !digest.matches_bytes(&bytes)? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(bytes)
+        })
+        .await
+    }
+
+    pub(crate) async fn get_blob_file(
+        &self,
+        digest: &CacheDigest,
+        staging_dir: &Path,
+    ) -> Result<tempfile::NamedTempFile> {
+        if digest.size > MAX_REMOTE_BLOB_BYTES {
+            bail!(
+                "remote cache blob declared {} bytes, over the {} byte limit",
+                digest.size,
+                MAX_REMOTE_BLOB_BYTES
+            );
+        }
+        let url = self.object_url(ObjectKind::Blob, digest)?;
+        let download = retry_async("GET", &url, self.retries, || async {
+            let mut response = self.get(&url).await?;
+            fs::create_dir_all(staging_dir)?;
+            let temporary = tempfile::NamedTempFile::new_in(staging_dir)?;
+            let mut output = tokio::fs::File::from_std(temporary.reopen()?);
+            let mut written = 0u64;
+            while let Some(chunk) = response.chunk().await? {
+                written += chunk.len() as u64;
+                if written > digest.size {
+                    bail!("remote cache blob exceeded the size of its digest");
+                }
+                output.write_all(&chunk).await?;
+            }
+            output.flush().await?;
+            drop(output);
+            if !digest.matches_file(temporary.path())? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(temporary)
+        });
+        tokio::time::timeout(self.download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
+    }
+
+    /// Fetch an object that must exist, turning any other status into an error.
+    async fn get(&self, url: &Url) -> Result<reqwest::Response> {
+        let response = self
+            .signed(reqwest::Method::GET, url, &PayloadHash::empty())?
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            Err(FailedRequest::read(response).await.report("read", url))
+        }
+    }
+
+    pub(crate) async fn get_action_result(
+        &self,
+        action: &CacheDigest,
+    ) -> Result<Option<RemoteActionResult>> {
+        let url = self.object_url(ObjectKind::ActionResult, action)?;
+        let result = retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .signed(reqwest::Method::GET, &url, &PayloadHash::empty())?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            if !response.status().is_success() {
+                return Err(FailedRequest::read(response).await.report("read", &url));
+            }
+            let bytes = read_bounded_json(response, "action result").await?;
+            Ok(Some(serde_json::from_slice::<RemoteActionResult>(&bytes)?))
+        })
+        .await?;
+        if let Some(result) = &result
+            && (result.version != 1 || result.action != *action)
+        {
+            bail!("remote action result does not match requested action");
+        }
+        Ok(result)
+    }
+
+    pub(crate) async fn put_action_result(&self, result: &RemoteActionResult) -> Result<()> {
+        let url = self.object_url(ObjectKind::ActionResult, &result.action)?;
+        let body = serde_json::to_vec(result)?;
+        retry_async("PUT", &url, self.retries, || async {
+            // Storing the same record twice is not an error: the key is its
+            // content address, so an existing object already holds these bytes.
+            self.put_create(&url, &body).await.map(drop)
+        })
+        .await
+    }
+
+    pub(crate) async fn get_action_manifest(
+        &self,
+        key: &CacheDigest,
+    ) -> Result<Option<RemoteActionManifest>> {
+        let url = self.object_url(ObjectKind::ActionManifest, key)?;
+        retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .signed(reqwest::Method::GET, &url, &PayloadHash::empty())?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            if !response.status().is_success() {
+                return Err(FailedRequest::read(response).await.report("read", &url));
+            }
+            let etag = parse_strong_etag(response.headers().get(ETAG))?;
+            let bytes = read_bounded_json(response, "action manifest").await?;
+            Ok(Some(RemoteActionManifest { bytes, etag }))
+        })
+        .await
+    }
+
+    pub(crate) async fn put_action_manifest(
+        &self,
+        key: &CacheDigest,
+        bytes: &[u8],
+        expected_etag: Option<&str>,
+    ) -> Result<ManifestPutOutcome> {
+        let url = self.object_url(ObjectKind::ActionManifest, key)?;
+        let body = bytes.to_vec();
+        let expected_etag = expected_etag.map(quoted_etag).transpose()?;
+        retry_async("PUT", &url, self.retries, || async {
+            let outcome = loop {
+                let conditional = self.conditionals_enabled();
+                let mut request = self
+                    .signed(reqwest::Method::PUT, &url, &PayloadHash::of(&body))?
+                    .header(CONTENT_LENGTH, body.len())
+                    .body(body.clone());
+                if conditional {
+                    request = match &expected_etag {
+                        Some(etag) => request.header(IF_MATCH, etag),
+                        None => request.header(IF_NONE_MATCH, "*"),
+                    };
+                }
+                let response = request.send().await?;
+                let status = response.status();
+                if status.is_success() {
+                    break ManifestPutOutcome::Stored;
+                }
+                if status == StatusCode::PRECONDITION_FAILED {
+                    // Either the manifest moved under us or, for a create, one
+                    // already exists. Both mean re-reading and merging.
+                    break ManifestPutOutcome::PreconditionFailed;
+                }
+                if status == StatusCode::CONFLICT {
+                    // A concurrent conditional write on the same key. S3 asks
+                    // that this be retried rather than treated as a conflict of
+                    // content.
+                    return Err(conditional_request_conflict(&url));
+                }
+                let failure = FailedRequest::read(response).await;
+                if conditional && failure.is_not_implemented() {
+                    if self.degrade_conditionals("rejected a conditional write") {
+                        continue;
+                    }
+                    return Err(failure.report("update", &url).wrap_err(
+                        "conditional writes are required but this store does not implement them",
+                    ));
+                }
+                return Err(failure.report("update", &url));
+            };
+            Ok(outcome)
+        })
+        .await
+    }
+
+    pub(crate) async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
+        upload.digest.validate()?;
+        let url = self.object_url(ObjectKind::Blob, &upload.digest)?;
+        retry_async("PUT", &url, self.retries, || async {
+            match &upload.source {
+                BlobSource::Bytes(bytes) => self.put_create(&url, bytes).await.map(drop),
+                BlobSource::File(file) => self.put_create_file(&url, file.path()).await,
+                BlobSource::Path(path) => self.put_create_file(&url, path).await,
+            }
+        })
+        .await
+    }
+
+    /// Store bytes under a key that is their content address.
+    ///
+    /// Returns whether this request is what created the object; an object that
+    /// was already there is success, since its key names these exact bytes.
+    async fn put_create(&self, url: &Url, body: &[u8]) -> Result<bool> {
+        loop {
+            let conditional = self.conditionals_enabled();
+            let mut request = self
+                .signed(reqwest::Method::PUT, url, &PayloadHash::of(body))?
+                .header(CONTENT_LENGTH, body.len())
+                .body(body.to_vec());
+            if conditional {
+                request = request.header(IF_NONE_MATCH, "*");
+            }
+            match self
+                .finish_create(url, request.send().await?, conditional)
+                .await?
+            {
+                Some(created) => return Ok(created),
+                None => continue,
+            }
+        }
+    }
+
+    /// Store a file under a key that is its content address.
+    ///
+    /// The body is streamed with an explicit length rather than chunked, which
+    /// S3 requires, and is signed as an unsigned payload so that a multi-gigabyte
+    /// artifact is not read twice just to compute a hash TLS and the content
+    /// address already stand behind.
+    async fn put_create_file(&self, url: &Url, path: &Path) -> Result<()> {
+        loop {
+            let conditional = self.conditionals_enabled();
+            let file = tokio::fs::File::open(path).await?;
+            let length = file.metadata().await?.len();
+            let mut request = self
+                .signed(reqwest::Method::PUT, url, &PayloadHash::Unsigned)?
+                .header(CONTENT_LENGTH, length)
+                .body(reqwest::Body::wrap_stream(
+                    tokio_util::io::ReaderStream::new(file),
+                ));
+            if conditional {
+                request = request.header(IF_NONE_MATCH, "*");
+            }
+            match self
+                .finish_create(url, request.send().await?, conditional)
+                .await?
+            {
+                Some(_) => return Ok(()),
+                None => continue,
+            }
+        }
+    }
+
+    /// Interpret the response to a create-only write.
+    ///
+    /// `None` asks the caller to send the same request again without its
+    /// conditional header, having just learned the store does not support one.
+    async fn finish_create(
+        &self,
+        url: &Url,
+        response: reqwest::Response,
+        conditional: bool,
+    ) -> Result<Option<bool>> {
+        let status = response.status();
+        if status.is_success() {
+            return Ok(Some(true));
+        }
+        if status == StatusCode::PRECONDITION_FAILED {
+            return Ok(Some(false));
+        }
+        if status == StatusCode::CONFLICT {
+            return Err(conditional_request_conflict(url));
+        }
+        let failure = FailedRequest::read(response).await;
+        if conditional && failure.is_not_implemented() {
+            if self.degrade_conditionals("rejected a create-only write") {
+                return Ok(None);
+            }
+            return Err(failure.report("store", url).wrap_err(
+                "conditional writes are required but this store does not implement them",
+            ));
+        }
+        Err(failure.report("store", url))
+    }
+
+    // Everything below is an extension a protocol server offers and a bucket
+    // does not. Reporting absence is what routes the caller to the per-object
+    // requests that every version of the protocol has made.
+
+    pub(crate) async fn get_action_results(
+        &self,
+        actions: &[CacheDigest],
+    ) -> Result<Option<Vec<RemoteActionResult>>> {
+        Ok(actions.is_empty().then(Vec::new))
+    }
+
+    pub(crate) async fn action_batch_limit(&self) -> Result<Option<usize>> {
+        Ok(None)
+    }
+
+    pub(crate) async fn get_blob_pack(
+        &self,
+        _digests: &[CacheDigest],
+        _staging_dir: &Path,
+    ) -> Result<Option<RemoteBlobPack>> {
+        Ok(None)
+    }
+
+    pub(crate) async fn get_blob_pack_with_limit(
+        &self,
+        _digests: &[CacheDigest],
+        _staging_dir: &Path,
+        _max_bytes: u64,
+    ) -> Result<Option<RemoteBlobPack>> {
+        Ok(None)
+    }
+
+    pub(crate) async fn blob_pack_upload_limits(&self) -> Result<Option<crate::BlobPackLimits>> {
+        Ok(None)
+    }
+
+    pub(crate) async fn put_blob_pack(
+        &self,
+        uploads: &[BlobUpload],
+    ) -> Result<Option<BlobPackReceipt>> {
+        Ok(uploads.is_empty().then_some(BlobPackReceipt {
+            created: 0,
+            existing: 0,
+        }))
+    }
+}
+
+/// A concurrent conditional write, which S3 asks callers to retry.
+fn conditional_request_conflict(url: &Url) -> eyre::Report {
+    eyre::Report::new(TransientRequest("conditional request conflict")).wrap_err(format!(
+        "a concurrent conditional write to {url} conflicted"
+    ))
+}
+
+/// A request that failed, read far enough to say why.
+///
+/// The body is consumed here because deciding what a failure means can depend
+/// on the store's own error code, and a response cannot be read twice.
+struct FailedRequest {
+    status: StatusCode,
+    code: Option<String>,
+}
+
+impl FailedRequest {
+    async fn read(mut response: reqwest::Response) -> Self {
+        let status = response.status();
+        // Bounded like every other body this client reads. An error document is
+        // a diagnostic, and a store that streams without end must not be able to
+        // exhaust this process through one.
+        let mut body = Vec::new();
+        while body.len() < MAX_ERROR_BODY_BYTES {
+            match response.chunk().await {
+                Ok(Some(chunk)) => body.extend_from_slice(&chunk),
+                Ok(None) | Err(_) => break,
+            }
+        }
+        body.truncate(MAX_ERROR_BODY_BYTES);
+        Self {
+            status,
+            code: error_code(&String::from_utf8_lossy(&body)).map(str::to_string),
+        }
+    }
+
+    /// Whether the store is saying it does not implement what was asked of it.
+    ///
+    /// S3-compatible stores disagree about how to say this. AWS answers `501`
+    /// for an unimplemented feature, while some others answer `400` with
+    /// `NotImplemented` in the document. A bare `400` is not enough on its own:
+    /// it is also how a store reports a request it merely disliked.
+    fn is_not_implemented(&self) -> bool {
+        self.status == StatusCode::NOT_IMPLEMENTED
+            || (self.status == StatusCode::BAD_REQUEST
+                && self.code.as_deref() == Some("NotImplemented"))
+    }
+
+    fn report(&self, verb: &str, url: &Url) -> eyre::Report {
+        match &self.code {
+            Some(code) => eyre!("failed to {verb} {url}: {} ({code})", self.status),
+            None => eyre!("failed to {verb} {url}: {}", self.status),
+        }
+    }
+}
+
+/// Extract the `<Code>` of an S3 error document.
+///
+/// S3 reports errors as XML, but only the code is ever acted on, so it is
+/// scanned for rather than parsed with an XML reader this crate would otherwise
+/// not need.
+fn error_code(body: &str) -> Option<&str> {
+    let start = body.find("<Code>")? + "<Code>".len();
+    let end = body[start..].find("</Code>")? + start;
+    Some(body[start..end].trim()).filter(|code| !code.is_empty())
+}
+
+/// Reject a bucket name that could not address the store it names.
+fn validate_bucket(bucket: &str) -> Result<()> {
+    let bucket = bucket.trim();
+    if bucket.is_empty() {
+        bail!("an S3 remote cache needs a bucket");
+    }
+    if bucket.contains('/') || bucket.starts_with('.') || bucket.ends_with('.') {
+        bail!("invalid S3 bucket name {bucket:?}");
+    }
+    Ok(())
+}
+
+/// Normalize a key prefix to empty, or to something ending in a single `/`.
+fn normalize_prefix(prefix: &str) -> Result<String> {
+    let prefix = prefix.trim().trim_matches('/');
+    if prefix.is_empty() {
+        return Ok(String::new());
+    }
+    validate_key_path(prefix, "remote cache prefix")?;
+    Ok(format!("{prefix}/"))
+}
+
+/// Reject anything that would not survive being spliced into an object key.
+///
+/// The protocol carries the namespace in a header, where a server decides what
+/// it means. In a bucket it is part of the key, so it has to be something a key
+/// can hold and something that cannot climb out of its own prefix.
+fn validate_key_path(value: &str, what: &str) -> Result<()> {
+    let value = value.trim();
+    if value.is_empty() {
+        bail!("{what} must not be empty");
+    }
+    if value.starts_with('/') || value.ends_with('/') {
+        bail!("{what} {value:?} must not start or end with a slash");
+    }
+    for segment in value.split('/') {
+        if segment.is_empty() {
+            bail!("{what} {value:?} must not contain an empty path segment");
+        }
+        if segment == "." || segment == ".." {
+            bail!("{what} {value:?} must not contain a relative path segment");
+        }
+        if !segment
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        {
+            bail!(
+                "{what} {value:?} must use only letters, digits, '.', '_', '-', and '/' \
+                 when the remote cache is an object store"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the bucket root a key is joined onto.
+///
+/// A custom endpoint addresses the bucket in the path, which is what MinIO and
+/// R2 expect and what a bucket whose name is not a valid DNS label requires.
+/// AWS itself is addressed by host, since a bucket-named host is what its TLS
+/// certificate covers -- unless the name contains a dot, which the wildcard
+/// certificate does not match.
+fn base_url(config: &S3RemoteCacheConfig) -> Result<Url> {
+    let bucket = config.bucket.trim();
+    let (mut url, path_style) = match &config.endpoint {
+        Some(endpoint) => (endpoint.clone(), config.force_path_style.unwrap_or(true)),
+        None => (
+            format!("https://s3.{}.amazonaws.com", config.region.trim()).parse()?,
+            config
+                .force_path_style
+                .unwrap_or_else(|| bucket.contains('.')),
+        ),
+    };
+    if path_style {
+        let path = url.path().trim_end_matches('/').to_string();
+        url.set_path(&format!("{path}/{bucket}/"));
+    } else {
+        let host = url
+            .host_str()
+            .ok_or_else(|| eyre!("an S3 endpoint must have a host"))?;
+        url.set_host(Some(&format!("{bucket}.{host}")))?;
+        url.set_path("/");
+    }
+    Ok(url)
+}
+
+#[cfg(test)]
+#[path = "remote_s3_tests.rs"]
+mod tests;

--- a/crates/mbx-cache-core/src/remote_s3_tests.rs
+++ b/crates/mbx-cache-core/src/remote_s3_tests.rs
@@ -1,0 +1,702 @@
+use super::*;
+use crate::*;
+
+/// An S3 error document, as a store would send one.
+fn s3_error_body(code: &str) -> String {
+    format!("<?xml version=\"1.0\"?><Error><Code>{code}</Code><Message>no</Message></Error>")
+}
+
+fn credentials() -> S3Credentials {
+    S3Credentials {
+        access_key_id: "AKIDEXAMPLE".into(),
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into(),
+        session_token: None,
+    }
+}
+
+fn config(server: &mockito::ServerGuard) -> S3RemoteCacheConfig {
+    S3RemoteCacheConfig {
+        bucket: "cache-bucket".into(),
+        prefix: String::new(),
+        namespace: "acme".into(),
+        region: "us-east-1".into(),
+        endpoint: Some(server.url().parse().unwrap()),
+        force_path_style: None,
+        conditional_writes: S3ConditionalWrites::Auto,
+        credentials: credentials(),
+        connect_timeout: Duration::from_secs(1),
+        read_timeout: Duration::from_secs(1),
+        download_timeout: Duration::from_secs(1),
+        retries: 0,
+    }
+}
+
+fn test_store(server: &mockito::ServerGuard) -> S3RemoteCache {
+    S3RemoteCache::new(config(server)).unwrap()
+}
+
+/// The key a blob of these bytes lands on, under the test configuration.
+fn blob_path(digest: &CacheDigest) -> String {
+    format!(
+        "/cache-bucket/acme/v1/blobs/{}/{}/{}",
+        digest.algorithm, digest.hash, digest.size
+    )
+}
+
+#[tokio::test]
+async fn a_blob_round_trips_through_its_content_addressed_key() {
+    let mut server = mockito::Server::new_async().await;
+    let contents = b"a cached object file";
+    let digest = CacheDigest::blake3(contents);
+    let request = server
+        .mock("GET", blob_path(&digest).as_str())
+        .match_header("x-amz-content-sha256", mockito::Matcher::Any)
+        .match_header("x-amz-date", mockito::Matcher::Any)
+        .match_header(
+            "authorization",
+            mockito::Matcher::Regex(
+                "^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/[0-9]{8}/us-east-1/s3/aws4_request, \
+                 SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$"
+                    .into(),
+            ),
+        )
+        .with_status(200)
+        .with_body(contents)
+        .expect(1)
+        .create_async()
+        .await;
+    let staging = tempfile::tempdir().unwrap();
+
+    let file = test_store(&server)
+        .get_blob_file(&digest, staging.path())
+        .await
+        .unwrap();
+
+    assert_eq!(fs::read(file.path()).unwrap(), contents);
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_blob_that_fails_verification_is_refused() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"what was asked for");
+    // The same length as what was asked for, so the size guard cannot reject it
+    // first and verification is what does.
+    server
+        .mock("GET", blob_path(&digest).as_str())
+        .with_status(200)
+        .with_body(b"something else!!!!")
+        .create_async()
+        .await;
+    let staging = tempfile::tempdir().unwrap();
+
+    let error = test_store(&server)
+        .get_blob_file(&digest, staging.path())
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("failed digest verification"));
+}
+
+#[tokio::test]
+async fn a_blob_larger_than_its_digest_stops_being_read() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"small");
+    server
+        .mock("GET", blob_path(&digest).as_str())
+        .with_status(200)
+        .with_body(vec![b'x'; 4096])
+        .create_async()
+        .await;
+    let staging = tempfile::tempdir().unwrap();
+
+    let error = test_store(&server)
+        .get_blob_file(&digest, staging.path())
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("exceeded the size of its digest")
+    );
+}
+
+#[tokio::test]
+async fn storing_a_blob_writes_it_create_only() {
+    let mut server = mockito::Server::new_async().await;
+    let contents = b"a published object";
+    let digest = CacheDigest::blake3(contents);
+    let request = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .match_header("if-none-match", "*")
+        .match_body(contents.to_vec())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+
+    test_store(&server)
+        .put_blob(&BlobUpload {
+            digest,
+            source: BlobSource::Bytes(contents.to_vec()),
+        })
+        .await
+        .unwrap();
+
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_blob_the_store_already_holds_is_not_an_error() {
+    let mut server = mockito::Server::new_async().await;
+    let contents = b"already stored";
+    let digest = CacheDigest::blake3(contents);
+    server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(412)
+        .with_body(s3_error_body("PreconditionFailed"))
+        .create_async()
+        .await;
+
+    // The key is the content address of these bytes, so an object already
+    // sitting there holds exactly what this upload would have written.
+    test_store(&server)
+        .put_blob(&BlobUpload {
+            digest,
+            source: BlobSource::Bytes(contents.to_vec()),
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_conflicting_conditional_write_is_retried() {
+    let mut server = mockito::Server::new_async().await;
+    let contents = b"contended object";
+    let digest = CacheDigest::blake3(contents);
+    let conflict = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(409)
+        .with_body(s3_error_body("ConditionalRequestConflict"))
+        .expect(1)
+        .create_async()
+        .await;
+    let stored = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let mut settings = config(&server);
+    settings.retries = 1;
+
+    S3RemoteCache::new(settings)
+        .unwrap()
+        .put_blob(&BlobUpload {
+            digest,
+            source: BlobSource::Bytes(contents.to_vec()),
+        })
+        .await
+        .unwrap();
+
+    conflict.assert_async().await;
+    stored.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_file_backed_blob_is_streamed_with_its_length() {
+    let mut server = mockito::Server::new_async().await;
+    let contents = vec![b'z'; 128 * 1024];
+    let digest = CacheDigest::blake3(&contents);
+    let request = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .match_header("content-length", contents.len().to_string().as_str())
+        // A streamed body is not hashed, so the signature covers everything
+        // about the request except bytes TLS and the content address stand
+        // behind.
+        .match_header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+        .match_body(contents.to_vec())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let file = tempfile::NamedTempFile::new().unwrap();
+    fs::write(file.path(), &contents).unwrap();
+
+    test_store(&server)
+        .put_blob(&BlobUpload {
+            digest,
+            source: BlobSource::Path(file.path().to_path_buf()),
+        })
+        .await
+        .unwrap();
+
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_missing_action_result_is_a_miss_rather_than_an_error() {
+    let mut server = mockito::Server::new_async().await;
+    let action = CacheDigest::blake3(b"an action");
+    server
+        .mock(
+            "GET",
+            format!(
+                "/cache-bucket/acme/v1/action-results/blake3/{}/{}",
+                action.hash, action.size
+            )
+            .as_str(),
+        )
+        .with_status(404)
+        .with_body(s3_error_body("NoSuchKey"))
+        .create_async()
+        .await;
+
+    assert!(
+        test_store(&server)
+            .get_action_result(&action)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn an_action_result_naming_another_action_is_refused() {
+    let mut server = mockito::Server::new_async().await;
+    let action = CacheDigest::blake3(b"an action");
+    let other = CacheDigest::blake3(b"a different action");
+    server
+        .mock(
+            "GET",
+            format!(
+                "/cache-bucket/acme/v1/action-results/blake3/{}/{}",
+                action.hash, action.size
+            )
+            .as_str(),
+        )
+        .with_status(200)
+        .with_body(
+            serde_json::to_vec(&RemoteActionResult {
+                action: other,
+                metadata: None,
+                output_root: None,
+                version: 1,
+            })
+            .unwrap(),
+        )
+        .create_async()
+        .await;
+
+    let error = test_store(&server)
+        .get_action_result(&action)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("does not match requested action")
+    );
+}
+
+/// The key a task action manifest lands on.
+fn manifest_path(key: &CacheDigest) -> String {
+    format!(
+        "/cache-bucket/acme/v1/action-manifests/blake3/{}/{}",
+        key.hash, key.size
+    )
+}
+
+#[tokio::test]
+async fn a_manifest_carries_the_entity_tag_its_update_must_send_back() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a task");
+    server
+        .mock("GET", manifest_path(&key).as_str())
+        .with_status(200)
+        .with_header("etag", "\"d41d8cd98f00b204e9800998ecf8427e\"")
+        .with_body("{}")
+        .create_async()
+        .await;
+    let update = server
+        .mock("PUT", manifest_path(&key).as_str())
+        .match_header("if-match", "\"d41d8cd98f00b204e9800998ecf8427e\"")
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let store = test_store(&server);
+
+    let manifest = store.get_action_manifest(&key).await.unwrap().unwrap();
+    assert_eq!(manifest.etag, "d41d8cd98f00b204e9800998ecf8427e");
+
+    let outcome = store
+        .put_action_manifest(&key, b"{}", Some(&manifest.etag))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, ManifestPutOutcome::Stored);
+    update.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_manifest_that_moved_reports_a_precondition_failure() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a contended task");
+    server
+        .mock("PUT", manifest_path(&key).as_str())
+        .match_header("if-match", "\"stale\"")
+        .with_status(412)
+        .with_body(s3_error_body("PreconditionFailed"))
+        .create_async()
+        .await;
+
+    let outcome = test_store(&server)
+        .put_action_manifest(&key, b"{}", Some("stale"))
+        .await
+        .unwrap();
+
+    // The agent answers this by re-reading, merging, and trying again, which is
+    // what keeps a concurrent writer's predictions.
+    assert_eq!(outcome, ManifestPutOutcome::PreconditionFailed);
+}
+
+#[tokio::test]
+async fn a_first_manifest_is_written_create_only() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a new task");
+    let request = server
+        .mock("PUT", manifest_path(&key).as_str())
+        .match_header("if-none-match", "*")
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let outcome = test_store(&server)
+        .put_action_manifest(&key, b"{}", None)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, ManifestPutOutcome::Stored);
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_store_without_conditional_writes_is_used_without_them() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a task");
+    let refused = server
+        .mock("PUT", manifest_path(&key).as_str())
+        .match_header("if-none-match", "*")
+        .with_status(501)
+        .with_body(s3_error_body("NotImplemented"))
+        .expect(1)
+        .create_async()
+        .await;
+    let unconditional = server
+        .mock("PUT", manifest_path(&key).as_str())
+        .match_header("if-none-match", mockito::Matcher::Missing)
+        .with_status(200)
+        .expect(2)
+        .create_async()
+        .await;
+    let store = test_store(&server);
+
+    assert_eq!(
+        store.put_action_manifest(&key, b"{}", None).await.unwrap(),
+        ManifestPutOutcome::Stored
+    );
+    // Having learned it once, the store stops asking for the rest of the
+    // session rather than spending a refused round trip on every write.
+    assert_eq!(
+        store.put_action_manifest(&key, b"{}", None).await.unwrap(),
+        ManifestPutOutcome::Stored
+    );
+
+    refused.assert_async().await;
+    unconditional.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_store_that_dislikes_a_request_is_not_mistaken_for_one_without_conditionals() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a task");
+    server
+        .mock("PUT", manifest_path(&key).as_str())
+        .with_status(400)
+        .with_body(s3_error_body("InvalidRequest"))
+        .create_async()
+        .await;
+    let store = test_store(&server);
+
+    let error = store
+        .put_action_manifest(&key, b"{}", None)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("InvalidRequest"));
+    assert!(store.conditionals_enabled());
+}
+
+#[tokio::test]
+async fn requiring_conditional_writes_refuses_a_store_without_them() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a task");
+    server
+        .mock("PUT", manifest_path(&key).as_str())
+        .with_status(501)
+        .with_body(s3_error_body("NotImplemented"))
+        .create_async()
+        .await;
+    let mut settings = config(&server);
+    settings.conditional_writes = S3ConditionalWrites::Required;
+
+    let error = S3RemoteCache::new(settings)
+        .unwrap()
+        .put_action_manifest(&key, b"{}", None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("conditional writes are required")
+    );
+}
+
+#[tokio::test]
+async fn a_reachable_bucket_passes_the_connection_probe() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .with_status(404)
+        .expect(1)
+        .create_async()
+        .await;
+
+    // A bucket that answers at all has proved the endpoint, the credentials,
+    // and its own existence. Whether this key is present says nothing.
+    test_store(&server).check_connection().await.unwrap();
+
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn rejected_credentials_are_named_in_the_connection_probe() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .with_status(403)
+        .create_async()
+        .await;
+
+    let error = test_store(&server).check_connection().await.unwrap_err();
+
+    assert!(error.to_string().contains("AWS_ACCESS_KEY_ID"));
+}
+
+#[tokio::test]
+async fn a_bucket_in_another_region_says_which_one() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .with_status(301)
+        .with_header("x-amz-bucket-region", "eu-west-1")
+        .create_async()
+        .await;
+
+    let error = test_store(&server).check_connection().await.unwrap_err();
+
+    assert!(error.to_string().contains("eu-west-1"));
+}
+
+#[tokio::test]
+async fn temporary_credentials_send_their_session_token() {
+    let mut server = mockito::Server::new_async().await;
+    let request = server
+        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .match_header("x-amz-security-token", "session-token")
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let mut settings = config(&server);
+    settings.credentials.session_token = Some("session-token".into());
+
+    S3RemoteCache::new(settings)
+        .unwrap()
+        .check_connection()
+        .await
+        .unwrap();
+
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn extensions_a_bucket_cannot_serve_report_themselves_absent() {
+    let server = mockito::Server::new_async().await;
+    let store = test_store(&server);
+    let digest = CacheDigest::blake3(b"anything");
+    let staging = tempfile::tempdir().unwrap();
+
+    // Reporting absence is what routes the agent and the upload queue to the
+    // per-object requests every version of the protocol has made.
+    assert!(store.action_batch_limit().await.unwrap().is_none());
+    assert!(store.blob_pack_upload_limits().await.unwrap().is_none());
+    assert!(
+        store
+            .get_action_results(std::slice::from_ref(&digest))
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        store
+            .get_blob_pack(std::slice::from_ref(&digest), staging.path())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        store
+            .put_blob_pack(&[BlobUpload {
+                digest,
+                source: BlobSource::Bytes(Vec::new()),
+            }])
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // An empty request is answered rather than declined, matching the protocol
+    // client, so a caller with nothing to do does not fall back for no reason.
+    assert_eq!(
+        store.get_action_results(&[]).await.unwrap(),
+        Some(Vec::new())
+    );
+    assert!(store.put_blob_pack(&[]).await.unwrap().is_some());
+}
+
+#[test]
+fn buckets_are_addressed_by_host_on_aws_and_by_path_elsewhere() {
+    let addressed = |bucket: &str, endpoint: Option<&str>, force: Option<bool>| {
+        base_url(&S3RemoteCacheConfig {
+            bucket: bucket.into(),
+            endpoint: endpoint.map(|endpoint| endpoint.parse().unwrap()),
+            force_path_style: force,
+            ..S3RemoteCacheConfig {
+                bucket: bucket.into(),
+                prefix: String::new(),
+                namespace: "acme".into(),
+                region: "us-west-2".into(),
+                endpoint: None,
+                force_path_style: None,
+                conditional_writes: S3ConditionalWrites::Auto,
+                credentials: credentials(),
+                connect_timeout: Duration::from_secs(1),
+                read_timeout: Duration::from_secs(1),
+                download_timeout: Duration::from_secs(1),
+                retries: 0,
+            }
+        })
+        .unwrap()
+        .to_string()
+    };
+
+    assert_eq!(
+        addressed("cache", None, None),
+        "https://cache.s3.us-west-2.amazonaws.com/"
+    );
+    // A dot in the name is not covered by the wildcard certificate that makes
+    // host addressing work, so such a bucket is addressed by path.
+    assert_eq!(
+        addressed("cache.example.com", None, None),
+        "https://s3.us-west-2.amazonaws.com/cache.example.com/"
+    );
+    assert_eq!(
+        addressed("cache", None, Some(true)),
+        "https://s3.us-west-2.amazonaws.com/cache/"
+    );
+    assert_eq!(
+        addressed("cache", Some("http://127.0.0.1:9000"), None),
+        "http://127.0.0.1:9000/cache/"
+    );
+    assert_eq!(
+        addressed(
+            "cache",
+            Some("https://account.r2.cloudflarestorage.com"),
+            None
+        ),
+        "https://account.r2.cloudflarestorage.com/cache/"
+    );
+    assert_eq!(
+        addressed("cache", Some("https://store.example.com"), Some(false)),
+        "https://cache.store.example.com/"
+    );
+}
+
+#[test]
+fn keys_are_laid_out_under_the_prefix_namespace_and_layout_version() {
+    let server = mockito::Server::new();
+    let mut settings = config(&server);
+    settings.prefix = "/teams/backend/".into();
+    let store = S3RemoteCache::new(settings).unwrap();
+    let digest = CacheDigest {
+        algorithm: "blake3".into(),
+        hash: "a".repeat(64),
+        size: 7,
+    };
+
+    assert!(
+        store
+            .object_url(ObjectKind::Blob, &digest)
+            .unwrap()
+            .path()
+            .ends_with(&format!(
+                "/cache-bucket/teams/backend/acme/v1/blobs/blake3/{}/7",
+                digest.hash
+            ))
+    );
+}
+
+#[test]
+fn a_namespace_that_could_escape_its_prefix_is_refused() {
+    let server = mockito::Server::new();
+    let refused = |namespace: &str| {
+        let mut settings = config(&server);
+        settings.namespace = namespace.into();
+        match S3RemoteCache::new(settings) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("namespace {namespace:?} should have been refused"),
+        }
+    };
+
+    // The protocol carries the namespace in a header a server interprets. In a
+    // bucket it is part of the key, so it has to stay inside its own prefix.
+    assert!(refused("../other").contains("relative path segment"));
+    assert!(refused("acme//backend").contains("empty path segment"));
+    assert!(refused("/acme").contains("must not start or end with a slash"));
+    assert!(refused("").contains("must not be empty"));
+    assert!(refused("acme backend").contains("must use only letters"));
+    // A namespace naming more than one level is ordinary and stays allowed.
+    let mut settings = config(&server);
+    settings.namespace = "acme/backend".into();
+    assert!(S3RemoteCache::new(settings).map(drop).is_ok());
+}
+
+#[test]
+fn error_codes_are_read_out_of_an_s3_error_document() {
+    assert_eq!(error_code(&s3_error_body("NoSuchKey")), Some("NoSuchKey"));
+    assert_eq!(error_code("not xml at all"), None);
+    assert_eq!(error_code("<Error><Code></Code></Error>"), None);
+    // A code at the very end of the document is still found: nothing may trim
+    // the tail off a body before scanning it.
+    assert_eq!(
+        error_code("<Code>AccessDenied</Code>"),
+        Some("AccessDenied")
+    );
+    assert_eq!(error_code(&"é".repeat(16 * 1024)), None);
+}

--- a/crates/mbx-cache-core/src/remote_s3_tests.rs
+++ b/crates/mbx-cache-core/src/remote_s3_tests.rs
@@ -385,6 +385,69 @@ async fn a_first_manifest_is_written_create_only() {
 }
 
 #[tokio::test]
+async fn a_retryable_status_is_retried() {
+    let mut server = mockito::Server::new_async().await;
+    let contents = b"an object the store was too busy for";
+    let digest = CacheDigest::blake3(contents);
+    // S3 answers 503 SlowDown for a prefix under load and asks the client to
+    // try again. The protocol backend retries these; so must this one.
+    let busy = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(503)
+        .with_body(s3_error_body("SlowDown"))
+        .expect(1)
+        .create_async()
+        .await;
+    let stored = server
+        .mock("PUT", blob_path(&digest).as_str())
+        .with_status(200)
+        .expect(1)
+        .create_async()
+        .await;
+    let mut settings = config(&server);
+    settings.retries = 1;
+
+    S3RemoteCache::new(settings)
+        .unwrap()
+        .put_blob(&BlobUpload {
+            digest,
+            source: BlobSource::Bytes(contents.to_vec()),
+        })
+        .await
+        .unwrap();
+
+    busy.assert_async().await;
+    stored.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_store_that_does_not_implement_something_else_is_not_retried_forever() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a task");
+    // 501 is not transient: a store that does not implement something will not
+    // implement it a moment later.
+    let refusals = server
+        .mock("PUT", manifest_path(&key).as_str())
+        .with_status(501)
+        .with_body(s3_error_body("NotImplemented"))
+        .expect(2)
+        .create_async()
+        .await;
+    let mut settings = config(&server);
+    settings.retries = 3;
+
+    let error = S3RemoteCache::new(settings)
+        .unwrap()
+        .put_action_manifest(&key, b"{}", None)
+        .await
+        .unwrap_err();
+
+    // One conditional attempt, one unconditional retry, and no more.
+    refusals.assert_async().await;
+    assert!(error.to_string().contains("failed to update"));
+}
+
+#[tokio::test]
 async fn a_store_without_conditional_writes_is_used_without_them() {
     let mut server = mockito::Server::new_async().await;
     let key = CacheDigest::blake3(b"a task");
@@ -418,6 +481,28 @@ async fn a_store_without_conditional_writes_is_used_without_them() {
 
     refused.assert_async().await;
     unconditional.assert_async().await;
+}
+
+#[tokio::test]
+async fn conditionals_stay_on_when_dropping_them_does_not_help() {
+    let mut server = mockito::Server::new_async().await;
+    let key = CacheDigest::blake3(b"a task");
+    // An intermediary answers 501 for a reason that has nothing to do with the
+    // condition, so the unconditional retry fails too. Concluding the store
+    // cannot do conditional writes would turn every later manifest update into
+    // a last-writer-wins one on no evidence.
+    server
+        .mock("PUT", manifest_path(&key).as_str())
+        .with_status(501)
+        .with_body(s3_error_body("NotImplemented"))
+        .expect_at_least(2)
+        .create_async()
+        .await;
+    let store = test_store(&server);
+
+    assert!(store.put_action_manifest(&key, b"{}", None).await.is_err());
+
+    assert!(store.conditionals_enabled());
 }
 
 #[tokio::test]
@@ -635,6 +720,15 @@ fn buckets_are_addressed_by_host_on_aws_and_by_path_elsewhere() {
     assert_eq!(
         addressed("cache", Some("https://store.example.com"), Some(false)),
         "https://cache.store.example.com/"
+    );
+    // An endpoint's own path survives being addressed by host.
+    assert_eq!(
+        addressed("cache", Some("https://gateway.example.com/s3"), Some(false)),
+        "https://cache.gateway.example.com/s3/"
+    );
+    assert_eq!(
+        addressed("cache", Some("https://gateway.example.com/s3"), None),
+        "https://gateway.example.com/s3/cache/"
     );
 }
 

--- a/crates/mbx-cache-core/src/remote_s3_tests.rs
+++ b/crates/mbx-cache-core/src/remote_s3_tests.rs
@@ -556,7 +556,7 @@ async fn requiring_conditional_writes_refuses_a_store_without_them() {
 async fn a_reachable_bucket_passes_the_connection_probe() {
     let mut server = mockito::Server::new_async().await;
     let request = server
-        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .mock("GET", "/cache-bucket/acme/v1/connectivity-probe")
         .with_status(404)
         .expect(1)
         .create_async()
@@ -573,8 +573,9 @@ async fn a_reachable_bucket_passes_the_connection_probe() {
 async fn rejected_credentials_are_named_in_the_connection_probe() {
     let mut server = mockito::Server::new_async().await;
     server
-        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .mock("GET", "/cache-bucket/acme/v1/connectivity-probe")
         .with_status(403)
+        .with_body(s3_error_body("SignatureDoesNotMatch"))
         .create_async()
         .await;
 
@@ -584,10 +585,77 @@ async fn rejected_credentials_are_named_in_the_connection_probe() {
 }
 
 #[tokio::test]
+async fn a_least_privilege_policy_still_passes_the_connection_probe() {
+    let mut server = mockito::Server::new_async().await;
+    // Without s3:ListBucket, S3 refuses a read of an absent object rather than
+    // reporting it absent -- and the probe key is never written. A working
+    // configuration must not be reported as broken credentials.
+    server
+        .mock("GET", "/cache-bucket/acme/v1/connectivity-probe")
+        .with_status(403)
+        .with_body(s3_error_body("AccessDenied"))
+        .create_async()
+        .await;
+
+    test_store(&server).check_connection().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_refused_read_is_a_miss_rather_than_a_failed_build() {
+    let mut server = mockito::Server::new_async().await;
+    let action = CacheDigest::blake3(b"an action");
+    let path = format!(
+        "/cache-bucket/acme/v1/action-results/blake3/{}/{}",
+        action.hash, action.size
+    );
+    server
+        .mock("GET", path.as_str())
+        .with_status(403)
+        .with_body(s3_error_body("AccessDenied"))
+        .create_async()
+        .await;
+
+    // Every cold lookup under a least-privilege policy arrives this way, so
+    // reporting them as errors would make such a policy unusable.
+    assert!(
+        test_store(&server)
+            .get_action_result(&action)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn credentials_s3_itself_rejected_are_not_mistaken_for_a_miss() {
+    let mut server = mockito::Server::new_async().await;
+    let action = CacheDigest::blake3(b"an action");
+    let path = format!(
+        "/cache-bucket/acme/v1/action-results/blake3/{}/{}",
+        action.hash, action.size
+    );
+    server
+        .mock("GET", path.as_str())
+        .with_status(403)
+        .with_body(s3_error_body("InvalidAccessKeyId"))
+        .create_async()
+        .await;
+
+    // A request that never authenticated says nothing about the object, and
+    // swallowing it would leave a permanently cold cache with no explanation.
+    let error = test_store(&server)
+        .get_action_result(&action)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("InvalidAccessKeyId"));
+}
+
+#[tokio::test]
 async fn a_bucket_in_another_region_says_which_one() {
     let mut server = mockito::Server::new_async().await;
     server
-        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .mock("GET", "/cache-bucket/acme/v1/connectivity-probe")
         .with_status(301)
         .with_header("x-amz-bucket-region", "eu-west-1")
         .create_async()
@@ -602,7 +670,7 @@ async fn a_bucket_in_another_region_says_which_one() {
 async fn temporary_credentials_send_their_session_token() {
     let mut server = mockito::Server::new_async().await;
     let request = server
-        .mock("HEAD", "/cache-bucket/acme/v1/connectivity-probe")
+        .mock("GET", "/cache-bucket/acme/v1/connectivity-probe")
         .match_header("x-amz-security-token", "session-token")
         .with_status(200)
         .expect(1)

--- a/crates/mbx-cache-core/src/sigv4.rs
+++ b/crates/mbx-cache-core/src/sigv4.rs
@@ -1,0 +1,554 @@
+//! AWS Signature Version 4 request signing.
+//!
+//! Only what an S3 object store needs: `GET`, `HEAD`, and `PUT` against a
+//! single object, signed with a fixed header set. There is no request
+//! execution here and no I/O -- [`sign`] takes a request's shape and returns
+//! the headers that authenticate it, which is what makes it testable against
+//! published vectors.
+
+use eyre::{Result, bail};
+use reqwest::header::{HeaderName, HeaderValue};
+use sha2::{Digest as _, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+use url::Url;
+
+/// The signing algorithm this module implements.
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+/// SigV4 signs per service; an object store is always `s3`.
+const SERVICE: &str = "s3";
+/// SHA-256 of the empty string, the payload hash of a body-less request.
+const EMPTY_PAYLOAD_SHA256: &str =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+/// What S3 accepts in place of a payload hash when the body is not read twice.
+const UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
+
+pub(crate) const X_AMZ_DATE: &str = "x-amz-date";
+pub(crate) const X_AMZ_CONTENT_SHA256: &str = "x-amz-content-sha256";
+pub(crate) const X_AMZ_SECURITY_TOKEN: &str = "x-amz-security-token";
+
+/// Long-lived or session credentials for an S3-compatible service.
+///
+/// Deliberately not `Debug`: the secret would otherwise reach any log line or
+/// panic message that formats a config.
+#[derive(Clone)]
+pub struct S3Credentials {
+    /// Access key identifier.
+    pub access_key_id: String,
+    /// Secret access key, never logged or formatted.
+    pub secret_access_key: String,
+    /// Session token accompanying temporary credentials.
+    pub session_token: Option<String>,
+}
+
+impl S3Credentials {
+    /// Read credentials from the environment variables the AWS tools set.
+    ///
+    /// This is the whole credential chain mbx implements. Anything that
+    /// produces temporary credentials -- an OIDC exchange, an instance role --
+    /// is expected to have exported them here first, which is what
+    /// `aws-actions/configure-aws-credentials` does on GitHub Actions.
+    pub fn from_env() -> Result<Self> {
+        let access_key_id = non_empty_var("AWS_ACCESS_KEY_ID");
+        let secret_access_key = non_empty_var("AWS_SECRET_ACCESS_KEY");
+        let (Some(access_key_id), Some(secret_access_key)) = (access_key_id, secret_access_key)
+        else {
+            bail!(
+                "an S3 remote cache needs AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY; \
+                 on GitHub Actions, aws-actions/configure-aws-credentials exports them \
+                 from an OIDC role assumption"
+            );
+        };
+        Ok(Self {
+            access_key_id,
+            secret_access_key,
+            session_token: non_empty_var("AWS_SESSION_TOKEN"),
+        })
+    }
+}
+
+fn non_empty_var(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// How the payload of a signed request is covered by its signature.
+pub(crate) enum PayloadHash {
+    /// Hex SHA-256 of the exact bytes being sent.
+    Sha256Hex(String),
+    /// The body is streamed from a file and deliberately not hashed.
+    ///
+    /// Hashing would mean reading an artifact twice, up to the 5 GiB single-PUT
+    /// ceiling, to protect bytes TLS already covers in transit and the content
+    /// address already covers at rest.
+    Unsigned,
+}
+
+impl PayloadHash {
+    /// The hash of a request with no body.
+    pub(crate) fn empty() -> Self {
+        Self::Sha256Hex(EMPTY_PAYLOAD_SHA256.to_string())
+    }
+
+    /// The hash of a body held in memory.
+    pub(crate) fn of(bytes: &[u8]) -> Self {
+        Self::Sha256Hex(hex::encode(Sha256::digest(bytes)))
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Sha256Hex(hash) => hash,
+            Self::Unsigned => UNSIGNED_PAYLOAD,
+        }
+    }
+}
+
+/// Everything about a request that its signature covers besides the payload.
+pub(crate) struct SigningContext<'a> {
+    pub(crate) credentials: &'a S3Credentials,
+    pub(crate) region: &'a str,
+    /// Request time. Injected rather than read from the clock so a signature
+    /// can be compared against a fixed expected value in tests.
+    pub(crate) timestamp: SystemTime,
+}
+
+/// Sign a request, returning the headers that authenticate it.
+///
+/// The signed header set is fixed at `host`, `x-amz-content-sha256`, and
+/// `x-amz-date`, plus `x-amz-security-token` when the credentials are
+/// temporary. Conditional headers and content types are deliberately left
+/// unsigned: S3 requires only `host` and the `x-amz-*` headers to be covered,
+/// and a fixed set keeps the canonical request predictable.
+pub(crate) fn sign(
+    method: &str,
+    url: &Url,
+    context: &SigningContext<'_>,
+    payload: &PayloadHash,
+) -> Result<Vec<(HeaderName, HeaderValue)>> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| eyre::eyre!("an S3 endpoint must have a host"))?;
+    let host = match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    };
+    let (date, date_time) = format_timestamp(context.timestamp)?;
+    let payload_hash = payload.as_str();
+
+    let mut headers = vec![
+        ("host".to_string(), host),
+        (X_AMZ_CONTENT_SHA256.to_string(), payload_hash.to_string()),
+        (X_AMZ_DATE.to_string(), date_time.clone()),
+    ];
+    if let Some(token) = &context.credentials.session_token {
+        headers.push((X_AMZ_SECURITY_TOKEN.to_string(), token.clone()));
+    }
+    headers.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let signed_headers = headers
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<Vec<_>>()
+        .join(";");
+    let canonical_headers = headers
+        .iter()
+        .map(|(name, value)| format!("{name}:{}\n", value.trim()))
+        .collect::<String>();
+
+    let canonical_request = format!(
+        "{method}\n{}\n{}\n{canonical_headers}\n{signed_headers}\n{payload_hash}",
+        canonical_uri(url.path()),
+        canonical_query(url),
+    );
+    let scope = format!("{date}/{}/{SERVICE}/aws4_request", context.region);
+    let string_to_sign = format!(
+        "{ALGORITHM}\n{date_time}\n{scope}\n{}",
+        hex::encode(Sha256::digest(canonical_request.as_bytes()))
+    );
+
+    let signature = hex::encode(hmac_sha256(
+        &signing_key(
+            &context.credentials.secret_access_key,
+            &date,
+            context.region,
+        ),
+        string_to_sign.as_bytes(),
+    ));
+    let authorization = format!(
+        "{ALGORITHM} Credential={}/{scope}, SignedHeaders={signed_headers}, Signature={signature}",
+        context.credentials.access_key_id
+    );
+
+    let mut signed = Vec::with_capacity(headers.len());
+    for (name, value) in headers {
+        // `host` is set by the HTTP layer from the URL; sending it again would
+        // duplicate it in the request.
+        if name == "host" {
+            continue;
+        }
+        signed.push((
+            HeaderName::from_bytes(name.as_bytes())?,
+            header_value(&name, &value)?,
+        ));
+    }
+    signed.push((
+        reqwest::header::AUTHORIZATION,
+        header_value("authorization", &authorization)?,
+    ));
+    Ok(signed)
+}
+
+fn header_value(name: &str, value: &str) -> Result<HeaderValue> {
+    let mut header = HeaderValue::from_str(value)?;
+    if name == X_AMZ_SECURITY_TOKEN || name == "authorization" {
+        header.set_sensitive(true);
+    }
+    Ok(header)
+}
+
+/// Derive the request's signing key from the secret, scoped to date and region.
+///
+/// The scoping is what keeps a leaked signature from being replayed against
+/// another day or another region.
+fn signing_key(secret: &str, date: &str, region: &str) -> Vec<u8> {
+    let date_key = hmac_sha256(format!("AWS4{secret}").as_bytes(), date.as_bytes());
+    let region_key = hmac_sha256(&date_key, region.as_bytes());
+    let service_key = hmac_sha256(&region_key, SERVICE.as_bytes());
+    hmac_sha256(&service_key, b"aws4_request")
+}
+
+/// HMAC-SHA256 (RFC 2104).
+///
+/// Hand-written over the SHA-256 this crate already depends on. Only signatures
+/// are produced here, never verified, so there is nothing to compare in
+/// constant time.
+fn hmac_sha256(key: &[u8], message: &[u8]) -> Vec<u8> {
+    const BLOCK_BYTES: usize = 64;
+    let mut block = [0_u8; BLOCK_BYTES];
+    if key.len() > BLOCK_BYTES {
+        block[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        block[..key.len()].copy_from_slice(key);
+    }
+    let mut inner = Sha256::new();
+    inner.update(block.map(|byte| byte ^ 0x36));
+    inner.update(message);
+    let mut outer = Sha256::new();
+    outer.update(block.map(|byte| byte ^ 0x5c));
+    outer.update(inner.finalize());
+    outer.finalize().to_vec()
+}
+
+/// The request path as the canonical request states it.
+///
+/// S3 is the one service that encodes the path exactly once rather than twice,
+/// and the caller passes [`Url::path`], which is already encoded. Encoding it
+/// again here would sign `%2520` for a key the request line spells `%20`, and
+/// every such key would fail to authenticate.
+fn canonical_uri(path: &str) -> String {
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+/// Encode a query string in the canonical form: sorted, and encoded per value.
+///
+/// mbx addresses objects by path alone, so this is empty in practice. It exists
+/// so that adding a query parameter later cannot silently break signing.
+fn canonical_query(url: &Url) -> String {
+    let mut pairs = url
+        .query_pairs()
+        .map(|(key, value)| (uri_encode(&key), uri_encode(&value)))
+        .collect::<Vec<_>>();
+    pairs.sort();
+    pairs
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Percent-encode everything outside AWS's unreserved set, with uppercase hex.
+fn uri_encode(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+/// Format a request time as the `YYYYMMDD` scope date and `YYYYMMDDTHHMMSSZ`
+/// stamp SigV4 requires.
+fn format_timestamp(timestamp: SystemTime) -> Result<(String, String)> {
+    let seconds = timestamp
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| eyre::eyre!("system clock is before the Unix epoch"))?
+        .as_secs();
+    let days = (seconds / 86_400) as i64;
+    let time_of_day = seconds % 86_400;
+    let (year, month, day) = civil_from_days(days);
+    Ok((
+        format!("{year:04}{month:02}{day:02}"),
+        format!(
+            "{year:04}{month:02}{day:02}T{:02}{:02}{:02}Z",
+            time_of_day / 3_600,
+            (time_of_day % 3_600) / 60,
+            time_of_day % 60
+        ),
+    ))
+}
+
+/// Convert a count of days since the Unix epoch to a civil date.
+///
+/// Howard Hinnant's `civil_from_days`, which shifts the year to start in March
+/// so that the leap day lands at the end of a 400-year era and needs no special
+/// case. Used instead of a date library because SigV4 needs exactly this and
+/// nothing else about calendars.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let shifted_month = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * shifted_month + 2) / 5 + 1) as u32;
+    let month = if shifted_month < 10 {
+        shifted_month + 3
+    } else {
+        shifted_month - 9
+    } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+/// A `SystemTime` a fixed number of seconds after the Unix epoch.
+#[cfg(test)]
+fn epoch_plus(seconds: u64) -> SystemTime {
+    UNIX_EPOCH + std::time::Duration::from_secs(seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credentials() -> S3Credentials {
+        S3Credentials {
+            access_key_id: "AKIDEXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into(),
+            session_token: None,
+        }
+    }
+
+    /// RFC 4231 test case 1.
+    #[test]
+    fn hmac_matches_rfc_4231() {
+        assert_eq!(
+            hex::encode(hmac_sha256(&[0x0b; 20], b"Hi There")),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+    }
+
+    /// RFC 4231 test case 3, whose message is longer than one hash block.
+    #[test]
+    fn hmac_matches_rfc_4231_multi_block_message() {
+        assert_eq!(
+            hex::encode(hmac_sha256(&[0xaa; 20], &[0xdd; 50])),
+            "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe"
+        );
+    }
+
+    /// RFC 4231 test case 6, whose key is longer than one hash block and is
+    /// therefore replaced by its own digest.
+    #[test]
+    fn hmac_hashes_keys_longer_than_a_block() {
+        assert_eq!(
+            hex::encode(hmac_sha256(
+                &[0xaa; 131],
+                b"Test Using Larger Than Block-Size Key - Hash Key First"
+            )),
+            "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54"
+        );
+    }
+
+    #[test]
+    fn empty_payload_constant_is_the_hash_of_no_bytes() {
+        let PayloadHash::Sha256Hex(hash) = PayloadHash::empty() else {
+            panic!("empty payload is hashed");
+        };
+        assert_eq!(hash, hex::encode(Sha256::digest(b"")));
+    }
+
+    #[test]
+    fn timestamps_format_as_sigv4_expects() {
+        assert_eq!(
+            format_timestamp(epoch_plus(0)).unwrap(),
+            ("19700101".to_string(), "19700101T000000Z".to_string())
+        );
+        // 2015-08-30T12:36:00Z, the instant AWS's own signing examples use.
+        assert_eq!(
+            format_timestamp(epoch_plus(1_440_938_160)).unwrap(),
+            ("20150830".to_string(), "20150830T123600Z".to_string())
+        );
+        // 2024-02-29T23:59:59Z: a leap day, at the end of the day.
+        assert_eq!(
+            format_timestamp(epoch_plus(1_709_251_199)).unwrap(),
+            ("20240229".to_string(), "20240229T235959Z".to_string())
+        );
+        // 2100-03-01T00:00:00Z: past a century that is not a leap year.
+        assert_eq!(
+            format_timestamp(epoch_plus(4_107_542_400)).unwrap(),
+            ("21000301".to_string(), "21000301T000000Z".to_string())
+        );
+    }
+
+    #[test]
+    fn paths_are_signed_exactly_as_the_request_spells_them() {
+        assert_eq!(
+            canonical_uri("/ns/v1/blobs/blake3/ab/12"),
+            "/ns/v1/blobs/blake3/ab/12"
+        );
+        assert_eq!(canonical_uri(""), "/");
+        // `Url::path` has already encoded the path. Encoding it a second time
+        // would sign a different key than the one the request asks for.
+        assert_eq!(canonical_uri("/a%20b"), "/a%20b");
+    }
+
+    #[test]
+    fn query_values_are_encoded_with_the_unreserved_set() {
+        assert_eq!(uri_encode("-._~"), "-._~");
+        assert_eq!(uri_encode("a b"), "a%20b");
+        assert_eq!(uri_encode("c+d/e"), "c%2Bd%2Fe");
+    }
+
+    #[test]
+    fn query_strings_are_sorted_and_encoded() {
+        let url: Url = "https://bucket.example.com/key?b=2&a=1&c=with%20space"
+            .parse()
+            .unwrap();
+        assert_eq!(canonical_query(&url), "a=1&b=2&c=with%20space");
+        let bare: Url = "https://bucket.example.com/key".parse().unwrap();
+        assert_eq!(canonical_query(&bare), "");
+    }
+
+    /// Pinned against an independent implementation of SigV4 (Python's `hmac`
+    /// and `hashlib` driving the same canonical request), so a change in this
+    /// module's own arithmetic cannot move the expected value with it.
+    #[test]
+    fn signs_a_get_the_way_the_specification_does() {
+        let url: Url = "https://examplebucket.s3.amazonaws.com/test.txt"
+            .parse()
+            .unwrap();
+        let context = SigningContext {
+            credentials: &credentials(),
+            region: "us-east-1",
+            timestamp: epoch_plus(1_440_938_160),
+        };
+
+        let headers = sign("GET", &url, &context, &PayloadHash::empty()).unwrap();
+
+        let authorization = header(&headers, "authorization");
+        assert_eq!(
+            authorization,
+            "AWS4-HMAC-SHA256 \
+             Credential=AKIDEXAMPLE/20150830/us-east-1/s3/aws4_request, \
+             SignedHeaders=host;x-amz-content-sha256;x-amz-date, \
+             Signature=bbfdf4d3c3eab24da182f8f790e0c7d8e2a20658191717a6546076effa9f5a5e"
+        );
+        assert_eq!(header(&headers, X_AMZ_DATE), "20150830T123600Z");
+        assert_eq!(header(&headers, X_AMZ_CONTENT_SHA256), EMPTY_PAYLOAD_SHA256);
+        assert!(!headers.iter().any(|(name, _)| name.as_str() == "host"));
+    }
+
+    #[test]
+    fn temporary_credentials_sign_and_send_their_session_token() {
+        let url: Url = "https://examplebucket.s3.amazonaws.com/test.txt"
+            .parse()
+            .unwrap();
+        let credentials = S3Credentials {
+            session_token: Some("session-token".into()),
+            ..credentials()
+        };
+        let context = SigningContext {
+            credentials: &credentials,
+            region: "us-east-1",
+            timestamp: epoch_plus(1_440_938_160),
+        };
+
+        let headers = sign("PUT", &url, &context, &PayloadHash::Unsigned).unwrap();
+
+        assert_eq!(
+            header(&headers, "authorization"),
+            "AWS4-HMAC-SHA256 \
+             Credential=AKIDEXAMPLE/20150830/us-east-1/s3/aws4_request, \
+             SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, \
+             Signature=37e8be08e60e6a292f591b6a462e7fb96436b4c1925f6978e8869a7c4577e12f"
+        );
+        assert_eq!(header(&headers, X_AMZ_SECURITY_TOKEN), "session-token");
+        assert_eq!(header(&headers, X_AMZ_CONTENT_SHA256), UNSIGNED_PAYLOAD);
+    }
+
+    #[test]
+    fn a_signature_covers_the_payload_the_method_and_the_key() {
+        let url: Url = "https://examplebucket.s3.amazonaws.com/test.txt"
+            .parse()
+            .unwrap();
+        let other: Url = "https://examplebucket.s3.amazonaws.com/other.txt"
+            .parse()
+            .unwrap();
+        let credentials = credentials();
+        let signature = |method: &str, url: &Url, region: &str, payload: PayloadHash| {
+            let context = SigningContext {
+                credentials: &credentials,
+                region,
+                timestamp: epoch_plus(1_440_938_160),
+            };
+            header(
+                &sign(method, url, &context, &payload).unwrap(),
+                "authorization",
+            )
+            .to_string()
+        };
+
+        let baseline = signature("GET", &url, "us-east-1", PayloadHash::empty());
+        for (what, other) in [
+            (
+                "method",
+                signature("PUT", &url, "us-east-1", PayloadHash::empty()),
+            ),
+            (
+                "key",
+                signature("GET", &other, "us-east-1", PayloadHash::empty()),
+            ),
+            (
+                "region",
+                signature("GET", &url, "eu-west-1", PayloadHash::empty()),
+            ),
+            (
+                "payload",
+                signature("GET", &url, "us-east-1", PayloadHash::of(b"body")),
+            ),
+            (
+                "unsigned payload",
+                signature("GET", &url, "us-east-1", PayloadHash::Unsigned),
+            ),
+        ] {
+            assert_ne!(baseline, other, "signature ignores the request's {what}");
+        }
+    }
+
+    fn header<'a>(headers: &'a [(HeaderName, HeaderValue)], name: &str) -> &'a str {
+        headers
+            .iter()
+            .find(|(header, _)| header.as_str() == name)
+            .map(|(_, value)| value.to_str().unwrap())
+            .unwrap_or_else(|| panic!("missing header {name}"))
+    }
+}

--- a/crates/mbx-cache-core/src/sigv4.rs
+++ b/crates/mbx-cache-core/src/sigv4.rs
@@ -6,7 +6,7 @@
 //! the headers that authenticate it, which is what makes it testable against
 //! published vectors.
 
-use eyre::{Result, bail};
+use eyre::Result;
 use reqwest::header::{HeaderName, HeaderValue};
 use sha2::{Digest as _, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -43,24 +43,15 @@ pub struct S3Credentials {
 impl S3Credentials {
     /// Read credentials from the environment variables the AWS tools set.
     ///
-    /// This is the whole credential chain mbx implements. Anything that
-    /// produces temporary credentials -- an OIDC exchange, an instance role --
-    /// is expected to have exported them here first, which is what
+    /// This is the whole credential chain mbx implements, and `None` means the
+    /// environment does not carry one. Anything that produces temporary
+    /// credentials -- an OIDC exchange, an instance role -- is expected to have
+    /// exported them here first, which is what
     /// `aws-actions/configure-aws-credentials` does on GitHub Actions.
-    pub fn from_env() -> Result<Self> {
-        let access_key_id = non_empty_var("AWS_ACCESS_KEY_ID");
-        let secret_access_key = non_empty_var("AWS_SECRET_ACCESS_KEY");
-        let (Some(access_key_id), Some(secret_access_key)) = (access_key_id, secret_access_key)
-        else {
-            bail!(
-                "an S3 remote cache needs AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY; \
-                 on GitHub Actions, aws-actions/configure-aws-credentials exports them \
-                 from an OIDC role assumption"
-            );
-        };
-        Ok(Self {
-            access_key_id,
-            secret_access_key,
+    pub fn from_env() -> Option<Self> {
+        Some(Self {
+            access_key_id: non_empty_var("AWS_ACCESS_KEY_ID")?,
+            secret_access_key: non_empty_var("AWS_SECRET_ACCESS_KEY")?,
             session_token: non_empty_var("AWS_SESSION_TOKEN"),
         })
     }

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 toml = "1.1"
 toml_edit = "0.25"
+url = "2"
 usage = { package = "usage-rs", version = "6", features = ["config"] }
 usage-config = { version = "6", features = ["toml"] }
 which = "8"

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -6,7 +6,7 @@
 use crate::util::parse_duration;
 use bytesize::ByteSize;
 use eyre::{Context, Result, bail};
-use mbx_cache_core::RemoteCacheMode;
+use mbx_cache_core::{RemoteCacheMode, S3ConditionalWrites};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use usage_config::{EnvLayer, FileLayer, FileScope, Layers};
@@ -159,6 +159,22 @@ struct RawRemote {
         choices("read-write", "read-only", "write-only")
     )]
     mode: String,
+    /// S3 endpoint for a store that is not AWS, such as MinIO or R2.
+    #[usage(env = "MBX_REMOTE_S3_ENDPOINT", ty = "url")]
+    s3_endpoint: Option<String>,
+    /// S3 region; Cloudflare R2 uses "auto".
+    #[usage(env = "MBX_REMOTE_S3_REGION")]
+    s3_region: Option<String>,
+    /// Address S3 buckets in the path rather than the host.
+    #[usage(env = "MBX_REMOTE_S3_FORCE_PATH_STYLE")]
+    s3_force_path_style: Option<bool>,
+    /// How to treat an S3 store that does not implement conditional writes.
+    #[usage(
+        env = "MBX_REMOTE_S3_CONDITIONAL_WRITES",
+        default = "auto",
+        choices("auto", "required", "off")
+    )]
+    s3_conditional_writes: String,
 }
 
 #[derive(Debug, usage::Config)]
@@ -241,6 +257,29 @@ pub struct Config {
     pub target: TargetSettings,
 }
 
+impl Config {
+    /// A configuration with everything defaulted, for tests that care about one
+    /// setting and should not have to spell out the rest.
+    #[cfg(test)]
+    pub fn for_test(cache_dir: &std::path::Path) -> Self {
+        Self {
+            cache_dir: cache_dir.to_path_buf(),
+            stats_report: None,
+            verify: false,
+            incremental: false,
+            share_out_dir: false,
+            events: false,
+            remote: Default::default(),
+            http: Default::default(),
+            gc: Default::default(),
+            target: TargetSettings {
+                views: true,
+                root: cache_dir.join("targets"),
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RemoteSettings {
     pub url: Option<String>,
@@ -249,6 +288,10 @@ pub struct RemoteSettings {
     pub token_file: Option<PathBuf>,
     pub oidc_audience: Option<String>,
     pub mode: RemoteCacheMode,
+    pub s3_endpoint: Option<String>,
+    pub s3_region: Option<String>,
+    pub s3_force_path_style: Option<bool>,
+    pub s3_conditional_writes: S3ConditionalWrites,
 }
 
 #[derive(Debug, Clone)]
@@ -474,6 +517,11 @@ impl Config {
                 .flatten(),
         };
         let mode = raw.remote.mode.parse().wrap_err("invalid remote.mode")?;
+        let s3_conditional_writes = raw
+            .remote
+            .s3_conditional_writes
+            .parse()
+            .wrap_err("invalid remote.s3_conditional_writes")?;
         let http = HttpSettings {
             timeout: parse_duration(&raw.http.timeout).wrap_err("invalid http.timeout")?,
             download_timeout: parse_duration(&raw.http.download_timeout)
@@ -505,6 +553,10 @@ impl Config {
                 token_file: raw.remote.token_file,
                 oidc_audience: raw.remote.oidc_audience,
                 mode,
+                s3_endpoint: raw.remote.s3_endpoint,
+                s3_region: raw.remote.s3_region,
+                s3_force_path_style: raw.remote.s3_force_path_style,
+                s3_conditional_writes,
             },
             http,
         };
@@ -692,6 +744,7 @@ mod tests {
             url = "https://file.example"
             namespace = "file"
             mode = "read-only"
+            s3_conditional_writes = "required"
             [http]
             timeout = "5s"
             retries = 9
@@ -723,6 +776,10 @@ mod tests {
         assert_eq!(config.gc.max_bytes, 2 * 1024 * 1024 * 1024);
         // Values absent from the environment still come from the file.
         assert_eq!(config.remote.namespace.unwrap(), "file");
+        assert_eq!(
+            config.remote.s3_conditional_writes,
+            S3ConditionalWrites::Required
+        );
         assert_eq!(config.http.retries, 9);
         assert!(!config.gc.auto);
         assert_eq!(config.gc.interval, Duration::from_secs(6 * 60 * 60));
@@ -733,6 +790,10 @@ mod tests {
     #[test]
     fn defaults_apply_without_configuration() {
         let (config, retention) = configured_retention(None, &[]).unwrap();
+        assert_eq!(
+            config.remote.s3_conditional_writes,
+            S3ConditionalWrites::Auto
+        );
         assert_eq!(config.http.timeout, DEFAULT_HTTP_TIMEOUT);
         assert_eq!(config.http.download_timeout, DEFAULT_HTTP_DOWNLOAD_TIMEOUT);
         assert_eq!(config.http.retries, DEFAULT_HTTP_RETRIES);
@@ -1050,6 +1111,10 @@ mod tests {
             "cache_dir = \"elsewhere\"",
             "verify = true",
             "[remote]\nurl = \"https://example.com\"",
+            // Credentials and the store they authenticate to are a machine's
+            // business, never a repository's.
+            "[remote]\ns3_endpoint = \"https://store.example.com\"",
+            "[remote]\ns3_region = \"us-west-2\"",
             "[gc]\nauto = false",
             "[target]\nviews = false",
         ] {

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -3,7 +3,6 @@
 use crate::config::Config;
 use crate::policy;
 use eyre::{Context, Result};
-use mbx_cache_core::{RemoteCacheClient, RemoteCacheConfig};
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
@@ -272,7 +271,13 @@ async fn remote_checks_with_policy(
     release_context: bool,
     effective_mode: Option<mbx_cache_core::RemoteCacheMode>,
 ) -> Vec<Check> {
-    let Some(base_url) = &config.remote.url else {
+    let Some(base_url) = config
+        .remote
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+    else {
         return vec![Check::pass(
             "remote",
             "not configured; using the local cache",
@@ -296,42 +301,22 @@ async fn remote_checks_with_policy(
             Check::pass("remote", "probe skipped because remote caching is disabled"),
         ];
     }
-    let Some(namespace) = config
+    let namespace = config
         .remote
         .namespace
         .as_deref()
-        .map(str::trim)
-        .filter(|namespace| !namespace.is_empty())
-    else {
-        return vec![
-            policy,
-            Check::fail(
-                "remote",
-                "remote.namespace is required when remote.url is set",
-            ),
-        ];
-    };
-    let parsed = match base_url.parse() {
-        Ok(url) => url,
-        Err(error) => {
+        .unwrap_or_default()
+        .trim();
+    // The build builds its client the same way, so a configuration it would
+    // refuse is reported here rather than discovered mid-compilation.
+    let client = match crate::remote::remote_client(config) {
+        Ok(Some(client)) => client,
+        Ok(None) => {
             return vec![
                 policy,
-                Check::fail("remote", format!("invalid URL {base_url:?}: {error}")),
+                Check::pass("remote", "not configured; using the local cache"),
             ];
         }
-    };
-    let client = match RemoteCacheClient::new(RemoteCacheConfig {
-        base_url: parsed,
-        namespace: namespace.to_string(),
-        token: config.remote.token.clone(),
-        token_file: config.remote.token_file.clone(),
-        oidc_audience: config.remote.oidc_audience.clone(),
-        connect_timeout: config.http.timeout,
-        read_timeout: config.http.timeout,
-        download_timeout: config.http.download_timeout,
-        retries: config.http.retries,
-    }) {
-        Ok(client) => client,
         Err(error) => return vec![policy, Check::fail("remote", format!("{error:#}"))],
     };
     let remote = match client

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -33,6 +33,7 @@ pub(crate) mod events;
 pub mod explain;
 #[doc(hidden)]
 pub mod policy;
+pub mod remote;
 pub(crate) mod savings;
 #[doc(hidden)]
 pub mod session;

--- a/crates/mbx/src/remote.rs
+++ b/crates/mbx/src/remote.rs
@@ -1,0 +1,364 @@
+//! Turning remote cache configuration into a client.
+//!
+//! The URL's scheme picks the backend: `https` reaches a cache server speaking
+//! the mbx protocol, and `s3` reaches an object store directly. Both are built
+//! here so that a build and `mbx doctor` cannot disagree about what a given
+//! configuration means.
+
+use crate::config::Config;
+use eyre::{Context as _, Result, bail};
+use mbx_cache_core::{RemoteCacheClient, RemoteCacheConfig, S3Credentials, S3RemoteCacheConfig};
+use url::Url;
+
+/// What the AWS environment variables say, read once at the edge so that
+/// everything below is a decision about configuration rather than about this
+/// process's environment.
+pub struct AwsEnvironment {
+    /// Credentials, absent when the environment carries none.
+    pub credentials: Option<S3Credentials>,
+    /// Region named by `AWS_REGION` or `AWS_DEFAULT_REGION`.
+    pub region: Option<String>,
+}
+
+impl AwsEnvironment {
+    fn from_env() -> Self {
+        Self {
+            credentials: S3Credentials::from_env(),
+            region: ["AWS_REGION", "AWS_DEFAULT_REGION"]
+                .into_iter()
+                .find_map(|name| {
+                    std::env::var(name)
+                        .ok()
+                        .map(|region| region.trim().to_string())
+                        .filter(|region| !region.is_empty())
+                }),
+        }
+    }
+}
+
+/// Build the client the configuration names, or `None` when none is configured.
+pub fn remote_client(config: &Config) -> Result<Option<RemoteCacheClient>> {
+    remote_client_with(config, AwsEnvironment::from_env())
+}
+
+pub(crate) fn remote_client_with(
+    config: &Config,
+    aws: AwsEnvironment,
+) -> Result<Option<RemoteCacheClient>> {
+    let Some(url) = config
+        .remote
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+    else {
+        return Ok(None);
+    };
+    let url: Url = url.parse().wrap_err("invalid remote cache URL")?;
+    let namespace = namespace(config)?;
+    if url.scheme() == "s3" {
+        return s3_client(config, &url, namespace, aws).map(Some);
+    }
+    if config.remote.s3_endpoint.is_some()
+        || config.remote.s3_region.is_some()
+        || config.remote.s3_force_path_style.is_some()
+    {
+        bail!("remote.s3_* settings apply to an s3:// remote cache URL, but remote.url is {url}");
+    }
+    Ok(Some(RemoteCacheClient::new(RemoteCacheConfig {
+        base_url: url,
+        namespace,
+        token: config.remote.token.clone(),
+        token_file: config.remote.token_file.clone(),
+        oidc_audience: config.remote.oidc_audience.clone(),
+        connect_timeout: config.http.timeout,
+        read_timeout: config.http.timeout,
+        download_timeout: config.http.download_timeout,
+        retries: config.http.retries,
+    })?))
+}
+
+/// The namespace, which isolates one project's cache and is always required.
+fn namespace(config: &Config) -> Result<String> {
+    config
+        .remote
+        .namespace
+        .as_deref()
+        .map(str::trim)
+        .filter(|namespace| !namespace.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| eyre::eyre!("a remote cache namespace is required when a URL is set"))
+}
+
+/// Build a client for `s3://bucket[/prefix]`.
+fn s3_client(
+    config: &Config,
+    url: &Url,
+    namespace: String,
+    aws: AwsEnvironment,
+) -> Result<RemoteCacheClient> {
+    // A bearer token or an OIDC audience authenticates to a cache server. An
+    // object store authenticates with AWS credentials and would ignore them, so
+    // a configuration naming both is a mistake worth reporting rather than
+    // quietly half-honouring.
+    if config.remote.token.is_some()
+        || config.remote.token_file.is_some()
+        || config.remote.oidc_audience.is_some()
+    {
+        bail!(
+            "an s3:// remote cache authenticates with AWS credentials; \
+             remove remote.token, remote.token_file, and remote.oidc_audience, and set \
+             AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY instead"
+        );
+    }
+    let bucket = url
+        .host_str()
+        .filter(|host| !host.is_empty())
+        .ok_or_else(|| eyre::eyre!("an s3:// remote cache URL must name a bucket"))?
+        .to_string();
+    let endpoint = config
+        .remote
+        .s3_endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|endpoint| !endpoint.is_empty())
+        .map(|endpoint| {
+            endpoint
+                .parse::<Url>()
+                .wrap_err("invalid remote.s3_endpoint")
+        })
+        .transpose()?;
+    if let Some(endpoint) = &endpoint {
+        validate_endpoint(endpoint)?;
+    }
+    let Some(credentials) = aws.credentials else {
+        bail!(
+            "an s3:// remote cache needs AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY; \
+             on GitHub Actions, aws-actions/configure-aws-credentials exports them from an \
+             OIDC role assumption"
+        );
+    };
+    RemoteCacheClient::new_s3(S3RemoteCacheConfig {
+        bucket,
+        prefix: url.path().to_string(),
+        namespace,
+        region: region(config, &aws.region, endpoint.is_some())?,
+        endpoint,
+        force_path_style: config.remote.s3_force_path_style,
+        conditional_writes: config.remote.s3_conditional_writes,
+        credentials,
+        connect_timeout: config.http.timeout,
+        read_timeout: config.http.timeout,
+        download_timeout: config.http.download_timeout,
+        retries: config.http.retries,
+    })
+}
+
+/// The region requests are signed for.
+///
+/// A signature is scoped to a region whether or not the store has one, so it is
+/// always needed. The AWS variables are consulted before giving up, since a
+/// machine set up for the AWS tools has already answered this.
+fn region(config: &Config, environment: &Option<String>, has_endpoint: bool) -> Result<String> {
+    let configured = config
+        .remote
+        .s3_region
+        .as_deref()
+        .map(str::trim)
+        .filter(|region| !region.is_empty())
+        .map(str::to_string)
+        .or_else(|| environment.clone());
+    match configured {
+        Some(region) => Ok(region),
+        // A store reached through an endpoint usually has no region of its own,
+        // and signs against whatever it is given.
+        None if has_endpoint => Ok("us-east-1".to_string()),
+        None => {
+            bail!("an s3:// remote cache needs a region; set MBX_REMOTE_S3_REGION or AWS_REGION")
+        }
+    }
+}
+
+/// Refuse an endpoint that would carry credentials over plain HTTP.
+///
+/// The same rule the protocol client applies to its own URL: a signature and
+/// the objects it fetches are readable in transit without TLS, and a developer
+/// running MinIO on loopback is the one case where that does not matter.
+fn validate_endpoint(endpoint: &Url) -> Result<()> {
+    if endpoint.scheme() == "https" {
+        return Ok(());
+    }
+    let loopback = endpoint.host().is_some_and(|host| match host {
+        url::Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+        url::Host::Ipv4(address) => address.is_loopback(),
+        url::Host::Ipv6(address) => address.is_loopback(),
+    });
+    if endpoint.scheme() == "http" && loopback {
+        Ok(())
+    } else {
+        bail!("remote.s3_endpoint must use HTTPS except for loopback development servers")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RemoteSettings;
+
+    fn aws() -> AwsEnvironment {
+        AwsEnvironment {
+            credentials: Some(S3Credentials {
+                access_key_id: "AKIDEXAMPLE".into(),
+                secret_access_key: "secret".into(),
+                session_token: None,
+            }),
+            region: Some("us-west-2".into()),
+        }
+    }
+
+    fn s3_remote() -> RemoteSettings {
+        RemoteSettings {
+            url: Some("s3://cache-bucket".into()),
+            namespace: Some("acme".into()),
+            ..RemoteSettings::default()
+        }
+    }
+
+    /// The message a configuration is refused with. A client has no `Debug`,
+    /// deliberately, so `unwrap_err` is not available here.
+    fn refusal(remote: RemoteSettings, aws: AwsEnvironment) -> String {
+        match client(remote, aws) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("this configuration should have been refused"),
+        }
+    }
+
+    fn client(remote: RemoteSettings, aws: AwsEnvironment) -> Result<Option<RemoteCacheClient>> {
+        let directory = tempfile::tempdir().unwrap();
+        remote_client_with(
+            &Config {
+                remote,
+                ..Config::for_test(directory.path())
+            },
+            aws,
+        )
+    }
+
+    #[test]
+    fn an_s3_url_builds_an_object_store_client() {
+        assert!(client(s3_remote(), aws()).unwrap().is_some());
+    }
+
+    #[test]
+    fn no_remote_url_builds_no_client() {
+        assert!(client(RemoteSettings::default(), aws()).unwrap().is_none());
+    }
+
+    #[test]
+    fn a_remote_cache_always_needs_a_namespace() {
+        let refusal = refusal(
+            RemoteSettings {
+                namespace: None,
+                ..s3_remote()
+            },
+            aws(),
+        );
+
+        assert!(refusal.contains("namespace is required"));
+    }
+
+    #[test]
+    fn an_s3_remote_without_credentials_says_which_variables_to_set() {
+        let refusal = refusal(
+            s3_remote(),
+            AwsEnvironment {
+                credentials: None,
+                ..aws()
+            },
+        );
+
+        assert!(refusal.contains("AWS_ACCESS_KEY_ID"));
+    }
+
+    #[test]
+    fn an_s3_remote_falls_back_to_the_aws_environment_for_its_region() {
+        let without_region = || AwsEnvironment {
+            region: None,
+            ..aws()
+        };
+
+        // Nothing names a region, and there is no endpoint to excuse it.
+        assert!(refusal(s3_remote(), without_region()).contains("MBX_REMOTE_S3_REGION"));
+
+        // The environment names one.
+        assert!(client(s3_remote(), aws()).unwrap().is_some());
+
+        // A store behind an endpoint signs against a default instead.
+        assert!(
+            client(
+                RemoteSettings {
+                    s3_endpoint: Some("http://127.0.0.1:9000".into()),
+                    ..s3_remote()
+                },
+                without_region(),
+            )
+            .unwrap()
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn bearer_credentials_and_an_object_store_are_not_combined() {
+        let refusal = refusal(
+            RemoteSettings {
+                token: Some("a-token".into()),
+                ..s3_remote()
+            },
+            aws(),
+        );
+
+        assert!(refusal.contains("AWS credentials"));
+    }
+
+    #[test]
+    fn s3_settings_on_a_protocol_url_are_refused() {
+        let refusal = refusal(
+            RemoteSettings {
+                url: Some("https://cache.example.com".into()),
+                namespace: Some("acme".into()),
+                s3_region: Some("us-west-2".into()),
+                ..RemoteSettings::default()
+            },
+            aws(),
+        );
+
+        assert!(refusal.contains("apply to an s3:// remote"));
+    }
+
+    #[test]
+    fn a_plaintext_endpoint_is_refused_unless_it_is_loopback() {
+        let endpoint = |endpoint: &str| {
+            client(
+                RemoteSettings {
+                    s3_endpoint: Some(endpoint.into()),
+                    ..s3_remote()
+                },
+                aws(),
+            )
+        };
+
+        assert!(endpoint("http://127.0.0.1:9000").unwrap().is_some());
+        assert!(endpoint("http://localhost:9000").unwrap().is_some());
+        assert!(endpoint("https://store.example.com").unwrap().is_some());
+        assert!(
+            refusal(
+                RemoteSettings {
+                    s3_endpoint: Some("http://store.example.com".into()),
+                    ..s3_remote()
+                },
+                aws(),
+            )
+            .contains("must use HTTPS")
+        );
+    }
+}

--- a/crates/mbx/src/remote.rs
+++ b/crates/mbx/src/remote.rs
@@ -7,7 +7,9 @@
 
 use crate::config::Config;
 use eyre::{Context as _, Result, bail};
-use mbx_cache_core::{RemoteCacheClient, RemoteCacheConfig, S3Credentials, S3RemoteCacheConfig};
+use mbx_cache_core::{
+    RemoteCacheClient, RemoteCacheConfig, S3ConditionalWrites, S3Credentials, S3RemoteCacheConfig,
+};
 use url::Url;
 
 /// What the AWS environment variables say, read once at the edge so that
@@ -62,6 +64,7 @@ pub(crate) fn remote_client_with(
     if config.remote.s3_endpoint.is_some()
         || config.remote.s3_region.is_some()
         || config.remote.s3_force_path_style.is_some()
+        || config.remote.s3_conditional_writes != S3ConditionalWrites::default()
     {
         bail!("remote.s3_* settings apply to an s3:// remote cache URL, but remote.url is {url}");
     }
@@ -322,17 +325,53 @@ mod tests {
 
     #[test]
     fn s3_settings_on_a_protocol_url_are_refused() {
-        let refusal = refusal(
+        // A setting that quietly does nothing is worse than one that is
+        // refused, so every S3-only key is checked, including the one with a
+        // default that makes its absence look like its presence.
+        for remote in [
             RemoteSettings {
-                url: Some("https://cache.example.com".into()),
-                namespace: Some("acme".into()),
                 s3_region: Some("us-west-2".into()),
                 ..RemoteSettings::default()
             },
-            aws(),
-        );
+            RemoteSettings {
+                s3_endpoint: Some("https://store.example.com".into()),
+                ..RemoteSettings::default()
+            },
+            RemoteSettings {
+                s3_force_path_style: Some(true),
+                ..RemoteSettings::default()
+            },
+            RemoteSettings {
+                s3_conditional_writes: S3ConditionalWrites::Required,
+                ..RemoteSettings::default()
+            },
+        ] {
+            let refusal = refusal(
+                RemoteSettings {
+                    url: Some("https://cache.example.com".into()),
+                    namespace: Some("acme".into()),
+                    ..remote
+                },
+                aws(),
+            );
+            assert!(refusal.contains("apply to an s3:// remote"), "{refusal}");
+        }
+    }
 
-        assert!(refusal.contains("apply to an s3:// remote"));
+    #[test]
+    fn a_protocol_url_is_accepted_with_the_s3_settings_left_alone() {
+        assert!(
+            client(
+                RemoteSettings {
+                    url: Some("https://cache.example.com".into()),
+                    namespace: Some("acme".into()),
+                    ..RemoteSettings::default()
+                },
+                aws(),
+            )
+            .unwrap()
+            .is_some()
+        );
     }
 
     #[test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -9,7 +9,7 @@ use eyre::{Context, Result, bail};
 use log::{debug, warn};
 use mbx_cache_core::{
     AGENT_PROTOCOL_VERSION, AgentEvent, AgentEventObserver, AgentRemoteCache, AgentRequest,
-    AgentResponse, AgentStats, CacheAgent, RemoteCacheClient, RemoteCacheConfig,
+    AgentResponse, AgentStats, CacheAgent,
 };
 use serde::Serialize;
 use std::cell::RefCell;
@@ -335,28 +335,9 @@ pub fn build_identity(workspace_root: &Path, command: &[String]) -> String {
 }
 
 fn action_remote_cache(config: &Config, store: &Path) -> Result<Option<AgentRemoteCache>> {
-    let Some(base_url) = config.remote.url.clone() else {
+    let Some(client) = crate::remote::remote_client(config)? else {
         return Ok(None);
     };
-    let namespace = config
-        .remote
-        .namespace
-        .as_deref()
-        .map(str::trim)
-        .filter(|namespace| !namespace.is_empty())
-        .ok_or_else(|| eyre::eyre!("a remote cache namespace is required when a URL is set"))?
-        .to_string();
-    let client = RemoteCacheClient::new(RemoteCacheConfig {
-        base_url: base_url.parse().wrap_err("invalid remote cache URL")?,
-        namespace,
-        token: config.remote.token.clone(),
-        token_file: config.remote.token_file.clone(),
-        oidc_audience: config.remote.oidc_audience.clone(),
-        connect_timeout: config.http.timeout,
-        read_timeout: config.http.timeout,
-        download_timeout: config.http.download_timeout,
-        retries: config.http.retries,
-    })?;
     // Release builds publish artifacts that must not depend on a cache, so they
     // do not read one either. The CLI already skips the whole session; this
     // keeps a library caller from reaching the remote behind its back.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -144,6 +144,44 @@ Remote namespace; required when a URL is configured.
 
 CI OIDC audience.
 
+### `remote.s3_conditional_writes`
+
+- **Type:** `string`
+- **Default:** `auto`
+- **Set with:** `MBX_REMOTE_S3_CONDITIONAL_WRITES`
+
+How to treat an S3 store that does not implement conditional writes.
+
+**Choices:**
+- `auto`
+- `required`
+- `off`
+
+
+### `remote.s3_endpoint`
+
+- **Type:** `option<url>`
+- **Optional:** true
+- **Set with:** `MBX_REMOTE_S3_ENDPOINT`
+
+S3 endpoint for a store that is not AWS, such as MinIO or R2.
+
+### `remote.s3_force_path_style`
+
+- **Type:** `option<bool>`
+- **Optional:** true
+- **Set with:** `MBX_REMOTE_S3_FORCE_PATH_STYLE`
+
+Address S3 buckets in the path rather than the host.
+
+### `remote.s3_region`
+
+- **Type:** `option<string>`
+- **Optional:** true
+- **Set with:** `MBX_REMOTE_S3_REGION`
+
+S3 region; Cloudflare R2 uses "auto".
+
 ### `remote.token`
 
 - **Type:** `option<string>`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,9 +41,11 @@ max_size = "30GiB"       # default: 10% of the cache disk
 max_age = "30d"          # default
 
 [remote]
-url = "https://cache.example.com"
+url = "https://cache.example.com"  # or "s3://bucket/prefix"
 namespace = "acme/backend"
 mode = "read-write"
+# s3_endpoint = "https://<account>.r2.cloudflarestorage.com"
+# s3_region = "auto"
 
 [http]
 timeout = "30s"

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -117,9 +117,17 @@ steps:
     with:
       role-to-assume: arn:aws:iam::111122223333:role/mbx-cache
       aws-region: us-west-2
-  - uses: jdx/mr-boxington-action@v1
+  - uses: jdx/mise-action@v4
+    with:
+      cache: false
+      install_args: mr-boxington
   - run: mbx build --workspace --all-features
 ```
+
+mbx is installed rather than set up through
+[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) here,
+because the action's GitHub Actions cache backend would store the same actions
+a second time. Use one or the other.
 
 mbx still refuses to publish from a pull request. Because a bucket has no
 server to authorize anything, make IAM agree: scope the role's trust policy to

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -95,6 +95,37 @@ and tag or release builds do not use the remote cache at all. If fork authors
 must not reach the host, use the GitHub backend for those jobs instead. A bearer
 token can be supplied with the action's `token` input when OIDC is unavailable.
 
+## S3-compatible bucket
+
+A bucket needs nothing running.
+[`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials)
+exchanges the runner's OIDC token for a role and exports the credentials mbx
+reads, so no long-lived secret is stored:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  MBX_REMOTE_URL: s3://acme-build-cache
+  MBX_REMOTE_NAMESPACE: acme/backend
+
+steps:
+  - uses: actions/checkout@v7
+  - uses: aws-actions/configure-aws-credentials@v5
+    with:
+      role-to-assume: arn:aws:iam::111122223333:role/mbx-cache
+      aws-region: us-west-2
+  - uses: jdx/mr-boxington-action@v1
+  - run: mbx build --workspace --all-features
+```
+
+mbx still refuses to publish from a pull request. Because a bucket has no
+server to authorize anything, make IAM agree: scope the role's trust policy to
+the branches allowed to assume it, and give pull request jobs a role that can
+only read. See [remote cache](/remote-cache#who-may-publish).
+
 ::: warning Release builds are never cached
 In a tag or release build (or with `MBX_RELEASE=1`), mbx runs plain Cargo —
 no local or remote cache — because published artifacts must not depend on any

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -49,10 +49,17 @@ one bucket between projects. Keys are laid out under
 `<prefix>/<namespace>/v1/`, so a bucket policy can scope a writer to its own
 prefix.
 
-An IAM policy needs `s3:GetObject` and `s3:PutObject` on that prefix, and
-`s3:ListBucket` on the bucket. mbx never lists anything, but without that
-permission S3 answers `403` instead of `404` for an object that is not there —
-and then every cache miss looks like a failure rather than a miss.
+An IAM policy needs `s3:GetObject` and `s3:PutObject` on that prefix. Add
+`s3:ListBucket` on the bucket if you can: mbx never lists anything, but AWS
+answers `403` rather than `404` for an object that is not there unless the
+caller holds it, and that permission is what lets a miss be told apart from a
+refusal.
+
+Without it mbx still works — a refused read is treated as a miss, and it says
+so once — but a credential that genuinely cannot read the cache then looks the
+same as a cold one, and only the warning distinguishes them. Credentials that
+S3 itself rejects, such as a wrong secret or an expired token, are always
+reported as errors either way.
 
 ### Cloudflare R2 and MinIO
 

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -49,8 +49,10 @@ one bucket between projects. Keys are laid out under
 `<prefix>/<namespace>/v1/`, so a bucket policy can scope a writer to its own
 prefix.
 
-An IAM policy needs only `s3:GetObject` and `s3:PutObject` on that prefix.
-Nothing lists the bucket.
+An IAM policy needs `s3:GetObject` and `s3:PutObject` on that prefix, and
+`s3:ListBucket` on the bucket. mbx never lists anything, but without that
+permission S3 answers `403` instead of `404` for an object that is not there —
+and then every cache miss looks like a failure rather than a miss.
 
 ### Cloudflare R2 and MinIO
 
@@ -70,7 +72,13 @@ in transit without TLS.
 
 ### What a bucket does not do
 
-A bucket stores objects; it does not answer batched lookups, stream blob packs,
+A cache server verifies every blob against the digest in its URL before storing
+it. A bucket stores what it is given, so a corrupted object in the local store
+can be published under a key naming different content, and because writes are
+create-only nothing later overwrites it: every machine that downloads it fails
+verification and recompiles. `mbx cache verify` finds such an object locally.
+
+A bucket also does not answer batched lookups, stream blob packs,
 or negotiate compression. mbx asks for none of them against S3 and falls back
 to per-object requests, which is what every version of the protocol has done
 against a server without the extensions. Expect more requests for the same

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -5,6 +5,11 @@ actions a build needs. The local content-addressed store remains the working
 cache; remote objects are downloaded into it and newly completed actions may be
 uploaded from trusted CI.
 
+mbx reaches a remote in one of two ways. A **cache server** speaks the mbx
+protocol and answers with the extensions built on top of it. An
+**S3-compatible bucket** stores the same objects with nothing to run. The URL's
+scheme chooses; everything else on this page applies to both.
+
 ## Configure a server
 
 ```toml
@@ -17,9 +22,83 @@ mode = "read-write"
 The namespace isolates one project's cache from another. It is required when a
 remote URL is set. To host your own server, see [cache server](/cache-server).
 
+## Configure an S3-compatible bucket
+
+```toml
+[remote]
+url = "s3://acme-build-cache"
+namespace = "acme/backend"
+mode = "read-write"
+```
+
+Credentials come from the standard AWS environment variables:
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` for
+temporary credentials. `MBX_REMOTE_S3_REGION` names the signing region, falling
+back to `AWS_REGION` or `AWS_DEFAULT_REGION`.
+
+Anything that mints temporary credentials must export them there first. On
+GitHub Actions that is
+[`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials),
+which exchanges the runner's OIDC token for a role, so no long-lived secret has
+to exist. Credential sources that are not environment variables — EKS IRSA,
+EC2 and ECS instance roles, `~/.aws/config` profiles, SSO — are not read
+directly; export the variables and they all work.
+
+The URL may carry a prefix, as `s3://acme-build-cache/teams/backend`, to share
+one bucket between projects. Keys are laid out under
+`<prefix>/<namespace>/v1/`, so a bucket policy can scope a writer to its own
+prefix.
+
+An IAM policy needs only `s3:GetObject` and `s3:PutObject` on that prefix.
+Nothing lists the bucket.
+
+### Cloudflare R2 and MinIO
+
+Set an endpoint, which switches to addressing the bucket in the path:
+
+```toml
+[remote]
+url = "s3://acme-build-cache"
+namespace = "acme/backend"
+s3_endpoint = "https://<account>.r2.cloudflarestorage.com"
+s3_region = "auto"
+```
+
+MinIO is the same with its own endpoint. `http://` is refused for anything but
+a loopback address, since a signature and the objects it fetches are readable
+in transit without TLS.
+
+### What a bucket does not do
+
+A bucket stores objects; it does not answer batched lookups, stream blob packs,
+or negotiate compression. mbx asks for none of them against S3 and falls back
+to per-object requests, which is what every version of the protocol has done
+against a server without the extensions. Expect more requests for the same
+build, and no compression on the wire.
+
+The one record mbx updates in place — the task action manifest that drives
+[prefetch](#prefetch) — needs conditional writes. AWS S3, R2, and current MinIO
+all implement them. Against a store that does not, mbx says so once and
+continues without: blobs and action results are content-addressed, so writing
+one twice is harmless, but concurrent manifest updates can then lose each
+other's predictions, which costs prefetch coverage on later builds and nothing
+else. `MBX_REMOTE_S3_CONDITIONAL_WRITES=required` refuses such a store instead.
+
+### Who may publish
+
+A cache server authenticates and authorizes every request. A bucket does not:
+whatever the credentials may write, mbx may write. The client-side [write
+policy](#read-and-write-policy) still applies — pull requests never publish —
+but with a bucket that policy is the only thing between an untrusted build and
+your cache unless IAM agrees.
+
+Scope the write credential to the builds you trust. On GitHub Actions, restrict
+the role's trust policy to the branches that may assume it, and give pull
+request jobs a read-only role.
+
 ## Authenticate
 
-Use one of:
+For a cache server, use one of:
 
 - `MBX_REMOTE_TOKEN` for a bearer token.
 - `MBX_REMOTE_TOKEN_FILE` for a file containing the token.
@@ -27,6 +106,9 @@ Use one of:
 
 Avoid long-lived secrets in pull request workflows. On GitHub Actions, OIDC
 requires `id-token: write` permission.
+
+These authenticate to a server and are refused alongside an `s3://` URL, which
+authenticates with AWS credentials instead.
 
 ## Read and write policy
 


### PR DESCRIPTION
A remote cache no longer requires running a cache server. Point mbx at a bucket:

```toml
[remote]
url = "s3://acme-build-cache"
namespace = "acme/backend"
```

AWS S3, Cloudflare R2, and MinIO, with credentials from the standard AWS
environment variables. This closes the largest gap between mbx and the tools
it competes with, whose most-used remote mode is exactly this — and it removes
the "you must first host something" step from adopting a shared cache.

## The protocol already fit

Almost nothing had to bend. Blobs and action results are immutable and
content-addressed, so they are written create-only and an object already at the
key holds precisely the bytes the upload would have written: a `412` is success,
not a conflict. The one record updated in place — the task action manifest —
carries an entity tag, and S3's conditional writes honour it, so `If-Match` maps
onto the same `PreconditionFailed` the agent already answers by re-reading,
merging, and retrying. **That merge loop is untouched.**

What a bucket cannot do it declines. Blob packs, batched lookups, and negotiated
compression all report themselves absent, which routes every caller to the
per-object requests the protocol has always made — the same path a server
without the extensions already takes. **No caller needed changing.**

## Three commits

**1. `refactor(cache)`** — `RemoteCacheClient` keeps its name, constructor, and
every method signature, and becomes a facade over a private `Backend` enum. The
agent, upload queue, session, and doctor compile untouched. Backends are a
closed set, so they dispatch through an enum rather than a trait: an `async fn`
in a trait is not object-safe, and boxing every call to work around that would
buy nothing when the alternative is a `match` the compiler sees through. The
HTTP implementation moves to `remote_http.rs` as a pure move.

**2. `feat(cache)`** — the S3 backend and a SigV4 signer.

**3. `feat`** — `MBX_REMOTE_URL=s3://…` selects it, plus docs.

## Three things worth review attention

**Signing is implemented here rather than taken from an SDK.** It is one
algorithm over the SHA-256 this crate already has, and `aws-sdk-s3` would have
brought its own HTTP and TLS stacks into a workspace whose TLS backend is a
feature matrix CI checks in every combination. Zero new dependencies. HMAC-SHA256
is pinned to RFC 4231 vectors and the full signature to one computed by an
independent implementation, so this module's own arithmetic cannot drift without
a test noticing. The cost is an honest one: the credential chain is the AWS
environment variables only. That covers GitHub Actions, where
`configure-aws-credentials` exports them from an OIDC role assumption, so the
no-long-lived-secrets story survives; IRSA and instance roles do not work
directly and are documented as such.

**The namespace becomes part of the object key**, where the protocol carries it
in a header a server interprets. That makes its character set load-bearing: a
namespace of `../other` would climb out of its own prefix and into another
project's cache. It is validated to path segments that cannot, and says so.

**Stores disagree about conditional writes.** AWS, R2, and current MinIO
implement them; others answer `501`, or `400` with `NotImplemented` in the
document — which is why the status alone cannot settle it, since a bare `400` is
also how a store reports a request it merely disliked. On `auto` the client gives
up once, warns, and continues: content-addressed writes lose nothing, and
manifests degrade to last-writer-wins, costing prefetch coverage rather than
correctness. `required` refuses such a store instead.

## The trust model genuinely weakens, and the docs say so

A cache server authenticates and authorizes every request. A bucket authorizes
nothing: whatever the credentials may write, mbx may write. The client-side write
policy still refuses to publish from pull requests, but with a bucket that policy
is the only thing between an untrusted build and the cache unless IAM agrees.
[remote-cache.md](docs/remote-cache.md) says this plainly and gives the
scoped-role recipe rather than leaving it implied.

## Verification

`mise run ci` green. 24 S3 backend tests and 10 signer tests, all in-process
through mockito — no new CI infrastructure, and nothing that needs Docker on the
macOS and Windows runners. All four TLS feature permutations compile.

The existing suite passes with **no test-logic edits** across the refactor, only
`use` paths — which is the evidence that commit 1 changed no behavior.

**Verified against real MinIO** ([details](https://github.com/jdx/mr-boxington/pull/140#issuecomment-5444093987)):
a build published 17 objects and a second checkout with a cold local cache
restored from the bucket alone; re-publishing into a bucket that already held
those objects took the `412` already-exists branch 9 times with 0 failures; and
a `pull_request` build holding read-write credentials read from the cache and
published nothing. Conditional writes were honoured throughout — the degradation
warning never fired.

**Not yet run against real AWS or R2**, which is where the `412`-vs-`409`
distinction and virtual-host addressing actually get exercised. MinIO hits
neither. I would want the AWS pass before this merges, since the status mapping
is what the design turns on.

## Follow-ups, deliberately not here

- Qualification against real AWS and R2, plus a >8 MiB artifact for the streamed
  `Content-Length` path and two builds genuinely racing on one manifest (my
  attempt hit fully-cached builds, so nothing raced).
- STS `AssumeRoleWithWebIdentity` for EKS IRSA, and IMDSv2 for instance roles.
- zstd on the wire for S3, which needs the body buffered to learn its length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new remote persistence path with SigV4 signing, IAM/403 semantics, and conditional-write degradation that can make manifest updates last-writer-wins; incorrect behavior would affect shared build cache integrity and credentials handling.
> 
> **Overview**
> **`RemoteCacheClient` is now a facade** over HTTP (`HttpRemoteCache`) and S3 (`S3RemoteCache`) backends via a private `Backend` enum. The public API (`new`, method signatures) stays the same; **`RemoteCacheClient::new_s3`** and exports like `S3RemoteCacheConfig`, `S3Credentials`, and `S3ConditionalWrites` are added. The former monolithic HTTP implementation moves to **`remote_http.rs`**; shared retry logic gains **`TransientRequest`** so S3 can retry `409` conditional-write conflicts.
> 
> **New S3 backend** maps protocol objects to content-addressed keys under `{prefix}{namespace}/v1/…`, signs requests with a new **`sigv4`** module, and implements get/put for blobs, action results, and manifests (including etag-based conditional updates). It **declines** blob packs, action batches, and negotiated compression by returning the same “unsupported” shapes callers already handle. Behavior covers least-privilege `403`-as-miss, optional conditional-write downgrade (`auto` / `required` / `off`), connectivity probes, and path vs virtual-host addressing.
> 
> Tests move with HTTP to `remote_http.rs` (`HttpRemoteCache` in `core_tests.rs`); **`remote_s3_tests.rs`** adds mockito coverage for signing, uploads, manifests, retries, and IAM edge cases. CLI wiring (per repo) uses **`s3://`** URLs with `RemoteCacheClient::new_s3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe9744413559b320d798c19881afbe008e693c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using S3-compatible buckets as remote cache backends.
  - Added AWS credential-based authentication, configurable regions, endpoints, prefixes, and path-style access.
  - Added configurable conditional-write behavior for S3 caching.
  - Added environment and configuration options for S3 remotes.

- **Bug Fixes**
  - Improved remote connectivity checks for unset URLs and namespaces.

- **Documentation**
  - Documented S3 configuration, permissions, authentication, GitHub Actions setup, and backend limitations.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->