### PR TITLE
feat: add Windows ARM64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,10 @@ jobs:
             os: windows-latest
             runner: windows-latest
             bin: mbx.exe
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            runner: windows-11-arm
+            bin: mbx.exe
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -232,7 +236,7 @@ jobs:
 
   attach:
     name: Attach to release
-    # Needs every target: a release carrying three of four archives is worse
+    # Needs every target: a release carrying only some of its archives is worse
     # than one that arrives late, and the draft stays unpublished either way.
     needs: build
     runs-on: namespace-profile-endev-linux-amd64

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
 ```
 
-Release archives also cover Linux ARM64, Apple Silicon, and Windows x86-64.
+Release archives also cover Linux ARM64, Apple Silicon, and Windows x86-64 and
+ARM64.
 Every release includes `SHA256SUMS`.
 
 [See all installation options →](https://mr-boxington.jdx.dev/getting-started)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,10 +47,26 @@ grep "  $archive$" SHA256SUMS | shasum -a 256 --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
 ```
 
-== Windows
+== Windows x86-64
 
 ```powershell
 $archive = "mbx-x86_64-pc-windows-msvc.zip"
+$release = "https://github.com/jdx/mr-boxington/releases/latest/download"
+Invoke-WebRequest "$release/$archive" -OutFile $archive
+Invoke-WebRequest "$release/SHA256SUMS" -OutFile SHA256SUMS
+$expected = (Select-String -Path SHA256SUMS -Pattern $archive).Line.Split(" ")[0]
+if ((Get-FileHash $archive -Algorithm SHA256).Hash -ne $expected.ToUpper()) {
+  throw "checksum mismatch"
+}
+Expand-Archive $archive -DestinationPath "$env:LOCALAPPDATA\Programs\mbx"
+```
+
+Add `%LOCALAPPDATA%\Programs\mbx` to `PATH`.
+
+== Windows ARM64
+
+```powershell
+$archive = "mbx-aarch64-pc-windows-msvc.zip"
 $release = "https://github.com/jdx/mr-boxington/releases/latest/download"
 Invoke-WebRequest "$release/$archive" -OutFile $archive
 Invoke-WebRequest "$release/SHA256SUMS" -OutFile SHA256SUMS
@@ -80,7 +96,7 @@ Release binaries cover:
 
 - Linux x86-64 and ARM64 (static musl builds)
 - macOS on Apple Silicon
-- Windows x86-64
+- Windows x86-64 and ARM64
 
 Other platforms with a Rust toolchain can build from source with
 `cargo install mbx`. mbx wraps whichever Cargo and rustc are active, including


### PR DESCRIPTION
## Summary

- build and publish `aarch64-pc-windows-msvc` release archives on GitHub's native Windows ARM runner
- smoke-test the release binary on Windows ARM64 before archiving it
- document the ARM64 archive and supported platform

## Tests

- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/release.yml`
- `cargo test --locked --workspace`
- `mise run check:docs`
- `mise run build:docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release matrix and documentation only; no runtime or cache logic changes.
> 
> **Overview**
> Adds **Windows on ARM64** (`aarch64-pc-windows-msvc`) to the release build matrix, using GitHub’s **`windows-11-arm`** runner so each release ships a fifth `mbx.exe` zip alongside the existing targets. The attach job comment is generalized to “only some archives” now that there are more than four binaries.
> 
> **README** and **getting-started** now list Windows ARM64 in supported platforms and document install steps for `mbx-aarch64-pc-windows-msvc.zip` (checksum verify + expand), with the Windows tab split into x86-64 and ARM64 sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9af455516ddf0424c0dc3b7b3cf8ee40d33d181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->