### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytesize",
  "demand",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "mbx-cache-core",
  "mbx-cache-rustc",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "blake3",
  "eyre",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.0...mbx-cache-cargo-v0.1.1) - 2026-08-28
+
+### Added
+
+- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
+
 ## [0.1.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-cargo-v0.1.0) - 2026-08-27
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.0"
+version = "0.1.1"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.7.0...mbx-cache-cc-v0.7.1) - 2026-08-28
+
+### Added
+
+- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
+
 ## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.1.0...mbx-cache-cc-v0.7.0) - 2026-08-27
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.7.0"
+version = "0.7.1"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.7.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.7.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.7.0...mbx-cache-core-v0.7.1) - 2026-08-28
+
+### Added
+
+- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
+
 ## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.5.1...mbx-cache-core-v0.7.0) - 2026-08-27
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.7.0"
+version = "0.7.1"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.1" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.2" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.1...mbx-cache-protocol-v0.5.2) - 2026-08-28
+
+### Added
+
+- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
+
 ## [0.5.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.0...mbx-cache-protocol-v0.5.1) - 2026-08-27
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.1"
+version = "0.5.2"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.7.0...mbx-cache-rustc-v0.7.1) - 2026-08-28
+
+### Added
+
+- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
+
 ## [0.7.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.5.1...mbx-cache-rustc-v0.7.0) - 2026-08-27
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.7.0"
+version = "0.7.1"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.0...mbx-cache-store-v0.1.1) - 2026-08-28
+
+### Added
+
+- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
+
 ## [0.1.0](https://github.com/jdx/mr-boxington/releases/tag/mbx-cache-store-v0.1.0) - 2026-08-27
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.0"
+version = "0.1.1"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/jdx/mr-boxington/compare/v0.5.2...v0.5.3) - 2026-08-28
+
+### Added
+
+- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
+
+### Fixed
+
+- *(exec)* never let a shim stand in for the compiler it shims ([#144](https://github.com/jdx/mr-boxington/pull/144))
+
+### Other
+
+- hand the shim search a PATH instead of setting one ([#146](https://github.com/jdx/mr-boxington/pull/146))
+
 ## [0.5.2](https://github.com/jdx/mr-boxington/compare/v0.5.1...v0.5.2) - 2026-08-27
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "0.5.2"
+version = "0.5.3"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ dirs = "6"
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.0", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.7.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.7.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.1", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.7.1", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.7.1", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.1", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx <SUBCOMMAND>`
 
-**Version:** 0.5.2
+**Version:** 0.5.3
 
 - **Usage:** `mbx <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `mbx-cache-core`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `mbx-cache-cc`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `mbx`: 0.5.2 -> 0.5.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.1...mbx-cache-protocol-v0.5.2) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.7.0...mbx-cache-core-v0.7.1) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.0...mbx-cache-cargo-v0.1.1) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.7.0...mbx-cache-rustc-v0.7.1) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.7.0...mbx-cache-cc-v0.7.1) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.0...mbx-cache-store-v0.1.1) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
</blockquote>

## `mbx`

<blockquote>

## [0.5.3](https://github.com/jdx/mr-boxington/compare/v0.5.2...v0.5.3) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))

### Fixed

- *(exec)* never let a shim stand in for the compiler it shims ([#144](https://github.com/jdx/mr-boxington/pull/144))

### Other

- hand the shim search a PATH instead of setting one ([#146](https://github.com/jdx/mr-boxington/pull/146))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump with no logic changes in the diff; risk from shipped fixes is limited to platform/exec behavior already merged in prior PRs.
> 
> **Overview**
> **Release PR** (release-plz) that publishes **mbx 0.5.3** and aligned patch bumps across the workspace: **mbx-cache-protocol** 0.5.2, **mbx-cache-core** / **mbx-cache-rustc** / **mbx-cache-cc** 0.7.1, **mbx-cache-cargo** and **mbx-cache-store** 0.1.1.
> 
> The diff updates crate `version` fields and path dependency pins, refreshes **CHANGELOG** entries for 2026-08-28, syncs **Cargo.lock**, and sets the generated CLI docs version to **0.5.3**. Documented user-facing changes in this release (from changelogs, not new code in this PR): **Windows ARM64 support** ([#147]) across the stack; for **mbx** specifically, an **exec** fix so a shim cannot resolve as the compiler it replaces ([#144) and passing **PATH** for shim lookup instead of overwriting it ([#146).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7b72eadd7437b840d30c77612ab23a004e667a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->