### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "mbx-cache-core",
  "mbx-cache-rustc",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "blake3",
  "eyre",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.2...mbx-cache-cargo-v0.1.3) - 2026-08-29
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.1...mbx-cache-cargo-v0.1.2) - 2026-08-28
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.2"
+version = "0.1.3"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.8.0...mbx-cache-cc-v0.9.0) - 2026-08-29
+
+### Other
+
+- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
+
 ## [0.7.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.7.0...mbx-cache-cc-v0.7.1) - 2026-08-28
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.8.0"
+version = "0.9.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.8.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.8.0...mbx-cache-core-v0.9.0) - 2026-08-29
+
+### Fixed
+
+- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))
+
+### Other
+
+- keep outputs that already hold the cached bytes ([#165](https://github.com/jdx/mr-boxington/pull/165))
+- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
+
 ## [0.8.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.7.1...mbx-cache-core-v0.8.0) - 2026-08-28
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.8.0"
+version = "0.9.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.2" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.3" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.2...mbx-cache-protocol-v0.5.3) - 2026-08-29
+
+### Fixed
+
+- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))
+
 ## [0.5.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.1...mbx-cache-protocol-v0.5.2) - 2026-08-28
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.2"
+version = "0.5.3"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.8.0...mbx-cache-rustc-v0.9.0) - 2026-08-29
+
+### Added
+
+- *(cache-rustc)* cache macOS debug links behind an oso_prefix the shim appends ([#166](https://github.com/jdx/mr-boxington/pull/166))
+
+### Fixed
+
+- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))
+- *(cache-rustc)* model -C link-arg where nothing links ([#161](https://github.com/jdx/mr-boxington/pull/161))
+
+### Other
+
+- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
+
 ## [0.8.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.7.1...mbx-cache-rustc-v0.8.0) - 2026-08-28
 
 ### Fixed

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.8.0"
+version = "0.9.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.2...mbx-cache-store-v0.1.3) - 2026-08-29
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.1...mbx-cache-store-v0.1.2) - 2026-08-28
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.2"
+version = "0.1.3"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/jdx/mr-boxington/compare/v0.6.0...v0.7.0) - 2026-08-29
+
+### Added
+
+- *(cache-rustc)* cache macOS debug links behind an oso_prefix the shim appends ([#166](https://github.com/jdx/mr-boxington/pull/166))
+- *(cli)* read the toolchain instead of forwarding it ([#159](https://github.com/jdx/mr-boxington/pull/159))
+
+### Fixed
+
+- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))
+
+### Other
+
+- keep outputs that already hold the cached bytes ([#165](https://github.com/jdx/mr-boxington/pull/165))
+- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
+- *(doctor)* reach the failure line without spawning a process ([#163](https://github.com/jdx/mr-boxington/pull/163))
+
 ## [0.6.0](https://github.com/jdx/mr-boxington/compare/v0.5.4...v0.6.0) - 2026-08-28
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "0.6.0"
+version = "0.7.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ dirs = "6"
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.8.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.2", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.8.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.8.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.3", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.3", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 0.6.0
+**Version:** 0.7.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `mbx-cache-core`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `mbx-cache-rustc`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `mbx-cache-cc`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `mbx`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.2 -> 0.1.3
* `mbx-cache-store`: 0.1.2 -> 0.1.3

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RestoreStats.reused_output_files in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-core/src/agent.rs:239
  field RestoreStats.reused_output_bytes in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-core/src/agent.rs:241

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:FileDigests in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-core/src/agent.rs:373
  variant AgentResponse:FileDigestsRecorded in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-core/src/agent.rs:378
  variant AgentRequest:FindFileDigests in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-core/src/agent.rs:200
  variant AgentRequest:RecordFileDigests in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-core/src/agent.rs:208
```

### ⚠ `mbx-cache-rustc` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  mbx_cache_rustc::RustcInvocation::discover_inputs_with_mappings takes 3 parameters in /tmp/.tmp2bguA9/mbx-cache-rustc/src/dep_info.rs:280, but now takes 4 parameters in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-rustc/src/dep_info.rs:333
  mbx_cache_rustc::RustcInputPrediction::discover takes 2 parameters in /tmp/.tmp2bguA9/mbx-cache-rustc/src/lib.rs:865, but now takes 3 parameters in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-rustc/src/lib.rs:901
```

### ⚠ `mbx-cache-cc` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  mbx_cache_cc::CcDiscoveredInputs::collect takes 3 parameters in /tmp/.tmp2bguA9/mbx-cache-cc/src/depfile.rs:150, but now takes 4 parameters in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-cc/src/depfile.rs:152
  mbx_cache_cc::CcInputPrediction::discover takes 2 parameters in /tmp/.tmp2bguA9/mbx-cache-cc/src/lib.rs:701, but now takes 3 parameters in /tmp/.tmp1jlTu1/mr-boxington/crates/mbx-cache-cc/src/lib.rs:701
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.2...mbx-cache-protocol-v0.5.3) - 2026-08-29

### Fixed

- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.9.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.8.0...mbx-cache-core-v0.9.0) - 2026-08-29

### Fixed

- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))

### Other

- keep outputs that already hold the cached bytes ([#165](https://github.com/jdx/mr-boxington/pull/165))
- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.9.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.8.0...mbx-cache-rustc-v0.9.0) - 2026-08-29

### Added

- *(cache-rustc)* cache macOS debug links behind an oso_prefix the shim appends ([#166](https://github.com/jdx/mr-boxington/pull/166))

### Fixed

- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))
- *(cache-rustc)* model -C link-arg where nothing links ([#161](https://github.com/jdx/mr-boxington/pull/161))

### Other

- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.9.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.8.0...mbx-cache-cc-v0.9.0) - 2026-08-29

### Other

- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
</blockquote>

## `mbx`

<blockquote>

## [0.7.0](https://github.com/jdx/mr-boxington/compare/v0.6.0...v0.7.0) - 2026-08-29

### Added

- *(cache-rustc)* cache macOS debug links behind an oso_prefix the shim appends ([#166](https://github.com/jdx/mr-boxington/pull/166))
- *(cli)* read the toolchain instead of forwarding it ([#159](https://github.com/jdx/mr-boxington/pull/159))

### Fixed

- *(cache-rustc)* predict a native search directory by name, not by its contents ([#162](https://github.com/jdx/mr-boxington/pull/162))

### Other

- keep outputs that already hold the cached bytes ([#165](https://github.com/jdx/mr-boxington/pull/165))
- [**breaking**] stop rehashing inputs the session already read in full ([#164](https://github.com/jdx/mr-boxington/pull/164))
- *(doctor)* reach the failure line without spawning a process ([#163](https://github.com/jdx/mr-boxington/pull/163))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.2...mbx-cache-cargo-v0.1.3) - 2026-08-29

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.2...mbx-cache-store-v0.1.3) - 2026-08-29

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The release documents breaking public API changes in cache-core/rustc/cc and cache-keying behavior; consumers must upgrade in lockstep, though this PR only changes version metadata.
> 
> **Overview**
> This is a **release-plz** cut that bumps crate versions, refreshes per-crate changelogs, updates `Cargo.lock`, and sets the generated CLI docs version to **0.7.0**. There are no functional code edits in the diff itself—the release tags work already merged on main.
> 
> **mbx 0.7.0** ships with cache and CLI improvements documented in the changelogs: macOS debug-link caching via an `oso_prefix`, the CLI **parses** `+toolchain` instead of forwarding it, native search dirs keyed **by directory name** rather than contents, skipping rewrites when restore outputs already match cached bytes, and a lighter `doctor` failure path.
> 
> **Breaking semver** for embedders of `mbx-cache-core`, `mbx-cache-rustc`, and `mbx-cache-cc`: stop rehashing inputs the session already read in full (new agent file-digest request/response variants and `RestoreStats` fields), plus extra parameters on rustc/cc input-discovery APIs. **`mbx-cache-protocol`** goes to **0.5.3** (compatible); **`mbx-cache-cargo`** and **`mbx-cache-store`** bump patch versions for the core dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c631c32bc17fb5e74d7ea124c12c8b2942da05fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->