### PR TITLE
fix(mbx): bump the stats report version for the new field

### DIFF
--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -608,7 +608,7 @@ struct SlowCompilationReport {
 impl From<&AgentStats> for StatsReport {
     fn from(stats: &AgentStats) -> Self {
         Self {
-            version: 2,
+            version: 3,
             session_duration_ns: stats.session_duration_ns,
             lookups: stats.lookups,
             hits: stats.hits,

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -438,12 +438,16 @@ fn writes_versioned_stats_report() {
         stats.remote_blob_pack_requests = 2;
         stats.remote_blob_pack_blobs = 100;
         stats.materialization_duration_ns = 9;
+        stats.predictions_loaded = 11;
     });
 
     write_stats_report(&path, &stats).unwrap();
     let report: serde_json::Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
 
-    assert_eq!(report["version"], 2);
+    // Bumped whenever the report grows a field, so a reader can tell from the
+    // version alone which ones it may expect.
+    assert_eq!(report["version"], 3);
+    assert_eq!(report["predictions_loaded"], 11);
     assert_eq!(report["session_duration_ns"], 42);
     assert_eq!(report["hits"], 2);
     assert_eq!(report["misses"], 2);


### PR DESCRIPTION
Follow-up to #153, which landed while I was still reviewing my own diff.

`StatsReport` carries a `version` so a reader can tell which fields it may expect, and the precedent is that adding fields bumps it — [#59](https://github.com/jdx/mr-boxington/pull/59) took it from 1 to 2 when it added the compiler-time fields. #153 added `predictions_loaded` and left the version at 2, so a consumer has no way to tell a version-2 report from a version-2 report that happens to carry the new field.

This bumps it to 3 and extends `writes_versioned_stats_report` to assert both the version and the new field, which it did not cover before.

`mise run ci` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-version and test-only changes to JSON stats output; no runtime cache or build behavior.
> 
> **Overview**
> Bumps the serialized session **stats report** `version` from **2** to **3** so consumers can tell v3 reports include **`predictions_loaded`** (added in #153 while the version stayed at 2).
> 
> The **`writes_versioned_stats_report`** test now sets **`predictions_loaded`**, expects version **3**, and documents that the version increments whenever the report schema gains fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a6ac9c9e34711d0ea3f12ce4c8dec47fa037fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->