### PR TITLE
fix(exec): never let a shim stand in for the compiler it shims

### DIFF
--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -962,10 +962,18 @@ pub fn install_path_shims(directory: &Path) -> Result<Option<PathShims>> {
     std::fs::create_dir_all(directory)?;
     let mut compilers = BTreeMap::new();
     for (name, _) in PATH_SHIM_NAMES {
-        let Some(real) = resolve_on_path_excluding(name, &executable) else {
+        let destination = directory.join(name);
+        let Some(real) = resolve_on_path_excluding(name, &executable, directory) else {
             continue;
         };
-        link_path_shim(&executable, &directory.join(name))?;
+        // Belt and braces for the recursion the exclusion above prevents: a
+        // shim that stood in for itself would exec itself forever, so leave
+        // the name uncached rather than install that.
+        if canonical(&real) == canonical(&destination) {
+            debug!("{name} resolved to its own shim; leaving it uncached");
+            continue;
+        }
+        link_path_shim(&executable, &destination)?;
         compilers.insert((*name).to_string(), real);
     }
     if compilers.is_empty() {
@@ -1019,11 +1027,30 @@ fn link_path_shim(_executable: &Path, _destination: &Path) -> Result<()> {
     eyre::bail!("PATH shims are not supported on this platform")
 }
 
-fn resolve_on_path_excluding(name: &str, this_binary: &Path) -> Option<PathBuf> {
+/// Find the real compiler `name` refers to, never a shim.
+///
+/// The shim directory is skipped by location, not by identity. Identity alone
+/// is not enough: a nested `mbx exec` sees that directory first on `PATH`, and
+/// a shim there may point at a *different* mbx binary -- an upgrade, or a build
+/// from another checkout -- which no inode comparison against the running one
+/// can recognize. Choosing it would pin a shim as the compiler and then relink
+/// it to the running binary, leaving it its own compiler and recursing until
+/// the process table fills. Nothing mbx puts in that directory is ever a real
+/// compiler, so the directory itself is the honest thing to exclude.
+///
+/// The identity check stays for the rest of `PATH`, where a copy of mbx under a
+/// compiler's name can still turn up outside any directory mbx owns.
+fn resolve_on_path_excluding(name: &str, this_binary: &Path, shims: &Path) -> Option<PathBuf> {
+    let shims = canonical(shims);
     let path = std::env::var_os("PATH")?;
     std::env::split_paths(&path)
+        .filter(|directory| canonical(directory) != shims)
         .map(|directory| directory.join(name))
         .find(|candidate| candidate.is_file() && !is_same_binary(candidate, Some(this_binary)))
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn install_session_shim(session_dir: &Path) -> Result<PathBuf> {

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -187,6 +187,44 @@ fn exec_identity_falls_back_to_the_directory_name() {
 
 #[cfg(unix)]
 #[test]
+fn a_shim_directory_never_supplies_the_real_compiler() {
+    // The shim there stands for a *different* mbx than the one resolving --
+    // an upgrade, or another checkout's build -- so no identity check against
+    // the running binary can rule it out. Taking it would pin a shim as its
+    // own compiler and recurse forever, so the directory is excluded by
+    // location.
+    let directory = tempfile::tempdir().unwrap();
+    let shims = directory.path().join("shims");
+    let real_dir = directory.path().join("bin");
+    std::fs::create_dir(&shims).unwrap();
+    std::fs::create_dir(&real_dir).unwrap();
+    let other_mbx = directory.path().join("other-mbx");
+    std::fs::write(&other_mbx, b"#!/bin/sh\n").unwrap();
+    std::os::unix::fs::symlink(&other_mbx, shims.join("cc")).unwrap();
+    let real_cc = real_dir.join("cc");
+    std::fs::write(&real_cc, b"#!/bin/sh\n").unwrap();
+
+    let running = directory.path().join("mbx");
+    std::fs::write(&running, b"#!/bin/sh\n").unwrap();
+    let path = std::env::join_paths([shims.as_path(), real_dir.as_path()]).unwrap();
+    // SAFETY: single-threaded test, and the value is restored below.
+    let previous = std::env::var_os("PATH");
+    unsafe { std::env::set_var("PATH", &path) };
+    let resolved = resolve_on_path_excluding("cc", &running, &shims);
+    match previous {
+        Some(value) => unsafe { std::env::set_var("PATH", value) },
+        None => unsafe { std::env::remove_var("PATH") },
+    }
+
+    assert_eq!(
+        resolved.map(|path| std::fs::canonicalize(path).unwrap()),
+        Some(std::fs::canonicalize(&real_cc).unwrap()),
+        "a shim must never be chosen as the compiler it stands in for"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn a_hard_linked_shim_is_recognized_as_the_same_binary() {
     // Both files are created here rather than linked from the running test
     // binary: a hard link needs one filesystem, and a temporary directory is


### PR DESCRIPTION
**Fork bomb in `mbx exec`, found by Bugbot on #138 after it merged. Not yet released** — the `mbx` 0.5.2 publish failed on an unrelated crates.io error, so this never reached users. Worth landing before the release is retried.

## The bug

`install_path_shims` skipped only the *running* mbx inode when resolving each driver from `PATH`. A nested `mbx exec` puts the shared `<cache>/shims` directory first on `PATH`, and a shim there may point at a **different** mbx binary — an upgrade, or another checkout's build. No inode comparison against the running binary recognizes that, so the shim was chosen as the "real" compiler; installing over it then relinked it to the running binary, leaving the shim pinned as its own compiler. Every compile would exec itself and recurse until the process table fills.

Reproduced with two copies of the binary, inspecting the pin rather than triggering the recursion:

```
# before
outer exec (binary A)                     cc -> /usr/bin/cc
nested exec (binary B, shims on PATH)     cc -> <cache>/shims/cc   # its own shim
```

## The fix

Exclude the shim directory **by location, not identity**. Nothing mbx puts there is ever a real compiler, so that is the honest invariant; the inode check stays for the rest of `PATH`, where a stray copy of mbx under a compiler's name can still appear. A name that somehow still resolves to its own shim is left uncached rather than installed.

```
# after
nested exec (binary B, shims on PATH)     cc -> /usr/bin/cc
```

## Testing

New unit test builds the exact shape — a shim directory whose `cc` points at a *different* binary, ahead of the real `cc` on `PATH` — and asserts the real one wins. `mise run lint` and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes PATH-based compiler pinning for `mbx exec` in a security-adjacent exec path; incorrect resolution could still recurse or mis-cache builds, but the fix is narrowly scoped and covered by a targeted test.
> 
> **Overview**
> Fixes a **fork bomb** in nested `mbx exec` when the shared cache shim directory is first on `PATH`. Compiler resolution used to skip only the running mbx binary by inode; a `cc` shim symlinked to a *different* mbx could still win, get relinked to the current binary, and recurse until the process table fills.
> 
> **`resolve_on_path_excluding`** now takes the shim install directory and **drops that entire directory from PATH lookup** (canonical path), on the invariant that nothing mbx places there is a real compiler. The inode/`is_same_binary` check remains for the rest of PATH. **`install_path_shims`** also skips installing when resolution still equals the shim destination (self-reference), leaving that name uncached.
> 
> Adds a Unix unit test where a shim-dir `cc` points at another mbx and a real `cc` is later on PATH; resolution must pick the real compiler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd96c9ba36acf4f6247c3e9e3062c63f2828642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->