### PR TITLE
fix(cache-rustc): model -C link-arg where nothing links

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -70,6 +70,8 @@ const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
     "force-frame-pointers",
     "force-unwind-tables",
     "instrument-coverage",
+    "link-arg",
+    "link-args",
     "link-dead-code",
     "link-self-contained",
     "lto",
@@ -183,6 +185,9 @@ pub enum BypassReason {
     /// A native link would embed something no other checkout can reproduce.
     #[error("native link is not reproducible across checkouts: {0}")]
     UnportableNativeLink(String),
+    /// A linked output was given an argument to pass on to its linker.
+    #[error("rustc link argument is not modeled by the cache adapter: {0}")]
+    UnmodeledLinkArgument(String),
     /// A library search-path kind is not modeled.
     #[error("rustc search path kind is not cacheable yet: {0}")]
     UnsupportedSearchPath(String),
@@ -1379,6 +1384,19 @@ impl<'a> Parser<'a> {
                     .unwrap_or_else(|| "bin".into()),
             ));
         };
+        // A link argument is handed to the linker verbatim, and its text is all
+        // the adapter has to go on. `-Clink-arg=-Tlink.x` names a linker script
+        // resolved off the search path, `-Clink-arg=-fuse-ld=lld` replaces the
+        // linker the identity in the key describes, and neither is told apart
+        // from `/STACK:8000000` by any rule short of knowing the linker's own
+        // grammar. Where nothing links there is nothing to tell apart: an rlib
+        // or an rmeta is produced without a linker invocation, so the option is
+        // inert and the key carries its text like any other codegen option.
+        if link_output != LinkOutput::Library
+            && let Some(option) = self.first_link_argument()
+        {
+            return Err(BypassReason::UnmodeledLinkArgument(option.to_owned()));
+        }
         if let Some(name) = self.parsed.iter().find_map(|argument| match argument {
             Argument::Extern { name, path: None } if name != "proc_macro" => Some(name),
             _ => None,
@@ -1404,6 +1422,19 @@ impl<'a> Parser<'a> {
 }
 
 impl Parser<'_> {
+    /// The first `-C link-arg` or `-C link-args` option in the invocation,
+    /// rendered as it appears in the action key.
+    fn first_link_argument(&self) -> Option<&str> {
+        self.parsed.iter().find_map(|argument| {
+            let Argument::Plain(value) = argument else {
+                return None;
+            };
+            let option = value.strip_prefix("--codegen=")?;
+            let name = option.split_once('=').map_or(option, |(name, _)| name);
+            matches!(name, "link-arg" | "link-args").then_some(option)
+        })
+    }
+
     /// Whether this invocation links a program for the host.
     ///
     /// An explicit `--target` bypasses even when it spells the host triple:

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -21,6 +21,10 @@ fn bypass_kinds_are_stable_and_field_independent() {
         "unportable-native-link"
     );
     assert_eq!(
+        BypassReason::UnmodeledLinkArgument("link-arg=-Tlink.x".into()).kind(),
+        "unmodeled-link-argument"
+    );
+    assert_eq!(
         BypassReason::AmbiguousOutputName(PathBuf::from("a.rlib")).kind(),
         "ambiguous-output-name"
     );
@@ -1296,4 +1300,95 @@ fn a_compilation_that_never_links_is_not_a_link() {
         RustcInvocation::parse_with(&with_debug, native_links()),
         Err(BypassReason::UnsupportedCrateType("test".into()))
     );
+}
+
+/// A `rustflags` entry in `.cargo/config.toml` reaches every compilation the
+/// target has, and nearly all of them build an rlib or an rmeta. Refusing the
+/// option outright is what left mise's Windows CI bypassing 1092 of its 1109
+/// compilations over a stack size only the linker would ever read.
+#[test]
+fn a_library_keeps_compiling_with_a_link_argument_it_never_uses() {
+    let library = |flag: &str| {
+        args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "--out-dir=target/debug/deps",
+            flag,
+            "src/lib.rs",
+        ])
+    };
+    let RustcAction { digest, bytes } =
+        RustcInvocation::parse(&library("-Clink-arg=/STACK:8000000"))
+            .unwrap()
+            .action(context(&[("src/lib.rs", "source")]))
+            .unwrap();
+    let json = String::from_utf8(bytes).unwrap();
+    assert!(
+        json.contains(r#""--codegen=link-arg=/STACK:8000000""#),
+        "the link argument belongs in the key: {json}"
+    );
+
+    // Inert here, but still keyed: the descriptor says what the command line
+    // said, and an argument dropped from it would have to be one this adapter
+    // can prove no output ever depends on.
+    let smaller_stack = RustcInvocation::parse(&library("-Clink-arg=/STACK:4000000"))
+        .unwrap()
+        .action(context(&[("src/lib.rs", "source")]))
+        .unwrap();
+    assert_ne!(digest, smaller_stack.digest);
+
+    // The plural spelling and a separated value are the same option.
+    for arguments in [
+        library("-Clink-args=-Wl,-z,now"),
+        args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata",
+            "--out-dir=target/debug/deps",
+            "-C",
+            "link-arg=/STACK:8000000",
+            "src/lib.rs",
+        ]),
+    ] {
+        assert!(
+            RustcInvocation::parse(&arguments).is_ok(),
+            "{arguments:?} should be cacheable"
+        );
+    }
+}
+
+/// Nothing in a link argument says whether it names a file, and the key never
+/// hashes one. `-Tlink.x` is a linker script found off the search path,
+/// `-fuse-ld=lld` replaces the linker the key describes, and both look exactly
+/// like the stack size that is safe to key.
+#[test]
+fn link_arguments_bypass_whatever_actually_links() {
+    for flag in ["-Clink-arg=--import-memory", "-Clink-args=-Tlink.x"] {
+        let wasm = args(&[
+            "--crate-type=bin",
+            "--emit=dep-info,link",
+            "--target=wasm32-unknown-unknown",
+            flag,
+            "src/main.rs",
+        ]);
+        assert_eq!(
+            RustcInvocation::parse(&wasm),
+            Err(BypassReason::UnmodeledLinkArgument(
+                flag.strip_prefix("-C").unwrap().into()
+            )),
+            "{flag} should not be cacheable on a wasm link"
+        );
+    }
+
+    for flag in ["-Clink-arg=-fuse-ld=lld", "-Clink-arg=/STACK:8000000"] {
+        let native = args(&["--test", "--emit=dep-info,link", flag, "src/lib.rs"]);
+        assert_eq!(
+            RustcInvocation::parse_with(&native, native_links()),
+            Err(BypassReason::UnmodeledLinkArgument(
+                flag.strip_prefix("-C").unwrap().into()
+            )),
+            "{flag} should not be cacheable on a native link"
+        );
+    }
 }


### PR DESCRIPTION
`-C link-arg` was absent from `SUPPORTED_CODEGEN_OPTIONS`, so `parse_codegen` bypassed every compilation carrying it with `unknown-codegen-option`. A `rustflags` entry in `.cargo/config.toml` reaches every compilation the target has, and nearly all of them build an rlib or an rmeta that no linker ever sees. jdx/mise sets `rustflags = ["-C", "link-arg=/STACK:8000000"]` for all Windows targets, which was enough to bypass 1092 of the 1109 compilations in its Windows CI (observed in the cache-benchmark workflow, run 33180759592, job "mbx (Windows)").

## What this does

**Accepts `-C link-arg` and `-C link-args`, keying the text like every other codegen option.** For a `LinkOutput::Library` invocation the option is inert — rustc produces the rlib or rmeta without ever invoking a linker — but it still enters the action key. Dropping an argument from the descriptor is a claim that no output can depend on it, and I would rather keep the key saying what the command line said. It costs only the sharing between builds that pass the flag and builds that do not, which is not a case that arises when the flag comes from `.cargo/config.toml`.

**Keeps bypassing wherever the invocation actually links**, with a new `unmodeled-link-argument` bypass reason instead of the old `unknown-codegen-option`.

I looked at folding link arguments into the key for wasm and native links, as the issue suggested, and could not find a sound rule. The argument reaches the linker verbatim and its text is all the key has:

- `-C link-arg=-Tlink.x` names a linker script resolved off the search path. Its content is never hashed, so a key built from the text alone would claim more than it can support. This is not a corner case — it is how every cortex-m project passes its memory layout.
- `-C link-arg=-fuse-ld=lld` replaces the linker that `LinkerIdentity` describes, and the identity is probed without the link arguments.

Neither is distinguished from `/STACK:8000000` by a shape test. Separator-based screening looked promising until `-Tlink.x`, which has no separator at all. Since native-link caching is opt-in and the wasm links here are 17 of mise's 1109 compilations, the tier is worth leaving where it is; `BypassReason`'s own doc frames the set as one that shrinks, so this can be modeled later by someone willing to teach it the linkers' grammar.

## Tests

Two new cases in `rustc_cache_tests.rs`: a library compile keeps its link argument, keys it (a different stack size is a different key), and accepts the plural spelling and the separated-value form; and a wasm link and a native link both bypass with the new reason. The new kind joins `bypass_kinds_are_stable_and_field_independent`.

`mise run ci` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rustc cache eligibility and action-key inputs for compilations with link flags; incorrect modeling could cause cache hits across incompatible link setups, but linking paths still bypass.
> 
> **Overview**
> **Treats `-C link-arg` / `-C link-args` as supported codegen options** instead of rejecting every invocation with `unknown-codegen-option`. That unblocks global `rustflags` (e.g. Windows `/STACK:…`) on the vast majority of **rlib/rmeta** builds where rustc never runs a linker.
> 
> For **`LinkOutput::Library`**, the flag stays in the **action key** like other codegen options (different stack sizes → different keys), even though the linker never sees it. For **wasm and native links**, any presence of these options still **bypasses the cache** via a new **`unmodeled-link-argument`** reason, because verbatim linker args cannot be modeled safely (scripts, `-fuse-ld`, etc.) without linker grammar.
> 
> Adds **`first_link_argument()`** in the parser and tests covering cacheable library invocations plus bypass on linked outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482fdd38f4f867380c9cfda436f056ccb4c53fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->