### PR TITLE
fix(cc): keep compiler shims stable across sessions

### DIFF
--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -70,7 +70,10 @@ impl CacheSession {
     pub async fn start(session_dir: &Path, config: &Config) -> Result<Self> {
         let shim = install_session_shim(session_dir)?;
         let cc_shims = if config.cc {
-            install_cc_shims(session_dir)?
+            // Build systems such as CMake persist HOST_CC as an absolute
+            // compiler path. Keep the C/C++ shims outside the temporary
+            // session so that path remains executable on the next mbx run.
+            install_cc_shims(&config.cache_dir.join("shims"))?
         } else {
             None
         };
@@ -977,7 +980,7 @@ const CC_CRATE_ENV: &[&str] = &["CC", "CXX", "HOST_CC", "HOST_CXX"];
 /// Resolution happens here rather than in the shim so the whole build agrees on
 /// one compiler, and so a machine with no C compiler simply gets no shims
 /// instead of a build script that fails differently than it would have.
-fn install_cc_shims(session_dir: &Path) -> Result<Option<CcShims>> {
+fn install_cc_shims(shims_dir: &Path) -> Result<Option<CcShims>> {
     if !cfg!(unix) {
         return Ok(None);
     }
@@ -989,18 +992,16 @@ fn install_cc_shims(session_dir: &Path) -> Result<Option<CcShims>> {
     // Wrapped first, because a cross image is entitled to ship the driver it
     // cross-compiles with and no host `cc` at all. Deciding there is nothing to
     // do before looking would leave exactly that build uncached.
-    let targeted = wrap_targeted_compilers(&executable, session_dir)?;
+    std::fs::create_dir_all(shims_dir)?;
+    let targeted = wrap_targeted_compilers(&executable, shims_dir)?;
     if real_cc.is_none() && real_cxx.is_none() && targeted.is_empty() {
         debug!("no C or C++ compiler was found on PATH; build script compiles are not cached");
         return Ok(None);
     }
     let shim = |language: CcLanguage| -> Result<PathBuf> {
-        install_shim_named(
-            &executable,
-            session_dir,
-            language.shim_stem(),
-            ShimLink::Tracking,
-        )
+        let destination = shims_dir.join(shim_file_name(language.shim_stem()));
+        link_path_shim(&executable, &destination)?;
+        Ok(destination)
     };
     let mut installed = CcShims {
         cc: None,
@@ -1024,13 +1025,13 @@ fn install_cc_shims(session_dir: &Path) -> Result<Option<CcShims>> {
 /// asked for by name is wrapped, and only when the name resolves to a single
 /// executable -- a value like `ccache gcc` is a command, not a path, and is
 /// left alone.
-fn wrap_targeted_compilers(executable: &Path, session_dir: &Path) -> Result<Vec<TargetedCompiler>> {
+fn wrap_targeted_compilers(executable: &Path, shims_dir: &Path) -> Result<Vec<TargetedCompiler>> {
     let mut wrapped = Vec::new();
     for (variable, value) in std::env::vars() {
         let Some(language) = targeted_compiler_language(&variable) else {
             continue;
         };
-        let Some(real) = resolve_named_compiler(&value, executable, session_dir) else {
+        let Some(real) = resolve_named_compiler(&value, executable, shims_dir) else {
             debug!("{variable} does not name a single executable; it is left as it is");
             continue;
         };
@@ -1041,7 +1042,8 @@ fn wrap_targeted_compilers(executable: &Path, session_dir: &Path) -> Result<Vec<
             language.shim_stem(),
             variable.to_ascii_lowercase().replace(['.', '/'], "_")
         );
-        let shim = install_shim_named(executable, session_dir, &shim_name, ShimLink::Tracking)?;
+        let shim = shims_dir.join(shim_file_name(&shim_name));
+        link_path_shim(executable, &shim)?;
         wrapped.push(TargetedCompiler {
             variable,
             shim_name,

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -20,6 +20,8 @@ use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::oneshot;
@@ -43,6 +45,8 @@ pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
 pub(crate) const BYPASS_LOG_ENV: &str = "MBX_BYPASS_LOG";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+#[cfg(unix)]
+static SHIM_STAGING_NONCE: AtomicU64 = AtomicU64::new(0);
 
 /// A cache session: the agent, its listener, and the shim cargo will invoke.
 pub struct CacheSession {
@@ -1159,12 +1163,13 @@ fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
         return Ok(());
     }
     let staging = destination.with_file_name(format!(
-        ".{}.{}",
+        ".{}.{}.{}",
         destination
             .file_name()
             .unwrap_or_default()
             .to_string_lossy(),
-        std::process::id()
+        std::process::id(),
+        SHIM_STAGING_NONCE.fetch_add(1, Ordering::Relaxed)
     ));
     let _ = std::fs::remove_file(&staging);
     std::os::unix::fs::symlink(&target, &staging)?;

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -102,6 +102,48 @@ async fn cc_shim_path_survives_and_is_reused_across_sessions() {
     second.finish().await.unwrap();
 }
 
+/// The persistent shim directory is shared by every mbx process using a cache.
+/// Concurrent sessions must not contend on the temporary name used to install
+/// the same shim.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_sessions_can_install_shared_cc_shims() {
+    if resolve_on_path(CcLanguage::C.default_driver()).is_none() {
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let mut config = test_config(cache.path());
+    config.cc = true;
+
+    let barrier = Arc::new(tokio::sync::Barrier::new(8));
+    let mut starts = tokio::task::JoinSet::new();
+    for _ in 0..8 {
+        let config = config.clone();
+        let barrier = Arc::clone(&barrier);
+        starts.spawn(async move {
+            let session_dir = tempfile::tempdir().unwrap();
+            barrier.wait().await;
+            let session = CacheSession::start(session_dir.path(), &config).await?;
+            let shim = session
+                .cc_shims
+                .as_ref()
+                .and_then(|shims| shims.cc.as_ref())
+                .map(|(shim, _)| shim.clone())
+                .unwrap();
+            session.finish().await?;
+            Ok::<_, eyre::Report>(shim)
+        });
+    }
+
+    let mut installed = Vec::new();
+    while let Some(result) = starts.join_next().await {
+        installed.push(result.unwrap().unwrap());
+    }
+    assert_eq!(installed.len(), 8);
+    assert!(installed.iter().all(|shim| shim == &installed[0]));
+    assert!(installed[0].is_file());
+}
+
 #[tokio::test]
 async fn incremental_builds_leave_cargo_incremental_alone() {
     let cache = tempfile::tempdir().unwrap();

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -52,6 +52,56 @@ async fn session_environment_directs_cargo_at_the_shim() {
     session.finish().await.unwrap();
 }
 
+/// Build scripts may hand HOST_CC to CMake, which records its absolute path in
+/// CMakeCache.txt and reuses it on later cargo invocations. That path must
+/// therefore outlive the temporary mbx session that first configured CMake.
+#[cfg(unix)]
+#[tokio::test]
+async fn cc_shim_path_survives_and_is_reused_across_sessions() {
+    if resolve_on_path(CcLanguage::C.default_driver()).is_none() {
+        return;
+    }
+    let cache = tempfile::tempdir().unwrap();
+    let mut config = test_config(cache.path());
+    config.cc = true;
+
+    let first_path = {
+        let session_dir = tempfile::tempdir().unwrap();
+        let session = CacheSession::start(session_dir.path(), &config)
+            .await
+            .unwrap();
+        let path = session
+            .cc_shims
+            .as_ref()
+            .and_then(|shims| shims.cc.as_ref())
+            .map(|(shim, _)| shim.clone())
+            .unwrap();
+        session.finish().await.unwrap();
+        path
+    };
+
+    assert!(
+        first_path.is_file(),
+        "the compiler path cached by a build system must survive its mbx session"
+    );
+
+    let second_dir = tempfile::tempdir().unwrap();
+    let second = CacheSession::start(second_dir.path(), &config)
+        .await
+        .unwrap();
+    let second_path = second
+        .cc_shims
+        .as_ref()
+        .and_then(|shims| shims.cc.as_ref())
+        .map(|(shim, _)| shim.as_path())
+        .unwrap();
+    assert_eq!(
+        second_path, first_path,
+        "later sessions must reuse the compiler path a build system cached"
+    );
+    second.finish().await.unwrap();
+}
+
 #[tokio::test]
 async fn incremental_builds_leave_cargo_incremental_alone() {
     let cache = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- install cargo build-script C/C++ shims in the persistent mbx cache directory
- atomically refresh stable host and targeted compiler shim paths for each session
- add regression coverage proving a compiler path cached by CMake survives and is reused by later mbx sessions

## Context

CMake persists `CMAKE_C_COMPILER` as an absolute path. The previous per-session shim path was deleted after the first mbx command, causing a later command against the same target directory to fail because CMake still referenced the deleted shim. This was reproduced by the macOS unit job in jdx/mise#12534.

## Validation

- `mise run test:cargo`
- `mise run lint`
- `mise run test:e2e` (25/25 passed)
- `cargo test -p mbx`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where compiler shims live and how they are atomically updated on a shared directory; wrong paths or install races could break C/C++ caching or CMake-driven rebuilds, though regression tests cover persistence and concurrency.
> 
> **Overview**
> Fixes builds where **CMake (and similar)** cache an absolute **C/C++ compiler path** from `HOST_CC` and later cargo runs fail because the old shim lived only in a **temporary session directory** that was removed when mbx exited.
> 
> **Cargo build-script C/C++ shims** (`mbx-cc`, `mbx-cxx`, and targeted cross-compiler shims) are now installed under **`{cache_dir}/shims`** instead of the per-session temp dir, and refreshed via the existing **`link_path_shim`** symlink-and-rename path so stable paths stay valid across runs. Host/targeted shims no longer use per-session **`install_shim_named`** tracking installs for those compilers.
> 
> Concurrent installs into the shared shim directory use a **process id plus atomic nonce** in the temporary staging filename so parallel sessions do not collide when updating the same shim link.
> 
> Adds **unix tests** that the CC shim file survives after `finish()`, that a second session reuses the same path, and that eight concurrent sessions can install shared shims without error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec876403fc028b517c11f0857983553368971bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * C and C++ compiler shims now persist across sessions instead of being removed when a session ends.
  * Subsequent sessions reuse the existing shim paths for more consistent compiler handling.

* **Tests**
  * Added coverage verifying shim files remain available and are reused across multiple sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->