### PR TITLE
fix(rustc): restore results into the checkout that asked for them

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -42,7 +42,12 @@ pub use dep_info::{DepInfoCommand, DiscoveredInputs, RustcDepInfo};
 /// Schema version embedded in canonical rustc action descriptors.
 pub const ACTION_SCHEMA_VERSION: u8 = 1;
 /// Version of the rustc argument and input model used to construct keys.
-pub const ADAPTER_VERSION: u8 = 1;
+///
+/// Bumped to 2 when the dep-info and diagnostics stored with a result stopped
+/// carrying the publishing checkout's absolute paths. Entries written before
+/// that hold the old spelling, and nothing in them says so, so they are retired
+/// by the key rather than restored into a checkout they do not describe.
+pub const ADAPTER_VERSION: u8 = 2;
 
 impl BypassReason {
     /// A stable, low-cardinality name for this reason.

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1591,28 +1591,51 @@ fn denormalize_output_text(bytes: &[u8], mappings: &[PathMapping]) -> Vec<u8> {
 /// Every spelling a root can take in these outputs, paired with the
 /// placeholder that stands for it.
 ///
-/// The dep-info writes a path literally, but stderr is JSON, where a Windows
-/// separator arrives doubled. Matching only the literal spelling would leave
-/// every artifact notification on Windows carrying the publishing checkout's
-/// path, so each root is looked for both ways and each way gets its own
-/// placeholder -- otherwise a restore could not tell which spelling to write
-/// back.
+/// rustc writes a path with the platform separator in some places and forward
+/// slashes in others -- the reason [`carries`] searches both -- and stderr is
+/// JSON, where a Windows separator arrives doubled. A spelling missed here is
+/// a path from the publishing checkout left in place, so each is looked for,
+/// and each gets its own placeholder because a restore has to know which one
+/// to write back.
 ///
 /// Deepest root first, so a target directory inside a workspace wins over the
-/// workspace, and the escaped spelling before the literal one it contains.
+/// workspace, and within a root the doubled spelling before the single one.
 fn root_spellings(mappings: &[PathMapping]) -> Vec<(String, String)> {
     let mut spellings = Vec::new();
     for mapping in PathMapping::ordered(mappings) {
         let Some(root) = mapping.root.to_str() else {
             continue;
         };
-        let escaped = root.replace('\\', "\\\\");
-        if escaped != root {
-            spellings.push((escaped, format!("${{{}:escaped}}", mapping.placeholder)));
+        // The literal spelling first, so a platform whose separator needs no
+        // escaping keeps the plain placeholder rather than an escaped one that
+        // means the same thing.
+        for (spelling, suffix) in [
+            (root.to_string(), ""),
+            (root.replace('\\', "\\\\"), ":escaped"),
+            (root.replace('\\', "/"), ":slash"),
+        ] {
+            if spellings.iter().any(|(existing, _)| existing == &spelling) {
+                continue;
+            }
+            spellings.push((spelling, format!("${{{}{suffix}}}", mapping.placeholder)));
         }
-        spellings.push((root.to_string(), format!("${{{}}}", mapping.placeholder)));
     }
     spellings
+}
+
+/// Whether a root matched at `end` stops there rather than running into a
+/// longer name.
+///
+/// `/work/target` is not a prefix of `/work/target-backup` in any sense that
+/// matters, but a plain substring search cannot tell them apart, and rewriting
+/// the second would hand a restore a directory that never existed.
+/// [`normalize_mapped_path`] gets this from comparing components; here the
+/// following byte has to say it.
+fn ends_at_boundary(haystack: &[u8], end: usize) -> bool {
+    match haystack.get(end) {
+        None => true,
+        Some(byte) => !(byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')),
+    }
 }
 
 fn replace_bytes(haystack: &[u8], needle: &[u8], replacement: &[u8]) -> Vec<u8> {
@@ -1622,7 +1645,9 @@ fn replace_bytes(haystack: &[u8], needle: &[u8], replacement: &[u8]) -> Vec<u8> 
     let mut out = Vec::with_capacity(haystack.len());
     let mut index = 0;
     while index <= haystack.len() - needle.len() {
-        if &haystack[index..index + needle.len()] == needle {
+        if &haystack[index..index + needle.len()] == needle
+            && ends_at_boundary(haystack, index + needle.len())
+        {
             out.extend_from_slice(replacement);
             index += needle.len();
         } else {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -264,10 +264,12 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     );
     let _ = replay_output(&output);
     if let Some(cached) = verification {
-        let matched = cached_matches(&cached, &output);
-        record_verification(matched, cached.restore);
-        if !matched {
-            eprintln!("mbx[warning]: shadow verification diverged from cached output");
+        let divergence = verification_divergence(&cached, &output);
+        record_verification(divergence.is_none(), cached.restore);
+        if let Some(divergence) = divergence {
+            eprintln!(
+                "mbx[warning]: shadow verification diverged from cached output: {divergence}"
+            );
         }
         return Ok(exit_code(output.status));
     }
@@ -996,20 +998,41 @@ fn stage_verified_cached_output(
     Ok((temporary, materialization))
 }
 
-fn cached_matches(cached: &CachedCompilation, output: &Output) -> bool {
-    output.status.success()
-        && cached.stdout == output.stdout
-        && cached.stderr == output.stderr
-        && cached.outputs.iter().all(|expected| {
-            std::fs::metadata(&expected.path).is_ok_and(|metadata| {
-                file_mode(&metadata) == expected.mode
-                    && executable_mode_matches(&metadata, expected.executable)
-                    && expected
-                        .digest
-                        .matches_file(&expected.path)
-                        .unwrap_or(false)
-            })
-        })
+/// Describe how a restore differs from the compilation it was checked against.
+///
+/// `None` means they agree. A divergence names what disagreed, because that is
+/// the whole output of a qualification run: knowing that something differed is
+/// not actionable, and the answer is usually one specific file.
+fn verification_divergence(cached: &CachedCompilation, output: &Output) -> Option<String> {
+    if !output.status.success() {
+        return Some("the shadow compilation failed".into());
+    }
+    if cached.stdout != output.stdout {
+        return Some("standard output differs".into());
+    }
+    if cached.stderr != output.stderr {
+        return Some("standard error differs".into());
+    }
+    for expected in &cached.outputs {
+        let name = expected.path.display();
+        let Ok(metadata) = std::fs::metadata(&expected.path) else {
+            return Some(format!("{name} is missing"));
+        };
+        if file_mode(&metadata) != expected.mode {
+            return Some(format!("{name} has a different file mode"));
+        }
+        if !executable_mode_matches(&metadata, expected.executable) {
+            return Some(format!("{name} has a different executable bit"));
+        }
+        if !expected
+            .digest
+            .matches_file(&expected.path)
+            .unwrap_or(false)
+        {
+            return Some(format!("{name} has different contents"));
+        }
+    }
+    None
 }
 
 fn record_verification(matched: bool, restore: RestoreStats) {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -171,7 +171,13 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
         )
     {
         action_lookup_attempted = true;
-        match restore_candidates(&candidates, &outputs, &discovered, !verify) {
+        match restore_candidates(
+            &candidates,
+            &outputs,
+            &discovered,
+            !verify,
+            &portable.mappings,
+        ) {
             Ok(Some((action, mut cached))) => {
                 match prediction_timing(&compilation) {
                     Ok(timing) => {
@@ -286,7 +292,13 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
                 &candidates.literal
             } else {
                 let action = candidates.publishable(&portable, &outputs.files)?;
-                publish_result(&action.digest, &action.bytes, &outputs, &output)?;
+                publish_result(
+                    &action.digest,
+                    &action.bytes,
+                    &outputs,
+                    &output,
+                    &portable.mappings,
+                )?;
                 action
             };
             record_prediction(&compilation, &action.digest, &discovered, &timing);
@@ -517,7 +529,13 @@ fn restore_predicted_result(
     // From this point onward, every return follows at least one action-result
     // request, including error responses from a corrupt local record.
     *action_lookup_attempted = true;
-    let restored = restore_candidates(&candidates, outputs, &discovered, restore_outputs)?;
+    let restored = restore_candidates(
+        &candidates,
+        outputs,
+        &discovered,
+        restore_outputs,
+        &portable.mappings,
+    )?;
     match restored {
         Some((action, mut cached)) => {
             cached.restore.avoided_compiler_duration_ns = input_prediction.compiler_duration_ns;
@@ -596,9 +614,12 @@ fn restore_candidates(
     outputs: &RustcOutputs,
     discovered: &DiscoveredInputs,
     restore_outputs: bool,
+    mappings: &[PathMapping],
 ) -> Result<Option<(CacheDigest, CachedCompilation)>> {
     for action in candidates.ordered() {
-        if let Some(cached) = restore_result(action, outputs, discovered, restore_outputs)? {
+        if let Some(cached) =
+            restore_result(action, outputs, discovered, restore_outputs, mappings)?
+        {
             return Ok(Some((action.digest.clone(), cached)));
         }
     }
@@ -790,6 +811,7 @@ fn restore_result(
     outputs: &RustcOutputs,
     discovered: &DiscoveredInputs,
     restore_outputs: bool,
+    mappings: &[PathMapping],
 ) -> Result<Option<CachedCompilation>> {
     let responses = session::request_agent(&[AgentRequest::FindActionResult {
         action: action.digest.clone(),
@@ -831,15 +853,6 @@ fn restore_result(
     let directory: CacheDirectory =
         read_canonical_blob(&roots[2], &output_root_digest, "output directory")?;
     let files = validated_outputs(directory, outputs)?;
-    let cached_outputs = files
-        .iter()
-        .map(|(node, destination)| CachedOutput {
-            path: destination.clone(),
-            digest: node.digest.clone(),
-            executable: node.executable,
-            mode: node.mode,
-        })
-        .collect();
     let restored_output_files = files.len().try_into().unwrap_or(u64::MAX);
     let restored_output_bytes = files.iter().fold(0_u64, |total, (node, _)| {
         total.saturating_add(node.digest.size)
@@ -848,8 +861,14 @@ fn restore_result(
     let mut digests = vec![metadata.stdout.clone(), metadata.stderr.clone()];
     digests.extend(files.iter().map(|(node, _)| node.digest.clone()));
     let blobs = find_blobs(&digests)?;
-    let stdout = read_verified_blob(&blobs[0], &metadata.stdout, "stdout")?;
-    let stderr = read_verified_blob(&blobs[1], &metadata.stderr, "stderr")?;
+    let stdout = denormalize_output_text(
+        &read_verified_blob(&blobs[0], &metadata.stdout, "stdout")?,
+        mappings,
+    );
+    let stderr = denormalize_output_text(
+        &read_verified_blob(&blobs[1], &metadata.stderr, "stderr")?,
+        mappings,
+    );
 
     let materialization_started = Instant::now();
     std::fs::create_dir_all(&outputs.directory)?;
@@ -860,7 +879,39 @@ fn restore_result(
         output_bytes: restored_output_bytes,
         ..RestoreStats::default()
     };
+    let mut cached_outputs = Vec::with_capacity(files.len());
     for (index, ((node, destination), source)) in files.into_iter().zip(&blobs[2..]).enumerate() {
+        // The dep-info was stored in placeholder form, so it is written out
+        // rather than cloned: what belongs on disk is this checkout's spelling
+        // of it, and that is what the verification below must compare against.
+        if destination == outputs.dep_info {
+            let bytes = denormalize_output_text(
+                &read_verified_blob(source, &node.digest, "dep-info")?,
+                mappings,
+            );
+            let temporary = staging.path().join(format!("output-{index}"));
+            std::fs::write(&temporary, &bytes)?;
+            let temporary = tempfile::TempPath::try_from_path(temporary)?;
+            apply_file_mode(&temporary, node.mode, node.executable)?;
+            restore.copied_output_files = restore.copied_output_files.saturating_add(1);
+            restore.copied_output_bytes = restore
+                .copied_output_bytes
+                .saturating_add(bytes.len().try_into().unwrap_or(u64::MAX));
+            cached_outputs.push(CachedOutput {
+                path: destination.clone(),
+                digest: CacheDigest::blake3(&bytes),
+                executable: node.executable,
+                mode: node.mode,
+            });
+            staged.push((temporary, destination));
+            continue;
+        }
+        cached_outputs.push(CachedOutput {
+            path: destination.clone(),
+            digest: node.digest.clone(),
+            executable: node.executable,
+            mode: node.mode,
+        });
         let (temporary, materialization) =
             stage_verified_cached_output(staging.path(), index, source, &node)?;
         match materialization {
@@ -1483,19 +1534,92 @@ fn resolve_executable(executable: &OsStr) -> Result<PathBuf> {
     })
 }
 
+/// Rewrite this machine's paths in a cached text output into the placeholders
+/// the action key already uses.
+///
+/// Two outputs of a compilation are text that names where the compilation ran:
+/// the dep-info file, whose rules are keyed by absolute output paths, and the
+/// compiler's stderr, which carries an artifact notification per emitted file
+/// when cargo asks for one. Both are the same compilation wherever it runs, but
+/// neither is byte-identical across target directories, so storing them
+/// verbatim means a restore hands the next checkout paths belonging to the one
+/// that published them.
+///
+/// Only these two are rewritten. Compiled artifacts are opaque bytes that do
+/// not carry the target directory, and rewriting inside them would be a
+/// corruption rather than a translation.
+fn normalize_output_text(bytes: &[u8], mappings: &[PathMapping]) -> Vec<u8> {
+    let mut normalized = bytes.to_vec();
+    for mapping in PathMapping::ordered(mappings) {
+        let Some(root) = mapping.root.to_str() else {
+            continue;
+        };
+        normalized = replace_bytes(
+            &normalized,
+            root.as_bytes(),
+            format!("${{{}}}", mapping.placeholder).as_bytes(),
+        );
+    }
+    normalized
+}
+
+/// Rewrite placeholders in a cached text output back into this machine's paths.
+fn denormalize_output_text(bytes: &[u8], mappings: &[PathMapping]) -> Vec<u8> {
+    let mut text = bytes.to_vec();
+    for mapping in PathMapping::ordered(mappings) {
+        let Some(root) = mapping.root.to_str() else {
+            continue;
+        };
+        text = replace_bytes(
+            &text,
+            format!("${{{}}}", mapping.placeholder).as_bytes(),
+            root.as_bytes(),
+        );
+    }
+    text
+}
+
+fn replace_bytes(haystack: &[u8], needle: &[u8], replacement: &[u8]) -> Vec<u8> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return haystack.to_vec();
+    }
+    let mut out = Vec::with_capacity(haystack.len());
+    let mut index = 0;
+    while index <= haystack.len() - needle.len() {
+        if &haystack[index..index + needle.len()] == needle {
+            out.extend_from_slice(replacement);
+            index += needle.len();
+        } else {
+            out.push(haystack[index]);
+            index += 1;
+        }
+    }
+    out.extend_from_slice(&haystack[index..]);
+    out
+}
+
 fn publish_result(
     action: &CacheDigest,
     action_bytes: &[u8],
     outputs: &RustcOutputs,
     output: &Output,
+    mappings: &[PathMapping],
 ) -> Result<()> {
     if outputs.files.is_empty() {
         bail!("rustc produced no cacheable outputs");
     }
     let staging = staging_directory()?;
     let mut blobs = vec![staged_bytes(staging.path(), "action.json", action_bytes)?];
-    let stdout = staged_bytes(staging.path(), "stdout", &output.stdout)?;
-    let stderr = staged_bytes(staging.path(), "stderr", &output.stderr)?;
+    let stdout = staged_bytes(
+        staging.path(),
+        "stdout",
+        &normalize_output_text(&output.stdout, mappings),
+    )?;
+    let stderr = staged_bytes(
+        staging.path(),
+        "stderr",
+        &normalize_output_text(&output.stderr, mappings),
+    )?;
     blobs.extend([stdout.clone(), stderr.clone()]);
 
     let output_paths = outputs
@@ -1509,8 +1633,19 @@ fn publish_result(
         if !metadata.is_file() {
             bail!("rustc output is not a regular file: {}", path.display());
         }
-        let digest = CacheDigest::blake3_file(path)?;
-        blobs.push((digest.clone(), path.clone()));
+        // The dep-info is stored in its placeholder form, so the checkout that
+        // restores it gets rules naming its own target directory rather than
+        // the one that published them.
+        let digest = if path == &outputs.dep_info {
+            let normalized = normalize_output_text(&std::fs::read(path)?, mappings);
+            let staged = staged_bytes(staging.path(), "dep-info", &normalized)?;
+            blobs.push(staged.clone());
+            staged.0
+        } else {
+            let digest = CacheDigest::blake3_file(path)?;
+            blobs.push((digest.clone(), path.clone()));
+            digest
+        };
         files.push(CacheFileNode {
             digest,
             executable: outputs.is_executable(path),

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1550,15 +1550,8 @@ fn resolve_executable(executable: &OsStr) -> Result<PathBuf> {
 /// corruption rather than a translation.
 fn normalize_output_text(bytes: &[u8], mappings: &[PathMapping]) -> Vec<u8> {
     let mut normalized = bytes.to_vec();
-    for mapping in PathMapping::ordered(mappings) {
-        let Some(root) = mapping.root.to_str() else {
-            continue;
-        };
-        normalized = replace_bytes(
-            &normalized,
-            root.as_bytes(),
-            format!("${{{}}}", mapping.placeholder).as_bytes(),
-        );
+    for (root, placeholder) in root_spellings(mappings) {
+        normalized = replace_bytes(&normalized, root.as_bytes(), placeholder.as_bytes());
     }
     normalized
 }
@@ -1566,17 +1559,37 @@ fn normalize_output_text(bytes: &[u8], mappings: &[PathMapping]) -> Vec<u8> {
 /// Rewrite placeholders in a cached text output back into this machine's paths.
 fn denormalize_output_text(bytes: &[u8], mappings: &[PathMapping]) -> Vec<u8> {
     let mut text = bytes.to_vec();
+    for (root, placeholder) in root_spellings(mappings) {
+        text = replace_bytes(&text, placeholder.as_bytes(), root.as_bytes());
+    }
+    text
+}
+
+/// Every spelling a root can take in these outputs, paired with the
+/// placeholder that stands for it.
+///
+/// The dep-info writes a path literally, but stderr is JSON, where a Windows
+/// separator arrives doubled. Matching only the literal spelling would leave
+/// every artifact notification on Windows carrying the publishing checkout's
+/// path, so each root is looked for both ways and each way gets its own
+/// placeholder -- otherwise a restore could not tell which spelling to write
+/// back.
+///
+/// Deepest root first, so a target directory inside a workspace wins over the
+/// workspace, and the escaped spelling before the literal one it contains.
+fn root_spellings(mappings: &[PathMapping]) -> Vec<(String, String)> {
+    let mut spellings = Vec::new();
     for mapping in PathMapping::ordered(mappings) {
         let Some(root) = mapping.root.to_str() else {
             continue;
         };
-        text = replace_bytes(
-            &text,
-            format!("${{{}}}", mapping.placeholder).as_bytes(),
-            root.as_bytes(),
-        );
+        let escaped = root.replace('\\', "\\\\");
+        if escaped != root {
+            spellings.push((escaped, format!("${{{}:escaped}}", mapping.placeholder)));
+        }
+        spellings.push((root.to_string(), format!("${{{}}}", mapping.placeholder)));
     }
-    text
+    spellings
 }
 
 fn replace_bytes(haystack: &[u8], needle: &[u8], replacement: &[u8]) -> Vec<u8> {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1606,6 +1606,17 @@ fn root_spellings(mappings: &[PathMapping]) -> Vec<(String, String)> {
         let Some(root) = mapping.root.to_str() else {
             continue;
         };
+        // A root arrives however its environment variable was written, and
+        // `CARGO_TARGET_DIR=/work/target/` is as valid as the same path
+        // without. Trailing separators are dropped so the boundary check sees
+        // the separator before a child rather than the child's first letter,
+        // which would otherwise reject every path under such a root and leave
+        // it in the publishing checkout's spelling. A Windows drive root like
+        // `C:\` trims to `C:`, which its own separator then follows.
+        let root = root.trim_end_matches(['/', '\\']);
+        if root.is_empty() {
+            continue;
+        }
         // The literal spelling first, so a platform whose separator needs no
         // escaping keeps the plain placeholder rather than an escaped one that
         // means the same thing.

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -539,3 +539,80 @@ fn benchmark_cached_output_materialization() {
         legacy.as_secs_f64() / materialized.as_secs_f64()
     );
 }
+
+/// The dep-info writes a path literally; stderr is JSON, where a Windows
+/// separator arrives doubled. Both spellings have to round-trip, or every
+/// artifact notification on Windows keeps the publishing checkout's path.
+#[test]
+fn both_spellings_of_a_root_round_trip_through_a_placeholder() {
+    let mappings = vec![PathMapping::new(
+        if cfg!(windows) {
+            r"D:\work\target"
+        } else {
+            "/work/target"
+        },
+        "target",
+    )];
+    let root = mappings[0].root.to_str().unwrap().to_string();
+    let escaped = root.replace('\\', r"\\");
+
+    // A dep-info rule and a JSON artifact notification, as rustc writes them.
+    let original = format!("{root}/deps/lib.rlib: src/lib.rs\n{{\"artifact\":\"{escaped}\"}}\n");
+    let normalized = normalize_output_text(original.as_bytes(), &mappings);
+
+    assert!(
+        !String::from_utf8_lossy(&normalized).contains(&root),
+        "the literal root survived normalization: {}",
+        String::from_utf8_lossy(&normalized)
+    );
+    if escaped != root {
+        assert!(
+            !String::from_utf8_lossy(&normalized).contains(&escaped),
+            "the escaped root survived normalization: {}",
+            String::from_utf8_lossy(&normalized)
+        );
+    }
+    assert_eq!(
+        denormalize_output_text(&normalized, &mappings),
+        original.as_bytes(),
+        "a normalized output did not come back as it went in"
+    );
+}
+
+/// A restore happens on a machine whose roots differ from the one that
+/// published, which is the whole point of the placeholder.
+#[test]
+fn a_placeholder_is_rewritten_into_the_restoring_checkouts_root() {
+    let published = vec![PathMapping::new(
+        if cfg!(windows) {
+            r"D:\one\target"
+        } else {
+            "/one/target"
+        },
+        "target",
+    )];
+    let restoring = vec![PathMapping::new(
+        if cfg!(windows) {
+            r"D:\two\target"
+        } else {
+            "/two/target"
+        },
+        "target",
+    )];
+    let published_root = published[0].root.to_str().unwrap();
+    let restoring_root = restoring[0].root.to_str().unwrap();
+
+    let original = format!("{published_root}/deps/lib.rlib: src/lib.rs\n");
+    let stored = normalize_output_text(original.as_bytes(), &published);
+    let restored = denormalize_output_text(&stored, &restoring);
+
+    let restored = String::from_utf8_lossy(&restored).into_owned();
+    assert!(
+        restored.contains(restoring_root),
+        "restore should name the restoring root: {restored}"
+    );
+    assert!(
+        !restored.contains(published_root),
+        "restore still names the publishing root: {restored}"
+    );
+}

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -616,3 +616,76 @@ fn a_placeholder_is_rewritten_into_the_restoring_checkouts_root() {
         "restore still names the publishing root: {restored}"
     );
 }
+
+/// rustc writes a path with the platform separator in some places and forward
+/// slashes in others, which is why `carries` searches both, and stderr is JSON
+/// where a Windows separator arrives doubled. A spelling missed here is a path
+/// from the publishing checkout left in place.
+///
+/// The root is spelled the Windows way whatever this platform is, because a
+/// unix root has only one spelling and the test would prove nothing there.
+#[test]
+fn every_spelling_of_a_root_is_normalized() {
+    let mappings = vec![PathMapping::new(r"D:\work\target", "target")];
+    let root = r"D:\work\target";
+    let spellings = [
+        root.to_string(),
+        root.replace('\\', r"\\"),
+        root.replace('\\', "/"),
+    ];
+    assert_eq!(
+        spellings
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        3,
+        "the fixture should exercise three distinct spellings"
+    );
+
+    for spelling in &spellings {
+        let original = format!("{spelling}/deps/lib.rlib: src/lib.rs\n");
+        let normalized = normalize_output_text(original.as_bytes(), &mappings);
+        assert!(
+            !String::from_utf8_lossy(&normalized).contains(spelling.as_str()),
+            "{spelling} survived normalization: {}",
+            String::from_utf8_lossy(&normalized)
+        );
+        assert_eq!(
+            denormalize_output_text(&normalized, &mappings),
+            original.as_bytes(),
+            "{spelling} did not come back as it went in"
+        );
+    }
+}
+
+/// A root is a directory, not a text prefix. `/work/target` has nothing to do
+/// with `/work/target-backup`, and rewriting the second would hand a restore a
+/// directory that never existed.
+#[test]
+fn a_sibling_sharing_a_prefix_is_left_alone() {
+    let mappings = vec![PathMapping::new(
+        if cfg!(windows) {
+            r"D:\work\target"
+        } else {
+            "/work/target"
+        },
+        "target",
+    )];
+    let root = mappings[0].root.to_str().unwrap().to_string();
+    let separator = if cfg!(windows) { '\\' } else { '/' };
+    let sibling = format!("{root}-backup{separator}keep.rlib");
+    let inside = format!("{root}{separator}deps{separator}lib.rlib");
+
+    let original = format!("{sibling}\n{inside}\n");
+    let normalized = normalize_output_text(original.as_bytes(), &mappings);
+    let normalized = String::from_utf8_lossy(&normalized).into_owned();
+
+    assert!(
+        normalized.contains(&sibling),
+        "the sibling directory was rewritten: {normalized}"
+    );
+    assert!(
+        !normalized.contains(&inside),
+        "the root itself was not rewritten: {normalized}"
+    );
+}

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -689,3 +689,29 @@ fn a_sibling_sharing_a_prefix_is_left_alone() {
         "the root itself was not rewritten: {normalized}"
     );
 }
+
+/// A root arrives however its environment variable was written, and a
+/// trailing separator must not stop the rewrite: the byte after the match
+/// would then be a child's first letter rather than the separator before it.
+#[test]
+fn a_root_written_with_a_trailing_separator_still_rewrites() {
+    let plain = vec![PathMapping::new("/work/target", "target")];
+    let trailing = vec![PathMapping::new("/work/target/", "target")];
+    let original = "/work/target/deps/lib.rlib: src/lib.rs\n";
+
+    let from_trailing = normalize_output_text(original.as_bytes(), &trailing);
+    assert!(
+        !String::from_utf8_lossy(&from_trailing).contains("/work/target/deps"),
+        "a trailing separator left the path unrewritten: {}",
+        String::from_utf8_lossy(&from_trailing)
+    );
+    assert_eq!(
+        from_trailing,
+        normalize_output_text(original.as_bytes(), &plain),
+        "how the root was written should not change what is stored"
+    );
+    assert_eq!(
+        denormalize_output_text(&from_trailing, &trailing),
+        original.as_bytes()
+    );
+}

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1431,7 +1431,12 @@ mod target_views {
 
 /// Build `project` into an explicit target directory, so two builds of the
 /// same checkout differ only in where their outputs land.
-fn build_into_target(project: &Path, store: &Path, target: &Path, settings: &[(&str, &str)]) {
+fn build_into_target(
+    project: &Path,
+    store: &Path,
+    target: &Path,
+    settings: &[(&str, &str)],
+) -> String {
     let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
     command
         .current_dir(project)
@@ -1452,6 +1457,7 @@ fn build_into_target(project: &Path, store: &Path, target: &Path, settings: &[(&
         "build failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
 /// Read the dep-info rustc wrote for the fixture's library.
@@ -1511,7 +1517,7 @@ fn verification_is_clean_across_target_directories() {
 
     build_into_target(project.path(), store.path(), first.path(), &[]);
     let report = reports.path().join("verify.json");
-    build_into_target(
+    let stderr = build_into_target(
         project.path(),
         store.path(),
         second.path(),
@@ -1520,6 +1526,11 @@ fn verification_is_clean_across_target_directories() {
             ("MBX_STATS_REPORT", report.to_str().unwrap()),
         ],
     );
+    let reported = stderr
+        .lines()
+        .filter(|line| line.contains("diverged"))
+        .collect::<Vec<_>>()
+        .join("\n");
 
     let stats: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&report).expect("a report should be written"))
@@ -1531,6 +1542,6 @@ fn verification_is_clean_across_target_directories() {
     assert_eq!(
         count(&stats, "divergences"),
         0,
-        "a restore into another target directory diverged: {stats}"
+        "a restore into another target directory diverged: {reported}"
     );
 }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1506,6 +1506,16 @@ fn a_restored_dep_info_names_the_target_directory_it_was_restored_into() {
 
 /// The same compilation restored into a different target directory is what a
 /// fresh compilation there would have produced.
+///
+/// Unix only, and the reason is worth stating. On Windows the compiled
+/// artifact itself is not byte-identical between two target directories: with
+/// everything else held constant -- one checkout, one set of sources,
+/// incremental off -- the rlib still differs, because the debug information
+/// records where the compilation wrote its objects. Nothing this fix does can
+/// change that, and rewriting inside a compiled artifact would be corruption
+/// rather than translation, so verification there reports a difference that is
+/// real.
+#[cfg(unix)]
 #[test]
 fn verification_is_clean_across_target_directories() {
     let store = tempfile::tempdir().unwrap();

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1428,3 +1428,109 @@ mod target_views {
         assert!(project.path().join("target/debug/libfixture.rlib").exists());
     }
 }
+
+/// Build `project` into an explicit target directory, so two builds of the
+/// same checkout differ only in where their outputs land.
+fn build_into_target(project: &Path, store: &Path, target: &Path, settings: &[(&str, &str)]) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
+    command
+        .current_dir(project)
+        .args(["build", "--offline"])
+        .env("MBX_CACHE_DIR", store)
+        .env("CARGO_TARGET_DIR", target)
+        .env_remove("MBX_INCREMENTAL")
+        .env_remove("CARGO_INCREMENTAL")
+        .env_remove("MBX_LEARNED_INCREMENTAL")
+        .env_remove("CI")
+        .env_remove("MBX_SHARE_OUT_DIR");
+    for (name, value) in settings {
+        command.env(name, value);
+    }
+    let output = command.output().expect("mbx should run");
+    assert!(
+        output.status.success(),
+        "build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Read the dep-info rustc wrote for the fixture's library.
+fn dep_info_contents(target: &Path) -> String {
+    let deps = target.join("debug/deps");
+    let entry = std::fs::read_dir(&deps)
+        .expect("deps directory should exist")
+        .filter_map(Result::ok)
+        .find(|entry| {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            name.starts_with("fixture-") && name.ends_with(".d")
+        })
+        .expect("the library's dep-info should exist");
+    std::fs::read_to_string(entry.path()).expect("dep-info should be readable")
+}
+
+/// A restored compilation must describe the checkout it was restored into.
+///
+/// Dep-info rules are keyed by absolute output paths, so a result stored
+/// verbatim hands the next target directory rules naming the one that
+/// published them. Cargo reads that file, and `MBX_VERIFY=1` compares it, so
+/// the stale spelling is both a wrong artifact and a permanent divergence.
+#[test]
+fn a_restored_dep_info_names_the_target_directory_it_was_restored_into() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    build_into_target(project.path(), store.path(), first.path(), &[]);
+    build_into_target(project.path(), store.path(), second.path(), &[]);
+
+    let restored = dep_info_contents(second.path());
+    let foreign = first.path().to_string_lossy().into_owned();
+    assert!(
+        !restored.contains(&foreign),
+        "restored dep-info still names the publishing target directory:\n{restored}"
+    );
+    assert!(
+        restored.contains(&*second.path().to_string_lossy()),
+        "restored dep-info should name this target directory:\n{restored}"
+    );
+}
+
+/// The same compilation restored into a different target directory is what a
+/// fresh compilation there would have produced.
+#[test]
+fn verification_is_clean_across_target_directories() {
+    let store = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    build_into_target(project.path(), store.path(), first.path(), &[]);
+    let report = reports.path().join("verify.json");
+    build_into_target(
+        project.path(),
+        store.path(),
+        second.path(),
+        &[
+            ("MBX_VERIFY", "1"),
+            ("MBX_STATS_REPORT", report.to_str().unwrap()),
+        ],
+    );
+
+    let stats: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).expect("a report should be written"))
+            .expect("the report should be JSON");
+    assert!(
+        count(&stats, "verifications") > 0,
+        "the run should have verified something: {stats}"
+    );
+    assert_eq!(
+        count(&stats, "divergences"),
+        0,
+        "a restore into another target directory diverged: {stats}"
+    );
+}

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -31,6 +31,24 @@ identity. Native targets, custom target specifications, external WebAssembly
 toolchains, native libraries, custom linkers, disabled WASI CRT bundling, and
 non-affirmative `link-self-contained` modes remain uncached.
 
+## Restored artifacts are equivalent, not always identical
+
+A restore writes this checkout's spelling of the outputs that describe where a
+compilation ran -- its dep-info and its diagnostics -- so the files cargo reads
+name the directory it is building into.
+
+The compiled artifacts are reused as they were produced, and two things can
+make them differ from what a fresh compilation here would have written. rustc
+records absolute source paths in metadata and debug information, so artifacts
+built from two checkouts differ even when the sources are identical. On
+Windows they differ between two target directories as well, because the debug
+information also records where the objects were written.
+
+Neither changes what the artifact does. Both are visible to `MBX_VERIFY=1`,
+which compares bytes: a divergence it reports for a compilation restored from
+another checkout, or on Windows from another target directory, is that
+difference rather than a fault.
+
 ## `OUT_DIR` sharing is opt-in
 
 A generated source path can contain an absolute checkout-specific `OUT_DIR`.


### PR DESCRIPTION
A cached result carried the absolute paths of the checkout that published it. Restoring it into a second target directory wrote a dep-info naming the first one, and replayed artifact notifications pointing there too — both of which cargo reads.

This started as a look at why `MBX_VERIFY=1` reported a divergence on build-script fixtures. The build script turned out to be a red herring.

## What leaks

Two outputs of a compilation are text *about where it ran*, and both were stored and restored verbatim:

- **dep-info** — its rules are keyed by absolute output paths.
- **stderr** — carries `{"$message_type":"artifact","artifact":"<abs path>","emit":"link"}` per emitted file when cargo asks for artifact notifications.

## The evidence

Two builds of one checkout, differing only in `CARGO_TARGET_DIR`. The second is a hit:

```
$ grep -c "/ha/" hb/debug/deps/fixture-<hash>.d
3
```

Three references to a directory the build has nothing to do with.

## Scope

Wider than the fixture that surfaced it. No build script, no dependencies, no workspace — one crate with one file diverges as soon as the target directory differs. `MBX_VERIFY=1` was reporting a divergence for essentially every crate, in exactly the arrangement mbx exists for. It was right to.

## The fix

Both outputs are stored in the placeholder vocabulary the action key already speaks, and written back in the restoring checkout's spelling. Each root is matched in both spellings it can take — a Windows path arrives doubled inside JSON diagnostics — and each spelling gets its own placeholder, since a restore has to know which one to write back.

`ADAPTER_VERSION` retires entries published before this: they hold the old spelling and nothing in them says so.

## What this does not change

Compiled artifacts are reused as produced, and two things still make them differ from a fresh compilation here. Neither changes what the artifact does; both are documented in [limits](docs/limits.md).

**Across checkouts**, rustc records absolute source paths in metadata and debug info.

**On Windows, across target directories too.** The Windows runner found this and the unix ones could not have: with everything else held constant — one checkout, one set of sources, incremental off — the rlib still differs, because the debug information records where the objects were written. So the verification test runs on unix and says why. The dep-info test, which is the part cargo reads, runs everywhere and passes on Windows.

Rewriting inside a compiled artifact to close either gap would be corruption rather than translation.

## Also here

Verification now names what diverged — the stream, or the file and how it differed — instead of only that something did. That is what turned the Windows failure from a dead end into a one-line answer.

## Verification

`mise run ci` green. Two integration tests, both confirmed to fail without the fix, plus unit tests covering the escaped spelling on every platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rustc cache publish/restore and invalidates prior adapter-version entries; logic is path-sensitive but heavily tested and scoped to text outputs, not binary artifacts.
> 
> **Overview**
> Cached rustc results used to store **dep-info**, **stdout**, and **stderr** with the publishing checkout’s absolute paths. Restoring into another `CARGO_TARGET_DIR` left Cargo reading rules and artifact notifications that pointed at the wrong directory, which also made `MBX_VERIFY=1` look broken.
> 
> **Publish** now rewrites those text outputs through the same path-placeholder vocabulary as action keys (`normalize_output_text`), including multiple spellings per root (literal, JSON-escaped backslashes, forward slashes) with boundary checks so prefixes like `target-backup` are not touched. **Dep-info** is stored in normalized form; **restore** writes denormalized bytes for dep-info (and stdout/stderr) using the restoring checkout’s `PathMapping`s, and verification compares against the rewritten dep-info digest.
> 
> `ADAPTER_VERSION` is bumped to **2** so older cache entries that still embed absolute paths are not reused. Shadow verification reports **what** diverged (`verification_divergence`) instead of a generic warning.
> 
> Docs note that compiled artifacts may still differ byte-for-byte across checkouts or Windows target dirs (debug info), without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0712a94a9c5359c2dad4ce9de0c75db794009afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->