### PR TITLE
ci(bench-refresh): open the pull request with the token that can

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Force-push the bench-refresh branch
         if: steps.dirty.outputs.dirty == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BENCH_REFRESH_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"
@@ -169,9 +169,10 @@ jobs:
       - name: Create or update the pull request
         if: steps.dirty.outputs.dirty == 'true'
         env:
-          # Falls back to the default token, whose pull requests do not start
-          # CI and need the repository to allow Actions to open them.
-          GITHUB_TOKEN: ${{ secrets.BENCH_REFRESH_TOKEN || secrets.GITHUB_TOKEN }}
+          # The same credential release-plz uses to open its pull requests.
+          # The default token cannot: this repository does not let Actions
+          # create them, and one it opened would not start CI anyway.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           WORKSPACE: ${{ needs.check.outputs.workspace }}
           BENCH: ${{ needs.check.outputs.bench }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
`bench-refresh` opened its pull request with `secrets.BENCH_REFRESH_TOKEN || secrets.GITHUB_TOKEN`. Neither works today:

- `BENCH_REFRESH_TOKEN` does not exist.
- The default token cannot create pull requests here — `can_approve_pull_request_reviews` is `false` on this repository, so `gh pr create` fails outright. Even where it is allowed, a pull request opened by `GITHUB_TOKEN` does not start CI, which is the opposite of what a "review these numbers" pull request needs.

So the first `workflow_dispatch` would have run the full benchmark and then failed on its last step.

This points the two steps at `RELEASE_PLZ_TOKEN`, which this repository already uses for exactly this — release-plz pushes a branch and opens a pull request with it. Reusing it beats adding a second secret that does the same job.

zizmor is clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only credential change reusing an existing secret already used for release-plz PRs; no application or data-path changes.
> 
> **Overview**
> The **bench-refresh** workflow’s `propose` job was failing at the end of a successful benchmark because neither `BENCH_REFRESH_TOKEN` (missing) nor the default `GITHUB_TOKEN` can open pull requests in this repo—and PRs from the default token would not run CI anyway.
> 
> Both the **force-push `bench-refresh` branch** step and **create or update the pull request** step now authenticate with `secrets.RELEASE_PLZ_TOKEN`, matching **release-plz**. Comments in the PR step explain why the default token is not used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4fd64e54884402001c6c12d96d88feeefedbeb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->