### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "mbx-cache-core",
  "mbx-cache-rustc",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.1...mbx-cache-cargo-v0.1.2) - 2026-08-28
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.0...mbx-cache-cargo-v0.1.1) - 2026-08-28
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.1"
+version = "0.1.2"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.7.1"
+version = "0.8.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.7.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.8.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.7.1...mbx-cache-core-v0.8.0) - 2026-08-28
+
+### Fixed
+
+- *(cc)* [**breaking**] keep shim diagnostics off the intercepted compiler's stderr ([#154](https://github.com/jdx/mr-boxington/pull/154))
+- *(cache-rustc)* key inert native search directories by path ([#153](https://github.com/jdx/mr-boxington/pull/153))
+
+### Other
+
+- stop rereading cached artifacts on warm hits ([#152](https://github.com/jdx/mr-boxington/pull/152))
+
 ## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.7.0...mbx-cache-core-v0.7.1) - 2026-08-28
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.7.1"
+version = "0.8.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.7.1...mbx-cache-rustc-v0.8.0) - 2026-08-28
+
+### Fixed
+
+- *(cache-rustc)* key inert native search directories by path ([#153](https://github.com/jdx/mr-boxington/pull/153))
+
 ## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.7.0...mbx-cache-rustc-v0.7.1) - 2026-08-28
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.7.1"
+version = "0.8.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.1...mbx-cache-store-v0.1.2) - 2026-08-28
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.0...mbx-cache-store-v0.1.1) - 2026-08-28
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.1"
+version = "0.1.2"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/jdx/mr-boxington/compare/v0.5.4...v0.6.0) - 2026-08-28
+
+### Fixed
+
+- *(cc)* [**breaking**] keep shim diagnostics off the intercepted compiler's stderr ([#154](https://github.com/jdx/mr-boxington/pull/154))
+- *(mbx)* bump the stats report version for the new field ([#157](https://github.com/jdx/mr-boxington/pull/157))
+- *(cache-rustc)* key inert native search directories by path ([#153](https://github.com/jdx/mr-boxington/pull/153))
+
+### Other
+
+- stop rereading cached artifacts on warm hits ([#152](https://github.com/jdx/mr-boxington/pull/152))
+
 ## [0.5.4](https://github.com/jdx/mr-boxington/compare/v0.5.3...v0.5.4) - 2026-08-28
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "0.5.4"
+version = "0.6.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ dirs = "6"
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.7.1", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.1", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.7.1", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.7.1", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.2", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.8.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.8.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.2", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx <SUBCOMMAND>`
 
-**Version:** 0.5.4
+**Version:** 0.6.0
 
 - **Usage:** `mbx <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)
* `mbx-cache-rustc`: 0.7.1 -> 0.8.0 (✓ API compatible changes)
* `mbx-cache-cc`: 0.7.1 -> 0.8.0
* `mbx`: 0.5.4 -> 0.6.0 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.1 -> 0.1.2
* `mbx-cache-store`: 0.1.1 -> 0.1.2

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentRequest:RecordWarning in /tmp/.tmphGCZaE/mr-boxington/crates/mbx-cache-core/src/agent.rs:188
  variant AgentResponse:WarningRecorded in /tmp/.tmphGCZaE/mr-boxington/crates/mbx-cache-core/src/agent.rs:344
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.8.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.7.1...mbx-cache-core-v0.8.0) - 2026-08-28

### Fixed

- *(cc)* [**breaking**] keep shim diagnostics off the intercepted compiler's stderr ([#154](https://github.com/jdx/mr-boxington/pull/154))
- *(cache-rustc)* key inert native search directories by path ([#153](https://github.com/jdx/mr-boxington/pull/153))

### Other

- stop rereading cached artifacts on warm hits ([#152](https://github.com/jdx/mr-boxington/pull/152))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.8.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.7.1...mbx-cache-rustc-v0.8.0) - 2026-08-28

### Fixed

- *(cache-rustc)* key inert native search directories by path ([#153](https://github.com/jdx/mr-boxington/pull/153))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.7.0...mbx-cache-cc-v0.7.1) - 2026-08-28

### Added

- add Windows ARM64 support ([#147](https://github.com/jdx/mr-boxington/pull/147))
</blockquote>

## `mbx`

<blockquote>

## [0.6.0](https://github.com/jdx/mr-boxington/compare/v0.5.4...v0.6.0) - 2026-08-28

### Fixed

- *(cc)* [**breaking**] keep shim diagnostics off the intercepted compiler's stderr ([#154](https://github.com/jdx/mr-boxington/pull/154))
- *(mbx)* bump the stats report version for the new field ([#157](https://github.com/jdx/mr-boxington/pull/157))
- *(cache-rustc)* key inert native search directories by path ([#153](https://github.com/jdx/mr-boxington/pull/153))

### Other

- stop rereading cached artifacts on warm hits ([#152](https://github.com/jdx/mr-boxington/pull/152))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.1...mbx-cache-cargo-v0.1.2) - 2026-08-28

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.1...mbx-cache-store-v0.1.2) - 2026-08-28

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Releases cache-key and restore-path changes that can shift hit/miss behavior, plus a breaking `mbx-cache-core` agent enum surface for embedders; the diff itself is versioning and docs only.
> 
> **Overview**
> **Release-only PR** (release-plz): bumps workspace crate versions, refreshes `Cargo.lock`, adds dated changelog sections, and updates the generated CLI docs version string to **0.6.0**.
> 
> Shipped under those tags (documented in changelogs, not new code in this diff): **mbx** `0.5.4` → `0.6.0`; **mbx-cache-core**, **mbx-cache-cc**, **mbx-cache-rustc** `0.7.1` → `0.8.0`; **mbx-cache-cargo** and **mbx-cache-store** `0.1.1` → `0.1.2`, with path dependency pins aligned to **mbx-cache-core** `0.8.0`.
> 
> Notable behavior called out for this release: C/C++ shim diagnostics no longer go to the intercepted compiler’s stderr (**breaking** for CC integration); rustc cache keys treat inert native search directories by path; warm cache hits skip rereading artifacts; stats report schema version bumped for a new field. **mbx-cache-core** also carries a semver-breaking public API change (new `AgentRequest::RecordWarning` / `AgentResponse::WarningRecorded` variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9dbf3372759d39cd920112a95f862dc8dfc707b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->