### PR TITLE
fix(benchmarks): stop a scratch-tree cleanup from discarding the run

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -100,7 +100,16 @@ jobs:
         run: mise run bench:refresh
       - name: Publish job summary
         if: always()
-        run: cat target/benchmarks/real-world.md >> "$GITHUB_STEP_SUMMARY"
+        # A run that failed before writing its summary has already reported
+        # why; a missing file here would only add a second, less informative
+        # red step on top of it.
+        run: |
+          if [ -f target/benchmarks/real-world.md ]; then
+            cat target/benchmarks/real-world.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "The benchmark did not get as far as writing a summary." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Upload measurements
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/benchmarks/real_world.py
+++ b/benchmarks/real_world.py
@@ -238,6 +238,18 @@ class Runner:
                 capture_output=True,
             )
             extra["summary"] = stats.stdout.strip().splitlines()
+            # Each cell points kache at its own runtime directory, so each one
+            # starts its own daemon. Stopping it keeps the cells independent
+            # and stops a draining daemon from writing into a tree that is
+            # about to be removed.
+            subprocess.run(
+                [kache, "daemon", "stop"],
+                cwd=checkout,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
 
         return {"tool": tool, "wall_duration_ns": duration_ns, **extra}
 
@@ -578,7 +590,14 @@ def main() -> int:
 
     # Checkouts, targets, and stores are large and disposable; only the reports
     # under --output survive the run.
-    with tempfile.TemporaryDirectory(prefix="mbx-real-world-") as temporary:
+    # ignore_cleanup_errors: the results are computed after this block, so a
+    # failure to remove the scratch tree would throw away the whole run. kache
+    # runs a daemon per cell that writes into its own runtime directory here,
+    # and one still draining while rmtree walks makes the removal fail. The
+    # tree is disposable; the measurements are not.
+    with tempfile.TemporaryDirectory(
+        prefix="mbx-real-world-", ignore_cleanup_errors=True
+    ) as temporary:
         work = Path(temporary)
         cargo_home = work / "cargo-home"
         cargo_home.mkdir()


### PR DESCRIPTION
The first dispatched refresh ([run 33225965974](https://github.com/jdx/mr-boxington/actions/runs/33225965974)) ran all five scenarios and then threw every measurement away.

## What happened

`TemporaryDirectory` removes the scratch tree when its `with` block ends, and the results are validated and written *after* that block. So when the removal raised `OSError: [Errno 39] Directory not empty`, it took the entire run with it — 31 minutes of building, no output.

The directory was not empty because **kache runs a daemon**. Each cell points it at its own `KACHE_RUNTIME_DIR` inside the scratch tree, so each cell starts its own daemon, and one still draining writes into that tree while `rmtree` walks it.

## Fixes

1. **Cleanup cannot discard a run.** `ignore_cleanup_errors=True`. The tree is disposable and the runner is ephemeral; nothing in it is worth a run's measurements.
2. **Cells stop the daemon they started.** This also keeps them properly independent rather than leaving one daemon per cell alive until the end.
3. **The summary step reports honestly.** It was failing on a `cat` of the summary the crash had prevented, adding a second red step that said less than the first.

## The numbers were fine

Recovered from the run's uploaded artifact — every gate would have passed:

| scenario | lookups | hits | predictions | restored |
| :--- | ---: | ---: | ---: | ---: |
| warm | 719 | 718 | 716 | 1218 |
| commit | 719 | 718 | 716 | 1218 |
| worktree | 719 | 683 | 716 | 1113 |
| toolchain | 2 | 2 | 716 | 2 |

Cross-worktree sharing holds on Linux, and the compiler-change guard held on a real runner. The job took 31 minutes against a 120-minute timeout, so there is plenty of headroom.

One thing to expect when the numbers land: cargo's own timings in the logs put kache ahead of mbx on the warm and cross-worktree scenarios. Those are not the harness's wall-clock measurements, which were lost, so I would not read much into them yet — but it is the sort of result this benchmark exists to surface rather than hide.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the real-world benchmark driver and CI summary publishing; no application runtime, auth, or data paths.
> 
> **Overview**
> Fixes a failure mode where a long **bench-refresh** run could finish all scenarios and still lose every measurement when tearing down the scratch directory.
> 
> In **`benchmarks/real_world.py`**, each **kache** cell now runs **`kache daemon stop`** after its build so per-cell daemons do not keep writing under **`KACHE_RUNTIME_DIR`** while the temp tree is removed. The scratch **`TemporaryDirectory`** also uses **`ignore_cleanup_errors=True`** so a non-empty tree (e.g. a draining daemon) cannot raise during cleanup *after* the timed work—validation and **`real-world.md` / `results.json`** are written outside that block.
> 
> In **`.github/workflows/bench-refresh.yml`**, the **Publish job summary** step only **`cat`**s **`target/benchmarks/real-world.md`** when the file exists; otherwise it adds a short message instead of failing on a missing summary when an earlier step already failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11764fc8da4a177298f65a7fceb52b6d51cc177f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->