### PR TITLE
feat(cache-rustc): cache macOS debug links behind an oso_prefix the shim appends

### DIFF
--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -439,6 +439,17 @@ fn render_argument(argument: &Argument) -> Result<OsString, BypassReason> {
             from.to_str()
                 .ok_or_else(|| BypassReason::NonUtf8Path(from.clone()))?
         ),
+        // Nothing links while emitting dep-info, so the prefix is inert here;
+        // it is replayed verbatim to keep the command faithful.
+        Argument::OsoPrefix {
+            path,
+            trailing_slash,
+        } => format!(
+            "--codegen=link-arg=-Wl,-oso_prefix,{}{}",
+            path.to_str()
+                .ok_or_else(|| BypassReason::NonUtf8Path(path.clone()))?,
+            if *trailing_slash { "/" } else { "" }
+        ),
     };
     Ok(rendered.into())
 }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -269,11 +269,29 @@ pub enum BypassReason {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Argument {
     Plain(String),
-    Path { flag: String, path: PathBuf },
-    SearchPath { kind: String, path: PathBuf },
-    Extern { name: String, path: Option<PathBuf> },
+    Path {
+        flag: String,
+        path: PathBuf,
+    },
+    SearchPath {
+        kind: String,
+        path: PathBuf,
+    },
+    Extern {
+        name: String,
+        path: Option<PathBuf>,
+    },
     Emit(Vec<Emit>),
-    RemapPath { from: PathBuf, to: String },
+    RemapPath {
+        from: PathBuf,
+        to: String,
+    },
+    /// An `-oso_prefix` handed to ld64, whose path strips checkout-specific
+    /// prefixes from the debug map the linker records.
+    OsoPrefix {
+        path: PathBuf,
+        trailing_slash: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1320,6 +1338,23 @@ impl<'a> Parser<'a> {
         if SUPPORTED_CODEGEN_OPTIONS.binary_search(&name).is_err() {
             return Err(BypassReason::UnknownCodegenOption(name.into()));
         }
+        // `-oso_prefix` names a checkout-specific path, so it is parsed
+        // rather than keyed as text: the path normalizes like every other
+        // path in the key, which is what lets two checkouts passing their own
+        // prefixes agree on one action.
+        if matches!(name, "link-arg" | "link-args")
+            && let Some((_, option)) = value.split_once('=')
+            && let Some(prefix) = option.strip_prefix("-Wl,-oso_prefix,")
+            && !prefix.trim_end_matches('/').is_empty()
+            && !prefix.contains(',')
+        {
+            let trailing_slash = prefix.ends_with('/');
+            self.parsed.push(Argument::OsoPrefix {
+                path: PathBuf::from(prefix.trim_end_matches('/')),
+                trailing_slash,
+            });
+            return Ok(());
+        }
         self.parsed
             .push(Argument::Plain(format!("--codegen={value}")));
         if name == "extra-filename" {
@@ -1410,6 +1445,21 @@ impl<'a> Parser<'a> {
         {
             return Err(BypassReason::UnmodeledLinkArgument(option.to_owned()));
         }
+        // `-oso_prefix` is modeled, but only where ld64 is the linker reading
+        // it: a native macOS link. Any other linker sees an option this
+        // adapter cannot vouch for, exactly like the arguments above.
+        if !matches!(
+            link_output,
+            LinkOutput::Library | LinkOutput::NativeExecutable
+        ) && self
+            .parsed
+            .iter()
+            .any(|argument| matches!(argument, Argument::OsoPrefix { .. }))
+        {
+            return Err(BypassReason::UnmodeledLinkArgument(
+                "link-arg=-Wl,-oso_prefix".into(),
+            ));
+        }
         if let Some(name) = self.parsed.iter().find_map(|argument| match argument {
             Argument::Extern { name, path: None } if name != "proc_macro" => Some(name),
             _ => None,
@@ -1445,6 +1495,34 @@ impl Parser<'_> {
             let option = value.strip_prefix("--codegen=")?;
             let name = option.split_once('=').map_or(option, |(name, _)| name);
             matches!(name, "link-arg" | "link-args").then_some(option)
+        })
+    }
+
+    /// Whether an `-oso_prefix` strips the directory this link's objects live
+    /// in from the debug map ld64 records.
+    ///
+    /// The objects a native link reads -- this unit's own compiled objects
+    /// and the rlibs it links -- sit in the output directory, so a prefix
+    /// covering that directory leaves the debug map naming spellings every
+    /// checkout shares. Toolchain objects stay absolute, as they do in the
+    /// paths rustc itself embeds on every platform.
+    fn oso_prefix_covers_outputs(&self) -> bool {
+        let Some(directory) = self
+            .out_dir
+            .as_deref()
+            .or_else(|| self.explicit_output.as_deref().and_then(Path::parent))
+        else {
+            return false;
+        };
+        if !directory.is_absolute() {
+            return false;
+        }
+        let directory = normalize_components(directory);
+        self.parsed.iter().any(|argument| {
+            let Argument::OsoPrefix { path, .. } = argument else {
+                return false;
+            };
+            path.is_absolute() && directory.starts_with(normalize_components(path))
         })
     }
 
@@ -1493,13 +1571,28 @@ impl Parser<'_> {
             };
             let unportable = match name {
                 // Packed debug info leaves a .dSYM bundle or .dwp file beside
-                // the binary, and mbx stores neither.
-                "split-debuginfo" => value != Some("off"),
+                // the binary, and mbx stores neither. Unpacked is macOS's
+                // debug-map arrangement -- debug info stays in the objects and
+                // nothing lands beside the binary -- so the same covering
+                // `-oso_prefix` that makes the debug map portable covers it.
+                "split-debuginfo" => match value {
+                    Some("off") => false,
+                    Some("unpacked") if cfg!(target_os = "macos") => {
+                        !self.oso_prefix_covers_outputs()
+                    }
+                    _ => true,
+                },
                 // ld64 records absolute object paths and their timestamps in
                 // the binary's debug map, so the same source links to
                 // different bytes in another checkout -- or the same one
-                // twice.
-                "debuginfo" if cfg!(target_os = "macos") => !matches!(value, Some("0" | "none")),
+                // twice. An `-oso_prefix` covering the output directory
+                // strips those paths down to spellings every checkout
+                // shares, which is the same leniency a Linux link already
+                // gets for the paths rustc itself embeds; what remains
+                // (object timestamps) only shows up under verification.
+                "debuginfo" if cfg!(target_os = "macos") => {
+                    !matches!(value, Some("0" | "none")) && !self.oso_prefix_covers_outputs()
+                }
                 // Both embed this checkout's absolute target directory.
                 "rpath" | "prefer-dynamic" => is_enabled(value),
                 // The CRT objects a self-contained link uses come from
@@ -1734,6 +1827,14 @@ impl<'a> ActionBuilder<'a> {
                 "--remap-path-prefix={}={}",
                 self.normalize_path(from)?,
                 to
+            )),
+            Argument::OsoPrefix {
+                path,
+                trailing_slash,
+            } => Ok(format!(
+                "--codegen=link-arg=-Wl,-oso_prefix,{}{}",
+                self.normalize_path(path)?,
+                if *trailing_slash { "/" } else { "" }
             )),
         }
     }

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1483,3 +1483,99 @@ fn link_arguments_bypass_whatever_actually_links() {
         );
     }
 }
+
+/// The one link argument the adapter models: ld64's `-oso_prefix` names a
+/// checkout-specific path, so its value normalizes like every other path in
+/// the key instead of pinning the key to one checkout's spelling.
+#[test]
+fn an_oso_prefix_normalizes_into_the_key() {
+    let workspace_prefix = format!(
+        "-Clink-arg=-Wl,-oso_prefix,{}/",
+        workspace().to_str().unwrap()
+    );
+    let library = args(&[
+        "--crate-name=widget",
+        "--crate-type=lib",
+        "--emit=dep-info,metadata,link",
+        "--out-dir=target/debug/deps",
+        &workspace_prefix,
+        "src/lib.rs",
+    ]);
+    let RustcAction { bytes, .. } = RustcInvocation::parse(&library)
+        .unwrap()
+        .action(context(&[("src/lib.rs", "source")]))
+        .unwrap();
+    let json = String::from_utf8(bytes).unwrap();
+    assert!(
+        json.contains(r#""--codegen=link-arg=-Wl,-oso_prefix,${workspace}/""#),
+        "the prefix must enter the key by its placeholder: {json}"
+    );
+}
+
+/// ld64 is the only linker that reads `-oso_prefix`, so anywhere but a native
+/// link the option stays what every other link argument is: unmodeled.
+#[test]
+fn an_oso_prefix_is_unmodeled_where_ld64_never_links() {
+    let wasm = args(&[
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--target=wasm32-unknown-unknown",
+        "-Clink-arg=-Wl,-oso_prefix,/work/project/",
+        "src/main.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse(&wasm),
+        Err(BypassReason::UnmodeledLinkArgument(
+            "link-arg=-Wl,-oso_prefix".into()
+        )),
+    );
+}
+
+/// On macOS the debug map is what makes a debug-info link unportable, and a
+/// prefix covering the output directory is what strips the debug map back to
+/// spellings every checkout shares.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_covering_oso_prefix_makes_a_debug_link_portable() {
+    let binary = |extra: &[&str]| {
+        let mut all = vec![
+            "--crate-name=widget",
+            "--crate-type=bin",
+            "--emit=dep-info,link",
+            "-Cdebuginfo=2",
+        ];
+        all.extend_from_slice(extra);
+        all.extend_from_slice(&["src/main.rs"]);
+        args(&all)
+    };
+    let out_dir = format!(
+        "--out-dir={}",
+        workspace().join("target/debug/deps").display()
+    );
+    let covering = format!(
+        "-Clink-arg=-Wl,-oso_prefix,{}/",
+        workspace().to_str().unwrap()
+    );
+    let elsewhere = "-Clink-arg=-Wl,-oso_prefix,/somewhere/else/";
+
+    // Without a prefix the debug map pins the checkout, as before.
+    assert_eq!(
+        RustcInvocation::parse_with(&binary(&[&out_dir]), native_links()),
+        Err(BypassReason::UnportableNativeLink("debuginfo=2".into())),
+    );
+    // A prefix covering the output directory lifts exactly that.
+    assert!(RustcInvocation::parse_with(&binary(&[&out_dir, &covering]), native_links()).is_ok());
+    // One covering something else does not.
+    assert_eq!(
+        RustcInvocation::parse_with(&binary(&[&out_dir, elsewhere]), native_links()),
+        Err(BypassReason::UnportableNativeLink("debuginfo=2".into())),
+    );
+    // And a relative output directory pins nothing a prefix could cover.
+    assert_eq!(
+        RustcInvocation::parse_with(
+            &binary(&["--out-dir=target/debug/deps", &covering]),
+            native_links()
+        ),
+        Err(BypassReason::UnportableNativeLink("debuginfo=2".into())),
+    );
+}

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -123,6 +123,8 @@ pub(crate) struct RawConfig {
     savings: String,
     /// Cache natively linked test binaries and executables. Experimental:
     /// qualify it on your own workload with MBX_VERIFY=1 before relying on it.
+    /// On macOS this also passes ld64 `-oso_prefix` so a debug-info link's
+    /// debug map stops naming this checkout, which is what lets it cache.
     #[usage(
         key = "cache_links",
         env = "MBX_CACHE_LINKS",

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -17,6 +17,7 @@ use mbx_cache_rustc::{
     normalize_mapped_path,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -122,6 +123,11 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     // has no parent session, so first parse just enough of the invocation to
     // learn its output directory and use that as the stable target mapping.
     let options = ParseOptions::caching_native_links(session::cache_links_requested());
+    // Appended before anything parses: the debug-map rule inside the parser is
+    // exactly what this flag satisfies, so an invocation that would bypass
+    // without it has to carry it going in.
+    let arguments = with_oso_prefix(arguments, session::cache_links_requested());
+    let arguments = arguments.as_ref();
     let initial_invocation = RustcInvocation::parse_with(arguments, options)?;
     let initial_outputs = initial_invocation.outputs(&working_dir)?;
     let portable = Portable::detect(
@@ -682,6 +688,46 @@ fn base_action_context(
 /// failure: not knowing the linker is a reason this compilation cannot be
 /// cached, which is what a bypass is, and reporting it as anything else leaves
 /// it out of the summary and out of `mbx explain`.
+/// Ask ld64 to strip this build's output directory from the debug map.
+///
+/// On macOS a linked binary records the absolute path and timestamp of every
+/// object behind it, which is what makes a debug-info link unportable across
+/// checkouts. The output directory is where all of them live, and only the
+/// shim sees its managed, hashed spelling on every invocation -- so when
+/// native links are being cached on this platform, the shim appends the
+/// prefix itself rather than asking anyone to discover it. An invocation that
+/// already carries one keeps what its caller chose, and an invocation without
+/// an output directory has no linker to hand this to.
+///
+/// Read straight off the argument list, because this runs before anything
+/// parses: the parser's own debug-map rule is exactly what the flag
+/// satisfies, so it has to be present going in.
+fn with_oso_prefix(arguments: &[OsString], cache_links: bool) -> Cow<'_, [OsString]> {
+    if !cfg!(target_os = "macos") || !cache_links {
+        return Cow::Borrowed(arguments);
+    }
+    let mut out_dir = None;
+    for (index, argument) in arguments.iter().enumerate() {
+        let Some(argument) = argument.to_str() else {
+            continue;
+        };
+        if argument.contains("-oso_prefix,") {
+            return Cow::Borrowed(arguments);
+        }
+        if argument == "--out-dir" {
+            out_dir = arguments.get(index + 1).map(PathBuf::from);
+        } else if let Some(value) = argument.strip_prefix("--out-dir=") {
+            out_dir = Some(PathBuf::from(value));
+        }
+    }
+    let Some(out_dir) = out_dir.filter(|out_dir| out_dir.is_absolute()) else {
+        return Cow::Borrowed(arguments);
+    };
+    let mut extended = arguments.to_vec();
+    extended.push(format!("-Clink-arg=-Wl,-oso_prefix,{}/", out_dir.display()).into());
+    Cow::Owned(extended)
+}
+
 fn linker_for(invocation: &RustcInvocation) -> Result<Option<LinkerIdentity>> {
     if !invocation.links_natively() {
         return Ok(None);

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -714,6 +714,13 @@ fn with_oso_prefix(arguments: &[OsString], cache_links: bool) -> Cow<'_, [OsStri
         if argument.contains("-oso_prefix,") {
             return Cow::Borrowed(arguments);
         }
+        // Only a host link is ld64's to read. An explicit `--target` never
+        // classifies as one -- wasm links in particular stay cacheable -- and
+        // handing those invocations this flag would turn it into the
+        // unmodeled link argument that bypasses them.
+        if argument == "--target" || argument.starts_with("--target=") {
+            return Cow::Borrowed(arguments);
+        }
         if argument == "--out-dir" {
             out_dir = arguments.get(index + 1).map(PathBuf::from);
         } else if let Some(value) = argument.strip_prefix("--out-dir=") {

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -736,3 +736,37 @@ fn a_root_written_with_a_trailing_separator_still_rewrites() {
         original.as_bytes()
     );
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn the_shim_appends_an_oso_prefix_for_cached_links() {
+    let arguments = |values: &[&str]| values.iter().map(OsString::from).collect::<Vec<_>>();
+    let base = arguments(&[
+        "--crate-name=app",
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--out-dir",
+        "/work/target/debug/deps",
+        "src/main.rs",
+    ]);
+    let extended = with_oso_prefix(&base, true);
+    assert_eq!(
+        extended.last().unwrap(),
+        &OsString::from("-Clink-arg=-Wl,-oso_prefix,/work/target/debug/deps/"),
+    );
+    // Off when links are not cached, when the caller chose a prefix, and when
+    // there is no output directory to cover.
+    assert_eq!(with_oso_prefix(&base, false).len(), base.len());
+    let mut chosen = base.clone();
+    chosen.push("-Clink-arg=-Wl,-oso_prefix,/elsewhere/".into());
+    assert_eq!(with_oso_prefix(&chosen, true).len(), chosen.len());
+    let query = arguments(&["--print=cfg"]);
+    assert_eq!(with_oso_prefix(&query, true).len(), query.len());
+    let relative = arguments(&["--out-dir", "target/debug/deps", "src/main.rs"]);
+    assert_eq!(with_oso_prefix(&relative, true).len(), relative.len());
+    let split = arguments(&["--out-dir=/work/target/debug/deps", "src/main.rs"]);
+    assert_eq!(
+        with_oso_prefix(&split, true).last().unwrap(),
+        &OsString::from("-Clink-arg=-Wl,-oso_prefix,/work/target/debug/deps/"),
+    );
+}

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -762,6 +762,27 @@ fn the_shim_appends_an_oso_prefix_for_cached_links() {
     assert_eq!(with_oso_prefix(&chosen, true).len(), chosen.len());
     let query = arguments(&["--print=cfg"]);
     assert_eq!(with_oso_prefix(&query, true).len(), query.len());
+    // An explicit `--target` is never a host link, so nothing is appended:
+    // handing a wasm link this flag would bypass it as unmodeled.
+    let wasm = arguments(&[
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--target=wasm32-unknown-unknown",
+        "--out-dir",
+        "/work/target/wasm32-unknown-unknown/debug/deps",
+        "src/main.rs",
+    ]);
+    assert_eq!(with_oso_prefix(&wasm, true).len(), wasm.len());
+    let split_target = arguments(&[
+        "--target",
+        "wasm32-unknown-unknown",
+        "--out-dir=/work/target/debug/deps",
+        "src/main.rs",
+    ]);
+    assert_eq!(
+        with_oso_prefix(&split_target, true).len(),
+        split_target.len()
+    );
     let relative = arguments(&["--out-dir", "target/debug/deps", "src/main.rs"]);
     assert_eq!(with_oso_prefix(&relative, true).len(), relative.len());
     let split = arguments(&["--out-dir=/work/target/debug/deps", "src/main.rs"]);

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -31,7 +31,7 @@ Cache root.
 - **Scope:** only from the environment or the command line
 - **Set with:** `MBX_CACHE_LINKS`
 
-Cache natively linked test binaries and executables. Experimental: qualify it on your own workload with MBX_VERIFY=1 before relying on it.
+Cache natively linked test binaries and executables. Experimental: qualify it on your own workload with MBX_VERIFY=1 before relying on it. On macOS this also passes ld64 `-oso_prefix` so a debug-info link's debug map stops naming this checkout, which is what lets it cache.
 
 ### `cc`
 


### PR DESCRIPTION
## What

macOS native links with debug info have always bypassed the cache (`unportable-native-link: debuginfo=2`), because ld64 records the absolute path and timestamp of every object in the binary's debug map. In today's hk benchmark that's every test binary and executable on macOS.

This teaches the shim to pass ld64's `-oso_prefix` itself, and the adapter to model it:

- **The shim appends** `-Clink-arg=-Wl,-oso_prefix,<out-dir>/` when native links are cached on macOS (`MBX_CACHE_LINKS=1`) — only the shim sees the managed target directory's hashed spelling on every invocation, so no user configuration can express this. An invocation already carrying a prefix keeps what its caller chose.
- **The parser models the flag** as its own argument whose path normalizes into the key like any other — so two checkouts passing their own prefixes agree on one action instead of pinning the key to one checkout's absolute path.
- **A covering prefix lifts the debug-map rule**: `debuginfo` links classify as portable when a prefix covers the output directory where every workspace object lives. macOS's default `split-debuginfo=unpacked` is the same debug-map arrangement, so it lifts under the same condition. What remains in the binary — toolchain object paths under rustup — is the leniency Linux links' rustc-embedded paths already get.
- **Anywhere ld64 never links** (wasm, explicit targets), the flag stays unmodeled and bypasses as all link arguments do.

## Verified

- Unit tests for the append (gating, existing-prefix respect, `--out-dir` forms) and the parse/render/classification (placeholder in key, wasm bypass, macOS coverage rule).
- End to end on this Mac: a `cargo new` bin with default dev profile (debuginfo=2, split-debuginfo=unpacked), `MBX_CACHE_LINKS=1`: seed publishes the link, a fresh-target rebuild **hits and restores the binary**, it runs, and `nm -pa` shows zero non-toolchain absolute paths in its debug map.
- Experimentally: with the prefix, two checkouts at different paths produce binaries differing only in object timestamps + UUID (68 bytes); without it, absolute checkout paths throughout.

`mise run ci` passes locally. Complements #164/#165 (which cut warm-walk overhead on all platforms); this one turns macOS's largest bypass category into hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experimental native-link caching and linker debug-map behavior on macOS; incorrect prefix or portability rules could allow cache hits that restore binaries with wrong debug paths or miss verification expectations.
> 
> **Overview**
> When **`MBX_CACHE_LINKS`** is on, the rustc shim on **macOS** injects **`-Clink-arg=-Wl,-oso_prefix,<absolute out-dir>/`** before parsing (unless the caller already set a prefix, the link is cross-target, or there is no absolute `--out-dir`).
> 
> The **rustc cache adapter** treats that flag as **`Argument::OsoPrefix`**, normalizing the path in the action key like other paths and round-tripping it in dep-info replay. On **native macOS links**, if the prefix **covers the output directory**, **`debuginfo`** and **`split-debuginfo=unpacked`** are no longer classified as unportable; on **non-ld64** links the flag still triggers **unmodeled link argument** bypass.
> 
> Config/docs note the macOS behavior; unit tests cover append gating, key normalization, wasm bypass, and the coverage rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 033aab965a7744f1d5deff91d4b3ab5233aa3983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->