### PR TITLE
test(doctor): reach the failure line without spawning a process

### DIFF
--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -5,7 +5,7 @@ use crate::policy;
 use eyre::{Context, Result};
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitCode, ExitStatus};
+use std::process::{Command, ExitCode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -187,7 +187,12 @@ fn command_check(name: &'static str, command: &OsStr, toolchain: Option<&str>) -
 /// reason a toolchain query fails — most often that the toolchain is not
 /// installed — is on stderr. Reporting the exit status alone leaves the reader
 /// with a diagnostic that diagnoses nothing.
-fn failure_detail(arguments: &[String], status: ExitStatus, stderr: &[u8]) -> String {
+///
+/// The status is taken as anything printable rather than as an `ExitStatus`,
+/// which has no portable constructor: a test would otherwise have to spawn a
+/// process that fails on every platform this runs on to reach one line of
+/// formatting.
+fn failure_detail(arguments: &[String], status: impl std::fmt::Display, stderr: &[u8]) -> String {
     let stderr = String::from_utf8_lossy(stderr);
     let reason = stderr
         .lines()
@@ -397,7 +402,7 @@ mod tests {
     #[test]
     fn a_failed_version_query_reports_what_it_asked_and_why_it_failed() {
         let arguments = version_arguments(Some("1.91"));
-        let status = std::process::Command::new("false").status().unwrap();
+        let status = "exit status: 1";
 
         let detail = failure_detail(
             &arguments,
@@ -405,18 +410,16 @@ mod tests {
             b"error: toolchain '1.91' is not installed\nnote: run rustup\n",
         );
 
-        assert!(
-            detail.starts_with("+1.91 --version exited with"),
-            "{detail}"
-        );
-        assert!(
-            detail.ends_with(": error: toolchain '1.91' is not installed"),
-            "{detail}"
+        assert_eq!(
+            detail,
+            "+1.91 --version exited with exit status: 1: error: toolchain '1.91' is not installed"
         );
         // Nothing on stderr leaves the status to end the line, rather than a
         // dangling separator.
-        let quiet = failure_detail(&arguments, status, b"  \n");
-        assert!(quiet.ends_with(&status.to_string()), "{quiet}");
+        assert_eq!(
+            failure_detail(&arguments, status, b"  \n"),
+            "+1.91 --version exited with exit status: 1"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to jdx/mr-boxington#159, on a finding that landed after it merged.

`a_failed_version_query_reports_what_it_asked_and_why_it_failed` needed an `ExitStatus`, and the only way to have one is to run a process that fails — so it ran `false`. That is a Unix program, and it works on GitHub's Windows runner only because Git for Windows puts it on PATH; the test did pass there. A Windows checkout without those tools would have panicked on `unwrap` while testing one line of string formatting.

`ExitStatus` has no portable constructor, so `failure_detail` now takes anything printable and the test passes the status as text. Production behavior is unchanged — `ExitStatus` is what still reaches it from `command_check`. The assertions got stronger on the way: they compare the whole line instead of its two ends.

## Test plan

`cargo test -p mbx --lib doctor` — 5 passed, no subprocess involved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor of a helper signature with no change to doctor runtime paths beyond Display-based status formatting.
> 
> **Overview**
> **`failure_detail`** now accepts any printable status (`impl Display`) instead of **`ExitStatus`**, so doctor tests can exercise one-line failure formatting without running a failing subprocess (e.g. Unix **`false`**, which is not reliably available on all Windows setups).
> 
> Runtime behavior is unchanged: **`command_check`** still passes **`output.status`**, which formats the same way in production messages. The **`a_failed_version_query_reports_what_it_asked_and_why_it_failed`** test uses a fixed status string and **`assert_eq!`** on the full diagnostic line for both stderr-present and empty-stderr cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1c8324e130bfbf31474c639f1c19be5fe1aed81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->