### PR TITLE
fix(cache-rustc): key inert native search directories by path

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -359,6 +359,15 @@ pub struct AgentStats {
     pub upload_drain_duration_ns: u64,
     /// Complete actions staged before an adapter requested them.
     pub prefetched_actions: u64,
+    /// Predictions carried by the task manifest this session loaded.
+    ///
+    /// Zero means no earlier build left a manifest behind -- a genuinely cold
+    /// start. Together with `lookups`, this is what tells a session that loaded
+    /// hundreds of predictions and matched none of them apart from one that had
+    /// nothing to match against; the first means the invocations changed (a
+    /// compiler update does this to every one of them at once), the second that
+    /// the store was empty.
+    pub predictions_loaded: u64,
     /// Compilations that were not cacheable, counted by reason.
     pub bypasses: BTreeMap<String, u64>,
     /// Estimated compiler time avoided by restored action hits.
@@ -454,6 +463,7 @@ struct AtomicAgentStats {
     remote_blob_pack_upload_blobs: AtomicU64,
     upload_drain_duration_ns: AtomicU64,
     prefetched_actions: AtomicU64,
+    predictions_loaded: AtomicU64,
     remote_failures: AtomicU64,
     remote_manifest_lookups: AtomicU64,
     remote_manifest_lookup_duration_ns: AtomicU64,
@@ -899,6 +909,13 @@ impl CacheAgent {
         let run =
             CacheDigest::blake3(format!("{task}\0{}\0{sequence}", std::process::id()).as_bytes())
                 .hash;
+        // The largest baseline rather than a sum: beginning the same task again
+        // in one session reloads the same manifest, and counting it twice would
+        // overstate what there was to match.
+        self.stats.predictions_loaded.fetch_max(
+            state.predictions.len().try_into().unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
         let predictions = state.predictions.values().cloned().collect();
         self.task_actions.lock().unwrap().insert(run.clone(), state);
         self.spawn_prefetch_predictions(predictions);
@@ -1193,6 +1210,7 @@ impl CacheAgent {
                 .load(Ordering::Relaxed),
             upload_drain_duration_ns: self.stats.upload_drain_duration_ns.load(Ordering::Relaxed),
             prefetched_actions: self.stats.prefetched_actions.load(Ordering::Relaxed),
+            predictions_loaded: self.stats.predictions_loaded.load(Ordering::Relaxed),
             bypasses: self.stats.bypasses.lock().unwrap().clone(),
             avoided_compiler_duration_ns: self
                 .stats

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -493,6 +493,40 @@ async fn coalesces_repeated_remote_action_lookups() {
 }
 
 #[tokio::test]
+async fn begin_task_reports_how_many_predictions_were_loaded() {
+    let directory = tempfile::tempdir().unwrap();
+    let cache = directory.path().join("cache");
+    let task = "b".repeat(64);
+
+    let seed = CacheAgent::new(&cache, "test-version");
+    let run = seed.begin_task(&task).await.unwrap();
+    assert_eq!(seed.stats().predictions_loaded, 0);
+    for name in ["first", "second"] {
+        assert!(matches!(
+            seed.respond(AgentRequest::RecordActionPrediction {
+                task: run.clone(),
+                prediction: ActionPrediction {
+                    invocation: CacheDigest::blake3(name.as_bytes()),
+                    action: CacheDigest::blake3(name.as_bytes()),
+                    adapter: "rustc".into(),
+                    payload: "{}".into(),
+                },
+            })
+            .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+    }
+    seed.commit_task(&run).await.unwrap();
+
+    // What was loaded, not what was recorded: this is the baseline a session
+    // had available to match against.
+    assert_eq!(seed.stats().predictions_loaded, 0);
+    let reader = CacheAgent::new(&cache, "test-version");
+    reader.begin_task(&task).await.unwrap();
+    assert_eq!(reader.stats().predictions_loaded, 2);
+}
+
+#[tokio::test]
 async fn publishes_only_successfully_committed_task_action_manifests() {
     let directory = tempfile::tempdir().unwrap();
     let cache = directory.path().join("cache");

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -313,6 +313,18 @@ impl RustcInvocation {
                 } else {
                     working_dir.join(path)
                 };
+                // An inert directory outside every mapped root enters the key
+                // by its literal path in the arguments, not by its contents --
+                // predictions skip it under the same rule, so both discovery
+                // paths agree on the action key.
+                if self.native_search_is_inert()
+                    && matches!(
+                        super::normalize_mapped_path(&directory, &working_dir, path_mappings),
+                        Err(BypassReason::UnmappedAbsolutePath(_))
+                    )
+                {
+                    continue;
+                }
                 collect_native_directory(
                     &directory,
                     &admitted_roots,
@@ -607,6 +619,116 @@ mod tests {
         assert_eq!(
             discovered.verify_not_modified_since(modified),
             Err(BypassReason::InputModifiedDuringCompilation(source))
+        );
+    }
+
+    /// The MSVC toolset directories `cc`-built dependencies hand to every
+    /// downstream compile on Windows: absolute, version-stamped, and outside
+    /// every mapped root.
+    fn toolchain_native_directory(version: &str) -> PathBuf {
+        if cfg!(windows) {
+            PathBuf::from(format!(r"C:\Program Files\MSVC\{version}\lib\x64"))
+        } else {
+            PathBuf::from(format!("/opt/msvc/{version}/lib/x64"))
+        }
+    }
+
+    fn library_with_native_search(source: &Path, directory: &Path) -> RustcInvocation {
+        RustcInvocation::parse(&[
+            "--crate-name=widget".into(),
+            "--crate-type=lib".into(),
+            "--emit=metadata,link".into(),
+            format!("-Lnative={}", directory.display()).into(),
+            source.to_path_buf().into_os_string(),
+        ])
+        .unwrap()
+    }
+
+    fn library_context(root: &Path, mappings: Vec<PathMapping>) -> ActionContext {
+        ActionContext {
+            compiler: crate::CompilerIdentity {
+                toolchain: "core:rust@test".into(),
+                rustc_version: "test".into(),
+                host: std::env::consts::ARCH.into(),
+            },
+            working_dir: root.to_path_buf(),
+            path_mappings: mappings,
+            environment: BTreeMap::new(),
+            portable_environment: BTreeSet::new(),
+            inputs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn unmapped_native_directory_is_keyed_by_path_for_library_emits() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let source = root.join("lib.rs");
+        std::fs::write(&source, "pub fn library() {}\n").unwrap();
+        let toolchain = toolchain_native_directory("14.51.36231");
+        let invocation = library_with_native_search(&source, &toolchain);
+        let mappings = vec![PathMapping::new(root, "workspace")];
+        let dep_info = RustcDepInfo::parse(&format!("output: {}\n", source.display())).unwrap();
+
+        // The directory does not even exist: its contents are not inputs.
+        let discovered = invocation
+            .discover_inputs_with_mappings(&dep_info, root, &mappings)
+            .unwrap();
+        assert_eq!(discovered.inputs.len(), 1);
+        assert_eq!(discovered.inputs[0].path, source);
+
+        // The literal path is key material, so a toolset update misses.
+        let context = library_context(root, mappings.clone());
+        let digest = invocation.invocation_digest(&context).unwrap();
+        let updated = library_with_native_search(&source, &toolchain_native_directory("14.52.0"));
+        assert_ne!(digest, updated.invocation_digest(&context).unwrap());
+
+        // The prediction skips the directory the same way discovery does, so a
+        // build that replays it derives the action key dep-info would have.
+        let mut recorded = context.clone();
+        discovered.clone().apply_to(&mut recorded).unwrap();
+        let action = invocation.action(recorded).unwrap();
+        let prediction = invocation.prediction(&context, &discovered).unwrap();
+        let replayed = prediction.discover(root, &context.path_mappings).unwrap();
+        let mut replay_context = context.clone();
+        replayed.apply_to(&mut replay_context).unwrap();
+        assert_eq!(
+            invocation.action(replay_context).unwrap().digest,
+            action.digest
+        );
+    }
+
+    #[test]
+    fn unmapped_native_directory_still_refuses_a_native_link() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let source = root.join("main.rs");
+        std::fs::write(&source, "fn main() {}\n").unwrap();
+        let toolchain = toolchain_native_directory("14.51.36231");
+        let invocation = RustcInvocation::parse_with(
+            &[
+                "--crate-name=app".into(),
+                "--crate-type=bin".into(),
+                "--emit=link".into(),
+                format!("-Lnative={}", toolchain.display()).into(),
+                source.clone().into_os_string(),
+            ],
+            crate::ParseOptions::caching_native_links(true),
+        )
+        .unwrap();
+        let mappings = vec![PathMapping::new(root, "workspace")];
+
+        // A linker reads those directories, so their contents stay inputs the
+        // key must account for, and an unmapped one stays a bypass.
+        let context = library_context(root, mappings.clone());
+        assert!(matches!(
+            invocation.invocation_digest(&context),
+            Err(BypassReason::UnmappedAbsolutePath(_))
+        ));
+        let dep_info = RustcDepInfo::parse(&format!("output: {}\n", source.display())).unwrap();
+        assert_eq!(
+            invocation.discover_inputs_with_mappings(&dep_info, root, &mappings),
+            Err(BypassReason::UnsupportedSearchPath("native".into()))
         );
     }
 

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -360,6 +360,22 @@ impl RustcInvocation {
         self.link_output == LinkOutput::NativeExecutable
     }
 
+    /// Whether the contents of native search directories cannot reach this
+    /// invocation's outputs.
+    ///
+    /// A library emit never runs a linker, so a `-L native` directory is only
+    /// read for a static library named by `-l` -- and any `-l` already bypasses
+    /// the whole invocation. On Windows every crate downstream of a `cc`-built
+    /// dependency carries the MSVC toolset's `-L native` directories, which sit
+    /// outside every checkout root; treating them as content inputs would leave
+    /// all of those compilations permanently uncacheable. A `#[link]` attribute
+    /// naming a bundled static library could in principle reach through such a
+    /// directory without an `-l` flag, but toolchain directories are
+    /// version-stamped by their path, which the key still carries verbatim.
+    fn native_search_is_inert(&self) -> bool {
+        self.link_output == LinkOutput::Library
+    }
+
     /// Return the source input passed to rustc.
     pub fn source(&self) -> &Path {
         &self.source
@@ -576,11 +592,20 @@ impl RustcInvocation {
             if let Argument::SearchPath { kind, path } = argument
                 && kind == "native"
             {
-                has_native_directory = true;
-                inputs.insert(format!(
-                    "{NATIVE_DIRECTORY_PREDICTION_PREFIX}{}",
-                    builder.normalize_path(path)?
-                ));
+                match builder.normalize_path(path) {
+                    Ok(normalized) => {
+                        has_native_directory = true;
+                        inputs.insert(format!("{NATIVE_DIRECTORY_PREDICTION_PREFIX}{normalized}"));
+                    }
+                    // Inert and outside every mapped root: the directory
+                    // contributes no content inputs, so the prediction has
+                    // nothing to replay for it. Input discovery skips it the
+                    // same way, which is what keeps the predicted action key
+                    // equal to the one dep-info discovery builds.
+                    Err(BypassReason::UnmappedAbsolutePath(_)) if self.native_search_is_inert() => {
+                    }
+                    Err(error) => return Err(error),
+                }
             }
         }
         Ok(RustcInputPrediction {
@@ -1623,7 +1648,26 @@ impl<'a> ActionBuilder<'a> {
             Argument::Plain(value) => Ok(value.clone()),
             Argument::Path { flag, path } => Ok(format!("{flag}={}", self.normalize_path(path)?)),
             Argument::SearchPath { kind, path } => {
-                Ok(format!("-L{kind}={}", self.normalize_path(path)?))
+                let text = match self.normalize_path(path) {
+                    Ok(text) => text,
+                    // A native directory outside every mapped root is a host
+                    // toolchain installation, not a checkout location. Its
+                    // literal path is the key material: the path is
+                    // version-stamped on the platforms that pass one (the MSVC
+                    // toolset, the Windows SDK), so hosts that differ miss,
+                    // which is the same identity-over-content stance
+                    // [`LinkerIdentity`] takes.
+                    Err(BypassReason::UnmappedAbsolutePath(absolute))
+                        if kind == "native" && self.invocation.native_search_is_inert() =>
+                    {
+                        absolute
+                            .to_str()
+                            .ok_or(BypassReason::NonUtf8Path(absolute.clone()))?
+                            .to_string()
+                    }
+                    Err(error) => return Err(error),
+                };
+                Ok(format!("-L{kind}={text}"))
             }
             Argument::Extern { name, path } => match path {
                 Some(path) => Ok(format!("--extern={name}={}", self.normalize_path(path)?)),

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -562,6 +562,7 @@ struct StatsReport {
     verifications: u64,
     divergences: u64,
     prefetched_actions: u64,
+    predictions_loaded: u64,
     prefetch_runs: u64,
     bypasses: BTreeMap<String, u64>,
     downloaded_bytes: u64,
@@ -638,6 +639,7 @@ impl From<&AgentStats> for StatsReport {
             verifications: stats.verifications,
             divergences: stats.divergences,
             prefetched_actions: stats.prefetched_actions,
+            predictions_loaded: stats.predictions_loaded,
             prefetch_runs: stats.prefetch_runs,
             bypasses: stats.bypasses.clone(),
             downloaded_bytes: stats.downloaded_bytes,
@@ -712,6 +714,9 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
             "mbx[cache]: could not look up {} compilations: no usable dep-info from an earlier build and no prediction to derive an action key from",
             stats.unconsulted,
         ));
+        if let Some(explanation) = stale_manifest_note(stats) {
+            note(&explanation);
+        }
     }
     if !stats.bypasses.is_empty() {
         let total: u64 = stats.bypasses.values().sum();
@@ -811,6 +816,22 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
             stats.verifications, stats.divergences,
         ));
     }
+}
+
+/// Explain a session that loaded a full manifest and matched none of it.
+///
+/// "No prediction to derive an action key from" reads as an empty store, and
+/// for a warm store that just watched its compiler change underneath it -- a
+/// CI runner image updating its preinstalled toolchain is the common way --
+/// that reading sends people hunting for restore failures. The distinction is
+/// observable: predictions were loaded, and not one lookup was ever made.
+fn stale_manifest_note(stats: &AgentStats) -> Option<String> {
+    (stats.unconsulted > 0 && stats.lookups == 0 && stats.predictions_loaded > 0).then(|| {
+        format!(
+            "mbx[cache]: a manifest predicting {} compilations was loaded, but none matched this build; the compiler or its flags changed since they were recorded (a toolchain update does this)",
+            stats.predictions_loaded,
+        )
+    })
 }
 
 /// Whether the cache took part in this build at all.

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -370,6 +370,30 @@ fn qualification_results_are_not_reported_as_misses() {
 }
 
 #[test]
+fn a_loaded_manifest_that_matched_nothing_is_called_out() {
+    // The shape a toolchain update leaves behind: a warm store, a manifest
+    // full of predictions, and not one lookup all build.
+    let unmatched = agent_stats(|stats| {
+        stats.unconsulted = 255;
+        stats.predictions_loaded = 257;
+    });
+    assert!(stale_manifest_note(&unmatched).unwrap().contains("257"));
+
+    // A genuinely cold store has nothing to explain.
+    let cold = agent_stats(|stats| stats.unconsulted = 255);
+    assert_eq!(stale_manifest_note(&cold), None);
+
+    // A session whose lookups happened was matching its manifest fine; the
+    // stragglers are ordinary cold units, not a stale baseline.
+    let live = agent_stats(|stats| {
+        stats.unconsulted = 2;
+        stats.lookups = 253;
+        stats.predictions_loaded = 257;
+    });
+    assert_eq!(stale_manifest_note(&live), None);
+}
+
+#[test]
 fn compiler_only_sessions_are_reportable() {
     let stats = agent_stats(|stats| {
         stats.compiler =

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx <SUBCOMMAND>`
 
-**Version:** 0.5.3
+**Version:** 0.5.4
 
 - **Usage:** `mbx <SUBCOMMAND>`
 


### PR DESCRIPTION
## What

Investigating jdx/hk's cache-benchmark \"mbx (Windows): 0 hits, 255 unconsulted\" runs (e.g. [run 33162808108](https://github.com/jdx/hk/actions/runs/33162808108)) turned up two separate things:

1. **The mass zero-hit was not an mbx bug.** The run restored a cache saved by a run of the *same commit* that had gotten 225 hits; the only delta was the runner image (20260818 → 20260824), which bumped the preinstalled Rust 1.97.1 → 1.98.0. hk pins the toolchain only on Linux, so every invocation digest changed at once — correct behavior, but the summary line (\"no usable dep-info … and no prediction\") reads as an empty store and sent this investigation hunting for restore/path bugs. Follow-ups belong in hk (pin the toolchain on Windows/macOS) and mr-boxington-action (include toolchain identity in the generated cache key, as Swatinem/rust-cache does).

2. **A real, permanent Windows-only cache loss underneath it:** on Windows, `cc`-built dependencies hand the MSVC toolset's `-L native` directories (`C:\Program Files\...\VC\Tools\MSVC\<version>\atlmfc\lib\x64`, …) to every downstream rustc compile. Those sit outside every mapped root, so key construction, prediction recording, and publication all failed — 9 compilations per hk Windows run warned `absolute path has no stable cache mapping` / `rustc search path kind is not cacheable yet: native` and could never cache, on any toolchain.

## Fix

- For **library emits**, where a native search directory is inert (any `-l` flag already bypasses the whole invocation), an unmapped `-L native` directory now enters the key by its **literal path** instead of erroring — the same identity-over-content stance `LinkerIdentity` documents. Toolset paths are version-stamped, so a toolset update still misses. Natively linked programs keep the strict behavior, since their linker actually reads those directories. Input discovery and prediction recording skip such directories under the same rule, so the dep-info-derived key and the prediction-replayed key stay equal (covered by a round-trip test).
- New `predictions_loaded` agent stat, and a summary line for the toolchain-change shape: when a manifest was loaded but not one lookup ever happened, the session now says *\"a manifest predicting N compilations was loaded, but none matched this build; the compiler or its flags changed since they were recorded (a toolchain update does this)\"*.

`AgentStats` is `#[non_exhaustive]`, so the new field is additive. Only invocations that previously errored get new key material, so no existing cache entries are invalidated.

Also includes the regenerated `docs/cli/index.md` (`mise run render:docs` output) that the 0.5.4 release bump had left stale — `mise run check:docs` fails on main without it.

## Tests

- MSVC-shaped unmapped-directory round trip (Windows paths under `cfg!(windows)`, unix equivalents elsewhere): contents are not inputs, the literal path is key material, prediction replay derives the same action key as dep-info discovery.
- Native links still refuse unmapped native directories.
- `predictions_loaded` reflects the loaded baseline, not what a session recorded.
- The stale-manifest note fires only for the loaded-but-never-looked-up shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rustc invocation digest and prediction logic for unmapped native search paths on library builds; limited to cases that previously errored, but it is core cache-key behavior.
> 
> **Overview**
> **Library emits** (`--emit` without linking) can now cache on Windows when rustc carries MSVC toolset `-L native` paths outside mapped roots. Those directories are treated as **inert**: the invocation key uses the **literal path** instead of failing with unmapped-path errors, input discovery skips scanning them, and predictions omit them so dep-info and replayed keys stay aligned. **Native link** invocations still bypass on unmapped native search paths.
> 
> Adds **`predictions_loaded`** to agent/session stats (max baseline size when a task manifest is loaded). When many compilations are **unconsulted** with **zero lookups** but predictions were loaded, the cache summary now suggests a **stale manifest** (e.g. toolchain bump) rather than looking like an empty store.
> 
> Includes tests for the MSVC-shaped round trip, `predictions_loaded`, and the stale-manifest note; regenerates CLI docs for **0.5.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47eb6ebc885606f10bacd8cc929b454afceff6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->