### PR TITLE
perf!: stop rehashing inputs the session already read in full

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -697,7 +697,11 @@ fn a_prediction_from_a_future_schema_bypasses() {
     };
     assert_eq!(
         prediction
-            .discover(Path::new("/work/one"), &[])
+            .discover(
+                Path::new("/work/one"),
+                &[],
+                &mbx_cache_core::NoFileDigestCache
+            )
             .unwrap_err()
             .kind(),
         "unsupported-prediction"

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -188,11 +188,7 @@ impl CcDiscoveredInputs {
             if total_bytes > MAX_INPUT_BYTES {
                 return Err(CcBypassReason::TooManyInputs);
             }
-            let identity = metadata.modified().ok().map(|modified| FileIdentity {
-                path: path.clone(),
-                len: metadata.len(),
-                modified,
-            });
+            let identity = FileIdentity::describe(&path, &metadata);
             identified.push((path, identity));
         }
         let queries = identified

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -4,7 +4,9 @@ use crate::{
     CcActionContext, CcActionInput, CcBypassReason, MAX_INPUT_BYTES, MAX_MANIFEST_ENTRIES,
     MAX_PREDICTED_INPUTS, normalize_components,
 };
-use mbx_cache_core::CacheDigest;
+use mbx_cache_core::{
+    CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, RecordedFileDigest,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -151,6 +153,7 @@ impl CcDiscoveredInputs {
         working_dir: &Path,
         files: BTreeSet<PathBuf>,
         directories: BTreeSet<PathBuf>,
+        digests: &dyn FileDigestCache,
     ) -> Result<Self, CcBypassReason> {
         if !working_dir.is_absolute() {
             return Err(CcBypassReason::RelativeWorkingDirectory(
@@ -163,6 +166,13 @@ impl CcDiscoveredInputs {
         let working_dir = normalize_components(working_dir);
         let mut inputs = Vec::with_capacity(files.len() + directories.len());
         let mut total_bytes = 0_u64;
+        // Stat everything first so one batched ledger lookup can stand in for
+        // rereading headers the session already scanned and hashed. A ledger
+        // entry in the cc scope was recorded after the timestamp-macro scan
+        // passed, so a hit skips the scan for the same reason it skips the
+        // hash: the identity says the contents have not changed since both
+        // were established.
+        let mut identified = Vec::with_capacity(files.len());
         for path in files {
             let metadata = std::fs::metadata(&path).map_err(|error| CcBypassReason::InputRead {
                 path: path.clone(),
@@ -178,15 +188,55 @@ impl CcDiscoveredInputs {
             if total_bytes > MAX_INPUT_BYTES {
                 return Err(CcBypassReason::TooManyInputs);
             }
-            if contains_timestamp_macro(&path)? {
-                return Err(CcBypassReason::EmbeddedTimestampMacro(path));
-            }
-            let digest =
-                CacheDigest::blake3_file(&path).map_err(|error| CcBypassReason::InputRead {
-                    path: path.clone(),
-                    message: error.to_string(),
-                })?;
+            let identity = metadata.modified().ok().map(|modified| FileIdentity {
+                path: path.clone(),
+                len: metadata.len(),
+                modified,
+            });
+            identified.push((path, identity));
+        }
+        let queries = identified
+            .iter()
+            .filter_map(|(_, identity)| identity.clone())
+            .collect::<Vec<_>>();
+        let mut recorded = digests.find(FileDigestScope::CcInput, &queries).into_iter();
+        let mut fresh = Vec::new();
+        for (path, identity) in identified {
+            let remembered = identity
+                .as_ref()
+                .and_then(|_| recorded.next().flatten())
+                .filter(|digest| {
+                    identity
+                        .as_ref()
+                        .is_some_and(|identity| identity.len == digest.size)
+                });
+            let digest = match remembered {
+                Some(digest) => digest,
+                None => {
+                    if contains_timestamp_macro(&path)? {
+                        return Err(CcBypassReason::EmbeddedTimestampMacro(path));
+                    }
+                    let digest = CacheDigest::blake3_file(&path).map_err(|error| {
+                        CcBypassReason::InputRead {
+                            path: path.clone(),
+                            message: error.to_string(),
+                        }
+                    })?;
+                    if let Some(identity) = identity
+                        && identity.len == digest.size
+                    {
+                        fresh.push(RecordedFileDigest {
+                            file: identity,
+                            digest: digest.clone(),
+                        });
+                    }
+                    digest
+                }
+            };
             inputs.push(CcActionInput { path, digest });
+        }
+        if !fresh.is_empty() {
+            digests.record(FileDigestScope::CcInput, fresh);
         }
         let mut manifest_entries = 0_usize;
         for directory in directories {

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::manifest_snapshot;
+use mbx_cache_core::NoFileDigestCache;
 use std::collections::BTreeSet;
 
 #[test]
@@ -62,14 +63,22 @@ fn timestamp_macro_tokens_in_any_read_file_bypass() {
     let source = write(root, "a.c", "int main(void) { return 0; }\n");
     let header = write(root, "a.h", "/* built on __DATE__ */\n");
 
-    let clean =
-        CcDiscoveredInputs::collect(root, BTreeSet::from([source.clone()]), BTreeSet::new())
-            .expect("clean inputs should be discovered");
+    let clean = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([source.clone()]),
+        BTreeSet::new(),
+        &NoFileDigestCache,
+    )
+    .expect("clean inputs should be discovered");
     assert_eq!(clean.inputs.len(), 1);
 
-    let reason =
-        CcDiscoveredInputs::collect(root, BTreeSet::from([source, header]), BTreeSet::new())
-            .unwrap_err();
+    let reason = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([source, header]),
+        BTreeSet::new(),
+        &NoFileDigestCache,
+    )
+    .unwrap_err();
     assert_eq!(reason.kind(), "embedded-timestamp-macro");
 }
 
@@ -78,8 +87,13 @@ fn file_macro_alone_does_not_bypass() {
     let directory = tempfile::tempdir().expect("tempdir");
     let root = directory.path();
     let source = write(root, "a.c", "#define A() assert(__FILE__ != 0)\n");
-    let discovered = CcDiscoveredInputs::collect(root, BTreeSet::from([source]), BTreeSet::new())
-        .expect("__FILE__ is not a timestamp macro");
+    let discovered = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([source]),
+        BTreeSet::new(),
+        &NoFileDigestCache,
+    )
+    .expect("__FILE__ is not a timestamp macro");
     assert_eq!(discovered.inputs.len(), 1);
 }
 
@@ -90,8 +104,13 @@ fn a_timestamp_macro_split_across_a_read_boundary_is_still_found() {
     let mut contents = "a".repeat(SCAN_CHUNK_BYTES - 4);
     contents.push_str("__TIMESTAMP__");
     let source = write(root, "a.c", &contents);
-    let reason =
-        CcDiscoveredInputs::collect(root, BTreeSet::from([source]), BTreeSet::new()).unwrap_err();
+    let reason = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([source]),
+        BTreeSet::new(),
+        &NoFileDigestCache,
+    )
+    .unwrap_err();
     assert_eq!(reason.kind(), "embedded-timestamp-macro");
 }
 
@@ -108,6 +127,7 @@ fn include_directory_manifests_change_the_key_when_a_shadowing_header_appears() 
         root,
         BTreeSet::from([source.clone()]),
         BTreeSet::from([include.clone()]),
+        &NoFileDigestCache,
     )
     .expect("discovery");
 
@@ -118,6 +138,7 @@ fn include_directory_manifests_change_the_key_when_a_shadowing_header_appears() 
         root,
         BTreeSet::from([source]),
         BTreeSet::from([include.clone()]),
+        &NoFileDigestCache,
     )
     .expect("discovery");
 
@@ -147,6 +168,7 @@ fn a_missing_include_directory_has_an_empty_manifest_rather_than_an_error() {
         root,
         BTreeSet::from([source]),
         BTreeSet::from([root.join("absent")]),
+        &NoFileDigestCache,
     )
     .expect("a directory that does not exist yet is not an error");
     assert_eq!(discovered.inputs.len(), 2);
@@ -157,9 +179,13 @@ fn discovery_rejects_inputs_modified_during_compilation() {
     let directory = tempfile::tempdir().expect("tempdir");
     let root = directory.path();
     let source = write(root, "a.c", "int a(void) { return 0; }\n");
-    let discovered =
-        CcDiscoveredInputs::collect(root, BTreeSet::from([source.clone()]), BTreeSet::new())
-            .expect("discovery");
+    let discovered = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([source.clone()]),
+        BTreeSet::new(),
+        &NoFileDigestCache,
+    )
+    .expect("discovery");
 
     // A file written before the compile started is what produced the object.
     assert!(
@@ -184,9 +210,14 @@ fn discovery_rejects_inputs_modified_during_compilation() {
 #[test]
 fn discovery_requires_an_absolute_working_directory() {
     assert_eq!(
-        CcDiscoveredInputs::collect(Path::new("relative"), BTreeSet::new(), BTreeSet::new())
-            .unwrap_err()
-            .kind(),
+        CcDiscoveredInputs::collect(
+            Path::new("relative"),
+            BTreeSet::new(),
+            BTreeSet::new(),
+            &NoFileDigestCache,
+        )
+        .unwrap_err()
+        .kind(),
         "relative-working-directory"
     );
 }
@@ -298,4 +329,73 @@ fn a_precompiled_header_appearing_beside_its_header_changes_the_manifest() {
         );
         std::fs::remove_file(include.join(precompiled)).expect("remove");
     }
+}
+
+/// A ledger that vouches for one cc input identity.
+struct VouchingLedger {
+    known: mbx_cache_core::FileIdentity,
+    digest: CacheDigest,
+}
+
+impl mbx_cache_core::FileDigestCache for VouchingLedger {
+    fn find(
+        &self,
+        scope: mbx_cache_core::FileDigestScope,
+        files: &[mbx_cache_core::FileIdentity],
+    ) -> Vec<Option<CacheDigest>> {
+        assert_eq!(scope, mbx_cache_core::FileDigestScope::CcInput);
+        files
+            .iter()
+            .map(|file| (*file == self.known).then(|| self.digest.clone()))
+            .collect()
+    }
+
+    fn record(
+        &self,
+        _scope: mbx_cache_core::FileDigestScope,
+        _entries: Vec<mbx_cache_core::RecordedFileDigest>,
+    ) {
+    }
+}
+
+#[test]
+fn a_vouched_cc_input_skips_the_scan_it_already_passed() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let root = directory.path();
+    // The macro token would bypass on a first encounter; a cc-scope ledger
+    // entry says this exact identity already passed the scan, so neither the
+    // scan nor the hash reads the file again.
+    let source = write(root, "a.c", "/* __DATE__ */ int main(void) { return 0; }\n");
+    let metadata = std::fs::metadata(&source).expect("metadata");
+    let digest = CacheDigest {
+        algorithm: "blake3".into(),
+        hash: "d".repeat(64),
+        size: metadata.len(),
+    };
+    let ledger = VouchingLedger {
+        known: mbx_cache_core::FileIdentity {
+            path: source.clone(),
+            len: metadata.len(),
+            modified: metadata.modified().expect("mtime"),
+        },
+        digest: digest.clone(),
+    };
+
+    let discovered = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([source.clone()]),
+        BTreeSet::new(),
+        &ledger,
+    )
+    .expect("the vouched identity answers without a scan");
+    assert_eq!(discovered.inputs.len(), 1);
+    assert_eq!(discovered.inputs[0].digest, digest);
+
+    // Rewrite the file to a new length: the identity no longer matches, so
+    // the scan runs and the macro token bypasses again.
+    std::fs::write(&source, "/* __DATE__ */ int main(void) { return 12345; }\n").expect("rewrite");
+    let reason =
+        CcDiscoveredInputs::collect(root, BTreeSet::from([source]), BTreeSet::new(), &ledger)
+            .unwrap_err();
+    assert_eq!(reason.kind(), "embedded-timestamp-macro");
 }

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -373,11 +373,7 @@ fn a_vouched_cc_input_skips_the_scan_it_already_passed() {
         size: metadata.len(),
     };
     let ledger = VouchingLedger {
-        known: mbx_cache_core::FileIdentity {
-            path: source.clone(),
-            len: metadata.len(),
-            modified: metadata.modified().expect("mtime"),
-        },
+        known: mbx_cache_core::FileIdentity::describe(&source, &metadata).expect("identity"),
         digest: digest.clone(),
     };
 

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -17,7 +17,7 @@
 //! roots are checkout-specific.
 #![deny(missing_docs)]
 
-use mbx_cache_core::{CacheDigest, canonical_json};
+use mbx_cache_core::{CacheDigest, FileDigestCache, canonical_json};
 use mbx_cache_rustc::{BypassReason as RustcBypassReason, PathMapping, normalize_mapped_path};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -702,6 +702,7 @@ impl CcInputPrediction {
         &self,
         working_dir: &Path,
         path_mappings: &[PathMapping],
+        digests: &dyn FileDigestCache,
     ) -> Result<CcDiscoveredInputs, CcBypassReason> {
         if self.version != 1 {
             return Err(CcBypassReason::UnsupportedPrediction);
@@ -722,7 +723,7 @@ impl CcInputPrediction {
                 }
             }
         }
-        CcDiscoveredInputs::collect(working_dir, files, directories)
+        CcDiscoveredInputs::collect(working_dir, files, directories, digests)
     }
 }
 

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -30,6 +30,13 @@ const MAX_WARNING_BYTES: usize = 4 * 1024;
 /// message, which deduplication already collapses; the cap only guards
 /// against a message that embeds something unique per compilation.
 const MAX_WARNINGS: usize = 128;
+/// Most file identities one digest lookup or record may carry.
+const MAX_FILE_DIGEST_BATCH: usize = 16 * 1024;
+/// Most recorded file digests one session retains across every scope.
+///
+/// Roughly two orders of magnitude above the largest workspace measured; the
+/// cap exists so a pathological build bounds the agent instead of growing it.
+const MAX_FILE_DIGEST_ENTRIES: usize = 1024 * 1024;
 const MAX_REMOTE_TRANSFERS: usize = 64;
 const MAX_PREFETCH_TRANSFERS: usize = 48;
 const MAX_PREFETCH_ACTION_BATCH: usize = 256;
@@ -52,7 +59,7 @@ pub struct AgentRemoteCache {
 }
 
 /// Wire protocol version used between an in-process cache agent and its shims.
-pub const AGENT_PROTOCOL_VERSION: u8 = 4;
+pub const AGENT_PROTOCOL_VERSION: u8 = 5;
 /// Largest single protocol request the agent will read.
 ///
 /// Requests are small JSON objects; the largest legitimate ones carry an output
@@ -188,6 +195,21 @@ pub enum AgentRequest {
     RecordWarning {
         /// Human-readable single-line diagnostic.
         message: String,
+    },
+    /// Find session-recorded digests for files with these identities.
+    FindFileDigests {
+        /// What the recorded digests may stand in for.
+        scope: FileDigestScope,
+        /// File identities to resolve, preserving request order in the
+        /// response.
+        files: Vec<FileIdentity>,
+    },
+    /// Record digests of files a shim hashed or wrote this session.
+    RecordFileDigests {
+        /// What the recorded digests may stand in for.
+        scope: FileDigestScope,
+        /// Hashed files and the identities their digests describe.
+        entries: Vec<RecordedFileDigest>,
     },
 }
 
@@ -342,6 +364,13 @@ pub enum AgentResponse {
     /// last: anywhere earlier renumbers the variants below it. New variants go
     /// here.
     WarningRecorded,
+    /// Digests recorded earlier for the requested file identities.
+    FileDigests {
+        /// Recorded digests or misses, in request order.
+        digests: Vec<Option<CacheDigest>>,
+    },
+    /// File digests were recorded.
+    FileDigestsRecorded,
 }
 
 /// Aggregate cache activity for one task session.
@@ -622,6 +651,9 @@ pub struct CacheAgent {
     /// Distinct shim diagnostics already surfaced, so a warning that fires
     /// once per compilation is printed once per session.
     warnings: Arc<Mutex<BTreeSet<String>>>,
+    /// Digests of files shims hashed or wrote this session, keyed by scope and
+    /// path, each entry standing while its recorded identity matches the disk.
+    file_digests: Arc<Mutex<BTreeMap<(FileDigestScope, PathBuf), RecordedFileDigest>>>,
     /// Deferred remote publication, present only when the session may write.
     uploads: Option<UploadQueue>,
 }
@@ -662,6 +694,74 @@ impl UploadSink for AgentUploadSink {
             .fetch_add(1, Ordering::Relaxed);
         self.stats.remote_failures.fetch_add(1, Ordering::Relaxed);
     }
+}
+
+/// The on-disk identity a recorded file digest describes.
+///
+/// The same trade [`VerifiedBlob`] makes for CAS reads, offered to shims for
+/// the files they hash: an overwrite moves the modification time and a
+/// truncation changes the length, so a digest recorded against both stands
+/// until either does. Only a replacement that reproduces both goes unnoticed,
+/// which is the freshness model the surrounding build tool already lives on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileIdentity {
+    /// Absolute path of the file.
+    pub path: PathBuf,
+    /// Length of the file in bytes.
+    pub len: u64,
+    /// Modification time of the file.
+    pub modified: SystemTime,
+}
+
+/// A file digest recorded against the identity it was read under.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecordedFileDigest {
+    /// Identity of the file when its contents were hashed.
+    pub file: FileIdentity,
+    /// Digest of those contents.
+    pub digest: CacheDigest,
+}
+
+/// What a recorded file digest may stand in for.
+///
+/// Adapters prove different things when they read a file: the cc adapter's
+/// input scan also establishes that a source embeds no timestamp macro, which
+/// a digest recorded by the rustc adapter never checked. Scoping the ledger
+/// keeps one adapter's shortcut from resting on a property another adapter
+/// never established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileDigestScope {
+    /// The digest describes the file's contents and nothing more.
+    Content,
+    /// The digest describes a cc compiler input that also passed the
+    /// timestamp-macro scan.
+    CcInput,
+}
+
+/// Recorded digests a session may consult instead of rehashing a file.
+///
+/// The agent's file-digest ledger answers through this everywhere a caller
+/// holds one; the no-op implementation stands in where reuse must not happen,
+/// such as under verification.
+pub trait FileDigestCache: Send + Sync {
+    /// Recorded digests for these identities, in request order.
+    fn find(&self, scope: FileDigestScope, files: &[FileIdentity]) -> Vec<Option<CacheDigest>>;
+    /// Record digests for files read under these identities.
+    fn record(&self, scope: FileDigestScope, entries: Vec<RecordedFileDigest>);
+}
+
+/// A [`FileDigestCache`] that remembers nothing and finds nothing.
+pub struct NoFileDigestCache;
+
+impl FileDigestCache for NoFileDigestCache {
+    fn find(&self, _scope: FileDigestScope, files: &[FileIdentity]) -> Vec<Option<CacheDigest>> {
+        vec![None; files.len()]
+    }
+
+    fn record(&self, _scope: FileDigestScope, _entries: Vec<RecordedFileDigest>) {}
 }
 
 /// A CAS blob whose contents this session hashed, and the file identity that
@@ -833,6 +933,7 @@ impl CacheAgent {
             prefetch_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_PREFETCH_TRANSFERS)),
             prefetch_tasks: Arc::new(Mutex::new(Vec::new())),
             warnings: Arc::new(Mutex::new(BTreeSet::new())),
+            file_digests: Arc::new(Mutex::new(BTreeMap::new())),
             uploads,
         }
     }
@@ -2226,6 +2327,10 @@ impl CacheAgent {
                 Ok(AgentResponse::UnconsultedRecorded)
             }
             AgentRequest::RecordWarning { message } => self.record_warning(message),
+            AgentRequest::FindFileDigests { scope, files } => self.find_file_digests(scope, files),
+            AgentRequest::RecordFileDigests { scope, entries } => {
+                self.record_file_digests(scope, entries)
+            }
             AgentRequest::RecordCompilerInvocation {
                 outcome,
                 crate_name,
@@ -2572,6 +2677,65 @@ impl CacheAgent {
             warnings.insert(message);
         }
         Ok(AgentResponse::WarningRecorded)
+    }
+
+    /// Answer file-digest lookups from the session ledger.
+    ///
+    /// A recorded digest is returned only when the requested identity matches
+    /// the recorded one exactly. The caller statted the file to build the
+    /// identity, so this is the [`VerifiedBlob`] freshness check with the
+    /// stat moved to the side that was already making it.
+    fn find_file_digests(
+        &self,
+        scope: FileDigestScope,
+        files: Vec<FileIdentity>,
+    ) -> Result<AgentResponse> {
+        if files.len() > MAX_FILE_DIGEST_BATCH {
+            bail!("too many file-digest lookups in one request");
+        }
+        let ledger = self.file_digests.lock().unwrap();
+        let digests = files
+            .into_iter()
+            .map(|file| {
+                let recorded = ledger.get(&(scope, file.path.clone()))?;
+                (recorded.file == file).then(|| recorded.digest.clone())
+            })
+            .collect();
+        Ok(AgentResponse::FileDigests { digests })
+    }
+
+    /// Record digests of files a shim read in full, for later reuse.
+    ///
+    /// Capped rather than evicted: a session that outgrows the cap loses the
+    /// shortcut for the overflow and nothing else, and no workload observed so
+    /// far comes near it.
+    fn record_file_digests(
+        &self,
+        scope: FileDigestScope,
+        entries: Vec<RecordedFileDigest>,
+    ) -> Result<AgentResponse> {
+        if entries.len() > MAX_FILE_DIGEST_BATCH {
+            bail!("too many file-digest records in one request");
+        }
+        for entry in &entries {
+            if !entry.file.path.is_absolute() {
+                bail!("file-digest records need absolute paths");
+            }
+            entry.digest.validate()?;
+            if entry.file.len != entry.digest.size {
+                bail!("file-digest record length does not match its digest");
+            }
+        }
+        let mut ledger = self.file_digests.lock().unwrap();
+        for entry in entries {
+            if ledger.len() >= MAX_FILE_DIGEST_ENTRIES
+                && !ledger.contains_key(&(scope, entry.file.path.clone()))
+            {
+                break;
+            }
+            ledger.insert((scope, entry.file.path.clone()), entry);
+        }
+        Ok(AgentResponse::FileDigestsRecorded)
     }
 
     fn find_action_prediction(

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -701,8 +701,11 @@ impl UploadSink for AgentUploadSink {
 /// The same trade [`VerifiedBlob`] makes for CAS reads, offered to shims for
 /// the files they hash: an overwrite moves the modification time and a
 /// truncation changes the length, so a digest recorded against both stands
-/// until either does. Only a replacement that reproduces both goes unnoticed,
-/// which is the freshness model the surrounding build tool already lives on.
+/// until either does. Where the platform reports a metadata-change time the
+/// identity carries that too, and it is the part a writer cannot restore: a
+/// rewrite that puts the modification time back still moves the change time,
+/// so only filesystems without one fall back to the freshness model the
+/// surrounding build tool already lives on.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileIdentity {
@@ -712,6 +715,35 @@ pub struct FileIdentity {
     pub len: u64,
     /// Modification time of the file.
     pub modified: SystemTime,
+    /// Platform metadata-change token, where one exists.
+    pub changed: Option<(i64, i64)>,
+}
+
+impl FileIdentity {
+    /// Describe a file from metadata already in hand, or nothing when the
+    /// filesystem reports no modification time to compare against later.
+    pub fn describe(path: &Path, metadata: &std::fs::Metadata) -> Option<Self> {
+        Some(Self {
+            path: path.to_path_buf(),
+            len: metadata.len(),
+            modified: metadata.modified().ok()?,
+            changed: change_token(metadata),
+        })
+    }
+}
+
+/// The metadata-change time as an opaque token, where the platform has one.
+#[cfg(unix)]
+fn change_token(metadata: &std::fs::Metadata) -> Option<(i64, i64)> {
+    use std::os::unix::fs::MetadataExt;
+    Some((metadata.ctime(), metadata.ctime_nsec()))
+}
+
+/// Windows reports creation rather than metadata-change time, which a rewrite
+/// does not move, so no token is better than a misleading one.
+#[cfg(not(unix))]
+fn change_token(_metadata: &std::fs::Metadata) -> Option<(i64, i64)> {
+    None
 }
 
 /// A file digest recorded against the identity it was read under.

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -3358,12 +3358,14 @@ fn recognizes_only_well_formed_task_identities() {
 }
 
 fn ledger_identity(path: &str, len: u64, nanos: u32) -> FileIdentity {
-    // Rooted per platform so `is_absolute` holds on both.
+    // Rooted per platform so `is_absolute` holds on both, and timed in
+    // multiples of 100ns so Windows file-time resolution keeps two distinct
+    // nanos values distinct.
     let root = if cfg!(windows) { "C:\\" } else { "/" };
     FileIdentity {
         path: PathBuf::from(format!("{root}{path}")),
         len,
-        modified: SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, nanos),
+        modified: SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, nanos * 100),
         changed: Some((1_700_000_000, nanos.into())),
     }
 }

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -3358,10 +3358,13 @@ fn recognizes_only_well_formed_task_identities() {
 }
 
 fn ledger_identity(path: &str, len: u64, nanos: u32) -> FileIdentity {
+    // Rooted per platform so `is_absolute` holds on both.
+    let root = if cfg!(windows) { "C:\\" } else { "/" };
     FileIdentity {
-        path: PathBuf::from(path),
+        path: PathBuf::from(format!("{root}{path}")),
         len,
         modified: SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, nanos),
+        changed: Some((1_700_000_000, nanos.into())),
     }
 }
 
@@ -3377,7 +3380,7 @@ fn ledger_digest(len: u64) -> CacheDigest {
 async fn file_digest_ledger_answers_only_matching_identities() {
     let directory = tempfile::tempdir().unwrap();
     let agent = CacheAgent::new(directory.path(), "test-version");
-    let file = ledger_identity("/work/target/libserde.rlib", 7, 21);
+    let file = ledger_identity("work/target/libserde.rlib", 7, 21);
 
     let response = agent
         .respond(AgentRequest::RecordFileDigests {
@@ -3396,9 +3399,9 @@ async fn file_digest_ledger_answers_only_matching_identities() {
             scope: FileDigestScope::Content,
             files: vec![
                 file.clone(),
-                ledger_identity("/work/target/libserde.rlib", 7, 22),
-                ledger_identity("/work/target/libserde.rlib", 8, 21),
-                ledger_identity("/work/target/absent.rlib", 7, 21),
+                ledger_identity("work/target/libserde.rlib", 7, 22),
+                ledger_identity("work/target/libserde.rlib", 8, 21),
+                ledger_identity("work/target/absent.rlib", 7, 21),
             ],
         })
         .await;
@@ -3416,7 +3419,7 @@ async fn file_digest_ledger_answers_only_matching_identities() {
 async fn file_digest_ledger_scopes_do_not_answer_for_each_other() {
     let directory = tempfile::tempdir().unwrap();
     let agent = CacheAgent::new(directory.path(), "test-version");
-    let file = ledger_identity("/work/vendor/header.h", 7, 21);
+    let file = ledger_identity("work/vendor/header.h", 7, 21);
 
     agent
         .respond(AgentRequest::RecordFileDigests {
@@ -3460,7 +3463,10 @@ async fn file_digest_records_are_validated() {
         .respond(AgentRequest::RecordFileDigests {
             scope: FileDigestScope::Content,
             entries: vec![RecordedFileDigest {
-                file: ledger_identity("relative/libserde.rlib", 7, 21),
+                file: FileIdentity {
+                    path: PathBuf::from("relative/libserde.rlib"),
+                    ..ledger_identity("work/libserde.rlib", 7, 21)
+                },
                 digest: ledger_digest(7),
             }],
         })
@@ -3471,7 +3477,7 @@ async fn file_digest_records_are_validated() {
         .respond(AgentRequest::RecordFileDigests {
             scope: FileDigestScope::Content,
             entries: vec![RecordedFileDigest {
-                file: ledger_identity("/work/libserde.rlib", 8, 21),
+                file: ledger_identity("work/libserde.rlib", 8, 21),
                 digest: ledger_digest(7),
             }],
         })

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -3356,3 +3356,128 @@ fn recognizes_only_well_formed_task_identities() {
     assert!(!is_task_identity(&"a".repeat(63)));
     assert!(!is_task_identity(""));
 }
+
+fn ledger_identity(path: &str, len: u64, nanos: u32) -> FileIdentity {
+    FileIdentity {
+        path: PathBuf::from(path),
+        len,
+        modified: SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, nanos),
+    }
+}
+
+fn ledger_digest(len: u64) -> CacheDigest {
+    CacheDigest {
+        algorithm: "blake3".into(),
+        hash: "b".repeat(64),
+        size: len,
+    }
+}
+
+#[tokio::test]
+async fn file_digest_ledger_answers_only_matching_identities() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = CacheAgent::new(directory.path(), "test-version");
+    let file = ledger_identity("/work/target/libserde.rlib", 7, 21);
+
+    let response = agent
+        .respond(AgentRequest::RecordFileDigests {
+            scope: FileDigestScope::Content,
+            entries: vec![RecordedFileDigest {
+                file: file.clone(),
+                digest: ledger_digest(7),
+            }],
+        })
+        .await;
+    assert!(matches!(response, AgentResponse::FileDigestsRecorded));
+
+    // The exact identity answers; a touched or truncated file does not.
+    let response = agent
+        .respond(AgentRequest::FindFileDigests {
+            scope: FileDigestScope::Content,
+            files: vec![
+                file.clone(),
+                ledger_identity("/work/target/libserde.rlib", 7, 22),
+                ledger_identity("/work/target/libserde.rlib", 8, 21),
+                ledger_identity("/work/target/absent.rlib", 7, 21),
+            ],
+        })
+        .await;
+    let AgentResponse::FileDigests { digests } = response else {
+        panic!("expected file digests");
+    };
+    assert_eq!(
+        digests,
+        vec![Some(ledger_digest(7)), None, None, None],
+        "only the recorded identity may answer"
+    );
+}
+
+#[tokio::test]
+async fn file_digest_ledger_scopes_do_not_answer_for_each_other() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = CacheAgent::new(directory.path(), "test-version");
+    let file = ledger_identity("/work/vendor/header.h", 7, 21);
+
+    agent
+        .respond(AgentRequest::RecordFileDigests {
+            scope: FileDigestScope::Content,
+            entries: vec![RecordedFileDigest {
+                file: file.clone(),
+                digest: ledger_digest(7),
+            }],
+        })
+        .await;
+
+    // A content digest never vouches for the cc input scan.
+    let response = agent
+        .respond(AgentRequest::FindFileDigests {
+            scope: FileDigestScope::CcInput,
+            files: vec![file.clone()],
+        })
+        .await;
+    assert!(
+        matches!(response, AgentResponse::FileDigests { digests } if digests == vec![None]),
+        "scopes must not answer for each other"
+    );
+
+    let response = agent
+        .respond(AgentRequest::FindFileDigests {
+            scope: FileDigestScope::Content,
+            files: vec![file],
+        })
+        .await;
+    assert!(
+        matches!(response, AgentResponse::FileDigests { digests } if digests == vec![Some(ledger_digest(7))])
+    );
+}
+
+#[tokio::test]
+async fn file_digest_records_are_validated() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = CacheAgent::new(directory.path(), "test-version");
+
+    let response = agent
+        .respond(AgentRequest::RecordFileDigests {
+            scope: FileDigestScope::Content,
+            entries: vec![RecordedFileDigest {
+                file: ledger_identity("relative/libserde.rlib", 7, 21),
+                digest: ledger_digest(7),
+            }],
+        })
+        .await;
+    assert!(matches!(response, AgentResponse::Error { .. }));
+
+    let response = agent
+        .respond(AgentRequest::RecordFileDigests {
+            scope: FileDigestScope::Content,
+            entries: vec![RecordedFileDigest {
+                file: ledger_identity("/work/libserde.rlib", 8, 21),
+                digest: ledger_digest(7),
+            }],
+        })
+        .await;
+    assert!(
+        matches!(response, AgentResponse::Error { .. }),
+        "a length that disagrees with the digest must be refused"
+    );
+}

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -46,7 +46,8 @@ mod uploads;
 
 pub use agent::{
     AGENT_PROTOCOL_VERSION, AgentEvent, AgentEventObserver, AgentRemoteCache, AgentRequest,
-    AgentResponse, AgentStats, CacheAgent, CompilerStats, RestoreStats, is_task_identity,
+    AgentResponse, AgentStats, CacheAgent, CompilerStats, FileDigestCache, FileDigestScope,
+    FileIdentity, NoFileDigestCache, RecordedFileDigest, RestoreStats, is_task_identity,
     task_manifest_actions,
 };
 pub use client::BlockingAgentClient;

--- a/crates/mbx-cache-core/tests/agent_protocol.rs
+++ b/crates/mbx-cache-core/tests/agent_protocol.rs
@@ -56,6 +56,7 @@ fn file_identity() -> FileIdentity {
         path: PathBuf::from("target/debug/deps/libserde.rlib"),
         len: 7,
         modified: std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(1_700_000_000, 21),
+        changed: Some((1_700_000_000, 21)),
     }
 }
 

--- a/crates/mbx-cache-core/tests/agent_protocol.rs
+++ b/crates/mbx-cache-core/tests/agent_protocol.rs
@@ -55,7 +55,10 @@ fn file_identity() -> FileIdentity {
     FileIdentity {
         path: PathBuf::from("target/debug/deps/libserde.rlib"),
         len: 7,
-        modified: std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(1_700_000_000, 21),
+        // A multiple of 100ns: Windows file times carry no finer resolution,
+        // and a value it truncates would give this fixture two spellings.
+        modified: std::time::SystemTime::UNIX_EPOCH
+            + std::time::Duration::new(1_700_000_000, 2_100),
         changed: Some((1_700_000_000, 21)),
     }
 }

--- a/crates/mbx-cache-core/tests/agent_protocol.rs
+++ b/crates/mbx-cache-core/tests/agent_protocol.rs
@@ -2,14 +2,15 @@ use mbx_cache_core::{
     ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, AGENT_PROTOCOL_VERSION,
     ActionPrediction, AgentRequest, AgentResponse, BLOB_MEDIA_TYPE, BLOB_PACK_MEDIA_TYPE,
     BLOB_PACK_RECEIPT_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, CacheDigest, CacheDirectory,
-    CacheFileNode, CcMetadata, DIRECTORY_MEDIA_TYPE, PROTOCOL_VERSION, RemoteActionResult,
-    RestoreStats, RustcMetadata, TASK_ACTION_MANIFEST_MEDIA_TYPE, canonical_json,
+    CacheFileNode, CcMetadata, DIRECTORY_MEDIA_TYPE, FileDigestScope, FileIdentity,
+    PROTOCOL_VERSION, RecordedFileDigest, RemoteActionResult, RestoreStats, RustcMetadata,
+    TASK_ACTION_MANIFEST_MEDIA_TYPE, canonical_json,
 };
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
-const AGENT_FIXTURE: &str = include_str!("fixtures/agent-protocol-v4.jsonl");
+const AGENT_FIXTURE: &str = include_str!("fixtures/agent-protocol-v5.jsonl");
 
 fn digest() -> CacheDigest {
     CacheDigest {
@@ -50,6 +51,14 @@ fn prediction() -> ActionPrediction {
     }
 }
 
+fn file_identity() -> FileIdentity {
+    FileIdentity {
+        path: PathBuf::from("target/debug/deps/libserde.rlib"),
+        len: 7,
+        modified: std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(1_700_000_000, 21),
+    }
+}
+
 fn environment() -> BTreeMap<String, Option<String>> {
     BTreeMap::from([
         ("RUSTFLAGS".into(), Some("-Cdebuginfo=1".into())),
@@ -84,7 +93,7 @@ fn requests() -> Vec<(&'static str, AgentRequest)> {
         (
             "request.hello",
             AgentRequest::Hello {
-                protocol: 4,
+                protocol: 5,
                 client_version: "0.3.0".into(),
             },
         ),
@@ -193,6 +202,23 @@ fn requests() -> Vec<(&'static str, AgentRequest)> {
                 stdout: b"rustc".to_vec(),
             },
         ),
+        (
+            "request.find_file_digests",
+            AgentRequest::FindFileDigests {
+                scope: FileDigestScope::Content,
+                files: vec![file_identity()],
+            },
+        ),
+        (
+            "request.record_file_digests",
+            AgentRequest::RecordFileDigests {
+                scope: FileDigestScope::CcInput,
+                entries: vec![RecordedFileDigest {
+                    file: file_identity(),
+                    digest: digest(),
+                }],
+            },
+        ),
     ]
 }
 
@@ -201,7 +227,7 @@ fn responses() -> Vec<(&'static str, AgentResponse)> {
         (
             "response.hello",
             AgentResponse::Hello {
-                protocol: 4,
+                protocol: 5,
                 agent_version: "0.3.0".into(),
             },
         ),
@@ -294,6 +320,16 @@ fn responses() -> Vec<(&'static str, AgentResponse)> {
             AgentResponse::Error {
                 message: "incompatible protocol".into(),
             },
+        ),
+        (
+            "response.file_digests",
+            AgentResponse::FileDigests {
+                digests: vec![Some(digest()), None],
+            },
+        ),
+        (
+            "response.file_digests_recorded",
+            AgentResponse::FileDigestsRecorded,
         ),
     ]
 }
@@ -396,7 +432,7 @@ fn agent_protocol_v3_shapes_match_the_conformance_fixture() {
 
 #[test]
 fn protocol_constants_match_the_contract() {
-    assert_eq!(AGENT_PROTOCOL_VERSION, 4);
+    assert_eq!(AGENT_PROTOCOL_VERSION, 5);
     assert_eq!(PROTOCOL_VERSION, 1);
     assert_eq!(
         ACTION_RESULT_MEDIA_TYPE,
@@ -448,6 +484,8 @@ define_variant_coverage!(request_variant_name, EXPECTED_REQUEST_VARIANTS, AgentR
     AgentRequest::RecordActionPrediction { .. } => "record_action_prediction",
     AgentRequest::FindExecutableIdentity { .. } => "find_executable_identity",
     AgentRequest::StoreExecutableIdentity { .. } => "store_executable_identity",
+    AgentRequest::FindFileDigests { .. } => "find_file_digests",
+    AgentRequest::RecordFileDigests { .. } => "record_file_digests",
 });
 
 define_variant_coverage!(response_variant_name, EXPECTED_RESPONSE_VARIANTS, AgentResponse, {
@@ -469,4 +507,6 @@ define_variant_coverage!(response_variant_name, EXPECTED_RESPONSE_VARIANTS, Agen
     AgentResponse::ActionPredictionRecorded => "action_prediction_recorded",
     AgentResponse::ExecutableIdentity { .. } => "executable_identity",
     AgentResponse::Error { .. } => "error",
+    AgentResponse::FileDigests { .. } => "file_digests",
+    AgentResponse::FileDigestsRecorded => "file_digests_recorded",
 });

--- a/crates/mbx-cache-core/tests/fixtures/agent-protocol-v5.jsonl
+++ b/crates/mbx-cache-core/tests/fixtures/agent-protocol-v5.jsonl
@@ -16,8 +16,8 @@ request.find_action_prediction	{"invocation":{"algorithm":"blake3","hash":"aaaaa
 request.record_action_prediction	{"prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"task":"task-id","type":"record_action_prediction"}
 request.find_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","type":"find_executable_identity"}
 request.store_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","stdout":[114,117,115,116,99],"type":"store_executable_identity"}
-request.find_file_digests	{"files":[{"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}],"scope":"content","type":"find_file_digests"}
-request.record_file_digests	{"entries":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"file":{"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}}],"scope":"cc_input","type":"record_file_digests"}
+request.find_file_digests	{"files":[{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}],"scope":"content","type":"find_file_digests"}
+request.record_file_digests	{"entries":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"file":{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}}],"scope":"cc_input","type":"record_file_digests"}
 response.hello	{"agent_version":"0.3.0","protocol":5,"type":"hello"}
 response.task_begun	{"run":"task-run","type":"task_begun"}
 response.task_committed	{"type":"task_committed"}

--- a/crates/mbx-cache-core/tests/fixtures/agent-protocol-v5.jsonl
+++ b/crates/mbx-cache-core/tests/fixtures/agent-protocol-v5.jsonl
@@ -16,8 +16,8 @@ request.find_action_prediction	{"invocation":{"algorithm":"blake3","hash":"aaaaa
 request.record_action_prediction	{"prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"task":"task-id","type":"record_action_prediction"}
 request.find_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","type":"find_executable_identity"}
 request.store_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","stdout":[114,117,115,116,99],"type":"store_executable_identity"}
-request.find_file_digests	{"files":[{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}],"scope":"content","type":"find_file_digests"}
-request.record_file_digests	{"entries":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"file":{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}}],"scope":"cc_input","type":"record_file_digests"}
+request.find_file_digests	{"files":[{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":2100,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}],"scope":"content","type":"find_file_digests"}
+request.record_file_digests	{"entries":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"file":{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":2100,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}}],"scope":"cc_input","type":"record_file_digests"}
 response.hello	{"agent_version":"0.3.0","protocol":5,"type":"hello"}
 response.task_begun	{"run":"task-run","type":"task_begun"}
 response.task_committed	{"type":"task_committed"}

--- a/crates/mbx-cache-core/tests/fixtures/agent-protocol-v5.jsonl
+++ b/crates/mbx-cache-core/tests/fixtures/agent-protocol-v5.jsonl
@@ -1,4 +1,4 @@
-request.hello	{"client_version":"0.3.0","protocol":4,"type":"hello"}
+request.hello	{"client_version":"0.3.0","protocol":5,"type":"hello"}
 request.begin_task	{"task":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","type":"begin_task"}
 request.commit_task	{"run":"task-run","type":"commit_task"}
 request.find_blob	{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"type":"find_blob"}
@@ -16,7 +16,9 @@ request.find_action_prediction	{"invocation":{"algorithm":"blake3","hash":"aaaaa
 request.record_action_prediction	{"prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"task":"task-id","type":"record_action_prediction"}
 request.find_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","type":"find_executable_identity"}
 request.store_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","stdout":[114,117,115,116,99],"type":"store_executable_identity"}
-response.hello	{"agent_version":"0.3.0","protocol":4,"type":"hello"}
+request.find_file_digests	{"files":[{"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}],"scope":"content","type":"find_file_digests"}
+request.record_file_digests	{"entries":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"file":{"len":7,"modified":{"nanos_since_epoch":21,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}}],"scope":"cc_input","type":"record_file_digests"}
+response.hello	{"agent_version":"0.3.0","protocol":5,"type":"hello"}
 response.task_begun	{"run":"task-run","type":"task_begun"}
 response.task_committed	{"type":"task_committed"}
 response.blob	{"path":"cache/blob","type":"blob"}
@@ -38,6 +40,8 @@ response.action_prediction_recorded	{"type":"action_prediction_recorded"}
 response.executable_identity	{"stdout":[114,117,115,116,99],"type":"executable_identity"}
 response.executable_identity_missing	{"stdout":null,"type":"executable_identity"}
 response.error	{"message":"incompatible protocol","type":"error"}
+response.file_digests	{"digests":[{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},null],"type":"file_digests"}
+response.file_digests_recorded	{"type":"file_digests_recorded"}
 record.action_result	{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"metadata":null,"output_root":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"version":1}
 record.directory	{"directories":[],"files":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"executable":false,"mode":420,"name":"lib.rlib"}],"symlinks":[],"version":1}
 record.rustc_metadata	{"kind":"rustc","stderr":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"stdout":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"version":1}

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -168,11 +168,7 @@ impl DiscoveredInputs {
                     message: "input is not a regular file".into(),
                 });
             }
-            let identity = metadata.modified().ok().map(|modified| FileIdentity {
-                path: path.clone(),
-                len: metadata.len(),
-                modified,
-            });
+            let identity = FileIdentity::describe(&path, &metadata);
             identified.push((path, identity));
         }
         let queries = identified
@@ -948,11 +944,7 @@ mod tests {
             size: metadata.len(),
         };
         let ledger = SentinelLedger {
-            known: FileIdentity {
-                path: known_path.clone(),
-                len: metadata.len(),
-                modified: metadata.modified().unwrap(),
-            },
+            known: FileIdentity::describe(&known_path, &metadata).unwrap(),
             digest: sentinel.clone(),
             recorded: std::sync::Mutex::new(Vec::new()),
         };
@@ -988,5 +980,57 @@ mod tests {
         assert_eq!(recorded.len(), 1, "only the fresh hash is recorded");
         assert_eq!(recorded[0].file.path, fresh_path);
         assert_eq!(recorded[0].digest, by_path(&fresh_path));
+    }
+
+    /// A rewrite that restores length and modification time must still be
+    /// hashed: the platform change token moves with every write, so the
+    /// identity the ledger recorded no longer describes the file.
+    #[cfg(unix)]
+    #[test]
+    fn a_disguised_rewrite_is_not_answered_from_the_ledger() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let path = root.join("lib.rs");
+        std::fs::write(&path, b"fn lib() -> u8 { 1 }").unwrap();
+        let before = std::fs::metadata(&path).unwrap();
+        let identity = FileIdentity::describe(&path, &before).unwrap();
+
+        // Same length, modification time put back: only the change token can
+        // tell this file has new contents.
+        std::fs::write(&path, b"fn lib() -> u8 { 2 }").unwrap();
+        let file = std::fs::File::options().write(true).open(&path).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(before.modified().unwrap()))
+            .unwrap();
+        drop(file);
+        let after = std::fs::metadata(&path).unwrap();
+        let disguised = FileIdentity::describe(&path, &after).unwrap();
+        assert_eq!(disguised.len, identity.len);
+        assert_eq!(disguised.modified, identity.modified);
+        assert_ne!(
+            disguised, identity,
+            "the change token must expose the rewrite"
+        );
+
+        let ledger = SentinelLedger {
+            known: identity,
+            digest: CacheDigest {
+                algorithm: "blake3".into(),
+                hash: "e".repeat(64),
+                size: after.len(),
+            },
+            recorded: std::sync::Mutex::new(Vec::new()),
+        };
+        let discovered = DiscoveredInputs::from_paths(
+            root,
+            BTreeSet::from([path.clone()]),
+            BTreeMap::new(),
+            &ledger,
+        )
+        .unwrap();
+        assert_eq!(
+            discovered.inputs[0].digest,
+            CacheDigest::blake3_file(&path).unwrap(),
+            "the disguised rewrite is hashed, not answered from the ledger"
+        );
     }
 }

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -2,7 +2,9 @@ use super::{
     ActionContext, ActionInput, Argument, BypassReason, MAX_NATIVE_INPUT_BYTES,
     MAX_PREDICTED_INPUTS, PathMapping, RustcInvocation, normalize_components,
 };
-use mbx_cache_core::CacheDigest;
+use mbx_cache_core::{
+    CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, RecordedFileDigest,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -141,6 +143,7 @@ impl DiscoveredInputs {
         working_dir: &Path,
         paths: BTreeSet<PathBuf>,
         environment: BTreeMap<String, Option<String>>,
+        digests: &dyn FileDigestCache,
     ) -> Result<Self, BypassReason> {
         if !working_dir.is_absolute() {
             return Err(BypassReason::RelativeWorkingDirectory(
@@ -148,7 +151,12 @@ impl DiscoveredInputs {
             ));
         }
         let working_dir = normalize_components(working_dir);
-        let mut inputs = Vec::with_capacity(paths.len());
+        // Stat everything first: the identities drive one batched ledger
+        // lookup, so an upstream rlib the session already hashed -- once, when
+        // it was materialized or published -- is not read again by every crate
+        // that links it. A file the filesystem reports no modification time
+        // for gets no identity and is simply hashed.
+        let mut identified = Vec::with_capacity(paths.len());
         for path in paths {
             let metadata = std::fs::metadata(&path).map_err(|error| BypassReason::InputRead {
                 path: path.clone(),
@@ -160,12 +168,53 @@ impl DiscoveredInputs {
                     message: "input is not a regular file".into(),
                 });
             }
-            let digest =
-                CacheDigest::blake3_file(&path).map_err(|error| BypassReason::InputRead {
-                    path: path.clone(),
-                    message: error.to_string(),
-                })?;
+            let identity = metadata.modified().ok().map(|modified| FileIdentity {
+                path: path.clone(),
+                len: metadata.len(),
+                modified,
+            });
+            identified.push((path, identity));
+        }
+        let queries = identified
+            .iter()
+            .filter_map(|(_, identity)| identity.clone())
+            .collect::<Vec<_>>();
+        let mut recorded = digests.find(FileDigestScope::Content, &queries).into_iter();
+        let mut inputs = Vec::with_capacity(identified.len());
+        let mut fresh = Vec::new();
+        for (path, identity) in identified {
+            let remembered = identity
+                .as_ref()
+                .and_then(|_| recorded.next().flatten())
+                .filter(|digest| {
+                    identity
+                        .as_ref()
+                        .is_some_and(|identity| identity.len == digest.size)
+                });
+            let digest = match remembered {
+                Some(digest) => digest,
+                None => {
+                    let digest = CacheDigest::blake3_file(&path).map_err(|error| {
+                        BypassReason::InputRead {
+                            path: path.clone(),
+                            message: error.to_string(),
+                        }
+                    })?;
+                    if let Some(identity) = identity
+                        && identity.len == digest.size
+                    {
+                        fresh.push(RecordedFileDigest {
+                            file: identity,
+                            digest: digest.clone(),
+                        });
+                    }
+                    digest
+                }
+            };
             inputs.push(ActionInput { path, digest });
+        }
+        if !fresh.is_empty() {
+            digests.record(FileDigestScope::Content, fresh);
         }
         Ok(Self {
             working_dir,
@@ -272,16 +321,25 @@ impl RustcInvocation {
         dep_info: &RustcDepInfo,
         working_dir: &Path,
     ) -> Result<DiscoveredInputs, BypassReason> {
-        self.discover_inputs_with_mappings(dep_info, working_dir, &[])
+        self.discover_inputs_with_mappings(
+            dep_info,
+            working_dir,
+            &[],
+            &mbx_cache_core::NoFileDigestCache,
+        )
     }
 
     /// Hash dep-info sources plus modeled compiler inputs, allowing native
     /// search directories beneath the working directory or a mapped root.
+    ///
+    /// `digests` may answer for files the session already read in full;
+    /// pass [`mbx_cache_core::NoFileDigestCache`] to hash everything.
     pub fn discover_inputs_with_mappings(
         &self,
         dep_info: &RustcDepInfo,
         working_dir: &Path,
         path_mappings: &[PathMapping],
+        digests: &dyn FileDigestCache,
     ) -> Result<DiscoveredInputs, BypassReason> {
         if !working_dir.is_absolute() {
             return Err(BypassReason::RelativeWorkingDirectory(
@@ -333,7 +391,7 @@ impl RustcInvocation {
                 )?;
             }
         }
-        DiscoveredInputs::from_paths(&working_dir, paths, dep_info.environment.clone())
+        DiscoveredInputs::from_paths(&working_dir, paths, dep_info.environment.clone(), digests)
     }
 }
 
@@ -672,7 +730,12 @@ mod tests {
 
         // The directory does not even exist: its contents are not inputs.
         let discovered = invocation
-            .discover_inputs_with_mappings(&dep_info, root, &mappings)
+            .discover_inputs_with_mappings(
+                &dep_info,
+                root,
+                &mappings,
+                &mbx_cache_core::NoFileDigestCache,
+            )
             .unwrap();
         assert_eq!(discovered.inputs.len(), 1);
         assert_eq!(discovered.inputs[0].path, source);
@@ -689,7 +752,13 @@ mod tests {
         discovered.clone().apply_to(&mut recorded).unwrap();
         let action = invocation.action(recorded).unwrap();
         let prediction = invocation.prediction(&context, &discovered).unwrap();
-        let replayed = prediction.discover(root, &context.path_mappings).unwrap();
+        let replayed = prediction
+            .discover(
+                root,
+                &context.path_mappings,
+                &mbx_cache_core::NoFileDigestCache,
+            )
+            .unwrap();
         let mut replay_context = context.clone();
         replayed.apply_to(&mut replay_context).unwrap();
         assert_eq!(
@@ -727,7 +796,12 @@ mod tests {
         ));
         let dep_info = RustcDepInfo::parse(&format!("output: {}\n", source.display())).unwrap();
         assert_eq!(
-            invocation.discover_inputs_with_mappings(&dep_info, root, &mappings),
+            invocation.discover_inputs_with_mappings(
+                &dep_info,
+                root,
+                &mappings,
+                &mbx_cache_core::NoFileDigestCache
+            ),
             Err(BypassReason::UnsupportedSearchPath("native".into()))
         );
     }
@@ -833,5 +907,86 @@ mod tests {
             discovered.verify(),
             Err(BypassReason::InputChanged(root.join("child.rs")))
         );
+    }
+
+    /// A ledger that answers with a sentinel and remembers what was recorded.
+    struct SentinelLedger {
+        known: FileIdentity,
+        digest: CacheDigest,
+        recorded: std::sync::Mutex<Vec<RecordedFileDigest>>,
+    }
+
+    impl FileDigestCache for SentinelLedger {
+        fn find(&self, scope: FileDigestScope, files: &[FileIdentity]) -> Vec<Option<CacheDigest>> {
+            assert_eq!(scope, FileDigestScope::Content);
+            files
+                .iter()
+                .map(|file| (*file == self.known).then(|| self.digest.clone()))
+                .collect()
+        }
+
+        fn record(&self, scope: FileDigestScope, entries: Vec<RecordedFileDigest>) {
+            assert_eq!(scope, FileDigestScope::Content);
+            self.recorded.lock().unwrap().extend(entries);
+        }
+    }
+
+    #[test]
+    fn discovery_reuses_recorded_digests_and_records_fresh_ones() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let known_path = root.join("libdep.rlib");
+        let fresh_path = root.join("lib.rs");
+        std::fs::write(&known_path, b"rlib bytes").unwrap();
+        std::fs::write(&fresh_path, b"fn lib() {}").unwrap();
+        let metadata = std::fs::metadata(&known_path).unwrap();
+        // A sentinel digest that hashing could never produce proves the read
+        // was skipped: the discovered input carries it verbatim.
+        let sentinel = CacheDigest {
+            algorithm: "blake3".into(),
+            hash: "c".repeat(64),
+            size: metadata.len(),
+        };
+        let ledger = SentinelLedger {
+            known: FileIdentity {
+                path: known_path.clone(),
+                len: metadata.len(),
+                modified: metadata.modified().unwrap(),
+            },
+            digest: sentinel.clone(),
+            recorded: std::sync::Mutex::new(Vec::new()),
+        };
+
+        let discovered = DiscoveredInputs::from_paths(
+            root,
+            BTreeSet::from([known_path.clone(), fresh_path.clone()]),
+            BTreeMap::new(),
+            &ledger,
+        )
+        .unwrap();
+
+        let by_path = |path: &Path| {
+            discovered
+                .inputs
+                .iter()
+                .find(|input| input.path == path)
+                .unwrap()
+                .digest
+                .clone()
+        };
+        assert_eq!(
+            by_path(&known_path),
+            sentinel,
+            "the recorded digest answers"
+        );
+        assert_eq!(
+            by_path(&fresh_path),
+            CacheDigest::blake3_file(&fresh_path).unwrap(),
+            "an unrecorded file is hashed"
+        );
+        let recorded = ledger.recorded.lock().unwrap();
+        assert_eq!(recorded.len(), 1, "only the fresh hash is recorded");
+        assert_eq!(recorded[0].file.path, fresh_path);
+        assert_eq!(recorded[0].digest, by_path(&fresh_path));
     }
 }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -28,7 +28,7 @@
 //! ```
 #![deny(missing_docs)]
 
-use mbx_cache_core::{CacheDigest, canonical_json};
+use mbx_cache_core::{CacheDigest, FileDigestCache, canonical_json};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
@@ -884,6 +884,7 @@ impl RustcInputPrediction {
         &self,
         working_dir: &Path,
         path_mappings: &[PathMapping],
+        digests: &dyn FileDigestCache,
     ) -> Result<DiscoveredInputs, BypassReason> {
         if !matches!(self.version, 1..=3) {
             return Err(BypassReason::UnsupportedPrediction);
@@ -926,7 +927,7 @@ impl RustcInputPrediction {
                 Ok((name.clone(), value))
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
-        DiscoveredInputs::from_paths(working_dir, paths, environment)
+        DiscoveredInputs::from_paths(working_dir, paths, environment, digests)
     }
 }
 

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -175,6 +175,7 @@ fn tracks_native_search_path_contents_but_still_rejects_native_libraries() {
             &dep_info,
             &working_dir,
             &[PathMapping::new(directory.path().join("target"), "target")],
+            &mbx_cache_core::NoFileDigestCache,
         )
         .unwrap();
     assert!(
@@ -197,7 +198,11 @@ fn tracks_native_search_path_contents_but_still_rejects_native_libraries() {
     assert_eq!(prediction.version, 3);
     std::fs::write(native.join("added.lib"), "second").unwrap();
     let predicted = prediction
-        .discover(&working_dir, &action_context.path_mappings)
+        .discover(
+            &working_dir,
+            &action_context.path_mappings,
+            &mbx_cache_core::NoFileDigestCache,
+        )
         .unwrap();
     assert!(
         predicted
@@ -635,7 +640,11 @@ fn predicts_inputs_without_reusing_stale_contents() {
     assert!(prediction.crate_name.is_empty());
 
     let predicted = prediction
-        .discover(&workspace, &context.path_mappings)
+        .discover(
+            &workspace,
+            &context.path_mappings,
+            &mbx_cache_core::NoFileDigestCache,
+        )
         .unwrap();
     let mut predicted_context = context.clone();
     predicted.apply_to(&mut predicted_context).unwrap();
@@ -643,7 +652,11 @@ fn predicts_inputs_without_reusing_stale_contents() {
 
     std::fs::write(workspace.join("src/lib.rs"), "pub fn value() -> u8 { 2 }").unwrap();
     let changed = prediction
-        .discover(&workspace, &context.path_mappings)
+        .discover(
+            &workspace,
+            &context.path_mappings,
+            &mbx_cache_core::NoFileDigestCache,
+        )
         .unwrap();
     let mut changed_context = context;
     changed.apply_to(&mut changed_context).unwrap();
@@ -695,7 +708,12 @@ fn a_native_search_directory_is_predicted_by_name_not_by_its_contents() {
         environment: BTreeMap::new(),
     };
     let discovered = invocation
-        .discover_inputs_with_mappings(&dep_info, &workspace, &mappings)
+        .discover_inputs_with_mappings(
+            &dep_info,
+            &workspace,
+            &mappings,
+            &mbx_cache_core::NoFileDigestCache,
+        )
         .unwrap();
     assert_eq!(discovered.inputs.len(), 1_201);
 
@@ -734,7 +752,7 @@ fn a_native_search_directory_is_predicted_by_name_not_by_its_contents() {
         .unwrap();
     let mut predicted_context = context.clone();
     prediction
-        .discover(&workspace, &mappings)
+        .discover(&workspace, &mappings, &mbx_cache_core::NoFileDigestCache)
         .unwrap()
         .apply_to(&mut predicted_context)
         .unwrap();

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -25,7 +25,8 @@ use mbx_cache_cc::{
 };
 use mbx_cache_core::{
     ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode,
-    CcMetadata, RemoteActionResult, RestoreStats, canonical_json,
+    CcMetadata, FileDigestScope, FileIdentity, RecordedFileDigest, RemoteActionResult,
+    RestoreStats, canonical_json,
 };
 use mbx_cache_rustc::PathMapping;
 use std::collections::{BTreeMap, BTreeSet};
@@ -66,7 +67,11 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     // Falling through compiles and republishes, which replaces it.
     let usable = find_prediction(&task, &invocation_digest)?.and_then(|prediction| {
         prediction
-            .discover(&working_dir, &context.path_mappings)
+            .discover(
+                &working_dir,
+                &context.path_mappings,
+                session::file_digest_cache(),
+            )
             .ok()
     });
     // Whether an action lookup actually ran. A cold compilation has no
@@ -219,6 +224,7 @@ fn discover(
         &context.working_dir,
         files.clone(),
         manifest_directories(invocation, context, &files),
+        session::file_digest_cache(),
     )?)
 }
 
@@ -615,6 +621,25 @@ fn restore_result(
     discovered.verify()?;
     if restore_outputs {
         persist_outputs(staged)?;
+        // The restored object is what a later native link hashes as an input,
+        // so its digest enters the content ledger the moment its identity is
+        // fixed by the rename.
+        if let Ok(metadata) = std::fs::metadata(&destination)
+            && metadata.len() == node.digest.size
+            && let Ok(modified) = metadata.modified()
+        {
+            session::record_file_digests(
+                FileDigestScope::Content,
+                vec![RecordedFileDigest {
+                    file: FileIdentity {
+                        path: destination.clone(),
+                        len: metadata.len(),
+                        modified,
+                    },
+                    digest: node.digest.clone(),
+                }],
+            );
+        }
     }
     restore.duration_ns = duration_ns(materialization_started.elapsed());
     Ok(Some(CachedCompilation {
@@ -679,6 +704,23 @@ fn publish_result(
 
     let digest = CacheDigest::blake3_file(object)?;
     blobs.push((digest.clone(), object.to_path_buf()));
+    // A freshly compiled object is a future native-link input; the hash just
+    // taken is the read a ledger entry stands in for.
+    if metadata.len() == digest.size
+        && let Ok(modified) = metadata.modified()
+    {
+        session::record_file_digests(
+            FileDigestScope::Content,
+            vec![RecordedFileDigest {
+                file: FileIdentity {
+                    path: object.to_path_buf(),
+                    len: metadata.len(),
+                    modified,
+                },
+                digest: digest.clone(),
+            }],
+        );
+    }
     let files = vec![CacheFileNode {
         digest,
         // An object file is never executable, which is what makes the mode

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -626,16 +626,12 @@ fn restore_result(
         // fixed by the rename.
         if let Ok(metadata) = std::fs::metadata(&destination)
             && metadata.len() == node.digest.size
-            && let Ok(modified) = metadata.modified()
+            && let Some(file) = FileIdentity::describe(&destination, &metadata)
         {
             session::record_file_digests(
                 FileDigestScope::Content,
                 vec![RecordedFileDigest {
-                    file: FileIdentity {
-                        path: destination.clone(),
-                        len: metadata.len(),
-                        modified,
-                    },
+                    file,
                     digest: node.digest.clone(),
                 }],
             );
@@ -707,16 +703,12 @@ fn publish_result(
     // A freshly compiled object is a future native-link input; the hash just
     // taken is the read a ledger entry stands in for.
     if metadata.len() == digest.size
-        && let Ok(modified) = metadata.modified()
+        && let Some(file) = FileIdentity::describe(object, &metadata)
     {
         session::record_file_digests(
             FileDigestScope::Content,
             vec![RecordedFileDigest {
-                file: FileIdentity {
-                    path: object.to_path_buf(),
-                    len: metadata.len(),
-                    modified,
-                },
+                file,
                 digest: digest.clone(),
             }],
         );

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1052,11 +1052,7 @@ fn record_output_digests(outputs: &[CachedOutput]) {
                 return None;
             }
             Some(RecordedFileDigest {
-                file: FileIdentity {
-                    path: output.path.clone(),
-                    len: metadata.len(),
-                    modified: metadata.modified().ok()?,
-                },
+                file: FileIdentity::describe(&output.path, &metadata)?,
                 digest: output.digest.clone(),
             })
         })
@@ -1548,13 +1544,11 @@ fn publish_result(
             // key, and this hash is the read that ledger entries stand in
             // for. The dep-info stays out -- its stored digest describes the
             // placeholder form, not what is on disk.
-            if let (Ok(modified), true) = (metadata.modified(), metadata.len() == digest.size) {
+            if metadata.len() == digest.size
+                && let Some(file) = FileIdentity::describe(path, &metadata)
+            {
                 hashed_outputs.push(RecordedFileDigest {
-                    file: FileIdentity {
-                        path: path.clone(),
-                        len: metadata.len(),
-                        modified,
-                    },
+                    file,
                     digest: digest.clone(),
                 });
             }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -9,7 +9,8 @@ use crate::{session, util::workspace_root};
 use eyre::{Context, Result, bail};
 use mbx_cache_core::{
     ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode,
-    RemoteActionResult, RestoreStats, RustcMetadata, canonical_json,
+    FileDigestScope, FileIdentity, RecordedFileDigest, RemoteActionResult, RestoreStats,
+    RustcMetadata, canonical_json,
 };
 use mbx_cache_rustc::{
     ActionContext, BypassReason, CompilerIdentity, DiscoveredInputs, LinkerIdentity, ParseOptions,
@@ -503,7 +504,11 @@ fn restore_predicted_result(
     if String::from_utf8(canonical_json(&input_prediction)?)? != prediction.payload {
         bail!("cache agent returned a non-canonical rustc action prediction");
     }
-    let discovered = input_prediction.discover(working_dir, &context.path_mappings)?;
+    let discovered = input_prediction.discover(
+        working_dir,
+        &context.path_mappings,
+        session::file_digest_cache(),
+    )?;
     discovered.clone().apply_to(&mut context)?;
     let candidates = ActionCandidates::build(invocation, context, compilation.linker.clone())?;
     // From this point onward, every return follows at least one action-result
@@ -650,8 +655,12 @@ fn action_from_parsed_dep_info(
         portable,
         ..
     } = compilation;
-    let discovered =
-        invocation.discover_inputs_with_mappings(dep_info, working_dir, &portable.mappings)?;
+    let discovered = invocation.discover_inputs_with_mappings(
+        dep_info,
+        working_dir,
+        &portable.mappings,
+        session::file_digest_cache(),
+    )?;
     let mut context = base_action_context(compilation.rustc, working_dir, portable)?;
     discovered.clone().apply_to(&mut context)?;
     let candidates = ActionCandidates::build(invocation, context, compilation.linker.clone())?;
@@ -1012,6 +1021,9 @@ fn restore_result(
     // most of the restore.
     verify_environment(&discovered.environment)?;
     finalize_restored_outputs(staged, restore_outputs)?;
+    if restore_outputs {
+        record_output_digests(&cached_outputs);
+    }
     restore.duration_ns = materialization_started
         .elapsed()
         .as_nanos()
@@ -1023,6 +1035,33 @@ fn restore_result(
         outputs: cached_outputs,
         restore,
     }))
+}
+
+/// Enter restored outputs into the session file-digest ledger.
+///
+/// The digests were verified when the blobs entered the store, and the rename
+/// that placed each file fixed the identity being recorded; a crate that links
+/// one of these artifacts can then key it without reading it back. Best-effort
+/// throughout: a file that cannot be described is simply not recorded.
+fn record_output_digests(outputs: &[CachedOutput]) {
+    let entries = outputs
+        .iter()
+        .filter_map(|output| {
+            let metadata = std::fs::metadata(&output.path).ok()?;
+            if metadata.len() != output.digest.size {
+                return None;
+            }
+            Some(RecordedFileDigest {
+                file: FileIdentity {
+                    path: output.path.clone(),
+                    len: metadata.len(),
+                    modified: metadata.modified().ok()?,
+                },
+                digest: output.digest.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    session::record_file_digests(FileDigestScope::Content, entries);
 }
 
 fn finalize_restored_outputs(staged: StagedOutputs, restore_outputs: bool) -> Result<()> {
@@ -1486,6 +1525,7 @@ fn publish_result(
         .iter()
         .chain(std::iter::once(&outputs.dep_info));
     let mut files = Vec::with_capacity(outputs.files.len() + 1);
+    let mut hashed_outputs = Vec::with_capacity(outputs.files.len());
     for path in output_paths {
         let metadata = std::fs::metadata(path)
             .wrap_err_with(|| format!("failed to inspect rustc output {}", path.display()))?;
@@ -1503,6 +1543,21 @@ fn publish_result(
         } else {
             let digest = CacheDigest::blake3_file(path)?;
             blobs.push((digest.clone(), path.clone()));
+            // Freshly compiled artifacts enter the ledger too: on a cold
+            // build these are exactly the rlibs every dependent is about to
+            // key, and this hash is the read that ledger entries stand in
+            // for. The dep-info stays out -- its stored digest describes the
+            // placeholder form, not what is on disk.
+            if let (Ok(modified), true) = (metadata.modified(), metadata.len() == digest.size) {
+                hashed_outputs.push(RecordedFileDigest {
+                    file: FileIdentity {
+                        path: path.clone(),
+                        len: metadata.len(),
+                        modified,
+                    },
+                    digest: digest.clone(),
+                });
+            }
             digest
         };
         files.push(CacheFileNode {
@@ -1517,6 +1572,7 @@ fn publish_result(
         });
     }
     files.sort_by(|left, right| left.name.cmp(&right.name));
+    session::record_file_digests(FileDigestScope::Content, hashed_outputs);
 
     let metadata = canonical_json(&RustcMetadata {
         version: 1,

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -10,7 +10,8 @@ use log::{debug, warn};
 use mbx_cache_cc::CcLanguage;
 use mbx_cache_core::{
     AGENT_PROTOCOL_VERSION, AgentEvent, AgentEventObserver, AgentRemoteCache, AgentRequest,
-    AgentResponse, AgentStats, CacheAgent, CacheDigest, canonical_json,
+    AgentResponse, AgentStats, CacheAgent, CacheDigest, FileDigestCache, FileDigestScope,
+    FileIdentity, NoFileDigestCache, RecordedFileDigest, canonical_json,
 };
 use serde::Serialize;
 use std::cell::RefCell;
@@ -2000,6 +2001,58 @@ fn crate_name_argument(arguments: &[OsString]) -> Option<String> {
 /// that an explicit disable cannot be mistaken for an enable.
 pub(crate) fn verify_requested() -> bool {
     std::env::var_os(VERIFY_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
+/// The session file-digest ledger, answered by the cache agent.
+///
+/// Both directions are best-effort: a lookup that cannot reach the agent
+/// reports misses and the caller hashes as it always did, and a record that
+/// fails is dropped -- the ledger is a shortcut, never a dependency.
+struct AgentFileDigestCache;
+
+impl FileDigestCache for AgentFileDigestCache {
+    fn find(&self, scope: FileDigestScope, files: &[FileIdentity]) -> Vec<Option<CacheDigest>> {
+        if files.is_empty() {
+            return Vec::new();
+        }
+        let response = request_agent(&[AgentRequest::FindFileDigests {
+            scope,
+            files: files.to_vec(),
+        }]);
+        match response.map(|responses| responses.into_iter().next()) {
+            Ok(Some(AgentResponse::FileDigests { digests })) if digests.len() == files.len() => {
+                digests
+            }
+            _ => vec![None; files.len()],
+        }
+    }
+
+    fn record(&self, scope: FileDigestScope, entries: Vec<RecordedFileDigest>) {
+        if entries.is_empty() {
+            return;
+        }
+        let _ = request_agent(&[AgentRequest::RecordFileDigests { scope, entries }]);
+    }
+}
+
+/// The file-digest ledger this shim may consult, or none under verification.
+///
+/// Verification exists to qualify the whole cached path end to end, so it
+/// rehashes every input the way a first encounter would rather than trusting
+/// what this same session recorded.
+pub(crate) fn file_digest_cache() -> &'static dyn FileDigestCache {
+    if verify_requested() {
+        &NoFileDigestCache
+    } else {
+        &AgentFileDigestCache
+    }
+}
+
+/// Record file digests in the session ledger, best-effort.
+pub(crate) fn record_file_digests(scope: FileDigestScope, entries: Vec<RecordedFileDigest>) {
+    if !verify_requested() {
+        AgentFileDigestCache.record(scope, entries);
+    }
 }
 
 /// Whether this build may cache natively linked programs.


### PR DESCRIPTION
## What

Adds a session file-digest ledger to the cache agent and teaches both adapters to consult it during key construction, so a file the session already read in full — an rlib it materialized, an artifact it just published, a header it scanned an hour of CPU ago — is never read again to be rehashed.

Today every compilation hashes every input from scratch: an upstream rlib is read once per crate that links it, and a shared C header once per translation unit that includes it. Profiling a warm 465-crate build showed the walk spending its time on exactly this (plus materialization), while the compiler itself was needed for under 2s.

## How

- The agent keeps `(scope, path) → (len, mtime, digest)`, the same freshness identity it already trusts for verified CAS reads (`VerifiedBlob`). Two new protocol requests, `find_file_digests` / `record_file_digests`, carry batched lookups and records; the protocol version moves to 5 and the conformance fixture is regenerated.
- `DiscoveredInputs::from_paths` stats everything first (it already did), asks the ledger once, hashes only the misses, and records what it hashed.
- Restored outputs enter the ledger the moment their identity is fixed by the rename; freshly published artifacts enter it from the hash publication already takes. Both are exactly the files dependents are about to key.
- The ledger is **scoped**: a digest recorded by the rustc adapter never vouches for the cc adapter's timestamp-macro scan. A cc entry is recorded only after the scan passed, so a cc hit may skip scan and hash together without resting on a property nobody established.
- `MBX_VERIFY=1` bypasses the ledger entirely — qualification rehashes end to end, and the pre-publication `verify()` barrier is untouched.

## Measurements

Warm build of this workspace (465 hits, M-series, fast NVMe — the runner-image worst case has 2 cores and slower disks, where the same reads cost proportionally more):

| | before | after |
|---|---:|---:|
| session | 14.29s | **13.56s** |
| input bytes hashed | 0.73 GB + repeated rlib reads | misses only |

This is also the foundation for a follow-up that skips rewriting outputs that already match on disk (breaking the cargo-fingerprint churn that makes back-to-back `mbx build` re-walk ~80% of units forever).

## Breaking

`cargo semver-checks` will flag this; per RELEASING.md the version stays untouched and release-plz picks the number:
- `mbx-cache-core`: new `AgentRequest`/`AgentResponse` variants (appended, per the discriminant-stability convention), new exported types (`FileIdentity`, `RecordedFileDigest`, `FileDigestScope`, `FileDigestCache`, `NoFileDigestCache`), `AGENT_PROTOCOL_VERSION` 4 → 5.
- `mbx-cache-rustc` / `mbx-cache-cc`: `discover_inputs_with_mappings`, prediction `discover`, and `CcDiscoveredInputs::collect` take a `&dyn FileDigestCache` (both crates declare "No API stability" in their manifests).

`mise run ci` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache-key input hashing and bumps the agent protocol; incorrect ledger reuse could affect hit/miss correctness, though identity checks, cc-specific scoping, and verify bypass mitigate that.
> 
> **Overview**
> Adds a **session-scoped file-digest ledger** in the cache agent so rustc and cc input discovery can skip re-reading files the build already hashed. Agent protocol bumps to **v5** with `find_file_digests` / `record_file_digests`; lookups are keyed by **path + file identity** (size, mtime, and ctime on Unix) and capped per batch/session.
> 
> **Rustc** and **cc** `collect` / `discover` paths now take a `&dyn FileDigestCache`: stat inputs, batch-lookup the ledger, hash only misses, and record fresh digests. **Cc** uses scope `CcInput` so a hit also skips the timestamp-macro scan that was done when the entry was recorded; rustc uses `Content` only.
> 
> The **mbx shim** talks to the agent via `AgentFileDigestCache`, passes the cache into prediction replay and dep-info discovery, and **records** digests when objects/rlibs are compiled or restored—so dependents can key shared artifacts without rehashing. **`MBX_VERIFY=1`** disables the ledger (`NoFileDigestCache`) so verification still hashes everything.
> 
> Tests and the v5 protocol fixture are updated; adapter call sites pass `NoFileDigestCache` where reuse must not happen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acf7297008442e97c3a8a6aff377f4292ffbacd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced repeated file hashing during C/C++ and Rust input discovery by reusing verified digests within a session.
  * Recorded digests for restored and newly compiled cacheable outputs.

* **Compatibility**
  * Updated the agent protocol to support file-digest lookup and recording.

* **Reliability**
  * Added validation to ensure cached digests match file identity and size.
  * Added coverage for digest reuse, invalid entries, and isolated cache scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->