### PR TITLE
fix(cc)!: keep shim diagnostics off the intercepted compiler's stderr

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -22,6 +22,14 @@ const MAX_EXECUTABLE_IDENTITY_SIZE: usize = 64 * 1024;
 const MAX_EXECUTABLE_IDENTITY_BYTES: usize = 256 * 1024;
 const TASK_ACTION_MANIFEST_VERSION: u8 = 1;
 const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
+/// Longest shim diagnostic the agent accepts, in bytes.
+const MAX_WARNING_BYTES: usize = 4 * 1024;
+/// Most distinct shim diagnostics one session surfaces before going quiet.
+///
+/// A failure mode that repeats across a build tends to repeat with the same
+/// message, which deduplication already collapses; the cap only guards
+/// against a message that embeds something unique per compilation.
+const MAX_WARNINGS: usize = 128;
 const MAX_REMOTE_TRANSFERS: usize = 64;
 const MAX_PREFETCH_TRANSFERS: usize = 48;
 const MAX_PREFETCH_ACTION_BATCH: usize = 256;
@@ -44,7 +52,7 @@ pub struct AgentRemoteCache {
 }
 
 /// Wire protocol version used between an in-process cache agent and its shims.
-pub const AGENT_PROTOCOL_VERSION: u8 = 3;
+pub const AGENT_PROTOCOL_VERSION: u8 = 4;
 /// Largest single protocol request the agent will read.
 ///
 /// Requests are small JSON objects; the largest legitimate ones carry an output
@@ -165,6 +173,22 @@ pub enum AgentRequest {
         /// Captured identity-command standard output.
         stdout: Vec<u8>,
     },
+    /// Surface a shim diagnostic through the session that owns the build.
+    ///
+    /// A shim must not print diagnostics itself: its stderr belongs to the
+    /// compiler it stands in for, and build scripts read that stream as part
+    /// of the compiler's answer -- cc-rs treats any stderr output from a flag
+    /// probe as "unsupported", which changes the flags of every compilation
+    /// that follows and, with them, every action key the build produces.
+    ///
+    /// Appended rather than grouped with the other `Record*` requests it
+    /// belongs beside: these variants carry no `repr`, so inserting one moves
+    /// the discriminant of every variant after it, and a break nobody asked
+    /// for is worth less than the grouping. New variants go here.
+    RecordWarning {
+        /// Human-readable single-line diagnostic.
+        message: String,
+    },
 }
 
 /// Local output restoration work performed by one action-cache adapter hit.
@@ -228,6 +252,11 @@ pub enum AgentEvent {
         matched: bool,
         /// Restoration work performed before rebuilding.
         restore: RestoreStats,
+    },
+    /// A shim reported a diagnostic for the session to surface.
+    Warning {
+        /// Human-readable single-line diagnostic.
+        message: String,
     },
 }
 
@@ -307,6 +336,12 @@ pub enum AgentResponse {
         /// Human-readable failure description.
         message: String,
     },
+    /// A shim diagnostic was accepted for the session to surface.
+    ///
+    /// Sits past `Error` for the reason [`AgentRequest::RecordWarning`] sits
+    /// last: anywhere earlier renumbers the variants below it. New variants go
+    /// here.
+    WarningRecorded,
 }
 
 /// Aggregate cache activity for one task session.
@@ -584,6 +619,9 @@ pub struct CacheAgent {
     remote_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    /// Distinct shim diagnostics already surfaced, so a warning that fires
+    /// once per compilation is printed once per session.
+    warnings: Arc<Mutex<BTreeSet<String>>>,
     /// Deferred remote publication, present only when the session may write.
     uploads: Option<UploadQueue>,
 }
@@ -794,6 +832,7 @@ impl CacheAgent {
             remote_transfers,
             prefetch_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_PREFETCH_TRANSFERS)),
             prefetch_tasks: Arc::new(Mutex::new(Vec::new())),
+            warnings: Arc::new(Mutex::new(BTreeSet::new())),
             uploads,
         }
     }
@@ -2186,6 +2225,7 @@ impl CacheAgent {
                 self.emit(|| AgentEvent::Unconsulted);
                 Ok(AgentResponse::UnconsultedRecorded)
             }
+            AgentRequest::RecordWarning { message } => self.record_warning(message),
             AgentRequest::RecordCompilerInvocation {
                 outcome,
                 crate_name,
@@ -2506,6 +2546,32 @@ impl CacheAgent {
 
     fn record_materialization(&self, restore: RestoreStats) {
         atomic_saturating_add(&self.stats.materialization_duration_ns, restore.duration_ns);
+    }
+
+    /// Surface a shim diagnostic on this process's stderr.
+    ///
+    /// The agent lives in the process that owns the session, so printing here
+    /// reaches the terminal running the build rather than the stderr of the
+    /// compilation the shim stands in for -- which build scripts read as part
+    /// of the compiler's answer. Deduplicated because one cause tends to fire
+    /// once per compilation, and capped so a message unique per compilation
+    /// cannot scroll the build away.
+    fn record_warning(&self, message: String) -> Result<AgentResponse> {
+        if message.is_empty()
+            || message.len() > MAX_WARNING_BYTES
+            || message.contains(['\n', '\r', '\0'])
+        {
+            bail!("invalid shim warning");
+        }
+        let mut warnings = self.warnings.lock().unwrap();
+        if !warnings.contains(&message) && warnings.len() < MAX_WARNINGS {
+            eprintln!("mbx[warning]: {message}");
+            self.emit(|| AgentEvent::Warning {
+                message: message.clone(),
+            });
+            warnings.insert(message);
+        }
+        Ok(AgentResponse::WarningRecorded)
     }
 
     fn find_action_prediction(

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -121,6 +121,88 @@ async fn records_compiler_time_by_outcome_and_crate() {
 }
 
 #[tokio::test]
+async fn surfaces_each_shim_warning_once() {
+    struct Collected(Mutex<Vec<String>>);
+    impl AgentEventObserver for Collected {
+        fn event(&self, event: AgentEvent) {
+            if let AgentEvent::Warning { message } = event {
+                self.0.lock().unwrap().push(message);
+            }
+        }
+    }
+    let directory = tempfile::tempdir().unwrap();
+    let observer = Arc::new(Collected(Mutex::new(Vec::new())));
+    let agent = CacheAgent::new(directory.path().join("cache"), "test-version")
+        .with_observer(observer.clone());
+
+    for _ in 0..3 {
+        let response = agent
+            .respond(AgentRequest::RecordWarning {
+                message: "cc result was not restored: blob missing".into(),
+            })
+            .await;
+        assert!(matches!(response, AgentResponse::WarningRecorded));
+    }
+    // A different message is its own diagnostic, not a repeat.
+    agent
+        .respond(AgentRequest::RecordWarning {
+            message: "verification was not recorded".into(),
+        })
+        .await;
+
+    assert_eq!(
+        *observer.0.lock().unwrap(),
+        vec![
+            "cc result was not restored: blob missing".to_string(),
+            "verification was not recorded".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn rejects_malformed_shim_warnings() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+    for message in [
+        String::new(),
+        "two\nlines".into(),
+        "wide".repeat(MAX_WARNING_BYTES),
+    ] {
+        let response = agent.respond(AgentRequest::RecordWarning { message }).await;
+        assert!(matches!(response, AgentResponse::Error { .. }));
+    }
+}
+
+#[tokio::test]
+async fn stops_surfacing_shim_warnings_at_the_cap() {
+    struct Counter(AtomicU64);
+    impl AgentEventObserver for Counter {
+        fn event(&self, event: AgentEvent) {
+            if matches!(event, AgentEvent::Warning { .. }) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+    let directory = tempfile::tempdir().unwrap();
+    let observer = Arc::new(Counter(AtomicU64::new(0)));
+    let agent = CacheAgent::new(directory.path().join("cache"), "test-version")
+        .with_observer(observer.clone());
+
+    for index in 0..MAX_WARNINGS + 10 {
+        agent
+            .respond(AgentRequest::RecordWarning {
+                message: format!("unique failure {index}"),
+            })
+            .await;
+    }
+
+    assert_eq!(
+        observer.0.load(Ordering::Relaxed),
+        u64::try_from(MAX_WARNINGS).unwrap()
+    );
+}
+
+#[tokio::test]
 async fn counts_bypasses_by_reason() {
     let directory = tempfile::tempdir().unwrap();
     let agent = CacheAgent::new(directory.path().join("cache"), "test-version");

--- a/crates/mbx-cache-core/tests/agent_protocol.rs
+++ b/crates/mbx-cache-core/tests/agent_protocol.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
-const AGENT_FIXTURE: &str = include_str!("fixtures/agent-protocol-v3.jsonl");
+const AGENT_FIXTURE: &str = include_str!("fixtures/agent-protocol-v4.jsonl");
 
 fn digest() -> CacheDigest {
     CacheDigest {
@@ -84,7 +84,7 @@ fn requests() -> Vec<(&'static str, AgentRequest)> {
         (
             "request.hello",
             AgentRequest::Hello {
-                protocol: 3,
+                protocol: 4,
                 client_version: "0.3.0".into(),
             },
         ),
@@ -138,6 +138,12 @@ fn requests() -> Vec<(&'static str, AgentRequest)> {
         (
             "request.record_unconsulted",
             AgentRequest::RecordUnconsulted,
+        ),
+        (
+            "request.record_warning",
+            AgentRequest::RecordWarning {
+                message: "cc result was not restored: blob missing".into(),
+            },
         ),
         (
             "request.record_compiler_invocation",
@@ -195,7 +201,7 @@ fn responses() -> Vec<(&'static str, AgentResponse)> {
         (
             "response.hello",
             AgentResponse::Hello {
-                protocol: 3,
+                protocol: 4,
                 agent_version: "0.3.0".into(),
             },
         ),
@@ -248,6 +254,7 @@ fn responses() -> Vec<(&'static str, AgentResponse)> {
             "response.unconsulted_recorded",
             AgentResponse::UnconsultedRecorded,
         ),
+        ("response.warning_recorded", AgentResponse::WarningRecorded),
         (
             "response.compiler_invocation_recorded",
             AgentResponse::CompilerInvocationRecorded,
@@ -389,7 +396,7 @@ fn agent_protocol_v3_shapes_match_the_conformance_fixture() {
 
 #[test]
 fn protocol_constants_match_the_contract() {
-    assert_eq!(AGENT_PROTOCOL_VERSION, 3);
+    assert_eq!(AGENT_PROTOCOL_VERSION, 4);
     assert_eq!(PROTOCOL_VERSION, 1);
     assert_eq!(
         ACTION_RESULT_MEDIA_TYPE,
@@ -433,6 +440,7 @@ define_variant_coverage!(request_variant_name, EXPECTED_REQUEST_VARIANTS, AgentR
     AgentRequest::RecordActionHit { .. } => "record_action_hit",
     AgentRequest::RecordBypass { .. } => "record_bypass",
     AgentRequest::RecordUnconsulted => "record_unconsulted",
+    AgentRequest::RecordWarning { .. } => "record_warning",
     AgentRequest::RecordCompilerInvocation { .. } => "record_compiler_invocation",
     AgentRequest::RecordActionVerification { .. } => "record_action_verification",
     AgentRequest::StoreActionResult { .. } => "store_action_result",
@@ -454,6 +462,7 @@ define_variant_coverage!(response_variant_name, EXPECTED_RESPONSE_VARIANTS, Agen
     AgentResponse::ActionVerificationRecorded => "action_verification_recorded",
     AgentResponse::BypassRecorded => "bypass_recorded",
     AgentResponse::UnconsultedRecorded => "unconsulted_recorded",
+    AgentResponse::WarningRecorded => "warning_recorded",
     AgentResponse::CompilerInvocationRecorded => "compiler_invocation_recorded",
     AgentResponse::ActionStored { .. } => "action_stored",
     AgentResponse::ActionPrediction { .. } => "action_prediction",

--- a/crates/mbx-cache-core/tests/fixtures/agent-protocol-v4.jsonl
+++ b/crates/mbx-cache-core/tests/fixtures/agent-protocol-v4.jsonl
@@ -1,4 +1,4 @@
-request.hello	{"client_version":"0.3.0","protocol":3,"type":"hello"}
+request.hello	{"client_version":"0.3.0","protocol":4,"type":"hello"}
 request.begin_task	{"task":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","type":"begin_task"}
 request.commit_task	{"run":"task-run","type":"commit_task"}
 request.find_blob	{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"type":"find_blob"}
@@ -8,6 +8,7 @@ request.find_action_result	{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaa
 request.record_action_hit	{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"crate_name":"serde","restore":{"avoided_compiler_duration_ns":10,"copied_output_bytes":17,"copied_output_files":16,"duration_ns":11,"output_bytes":13,"output_files":12,"reflinked_output_bytes":15,"reflinked_output_files":14},"type":"record_action_hit"}
 request.record_bypass	{"kind":"compiler-query","type":"record_bypass"}
 request.record_unconsulted	{"type":"record_unconsulted"}
+request.record_warning	{"message":"cc result was not restored: blob missing","type":"record_warning"}
 request.record_compiler_invocation	{"crate_name":"fixture","duration_ns":19,"outcome":"miss","type":"record_compiler_invocation"}
 request.record_action_verification	{"matched":true,"restore":{"avoided_compiler_duration_ns":10,"copied_output_bytes":17,"copied_output_files":16,"duration_ns":11,"output_bytes":13,"output_files":12,"reflinked_output_bytes":15,"reflinked_output_files":14},"type":"record_action_verification"}
 request.store_action_result	{"result":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"metadata":null,"output_root":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"version":1},"type":"store_action_result"}
@@ -15,7 +16,7 @@ request.find_action_prediction	{"invocation":{"algorithm":"blake3","hash":"aaaaa
 request.record_action_prediction	{"prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"task":"task-id","type":"record_action_prediction"}
 request.find_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","type":"find_executable_identity"}
 request.store_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","stdout":[114,117,115,116,99],"type":"store_executable_identity"}
-response.hello	{"agent_version":"0.3.0","protocol":3,"type":"hello"}
+response.hello	{"agent_version":"0.3.0","protocol":4,"type":"hello"}
 response.task_begun	{"run":"task-run","type":"task_begun"}
 response.task_committed	{"type":"task_committed"}
 response.blob	{"path":"cache/blob","type":"blob"}
@@ -28,6 +29,7 @@ response.action_hit_recorded	{"type":"action_hit_recorded"}
 response.action_verification_recorded	{"type":"action_verification_recorded"}
 response.bypass_recorded	{"type":"bypass_recorded"}
 response.unconsulted_recorded	{"type":"unconsulted_recorded"}
+response.warning_recorded	{"type":"warning_recorded"}
 response.compiler_invocation_recorded	{"type":"compiler_invocation_recorded"}
 response.action_stored	{"path":"cache/action","type":"action_stored"}
 response.action_prediction	{"prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"type":"action_prediction"}

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -91,7 +91,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         ) {
             Ok(restored) => restored,
             Err(error) => {
-                eprintln!("mbx[warning]: cc result was not restored: {error:#}");
+                session::report_shim_warning(&format!("cc result was not restored: {error:#}"));
                 None
             }
         };
@@ -143,7 +143,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         let matched = cached_matches(&cached, &output);
         record_verification(matched, cached.restore);
         if !matched {
-            eprintln!("mbx[warning]: shadow verification diverged from cached output");
+            session::report_shim_warning("shadow verification diverged from cached output");
         }
     }
 
@@ -166,7 +166,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         before,
     ) {
         #[cfg(debug_assertions)]
-        eprintln!("mbx[warning]: cc result was not published: {error:#}");
+        session::report_shim_warning(&format!("cc result was not published: {error:#}"));
         #[cfg(not(debug_assertions))]
         let _ = error;
     }

--- a/crates/mbx/src/materialize.rs
+++ b/crates/mbx/src/materialize.rs
@@ -173,10 +173,10 @@ pub(crate) fn persist_outputs(staged: StagedOutputs) -> Result<()> {
                 match std::fs::remove_file(destination) {
                     Ok(()) => {}
                     Err(remove_error) if remove_error.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(remove_error) => eprintln!(
-                        "mbx[warning]: failed to roll back {}: {remove_error}",
+                    Err(remove_error) => session::report_shim_warning(&format!(
+                        "failed to roll back {}: {remove_error}",
                         destination.display()
-                    ),
+                    )),
                 }
             }
             return Err(error);
@@ -233,11 +233,11 @@ pub(crate) fn record_action_hit(action: &CacheDigest, restore: RestoreStats, cra
     match responses.map(|responses| responses.into_iter().next()) {
         Ok(Some(AgentResponse::ActionHitRecorded)) => {}
         Ok(Some(AgentResponse::Error { message })) => {
-            eprintln!("mbx[warning]: hit was not recorded: {message}");
+            session::report_shim_warning(&format!("hit was not recorded: {message}"));
         }
-        Ok(_) => eprintln!("mbx[warning]: hit was not recorded"),
+        Ok(_) => session::report_shim_warning("hit was not recorded"),
         Err(error) => {
-            eprintln!("mbx[warning]: hit was not recorded: {error:#}");
+            session::report_shim_warning(&format!("hit was not recorded: {error:#}"));
         }
     }
 }
@@ -249,11 +249,11 @@ pub(crate) fn record_verification(matched: bool, restore: RestoreStats) {
     match responses.map(|responses| responses.into_iter().next()) {
         Ok(Some(AgentResponse::ActionVerificationRecorded)) => {}
         Ok(Some(AgentResponse::Error { message })) => {
-            eprintln!("mbx[warning]: verification was not recorded: {message}");
+            session::report_shim_warning(&format!("verification was not recorded: {message}"));
         }
-        Ok(_) => eprintln!("mbx[warning]: verification was not recorded"),
+        Ok(_) => session::report_shim_warning("verification was not recorded"),
         Err(error) => {
-            eprintln!("mbx[warning]: verification was not recorded: {error:#}");
+            session::report_shim_warning(&format!("verification was not recorded: {error:#}"));
         }
     }
 }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -867,6 +867,49 @@ pub(crate) fn note(message: &str) {
     let _ = writeln!(std::io::stderr(), "{message}");
 }
 
+/// Whether this process's stderr belongs to the compiler it stands in for.
+///
+/// Set once at cc-shim entry. Build scripts read an intercepted compiler's
+/// stderr as part of its answer -- cc-rs marks a probed flag unsupported the
+/// moment anything lands there -- so one printed warning changes the flags of
+/// every compilation the build script produces afterwards, and with them
+/// every action key, orphaning the whole build's predictions.
+static STDERR_RESERVED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Declare that this process replays compiler output on stderr and must not
+/// mix its own diagnostics into it.
+pub(crate) fn reserve_stderr_for_compiler() {
+    STDERR_RESERVED.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Report a shim diagnostic without polluting a reserved stderr.
+///
+/// Delivered to the session's agent, which prints it from the process that
+/// owns the build. When the agent cannot take it, the message falls back to
+/// this process's stderr only where that stream is not the compiler's --
+/// losing a diagnostic costs a little visibility, while poisoning a configure
+/// probe costs the build its cache keys.
+pub(crate) fn report_shim_warning(message: &str) {
+    let mut message = message.replace(['\n', '\r'], "; ");
+    // Stay under the agent's acceptance limit rather than losing the whole
+    // diagnostic to it; the start of an error chain names the failure.
+    if message.len() > 2048 {
+        let end = (0..=2048).rfind(|&index| message.is_char_boundary(index));
+        message.truncate(end.unwrap_or_default());
+        message.push_str("...");
+    }
+    let delivered = matches!(
+        request_agent(&[AgentRequest::RecordWarning {
+            message: message.clone(),
+        }])
+        .map(|responses| responses.into_iter().next()),
+        Ok(Some(AgentResponse::WarningRecorded))
+    );
+    if !delivered && !STDERR_RESERVED.load(std::sync::atomic::Ordering::Relaxed) {
+        note(&format!("mbx[warning]: {message}"));
+    }
+}
+
 fn write_stats_report(path: &Path, stats: &AgentStats) -> Result<()> {
     let mut report = serde_json::to_vec_pretty(&StatsReport::from(stats))?;
     report.push(b'\n');
@@ -1715,6 +1758,10 @@ fn shim_invocation_name() -> Option<String> {
 /// shim that cannot find one falls back to the platform default rather than
 /// failing a build it was only meant to observe.
 pub fn run_cc_shim(language: CcLanguage) -> ExitCode {
+    // From here on, stderr carries only what the real compiler would have
+    // written: build scripts probe compilers by running them and reading that
+    // stream, and a diagnostic mixed into it changes what they decide.
+    reserve_stderr_for_compiler();
     let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
     let compiler = match real_compiler(language) {
         Ok(compiler) => compiler,
@@ -1730,7 +1777,7 @@ pub fn run_cc_shim(language: CcLanguage) -> ExitCode {
     // ordinary way a persisted compiler path is invoked: a build configured
     // under `mbx exec` and then built without it. Stand aside before probing
     // anything, so that costs one exec rather than a compiler query first.
-    if std::env::var_os(SOCKET_ENV).is_none() {
+    if session_socket().is_none() {
         return run_transparent_cc(compiler, arguments);
     }
     match crate::cc::compile(&compiler, &arguments, language) {
@@ -1738,7 +1785,7 @@ pub fn run_cc_shim(language: CcLanguage) -> ExitCode {
         Err(error) => {
             record_cc_bypass(&error);
             #[cfg(debug_assertions)]
-            eprintln!("mbx[warning]: cc cache bypassed: {error:#}");
+            report_shim_warning(&format!("cc cache bypassed: {error:#}"));
         }
     }
     run_transparent_cc(compiler, arguments)
@@ -2076,10 +2123,21 @@ fn append_line(path: &OsString, line: &str) -> std::io::Result<()> {
 }
 
 pub(crate) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
-    match std::env::var_os(SOCKET_ENV).filter(|socket| !socket.is_empty()) {
+    match session_socket() {
         Some(socket) => request_agent_at(&socket, requests),
         None => request_standalone_agent(requests),
     }
+}
+
+/// The session socket a shim should ask, if a session named one.
+///
+/// An empty value means the same as an absent one: there is no session to
+/// reach. Everything that asks whether this process has a session has to
+/// agree on that, because the alternatives are not equivalent for a cc shim
+/// -- a standalone agent runs in the shim itself and writes to the stderr the
+/// compiler owns, which is what [`report_shim_warning`] exists to avoid.
+fn session_socket() -> Option<OsString> {
+    std::env::var_os(SOCKET_ENV).filter(|socket| !socket.is_empty())
 }
 
 /// Serve a persistent Cargo wrapper directly from the local store.

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -14,16 +14,19 @@ the handshake and do not exchange cache requests. Adding, removing, or changing
 a request or response therefore requires incrementing `AGENT_PROTOCOL_VERSION`.
 
 `crates/mbx-cache-core/tests/agent_protocol.rs` exercises every request and
-response variant against `tests/fixtures/agent-protocol-v3.jsonl`. Its exhaustive
+response variant against `tests/fixtures/agent-protocol-v4.jsonl`. Its exhaustive
 matches make a newly added variant fail to compile until the fixture and the
 protocol-version decision are reviewed together.
 
 Agent protocol v2 added compiler-duration accounting to hits and real compiler
 invocations. v3 adds the crate name to a recorded hit plus `begin_task` and
 `commit_task`, allowing an embedded Cargo shim to create one prediction manifest
-for each real Cargo invocation. The client and agent still require exact
-protocol and application-version equality, including when different
-applications ship them.
+for each real Cargo invocation. v4 adds `record_warning`, which is how a shim
+reports a diagnostic at all: a C or C++ shim stands in for a compiler whose
+stderr its caller reads as an answer, so it cannot write there itself, and the
+agent prints each distinct message once from the process that owns the build.
+The client and agent still require exact protocol and application-version
+equality, including when different applications ship them.
 
 ## Remote cache protocol
 

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -103,6 +103,66 @@ object_in() {
   assert_success
 }
 
+@test "a bypassed compile leaves the stderr a build script reads empty" {
+  # cc-rs decides whether a flag is supported by running the compiler and
+  # checking that it wrote nothing to stderr. The shim stands in for that
+  # compiler, so anything the shim prints there is read as the compiler's
+  # answer: the flag is dropped, every later compilation carries different
+  # arguments than the build that populated the cache, and none of them match
+  # a stored key again. `-Wp,` is the trigger with the fewest moving parts --
+  # the real compiler takes it silently, and mbx bypasses rather than model
+  # what it forwards.
+  local probe_project="$BATS_TEST_TMPDIR/probe"
+  mkdir -p "$probe_project/src"
+  cat >"$probe_project/Cargo.toml" <<'EOF'
+[package]
+name = "probe-fixture"
+version = "0.1.0"
+edition = "2021"
+EOF
+  cat >"$probe_project/build.rs" <<'EOF'
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let compiler = env::var("HOST_CC")
+        .or_else(|_| env::var("CC"))
+        .unwrap_or_else(|_| "cc".into());
+    let source = out.join("flag_check.c");
+    std::fs::write(&source, "int main(void) { return 0; }").expect("probe source");
+    let output = Command::new(&compiler)
+        .arg("-Wp,-DMBX_PROBE=1")
+        .arg("-c")
+        .arg("-o")
+        .arg(out.join("flag_check.o"))
+        .arg(&source)
+        .output()
+        .expect("the C compiler should run");
+    assert!(output.status.success(), "the probe compile failed");
+    assert!(
+        output.stderr.is_empty(),
+        "the compiler wrote to stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+EOF
+  echo 'pub fn value() -> u32 { 7 }' >"$probe_project/src/lib.rs"
+  run cargo generate-lockfile --offline --manifest-path "$probe_project/Cargo.toml"
+  assert_success
+
+  local report="$BATS_TEST_TMPDIR/probe.json"
+  run env \
+    CARGO_TARGET_DIR="$BATS_TEST_TMPDIR/probe-target" \
+    MBX_STATS_REPORT="$report" \
+    "$MBX_BIN" build --offline --manifest-path "$probe_project/Cargo.toml"
+  assert_success
+
+  # Guard the guard: a fixture that stopped bypassing would pass this test
+  # without ever exercising the path that used to print.
+  run grep -F 'cc-tool-passthrough' "$report"
+  assert_success
+}
+
 @test "MBX_CC=0 leaves the build script's compiler alone" {
   local first_target="$BATS_TEST_TMPDIR/off-first"
   local second_target="$BATS_TEST_TMPDIR/off-second"


### PR DESCRIPTION
## Summary

Root-causes and fixes the macOS cache collapse visible in hk's cache benchmark: ~467 cc compilations report "could not look up … no prediction to derive an action key from" on every macOS run while Linux hits almost everything.

The chain:

1. cc-rs's `is_flag_supported` compiles `flag_check.c` through `$CC` — the mbx cc shim — and judges the flag by `status.success() && stderr.is_empty()`.
2. The shim printed `mbx[warning]: …` lines onto its own stderr, which the probe captures. One warning during the probe (a failed restore against a stale store, or a publish made unverifiable by the build script racing its own OUT_DIR) makes cc-rs conclude `-mno-omit-leaf-frame-pointer` is unsupported.
3. Every compilation that build script emits then carries different arguments than the seeding build recorded, so every cc unit's invocation digest misses its prediction — permanently, because the benchmark cache is saved once per commit key.

Diffing the invocation descriptors across a seeded rebuild of hk's libgit2-sys confirmed it: 205 of 206 cc units differed by exactly `-mno-omit-leaf-frame-pointer`.

## Fix

Shim diagnostics now travel to the session's agent (`record_warning`), which prints each distinct message once from the process that owns the build — the compilation's stderr stays exactly what the real compiler wrote. A warning the agent cannot take is dropped in a cc shim rather than printed; rustc-shim paths keep their stderr fallback, which cargo already surfaces to the user.

The two places that ask whether this process has a session now share one predicate. They disagreed about an empty `MBX_SOCKET`: the cc shim treated it as "in a session" and took the cache path, while `request_agent` treated it as "no session" and answered from an in-process agent — which writes to the stderr the compiler owns, reintroducing the same bug from the other side.

## Measured

Rebuilding hk from a seeded store in a fresh checkout (the CI shape):

| | before | after |
|---|---:|---:|
| libgit2-sys (216 cc units) | 208 unconsulted, 0 hits | **214 hits**, 2 unconsulted (the uncacheable flag probes) |
| full hk workspace | 263 hits / 254 misses / 216 unconsulted | **656 hits** / 61 misses / 10 unconsulted |

With this in the mbx release hk/mise CI pins, the macOS benchmark arm should recover its ~470 cc units per run.

## Tests

A bats fixture now probes the way cc-rs does — running the compiler and judging it by whether it wrote anything at all — and asserts the bypass it triggers actually happened, so a fixture that quietly stopped bypassing cannot pass by exercising nothing. Against the parent commit that assertion fails: the bypass path did `eprintln!` straight to the shim's stderr, and the bats suite bootstraps a debug build where that line is compiled in.

Agent-side unit tests cover deduplication, the message cap, and rejection of malformed diagnostics; the protocol conformance fixture gains golden vectors for the new pair.

`mise run ci` passes locally in full.

## Why the new variants are not `#[non_exhaustive]`

Opening these two enums would make every future variant free, and a PR already taking a declared break is the cheapest moment to do it — so it is worth saying why I did not.

`docs/protocol-compatibility.md` describes the exhaustive matches in `tests/agent_protocol.rs` as the thing that "make[s] a newly added variant fail to compile until the fixture and the protocol-version decision are reviewed together." I checked what marking them costs: the conformance test stops compiling with `E0004`, and the fix is a wildcard arm that would swallow every future variant silently. That gate is not decorative — it fired here, and following it to the fixture is what surfaced the v3→v4 decision.

There is also no runtime compatibility to buy. The handshake demands exact equality on both protocol and package version, so a mismatched shim/agent pair never exchanges a request. That is the same line the docs already draw: `Capabilities`, `BypassReason`, `AgentStats`, and `AgentEvent` are open to extension, while the canonical records stay exhaustive. `AgentEvent::Warning` is free here for exactly that reason and never appears in the semver output.

Happy to take the break instead if you would rather have the openness.

## The one red check

`public API compatibility` reports a single lint, `enum_variant_added`, naming exactly `AgentRequest::RecordWarning` and `AgentResponse::WarningRecorded`. Per `docs/protocol-compatibility.md` a deliberate break leaves it red until the release PR exists, and #103 merged in the same state; `final` aggregates it.

Two failures that were there earlier are gone rather than excused. The variants were first inserted mid-enum, which renumbered 11 existing discriminants — an unintended break, now avoided by appending them. And `docs` plus a `struct_pub_field_missing` on `AgentStats::predictions_loaded` were both artifacts of this branch predating #152/#153/#155; rebasing cleared both.

BREAKING CHANGE: the shim/agent protocol is now v4. `record_warning` and its `warning_recorded` response join `AgentRequest` and `AgentResponse`, which are deliberately exhaustive so the conformance test forces a golden vector for every variant. A shim and agent must already match on both protocol and package version, so no mixed pair is affected at runtime; embedders matching these enums exhaustively need a new arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)