### PR TITLE
ci: build the docs render before opening the release PR

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -221,6 +221,30 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
+      # Everything below the release-plz step races a human merging the release
+      # PR: once that PR is merged, a docs commit pushed to its branch is lost,
+      # and `main` ships a `docs/cli` that disagrees with the version that was
+      # just released. Regenerating the reference needs a built `mbx` to dump
+      # the usage spec, so the cache and the warm build are deliberately hoisted
+      # above the step that opens the PR. They cost the same either way; the
+      # difference is whether they are spent before the PR exists or inside the
+      # window where merging it drops the result. That is how v0.5.4 shipped
+      # with a 0.5.3 reference: the PR was merged 37s after it opened, and the
+      # render was still compiling dependencies at 57s.
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: rust
+
+      - name: Install documentation tools
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+
+      # Builds `mbx` at the version currently on `main`. The release branch
+      # differs only in version numbers and changelogs, so the render below
+      # rebuilds the workspace crates whose versions moved and reuses every
+      # cached dependency.
+      - name: Warm the documentation build
+        run: mise run bootstrap
+
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
@@ -228,10 +252,6 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-
-      - name: Install documentation tools
-        if: steps.release-plz.outputs.prs_created == 'true'
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: Update generated documentation in the release PR
         if: steps.release-plz.outputs.prs_created == 'true'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,19 +7,44 @@ hand.
 
 1. Commits land on `main`. `release-plz-pr` opens (or updates) a release PR
    that bumps versions and writes `CHANGELOG.md`.
-2. Merging that PR runs `release-plz-release`, which tags, publishes the crates
+2. The same job then pushes a `docs: update generated CLI reference` commit onto
+   that branch, because `docs/cli/index.md` carries the `mbx` version and a bump
+   leaves it stale. **Wait for it before merging** — see [Merging the release
+   PR](#merging-the-release-pr).
+3. Merging that PR runs `release-plz-release`, which tags, publishes the crates
    to crates.io, and creates the GitHub release **as a draft**.
-3. `release.yml` builds a binary per target and attaches the archives plus
+4. `release.yml` builds a binary per target and attaches the archives plus
    `SHA256SUMS` to that draft.
-4. While the binaries build, Communiqué rewrites the draft's raw changelog into
+5. While the binaries build, Communiqué rewrites the draft's raw changelog into
    release notes informed by the commits, pull requests, and diffs. If that
    optional enhancement fails, the original release-plz notes remain in place.
-5. `publish-release` waits for both paths, then undrafts it. A release is
+6. `publish-release` waits for both paths, then undrafts it. A release is
    therefore never visible without its assets, and no asset upload runs after
    immutable releases lock the tag and asset set.
 
 `release_always = false`, so a push to `main` that merely carries a version
 bump does not release — only merging a release PR does.
+
+## Merging the release PR
+
+A release PR is not complete the moment it appears. `release-plz-pr` pushes a
+second commit regenerating `docs/cli`, and that push has nowhere to land once
+the PR is merged — the branch is gone and release-plz never revisits a merged
+PR. Merging early therefore ships a reference that names the previous version,
+and `check:docs` then fails on `main` and on every pull request opened against
+it until someone regenerates by hand.
+
+That is not hypothetical: v0.5.4 was merged 37 seconds after its PR opened,
+while the render was still compiling, and `main` went red with a `0.5.3`
+reference. The job now warms the Rust cache and builds `mbx` *before* it asks
+release-plz to open the PR, so the docs commit follows within seconds rather
+than a minute. The window is small, not zero — wait for the second commit, and
+for the PR's own CI, rather than merging on sight.
+
+Requiring the `docs` check on `main` closes the rest of the gap, since the
+release PR's CI cannot be green until the regenerated reference is on the
+branch. That is a branch-protection setting, not something this repository can
+assert for itself.
 
 ## Versions
 


### PR DESCRIPTION
## Why

`release-plz-pr` already regenerates `docs/cli` and pushes it onto the release branch — that step has existed since #85 and worked on the four releases before v0.5.4. It failed for v0.5.4, which is why `main` currently ships a reference that says `**Version:** 0.5.3` against a 0.5.4 crate.

It failed because it lost a race, not because anything was misconfigured:

| time | event |
| --- | --- |
| 02:01:39 | release-plz opens #151 |
| 02:02:16 | #151 merged (37s later) |
| 02:02:36 | `render:docs` finishes, commits `9358e0d` |
| 02:02:37 | run cancelled, before `git push` |

The merge beat the docs commit by 20 seconds and the cancel finished it off. Once the PR is merged the commit has nowhere to land, and release-plz never revisits a merged PR — so the drift is permanent until someone regenerates by hand, and `check:docs` fails on `main` and on every PR opened against it in the meantime.

Of the 57 seconds, roughly 50 were `cargo` compiling dependencies: `render:docs` depends on `bootstrap`, because generating the reference means running `mbx __usage_spec__`.

## What changed

Hoist the Rust cache and a warm `mise run bootstrap` **above** the step that opens the PR. The build costs the same wall-clock either way; the difference is whether it is spent before the PR exists or inside the window where merging discards the result. After the switch to the release branch, only the workspace crates whose versions moved need rebuilding — every dependency is already in the target dir and the nscloud cache.

`mise-action` loses its `prs_created` guard as a consequence of moving above the step that produces it. That means every push to `main` now warms the build in this job even when no release PR results. That is the cost of the fix, and it runs alongside jobs that already take longer.

I checked one thing I'd flagged as a possible second gap and it isn't one: the action computes `prs_created` as `prs.length != 0` and `pr` as `prs[0]`, so gating on `pr` instead would be the identical condition. Left alone.

## What this does not do

The window is smaller, not zero. `RELEASING.md` now documents the flow's second commit and says to wait for it. The real closure is requiring the `docs` check on `main` — the release PR's CI cannot go green until the regenerated reference is on the branch, and #151 was merged while its CI was still running and already failing. That is a branch-protection setting, so it is written down rather than committed.

## Note on CI here

This branch's own `docs` job will fail for the pre-existing reason — it is based on the drifted `main`. #152 and #153 both already carry the regenerated `0.5.4` reference; once either lands, a rebase turns this green. I deliberately did not add a third copy of that one-line regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and release-process documentation only; no runtime or application code changes.
> 
> **Overview**
> Fixes a race where merging a release PR before the automated `docs/cli` commit lands leaves `main` with a stale CLI reference (as in v0.5.4).
> 
> The **release-plz-pr** job now runs Rust cache restore, `mise-action`, and **`mise run bootstrap`** *before* `release-plz` opens the PR, so `render:docs` on the release branch reuses warmed dependencies and the follow-up docs commit lands in seconds instead of ~a minute. **`mise-action`** no longer gates on `prs_created`, so every `main` push in that job pays for the warm build even when no release PR is created.
> 
> **`RELEASING.md`** documents the second docs commit in the release flow, warns maintainers to wait for it and PR CI before merging, and notes that requiring the **`docs`** check on `main` (branch protection) is the remaining safeguard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45879d0ad67e6ebeed7a8dcbaf34d5c7509a50ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->