### PR TITLE
docs: define download_timeout as a whole-download deadline

### DIFF
--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -753,6 +753,14 @@ async fn downloads_decompress_zstd_responses() {
 }
 
 fn test_client(server: &mockito::ServerGuard) -> HttpRemoteCache {
+    test_client_with(server, Duration::from_secs(1), 0)
+}
+
+fn test_client_with(
+    server: &mockito::ServerGuard,
+    download_timeout: Duration,
+    retries: i64,
+) -> HttpRemoteCache {
     HttpRemoteCache::new(RemoteCacheConfig {
         base_url: server.url().parse().unwrap(),
         namespace: "test".into(),
@@ -761,8 +769,8 @@ fn test_client(server: &mockito::ServerGuard) -> HttpRemoteCache {
         oidc_audience: None,
         connect_timeout: Duration::from_secs(1),
         read_timeout: Duration::from_secs(1),
-        download_timeout: Duration::from_secs(1),
-        retries: 0,
+        download_timeout,
+        retries,
     })
     .unwrap()
 }
@@ -1295,4 +1303,107 @@ fn remote_urls_require_https_for_authenticated_requests() {
     assert!(validate_remote_url(&insecure, true).is_err());
     validate_remote_url(&insecure, false).unwrap();
     assert!(validate_remote_url(&"ftp://localhost/cache".parse().unwrap(), false).is_err());
+}
+
+/// `download_timeout` is a deadline for the whole download rather than a budget
+/// each attempt gets afresh, so it has to expire while retries are still
+/// unspent. Four retries sleep at least 100ms + 500ms + 2s + 7.5s between
+/// attempts, so returning well inside that shows the deadline cut the retry
+/// loop short instead of restarting with every attempt.
+#[tokio::test]
+async fn blob_download_timeout_spans_retries_rather_than_one_attempt() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"retried blob");
+    let request = server
+        .mock(
+            "GET",
+            format!("/v1/blobs/blake3/{}/{}", digest.hash, digest.size).as_str(),
+        )
+        .with_status(503)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let client = test_client_with(&server, Duration::from_millis(200), 4);
+    let staging = tempfile::tempdir().unwrap();
+
+    let started = Instant::now();
+    let error = client
+        .get_blob_file(&digest, staging.path())
+        .await
+        .err()
+        .unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        error
+            .to_string()
+            .contains("exceeded its 200ms budget across all attempts"),
+        "{error}"
+    );
+    assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+    request.assert_async().await;
+}
+
+/// The packed path shares the deadline semantics of the single-blob path; only
+/// the size of the budget differs, scaled by what the pack declares.
+#[tokio::test]
+async fn blob_pack_download_timeout_spans_retries_rather_than_one_attempt() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"retried packed blob");
+    mock_blob_pack_capabilities(&mut server).await;
+    let request = server
+        .mock("POST", "/v1/blobs:pack")
+        .with_status(503)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let client = test_client_with(&server, Duration::from_millis(200), 4);
+    let staging = tempfile::tempdir().unwrap();
+
+    let started = Instant::now();
+    let error = client
+        .get_blob_pack(&[digest], staging.path())
+        .await
+        .err()
+        .unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        error
+            .to_string()
+            .contains("exceeded its 200ms budget across all attempts"),
+        "{error}"
+    );
+    assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+    request.assert_async().await;
+}
+
+/// A 503 is transient, so without the deadline the retry loop would run to the
+/// end of its backoff. This is the control for the two tests above: the same
+/// server, given a budget large enough to cover the whole loop, spends every
+/// retry and fails with the server's error rather than a timeout.
+#[tokio::test]
+async fn transient_failures_exhaust_retries_within_a_generous_deadline() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"retried blob");
+    let request = server
+        .mock(
+            "GET",
+            format!("/v1/blobs/blake3/{}/{}", digest.hash, digest.size).as_str(),
+        )
+        .with_status(503)
+        .expect(2)
+        .create_async()
+        .await;
+    let client = test_client_with(&server, Duration::from_secs(30), 1);
+    let staging = tempfile::tempdir().unwrap();
+
+    let error = client
+        .get_blob_file(&digest, staging.path())
+        .await
+        .err()
+        .unwrap();
+
+    assert!(!error.to_string().contains("budget"), "{error}");
+    request.assert_async().await;
 }

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -161,7 +161,14 @@ pub struct RemoteCacheConfig {
     pub connect_timeout: Duration,
     /// Maximum time without response progress for ordinary requests.
     pub read_timeout: Duration,
-    /// Overall deadline for an individual blob download attempt.
+    /// Deadline for one blob download, spanning every retry attempt and the
+    /// backoff between them rather than bounding a single attempt.
+    ///
+    /// A single stalled attempt is already bounded by `connect_timeout` and
+    /// `read_timeout`, so this budget exists to cap the total wall-clock one
+    /// logical download may spend: exhausting it fails the download even when
+    /// retries remain. Size it for the largest artifact worth waiting on, not
+    /// for one attempt at it.
     pub download_timeout: Duration,
     /// Number of attempts after the initial request for retryable failures.
     pub retries: i64,

--- a/crates/mbx-cache-core/src/remote_http.rs
+++ b/crates/mbx-cache-core/src/remote_http.rs
@@ -455,9 +455,16 @@ impl HttpRemoteCache {
                 decode_blob_pack(response, digests, staging_dir).await?,
             ))
         });
+        // Deliberately outside `retry_async`: `download_timeout` is a deadline
+        // for the whole download, not a per-attempt bound. A stalled attempt is
+        // already caught by the client's connect and read timeouts.
         tokio::time::timeout(download_timeout, download)
             .await
-            .map_err(|_| eyre!("remote cache blob pack download timed out for {url}"))?
+            .map_err(|_| {
+                eyre!(
+                    "remote cache blob pack download for {url} exceeded its {download_timeout:?} budget across all attempts"
+                )
+            })?
     }
 
     pub(crate) async fn get_action_result(
@@ -730,9 +737,17 @@ impl HttpRemoteCache {
             }
             Ok(temporary)
         });
-        tokio::time::timeout(self.download_timeout, download)
+        let download_timeout = self.download_timeout;
+        // Deliberately outside `retry_async`: `download_timeout` is a deadline
+        // for the whole download, not a per-attempt bound. A stalled attempt is
+        // already caught by the client's connect and read timeouts.
+        tokio::time::timeout(download_timeout, download)
             .await
-            .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
+            .map_err(|_| {
+                eyre!(
+                    "remote cache blob download for {url} exceeded its {download_timeout:?} budget across all attempts"
+                )
+            })?
     }
 
     pub(crate) async fn blob_pack_upload_limits(&self) -> Result<Option<BlobPackLimits>> {
@@ -916,6 +931,11 @@ pub(crate) fn blob_pack_chunk(
     Ok(chunk)
 }
 
+/// Scale the configured download deadline by the work a pack declares.
+///
+/// The deadline covers the whole download, retries included, so one request
+/// carrying many megabytes or thousands of objects needs a proportionally
+/// larger budget than the single blob the configured value is written for.
 fn blob_pack_download_timeout(base: Duration, digests: &[CacheDigest]) -> Duration {
     let bytes = digests
         .iter()

--- a/crates/mbx-cache-core/src/remote_s3.rs
+++ b/crates/mbx-cache-core/src/remote_s3.rs
@@ -77,7 +77,14 @@ pub struct S3RemoteCacheConfig {
     pub connect_timeout: Duration,
     /// Maximum time without response progress for ordinary requests.
     pub read_timeout: Duration,
-    /// Overall deadline for an individual blob download attempt.
+    /// Deadline for one blob download, spanning every retry attempt and the
+    /// backoff between them rather than bounding a single attempt.
+    ///
+    /// A single stalled attempt is already bounded by `connect_timeout` and
+    /// `read_timeout`, so this budget exists to cap the total wall-clock one
+    /// logical download may spend: exhausting it fails the download even when
+    /// retries remain. Size it for the largest artifact worth waiting on, not
+    /// for one attempt at it.
     pub download_timeout: Duration,
     /// Number of attempts after the initial request for retryable failures.
     pub retries: i64,
@@ -345,9 +352,17 @@ impl S3RemoteCache {
             }
             Ok(temporary)
         });
-        tokio::time::timeout(self.download_timeout, download)
+        let download_timeout = self.download_timeout;
+        // Deliberately outside `retry_async`: `download_timeout` is a deadline
+        // for the whole download, not a per-attempt bound. A stalled attempt is
+        // already caught by the client's connect and read timeouts.
+        tokio::time::timeout(download_timeout, download)
             .await
-            .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
+            .map_err(|_| {
+                eyre!(
+                    "remote cache blob download for {url} exceeded its {download_timeout:?} budget across all attempts"
+                )
+            })?
     }
 
     /// Fetch an object that must exist, turning any other status into an error.

--- a/crates/mbx-cache-core/src/remote_s3_tests.rs
+++ b/crates/mbx-cache-core/src/remote_s3_tests.rs
@@ -35,6 +35,19 @@ fn test_store(server: &mockito::ServerGuard) -> S3RemoteCache {
     S3RemoteCache::new(config(server)).unwrap()
 }
 
+fn test_store_with(
+    server: &mockito::ServerGuard,
+    download_timeout: Duration,
+    retries: i64,
+) -> S3RemoteCache {
+    S3RemoteCache::new(S3RemoteCacheConfig {
+        download_timeout,
+        retries,
+        ..config(server)
+    })
+    .unwrap()
+}
+
 /// The key a blob of these bytes lands on, under the test configuration.
 fn blob_path(digest: &CacheDigest) -> String {
     format!(
@@ -861,4 +874,69 @@ fn error_codes_are_read_out_of_an_s3_error_document() {
         Some("AccessDenied")
     );
     assert_eq!(error_code(&"é".repeat(16 * 1024)), None);
+}
+
+/// The bucket backend reads `download_timeout` exactly as the protocol backend
+/// does: a deadline for the whole download, not a budget each attempt gets
+/// afresh. A `503` is what a store sends for a prefix under load and is
+/// retryable, so four retries would otherwise sleep at least
+/// 100ms + 500ms + 2s + 7.5s; returning well inside that shows the deadline cut
+/// the retry loop short instead of restarting with every attempt.
+#[tokio::test]
+async fn blob_download_timeout_spans_retries_rather_than_one_attempt() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"retried blob");
+    let request = server
+        .mock("GET", blob_path(&digest).as_str())
+        .with_status(503)
+        .with_body(s3_error_body("SlowDown"))
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let store = test_store_with(&server, Duration::from_millis(200), 4);
+    let staging = tempfile::tempdir().unwrap();
+
+    let started = Instant::now();
+    let error = store
+        .get_blob_file(&digest, staging.path())
+        .await
+        .err()
+        .unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        error
+            .to_string()
+            .contains("exceeded its 200ms budget across all attempts"),
+        "{error}"
+    );
+    assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+    request.assert_async().await;
+}
+
+/// The control for the test above: the same store, given a budget large enough
+/// to cover the whole retry loop, spends every retry and fails with the store's
+/// own error rather than a timeout.
+#[tokio::test]
+async fn transient_failures_exhaust_retries_within_a_generous_deadline() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"retried blob");
+    let request = server
+        .mock("GET", blob_path(&digest).as_str())
+        .with_status(503)
+        .with_body(s3_error_body("SlowDown"))
+        .expect(2)
+        .create_async()
+        .await;
+    let store = test_store_with(&server, Duration::from_secs(30), 1);
+    let staging = tempfile::tempdir().unwrap();
+
+    let error = store
+        .get_blob_file(&digest, staging.path())
+        .await
+        .err()
+        .unwrap();
+
+    assert!(!error.to_string().contains("budget"), "{error}");
+    request.assert_async().await;
 }

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -223,7 +223,7 @@ struct RawHttp {
     /// Connect and request timeout.
     #[usage(env = "MBX_HTTP_TIMEOUT", default = "30s", ty = "duration")]
     timeout: String,
-    /// Blob download timeout.
+    /// Deadline for one blob download, retries and backoff included.
     #[usage(env = "MBX_HTTP_DOWNLOAD_TIMEOUT", default = "10m", ty = "duration")]
     download_timeout: String,
     /// Request retries.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -71,7 +71,7 @@ Combined action-store and managed-target budget, or "none".
 - **Default:** `10m`
 - **Set with:** `MBX_HTTP_DOWNLOAD_TIMEOUT`
 
-Blob download timeout.
+Deadline for one blob download, retries and backoff included.
 
 ### `http.retries`
 

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -228,3 +228,13 @@ Remote blobs are compressed with zstd. `MBX_HTTP_DOWNLOAD_TIMEOUT` is separate
 from the normal request timeout because artifacts can be much larger than
 metadata responses. Failed requests are retried according to
 `MBX_HTTP_RETRIES`.
+
+`MBX_HTTP_DOWNLOAD_TIMEOUT` is a deadline for the whole download rather than a
+budget per attempt: it spans every retry named by `MBX_HTTP_RETRIES` and the
+backoff between them, so a download that exhausts it fails even with retries
+left. That bounds how long one blob can hold a build open, and a stalled attempt
+is separately cut short by `MBX_HTTP_TIMEOUT`. Both the protocol server and the
+bucket backend read it the same way; a packed request to a protocol server
+scales the deadline up with the bytes and object count it asks for, since the
+configured value describes a single blob. Raise `MBX_HTTP_DOWNLOAD_TIMEOUT` if a
+slow link makes large artifacts run out of time before their retries are spent.


### PR DESCRIPTION
Resolves the `download_timeout` ambiguity CodeRabbit raised on #140 and that was
deliberately deferred there, since it is pre-existing behavior shared by both
remote backends.

## The ambiguity

`http.download_timeout` is applied by wrapping the entire `retry_async` future in
`tokio::time::timeout`, at all three download sites:

- `get_blob_file` and `download_blob_pack_chunk` in `remote_http.rs`
- `get_blob_file` in `remote_s3.rs`

So it has always bounded every retry attempt plus the backoff between them, not
one attempt — while the doc comment on both config structs said "Overall deadline
for an individual blob download **attempt**", and the generated config reference
said only "Blob download timeout".

## What this does

Keeps the current placement and documents it as a whole-download deadline, rather
than moving the timeout inside the retry closures.

Why that reading:

- **A stalled attempt is already bounded.** Both backends build their reqwest
  client with `connect_timeout` and `read_timeout`, so an attempt that stops
  making progress dies on its own. A per-attempt `download_timeout` would
  duplicate that and leave nothing bounding the wall clock one blob can hold a
  build open for — the worst case would become `retries × timeout` plus backoff.
- **`blob_pack_download_timeout` scales the budget** by the pack's declared bytes
  and object count. That is a budget for a quantity of work in flight: coherent
  as a deadline for the whole download, incoherent as a per-attempt bound.
- **No behavior changes for existing users**, which is what made this worth
  separating from #140 in the first place.

The known cost, now stated in the docs: on a slow-but-working link a transient
failure early can leave too little of the budget for a later attempt to finish.
The remedy is to raise `MBX_HTTP_DOWNLOAD_TIMEOUT`, and `docs/remote-cache.md`
says so.

## Changes

- Both config structs — `RemoteCacheConfig` and `S3RemoteCacheConfig` — carried
  identical stale wording; both now describe the deadline and point at the
  connect/read timeouts as the per-attempt bound.
- All three call sites carry a comment noting the placement outside `retry_async`
  is deliberate, so it does not get "fixed" later.
- Timeout errors now name the budget they exceeded
  (`exceeded its 200ms budget across all attempts`). The old bare "timed out"
  read like a per-attempt failure.
- `http.download_timeout` in `crates/mbx/src/config.rs`, with
  `docs/cli/configuration.md` regenerated, and a paragraph in
  `docs/remote-cache.md` under "Transfer behavior".

## Tests

Five, pinning both backends to the same semantics — three protocol-side, two
bucket-side.

The shape: a 200ms deadline against a server returning `503`, with 4 retries whose
backoff sums to at least 10s. It fails with the budget error in ~200ms; under
per-attempt semantics it would spend the full backoff and fail with the server's
error instead. The S3 case sends a `SlowDown` document, which that backend routes
through `is_transient` via its `TransientRequest` marker.

Each backend also gets a control at a 30s deadline, asserting exactly 2 requests
and a non-timeout error — so the pins would catch retries being broken outright,
not just the deadline moving.

## Reviewer notes

- `is_transient` needed no change under this reading. It would have had to learn
  about elapsed-timeout errors under the per-attempt alternative, or the retry
  budget would have been silently unusable.
- `blob_pack_download_timeout` is protocol-only; a bucket has no pack endpoint, so
  the S3 backend uses the configured value unscaled.

`mise run ci` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, error-message wording, and regression tests only; download timeout placement and retry logic are unchanged.
> 
> **Overview**
> Clarifies that **`download_timeout` / `MBX_HTTP_DOWNLOAD_TIMEOUT`** caps **one logical blob download end-to-end**—all retry attempts plus backoff—not a fresh budget per attempt. Docs on `RemoteCacheConfig`, `S3RemoteCacheConfig`, CLI config, and `docs/remote-cache.md` are updated; inline comments at the HTTP/S3 timeout sites state that wrapping **`retry_async`** is intentional.
> 
> Timeout failures now say they **exceeded the configured budget across all attempts** instead of a generic per-request “timed out”. A short doc comment on **`blob_pack_download_timeout`** explains why pack downloads scale the deadline by bytes/object count.
> 
> **Tests** pin the same semantics on HTTP (single blob, blob pack) and S3: a 200ms budget against retryable `503`s fails quickly with the budget error; a generous deadline control still exhausts retries without a budget error. Test helpers **`test_client_with`** / **`test_store_with`** configure timeout and retries. **No runtime behavior change** beyond clearer errors and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dfcbbe2307fe840ac43eca2f689555279d7c8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->