### PR TITLE
test: hand the shim search a PATH instead of setting one

### DIFF
--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1041,9 +1041,18 @@ fn link_path_shim(_executable: &Path, _destination: &Path) -> Result<()> {
 /// The identity check stays for the rest of `PATH`, where a copy of mbx under a
 /// compiler's name can still turn up outside any directory mbx owns.
 fn resolve_on_path_excluding(name: &str, this_binary: &Path, shims: &Path) -> Option<PathBuf> {
+    resolve_in_path(&std::env::var_os("PATH")?, name, this_binary, shims)
+}
+
+/// The search itself, over a `PATH` the caller supplies.
+///
+/// Separated from the environment so a test can hand it one: `PATH` is process
+/// global, and cargo runs these tests on a thread pool, so setting it here
+/// would race every other test that reads one -- `which` in the linker tests
+/// among them.
+fn resolve_in_path(path: &OsStr, name: &str, this_binary: &Path, shims: &Path) -> Option<PathBuf> {
     let shims = canonical(shims);
-    let path = std::env::var_os("PATH")?;
-    std::env::split_paths(&path)
+    std::env::split_paths(path)
         .filter(|directory| canonical(directory) != shims)
         .map(|directory| directory.join(name))
         .find(|candidate| candidate.is_file() && !is_same_binary(candidate, Some(this_binary)))

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -206,15 +206,10 @@ fn a_shim_directory_never_supplies_the_real_compiler() {
 
     let running = directory.path().join("mbx");
     std::fs::write(&running, b"#!/bin/sh\n").unwrap();
+    // Handed in rather than set: `PATH` is process global and these tests run
+    // on a thread pool, so writing it would race whatever else reads one.
     let path = std::env::join_paths([shims.as_path(), real_dir.as_path()]).unwrap();
-    // SAFETY: single-threaded test, and the value is restored below.
-    let previous = std::env::var_os("PATH");
-    unsafe { std::env::set_var("PATH", &path) };
-    let resolved = resolve_on_path_excluding("cc", &running, &shims);
-    match previous {
-        Some(value) => unsafe { std::env::set_var("PATH", value) },
-        None => unsafe { std::env::remove_var("PATH") },
-    }
+    let resolved = resolve_in_path(&path, "cc", &running, &shims);
 
     assert_eq!(
         resolved.map(|path| std::fs::canonicalize(path).unwrap()),


### PR DESCRIPTION
Addresses the Bugbot finding on #144, which landed after that PR merged.

The test I added set `PATH` with `unsafe { set_var }` and justified it as "single-threaded". That is wrong: cargo runs unit tests on a thread pool, so the write raced every other test that reads the variable — `which::which("cc")` in the linker tests among them — and the `unsafe` turned a flake into unsoundness.

The search now takes the `PATH` to walk as a parameter, with the environment read only by the thin wrapper. The test supplies its own and touches no process state, so there is no `unsafe` left in the file.

No behaviour change: `resolve_on_path_excluding` still reads `PATH` exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test refactor and internal extraction only; production PATH resolution is unchanged.
> 
> **Overview**
> Fixes a **thread-unsafe unit test** that temporarily overwrote process-global `PATH` with `unsafe { set_var }`, which could race other parallel tests (e.g. linker tests calling `which::which("cc")`).
> 
> The compiler lookup used by `resolve_on_path_excluding` is split into **`resolve_in_path`**, which walks a caller-supplied `PATH`. The public wrapper still reads `std::env::var_os("PATH")` exactly as before, so **runtime behavior is unchanged**. The shim-directory exclusion test now builds a synthetic `PATH` and calls `resolve_in_path` directly, removing all `unsafe` env manipulation from that test file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01a9ae82ff078fe9487b0bfcc7f741122ab53e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->