### PR TITLE
perf: isolate the usage 6.5 upgrade cost (measurement only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,24 +2873,24 @@ dependencies = [
 
 [[package]]
 name = "usage-argv"
-version = "6.3.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb8bc2270df585912b1c3eca56c1319c441b6c4e4f977a107e93e709d5e7650"
+checksum = "8cf8735c2d0154550e8241d30579e28b2840394c7a3efaf33b28ce706babe6f4"
 
 [[package]]
 name = "usage-config"
-version = "6.3.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8c6ac7af0ff53e70e85b889acce2daaebe98a44508f34c584fa84735cf4ea3"
+checksum = "d36ebe58117e32cef4748acc757e2754c0e53a4c227f3a48e5a1fca6114f175c"
 dependencies = [
  "toml",
 ]
 
 [[package]]
 name = "usage-derive"
-version = "6.3.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ba84e10f41a34ec00b52e8a4f1c875b2811a0a4c65b0d352ab180138d6e491"
+checksum = "bfa7bc7653408788950770f2aa53f0600e025d50c8b049cdab054284436d2413"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2899,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.3.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da081ad5fff1d9a3e5d8ef4e2cb90a212fe23387682c99302f6562cb641b896f"
+checksum = "c12de82d13507fdafd64170f5f735bd5fa7778f94b1f4a55e3b66e8ea3bde301"
 dependencies = [
  "usage-argv",
  "usage-config",

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -38,7 +38,7 @@ tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync",
 toml = "1.1"
 toml_edit = "0.25"
 url = "2"
-usage = { package = "usage-rs", version = "6", features = ["config"] }
+usage = { package = "usage-rs", version = "6.5", features = ["config"] }
 usage-config = { version = "6", features = ["toml"] }
 which = "8"
 


### PR DESCRIPTION
Draft, not for merge. Measures `mbx --help` instruction counts with the usage 6.5 upgrade alone, so the +4.58% seen on jdx/mr-boxington#159 can be split between the dependency and the argument that PR declares.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no logic changes; intended for benchmarking, not merge.
> 
> **Overview**
> This PR **only bumps the `usage-rs` dependency** from **6.3.0** to **6.5.0** (via `Cargo.lock` and a tighter `usage` version constraint in `crates/mbx/Cargo.toml`: `"6"` → `"6.5"`). There are **no application or CLI code changes**.
> 
> It is a **measurement-only draft** meant to isolate how much of the ~**+4.58%** instruction-count regression on `mbx --help` (noted on the related PR) comes from the **usage upgrade alone**, separate from other argument-handling changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2cf0eaf8e1dc682e4c7a3764e4ee63e4c453a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->