### PR TITLE
perf(scheduler): retire the link guess, and wake waiters on release

### DIFF
--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -19,10 +19,12 @@
 //! permit: the sum of admitted weights never exceeds the capacity, so the
 //! *predicted* memory of everything running stays inside the configured
 //! budget. Prediction comes from a small ledger of peak RSS per crate name,
-//! measured after every real compile on Unix. Two things remain out of reach
-//! and are accepted: a single compilation larger than the machine will still
-//! be too large when it runs alone, and a simultaneous pile-up of
-//! never-measured crates can overshoot before the ledger has learned them.
+//! measured after every real compile on Unix; the static link weight is only
+//! the guess that stands in until one has been measured. Two things remain
+//! out of reach and are accepted: a single compilation larger than the
+//! machine will still be too large when it runs alone, and a simultaneous
+//! pile-up of never-measured crates can overshoot before the ledger has
+//! learned them.
 //!
 //! Concurrent sessions may be configured with different capacities; each
 //! enforces its own bound against the same leases, so the loosest
@@ -43,6 +45,11 @@
 //! is fixed and acyclic: a flight is joined before its permit is requested,
 //! never around the other way, and a waiter blocked on a flight holds no
 //! permit.
+//!
+//! Waiting is a timer everywhere and a wakeup on Linux, where a released
+//! permit is a deleted lease file and [`ReleaseWake`] watches for exactly
+//! that. The timer stays underneath it as the backstop, so nothing depends
+//! on the watch existing.
 
 use crate::config::{Config, SchedulerPriority};
 use eyre::{Context, Result};
@@ -102,10 +109,11 @@ const LINK_WEIGHT: u64 = 2;
 const POLL_INITIAL: Duration = Duration::from_millis(2);
 /// Longest delay between admission attempts.
 ///
-/// A permit is released the instant its compiler exits and nothing wakes the
-/// waiters, so this bounds how long a core sits idle with work queued for
-/// it. Kept short for that reason: one attempt is a readdir and a handful of
-/// `try_lock`s, which even a full pool of waiters can afford at this rate.
+/// On Linux a release wakes waiters through the leases watch (see
+/// [`ReleaseWake`]) and this is only the backstop; elsewhere it bounds how
+/// long a core sits idle with work queued for it. Kept short for that
+/// reason: one attempt is a readdir and a handful of `try_lock`s, which even
+/// a full pool of waiters can afford at this rate.
 const POLL_MAX: Duration = Duration::from_millis(25);
 /// How recently the stamp must have been touched to hold low priority back.
 const PRIORITY_WAIT_FRESHNESS: Duration = Duration::from_secs(2);
@@ -483,10 +491,11 @@ fn bytes_per_permit(memory_bytes: Option<u64>, cpus: u64) -> u64 {
 
 /// Record what the compiler that just ran cost, for the next admission.
 ///
-/// Only crates that would weigh more than one permit are recorded, which keeps
-/// the ledger to the genuinely heavy. A compiler killed by SIGKILL -- the
-/// Linux OOM killer's signature -- is recorded *heavier* than it measured, so
-/// the retry runs with more room instead of repeating the crash.
+/// Crates that fit inside one permit are not worth remembering -- except
+/// links, whose measurement is what retires the static floor they are
+/// otherwise charged. A compiler killed by SIGKILL -- the Linux OOM killer's
+/// signature -- is recorded *heavier* than it measured, so the retry runs
+/// with more room instead of repeating the crash.
 pub(crate) fn record_compiler_memory(demand: &Demand, status: &ExitStatus) {
     let Some(pool) = pool() else {
         return;
@@ -532,6 +541,7 @@ impl Pool {
         let mut delay = POLL_INITIAL;
         let mut stamped: Option<Instant> = None;
         let mut complained = false;
+        let mut wake: Option<Option<ReleaseWake>> = None;
         loop {
             // The gate stops applying at its deadline so a machine that stays
             // short of memory delays this compilation rather than starving it.
@@ -564,7 +574,16 @@ impl Pool {
                     self.capacity, demand.name
                 );
             }
-            std::thread::sleep(jittered(delay));
+            // Armed after the first refusal rather than before the first
+            // attempt: most admissions succeed immediately and should not pay
+            // for a watch. Arming races the release it would have caught,
+            // which the timeout below absorbs; from the next iteration on,
+            // a release lands in the watch before the scan it should wake.
+            let wake = wake.get_or_insert_with(|| ReleaseWake::new(&self.dir.join(LEASES_DIR)));
+            match wake {
+                Some(wake) => wake.wait(jittered(delay)),
+                None => std::thread::sleep(jittered(delay)),
+            }
             delay = (delay * 2).min(POLL_MAX);
         }
     }
@@ -580,10 +599,14 @@ impl Pool {
             .get(&demand.name)
             .copied();
         let link_bytes = link_floor.map(|weight| weight.saturating_mul(self.bytes_per_permit));
-        let predicted = match (recorded, link_bytes) {
-            (Some(recorded), Some(link)) => Some(recorded.max(link)),
-            (one, other) => one.or(other),
-        };
+        // History replaces the floor rather than merely raising it. The floor
+        // is a guess for links the pool has never seen; once one has been
+        // measured, charging it the guess anyway would hold the tail of every
+        // build -- the link-heavy stretch -- to half the concurrency its real
+        // memory justifies. The ledger never lowers a recorded peak and an
+        // OOM kill escalates past it, so trusting the measurement stays safe
+        // in the direction that matters.
+        let predicted = recorded.or(link_bytes);
         let weight = predicted
             .map_or(1, |bytes| bytes.div_ceil(self.bytes_per_permit))
             .clamp(1, self.capacity);
@@ -722,7 +745,12 @@ impl Pool {
         let Some(measured) = child_peak_rss_bytes() else {
             return;
         };
-        let Some(peak) = ledger_peak(measured, oom_killed(status), self.bytes_per_permit) else {
+        let Some(peak) = ledger_peak(
+            measured,
+            oom_killed(status),
+            demand.links,
+            self.bytes_per_permit,
+        ) else {
             return;
         };
         if let Err(error) = self.record_peak(&demand.name, peak) {
@@ -797,16 +825,22 @@ fn scan_leases(leases: &Path) -> Result<Vec<u64>> {
 /// What the ledger should remember about one finished compilation.
 ///
 /// `None` means nothing worth writing: the compile fit comfortably inside a
-/// single permit. An OOM kill is recorded past what was measured -- the
-/// measurement is where the killer stopped it, not what it needed -- and past
-/// one permit, so the retry provably weighs more.
-fn ledger_peak(measured: u64, oom_killed: bool, bytes_per_permit: u64) -> Option<u64> {
+/// single permit and carried no static weight worth correcting. A link is
+/// always recorded, even light, because an unmeasured link is charged a
+/// deliberately heavy floor and the measurement is what retires it. An OOM
+/// kill is recorded past what was measured -- the measurement is where the
+/// killer stopped it, not what it needed -- and past one permit, so the
+/// retry provably weighs more.
+fn ledger_peak(measured: u64, oom_killed: bool, links: bool, bytes_per_permit: u64) -> Option<u64> {
     if oom_killed {
         return Some(
             measured
                 .saturating_mul(2)
                 .max(bytes_per_permit.saturating_add(1)),
         );
+    }
+    if links {
+        return Some(measured);
     }
     (measured > bytes_per_permit).then_some(measured)
 }
@@ -870,6 +904,87 @@ fn oom_killed(_status: &ExitStatus) -> bool {
 fn jittered(delay: Duration) -> Duration {
     use rand::RngExt as _;
     delay + delay.mul_f64(rand::rng().random_range(0.0..0.5))
+}
+
+/// Wakes a waiter the moment a permit is released, on hosts that can.
+///
+/// A permit's release *is* the deletion of its lease file, so on Linux the
+/// leases directory is watched for deletions through inotify and a refused
+/// waiter sleeps on the watch instead of a timer -- the gap between a
+/// compiler exiting and the next admission goes from a poll interval to a
+/// wakeup. The timer stays underneath as the backstop: a release can slip
+/// past while the watch is first armed, and inotify instances are a bounded
+/// per-user resource that a large enough build simply runs out of. Failing
+/// to watch therefore just means waiting the way every other platform does.
+#[cfg(target_os = "linux")]
+struct ReleaseWake {
+    fd: std::os::fd::OwnedFd,
+}
+
+#[cfg(target_os = "linux")]
+impl ReleaseWake {
+    fn new(leases: &Path) -> Option<Self> {
+        use std::os::fd::{AsRawFd as _, FromRawFd as _};
+        use std::os::unix::ffi::OsStrExt as _;
+        let path = std::ffi::CString::new(leases.as_os_str().as_bytes()).ok()?;
+        // SAFETY: inotify_init1 returns a new descriptor that nothing else
+        // owns; wrapping it immediately gives it an owner that closes it.
+        let fd = unsafe { libc::inotify_init1(libc::IN_NONBLOCK | libc::IN_CLOEXEC) };
+        if fd < 0 {
+            return None;
+        }
+        let fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
+        // SAFETY: the descriptor is a live inotify instance and the path is a
+        // valid NUL-terminated string for the duration of the call.
+        let watch =
+            unsafe { libc::inotify_add_watch(fd.as_raw_fd(), path.as_ptr(), libc::IN_DELETE) };
+        (watch >= 0).then_some(Self { fd })
+    }
+
+    /// Sleep until a lease is released or the timeout passes.
+    fn wait(&self, timeout: Duration) {
+        use std::os::fd::AsRawFd as _;
+        let mut poll = libc::pollfd {
+            fd: self.fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let millis = i32::try_from(timeout.as_millis().max(1)).unwrap_or(i32::MAX);
+        // SAFETY: one valid pollfd is handed over for the duration of the call.
+        let ready = unsafe { libc::poll(&mut poll, 1, millis) };
+        if ready <= 0 {
+            return;
+        }
+        // Drained so the next wait sleeps on releases that have not been
+        // seen rather than returning instantly on ones that have. What the
+        // events say does not matter; that they happened is the signal.
+        let mut buffer = [0_u8; 4096];
+        // SAFETY: reads only ever land inside the local buffer, and the
+        // descriptor is nonblocking, so the loop cannot hang.
+        while unsafe {
+            libc::read(
+                self.fd.as_raw_fd(),
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+            )
+        } > 0
+        {}
+    }
+}
+
+/// Hosts without a release watch wait on the timer alone.
+#[cfg(not(target_os = "linux"))]
+struct ReleaseWake;
+
+#[cfg(not(target_os = "linux"))]
+impl ReleaseWake {
+    fn new(_leases: &Path) -> Option<Self> {
+        None
+    }
+
+    fn wait(&self, timeout: Duration) {
+        std::thread::sleep(timeout)
+    }
 }
 
 #[cfg(test)]

--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -492,10 +492,10 @@ fn bytes_per_permit(memory_bytes: Option<u64>, cpus: u64) -> u64 {
 /// Record what the compiler that just ran cost, for the next admission.
 ///
 /// Crates that fit inside one permit are not worth remembering -- except
-/// links, whose measurement is what retires the static floor they are
-/// otherwise charged. A compiler killed by SIGKILL -- the Linux OOM killer's
-/// signature -- is recorded *heavier* than it measured, so the retry runs
-/// with more room instead of repeating the crash.
+/// links that succeeded, whose measurement is what retires the static floor
+/// they are otherwise charged. A compiler killed by SIGKILL -- the Linux OOM
+/// killer's signature -- is recorded *heavier* than it measured, so the retry
+/// runs with more room instead of repeating the crash.
 pub(crate) fn record_compiler_memory(demand: &Demand, status: &ExitStatus) {
     let Some(pool) = pool() else {
         return;
@@ -757,6 +757,7 @@ impl Pool {
             measured,
             oom_killed(status),
             demand.links,
+            status.success(),
             self.bytes_per_permit,
         ) else {
             return;
@@ -848,13 +849,29 @@ fn scan_leases(leases: &Path) -> Result<Vec<u64>> {
 /// What the ledger should remember about one finished compilation.
 ///
 /// `None` means nothing worth writing: the compile fit comfortably inside a
-/// single permit and carried no static weight worth correcting. A link is
-/// always recorded, even light, because an unmeasured link is charged a
-/// deliberately heavy floor and the measurement is what retires it. An OOM
-/// kill is recorded past what was measured -- the measurement is where the
-/// killer stopped it, not what it needed -- and past one permit, so the
-/// retry provably weighs more.
-fn ledger_peak(measured: u64, oom_killed: bool, links: bool, bytes_per_permit: u64) -> Option<u64> {
+/// single permit and carried no static weight worth correcting. An OOM kill
+/// is recorded past what was measured -- the measurement is where the killer
+/// stopped it, not what it needed -- and past one permit, so the retry
+/// provably weighs more.
+///
+/// The link case is the reason this takes an outcome at all, and the rule is
+/// deliberately asymmetric: a *successful* link is recorded whatever it
+/// measured, because that is a true reading of what linking that crate costs
+/// and it is what retires the static floor. A failed one is not. Whether an
+/// invocation links is read off its crate type, so a binary that dies in type
+/// checking never reached the linker at all -- and recording its small peak
+/// would retire the floor using a number from a compilation that never did
+/// the expensive thing, machine-wide, for every later build sharing the
+/// cache. A failure is therefore held to the ordinary bar, where it can still
+/// teach the ledger that something is *heavy* (a link that died reaching for
+/// memory) but can never argue that anything is light.
+fn ledger_peak(
+    measured: u64,
+    oom_killed: bool,
+    links: bool,
+    succeeded: bool,
+    bytes_per_permit: u64,
+) -> Option<u64> {
     if oom_killed {
         return Some(
             measured
@@ -862,7 +879,7 @@ fn ledger_peak(measured: u64, oom_killed: bool, links: bool, bytes_per_permit: u
                 .max(bytes_per_permit.saturating_add(1)),
         );
     }
-    if links {
+    if links && succeeded {
         return Some(measured);
     }
     (measured > bytes_per_permit).then_some(measured)

--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -596,7 +596,7 @@ impl Pool {
         }
         let recorded = read_ledger(&self.ledger_path())
             .crates
-            .get(&demand.name)
+            .get(&ledger_key(&demand.name, demand.links))
             .copied();
         let link_bytes = link_floor.map(|weight| weight.saturating_mul(self.bytes_per_permit));
         // History replaces the floor rather than merely raising it. The floor
@@ -606,6 +606,14 @@ impl Pool {
         // memory justifies. The ledger never lowers a recorded peak and an
         // OOM kill escalates past it, so trusting the measurement stays safe
         // in the direction that matters.
+        //
+        // Only a *link's* own history may retire the link floor, which is why
+        // the two are separate ledger entries. One crate is compiled both
+        // ways in a single build -- `cargo check` emits metadata where `cargo
+        // build` links -- and the metadata-only measurement is the smaller of
+        // the two by far. Keyed by name alone it would retire the floor for
+        // the link beside it, which is over-admission with a plausible number
+        // attached to it.
         let predicted = recorded.or(link_bytes);
         let weight = predicted
             .map_or(1, |bytes| bytes.div_ceil(self.bytes_per_permit))
@@ -753,7 +761,7 @@ impl Pool {
         ) else {
             return;
         };
-        if let Err(error) = self.record_peak(&demand.name, peak) {
+        if let Err(error) = self.record_peak(&ledger_key(&demand.name, demand.links), peak) {
             debug!("compiler memory was not recorded: {error:#}");
         }
     }
@@ -787,6 +795,21 @@ impl Pool {
         let mut contents = serde_json::to_vec(&ledger)?;
         contents.push(b'\n');
         crate::util::write_atomic(&path, &contents)
+    }
+}
+
+/// What one crate's memory is remembered under.
+///
+/// A link and a metadata-only compile of the same crate are different
+/// workloads with the same name -- `cargo check` and `cargo build` run both
+/// against one crate, often at the same moment -- so they are remembered
+/// apart. The suffix cannot collide with a crate name, which is a Rust
+/// identifier and can hold neither a space nor a bracket.
+fn ledger_key(name: &str, links: bool) -> String {
+    if links {
+        format!("{name} [link]")
+    } else {
+        name.to_string()
     }
 }
 

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -345,11 +345,12 @@ fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
     let pool = pool_at(directory.path(), 4, 1000);
 
     // Under one permit's worth of memory: not worth a ledger entry.
-    assert_eq!(ledger_peak(900, false, false, 1000), None);
+    assert_eq!(ledger_peak(900, false, false, true, 1000), None);
     // Over it: recorded as measured.
-    assert_eq!(ledger_peak(1500, false, false, 1000), Some(1500));
-    // A link is recorded even light, because that is what retires its floor.
-    assert_eq!(ledger_peak(900, false, true, 1000), Some(900));
+    assert_eq!(ledger_peak(1500, false, false, true, 1000), Some(1500));
+    // A link that succeeded is recorded even light, because that is what
+    // retires its floor.
+    assert_eq!(ledger_peak(900, false, true, true, 1000), Some(900));
 
     pool.record_peak("crate", 1500).unwrap();
     pool.record_peak("crate", 1200).unwrap();
@@ -369,11 +370,30 @@ fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
 #[test]
 fn an_oom_kill_escalates_past_what_was_measured() {
     // The killer stopped it at 1500; the record says it needs more than that.
-    assert_eq!(ledger_peak(1500, true, false, 1000), Some(3000));
+    assert_eq!(ledger_peak(1500, true, false, false, 1000), Some(3000));
     // Even a tiny measurement escalates past one permit, so the weight rises.
-    assert_eq!(ledger_peak(10, true, false, 1000), Some(1001));
+    assert_eq!(ledger_peak(10, true, false, false, 1000), Some(1001));
     // A killed link escalates too, rather than recording what it reached.
-    assert_eq!(ledger_peak(1500, true, true, 1000), Some(3000));
+    assert_eq!(ledger_peak(1500, true, true, false, 1000), Some(3000));
+}
+
+#[test]
+fn a_link_that_never_reached_the_linker_cannot_cheapen_the_ones_that_do() {
+    // Whether an invocation links is its crate type, not its outcome: a
+    // binary that dies in type checking is a "link" that never ran one. Its
+    // small peak must not retire the floor -- machine-wide, for every later
+    // build sharing the cache -- on the strength of a compilation that never
+    // did the expensive thing.
+    assert_eq!(
+        ledger_peak(900, false, true, false, 1000),
+        None,
+        "a failed link records nothing it could later be admitted on"
+    );
+    // The failure can still say something is heavy, which is the direction
+    // that keeps a link that died reaching for memory from repeating itself.
+    assert_eq!(ledger_peak(4000, false, true, false, 1000), Some(4000));
+    // And the successful link of the same shape still retires its floor.
+    assert_eq!(ledger_peak(900, false, true, true, 1000), Some(900));
 }
 
 #[test]

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -295,6 +295,17 @@ fn plans_weigh_history_links_and_nothing() {
         "history above the link floor wins"
     );
 
+    // A link the pool has measured is weighted by what it used, not by the
+    // guess it was charged before anyone had seen it: the floor exists for
+    // unmeasured links, and a measurement retires it in either direction.
+    pool.record_peak("light-link", 700).unwrap();
+    let (weight, predicted) = pool.plan(&Demand::new("light-link", true));
+    assert_eq!(
+        (weight, predicted),
+        (1, Some(700)),
+        "history below the link floor also wins"
+    );
+
     let (weight, _) = pool.plan(&Demand::new("enormous", false));
     assert_eq!(weight, 8, "weights clamp to the capacity");
 
@@ -314,9 +325,11 @@ fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
     let pool = pool_at(directory.path(), 4, 1000);
 
     // Under one permit's worth of memory: not worth a ledger entry.
-    assert_eq!(ledger_peak(900, false, 1000), None);
+    assert_eq!(ledger_peak(900, false, false, 1000), None);
     // Over it: recorded as measured.
-    assert_eq!(ledger_peak(1500, false, 1000), Some(1500));
+    assert_eq!(ledger_peak(1500, false, false, 1000), Some(1500));
+    // A link is recorded even light, because that is what retires its floor.
+    assert_eq!(ledger_peak(900, false, true, 1000), Some(900));
 
     pool.record_peak("crate", 1500).unwrap();
     pool.record_peak("crate", 1200).unwrap();
@@ -336,9 +349,11 @@ fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
 #[test]
 fn an_oom_kill_escalates_past_what_was_measured() {
     // The killer stopped it at 1500; the record says it needs more than that.
-    assert_eq!(ledger_peak(1500, true, 1000), Some(3000));
+    assert_eq!(ledger_peak(1500, true, false, 1000), Some(3000));
     // Even a tiny measurement escalates past one permit, so the weight rises.
-    assert_eq!(ledger_peak(10, true, 1000), Some(1001));
+    assert_eq!(ledger_peak(10, true, false, 1000), Some(1001));
+    // A killed link escalates too, rather than recording what it reached.
+    assert_eq!(ledger_peak(1500, true, true, 1000), Some(3000));
 }
 
 #[test]
@@ -358,6 +373,36 @@ fn the_ledger_drops_its_smallest_entries_at_the_cap() {
     );
     let largest = format!("crate-{}", MAX_LEDGER_ENTRIES + 9);
     assert!(ledger.crates.contains_key(&largest));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_released_permit_wakes_a_waiter_rather_than_leaving_it_to_time_out() {
+    let directory = tempfile::tempdir().unwrap();
+    let pool = pool_at(directory.path(), 1, 0);
+    let held = pool.try_admit(1, None).unwrap().expect("the only permit");
+
+    let wake = ReleaseWake::new(&directory.path().join(LEASES_DIR)).expect("a watch");
+    let releasing = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(50));
+        drop(held);
+    });
+
+    // A timeout far longer than the release it is waiting for: returning
+    // early is only possible if the watch saw the lease disappear.
+    let started = Instant::now();
+    wake.wait(Duration::from_secs(10));
+    let waited = started.elapsed();
+    releasing.join().unwrap();
+
+    assert!(
+        waited < Duration::from_secs(5),
+        "the release woke the waiter after {waited:?} rather than at the timeout"
+    );
+    assert!(
+        pool.try_admit(1, None).unwrap().is_some(),
+        "the permit really was free by the time the waiter woke"
+    );
 }
 
 #[test]

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -181,7 +181,7 @@ fn a_predicted_heavy_compile_does_not_wait_out_the_gate_on_an_idle_machine() {
     // Through `plan`, because that is the only weight production ever asks
     // for -- and it clamps to the capacity, so a rule written against
     // heavier-than-capacity weights would never fire for a real compilation.
-    pool.record_peak("enormous", bytes_per_permit * 1000)
+    pool.record_peak(&ledger_key("enormous", true), bytes_per_permit * 1000)
         .unwrap();
     let (weight, predicted) = pool.plan(&Demand::new("enormous", true));
     assert_eq!(
@@ -288,22 +288,42 @@ fn plans_weigh_history_links_and_nothing() {
     let (weight, predicted) = pool.plan(&Demand::new("heavy", false));
     assert_eq!((weight, predicted), (4, Some(3500)));
 
+    // "heavy" was measured compiling to metadata, and a link of that same
+    // crate must not inherit it: `cargo check` and `cargo build` name one
+    // crate for two very different workloads, and the metadata-only number
+    // is the smaller. Inheriting it retires the link floor with a
+    // measurement that was never a link's -- over-admission with a
+    // plausible number attached. An unmeasured link keeps the floor.
     let (weight, predicted) = pool.plan(&Demand::new("heavy", true));
     assert_eq!(
         (weight, predicted),
-        (4, Some(3500)),
-        "history above the link floor wins"
+        (LINK_WEIGHT, Some(LINK_WEIGHT * bytes_per_permit)),
+        "a metadata-only measurement never speaks for the link beside it"
     );
 
-    // A link the pool has measured is weighted by what it used, not by the
-    // guess it was charged before anyone had seen it: the floor exists for
-    // unmeasured links, and a measurement retires it in either direction.
-    pool.record_peak("light-link", 700).unwrap();
+    // A link measured *as a link* is weighted by what it used, whichever
+    // side of the floor that falls on -- above it,
+    pool.record_peak(&ledger_key("heavy", true), 9000).unwrap();
+    let (weight, predicted) = pool.plan(&Demand::new("heavy", true));
+    assert_eq!(
+        (weight, predicted),
+        (8, Some(9000)),
+        "a link's own history above the floor wins"
+    );
+    // and below it, which is the floor being retired rather than raised.
+    pool.record_peak(&ledger_key("light-link", true), 700)
+        .unwrap();
     let (weight, predicted) = pool.plan(&Demand::new("light-link", true));
     assert_eq!(
         (weight, predicted),
         (1, Some(700)),
-        "history below the link floor also wins"
+        "a link's own history below the floor also wins"
+    );
+    // The two entries are genuinely separate, not one overwriting the other.
+    assert_eq!(
+        pool.plan(&Demand::new("heavy", false)),
+        (4, Some(3500)),
+        "the metadata entry survives the link entry beside it"
     );
 
     let (weight, _) = pool.plan(&Demand::new("enormous", false));

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,11 +118,14 @@ for everything that is not a compiler; `"none"` keeps plain CPU permits). In a
 container, "physical memory" means the cgroup's limit rather than the host's
 RAM — a build in a 4GiB container on a large machine is budgeted by the 4GiB,
 because the rest was never its to spend.
-Native links start at two permits, and crates whose compilations have measured
-memory-heavy are weighted by what they actually used, so the predicted memory
-of everything running stays inside the budget. A compilation the Linux OOM
-killer stops is recorded heavier than it measured, so its retry runs with more
-room instead of repeating the crash.
+Native links start at two permits, and every compilation is thereafter
+weighted by what it actually used, so the predicted memory of everything
+running stays inside the budget. The two-permit start is a guess for links
+nobody has measured yet, and the first measurement replaces it in either
+direction: a link that turns out to fit in one permit stops being charged for
+two, which is what keeps the link-heavy tail of a build from running at half
+concurrency. A compilation the Linux OOM killer stops is recorded heavier than
+it measured, so its retry runs with more room instead of repeating the crash.
 
 `priority = "low"` (`MBX_SCHEDULER_PRIORITY`) is for builds nobody is sitting
 at — CI on a shared box, an editor's background check. While a normal-priority


### PR DESCRIPTION
Two things the permit pool was leaving on the floor now that #170 has stopped
concurrent builds duplicating each other's compilations.

## The link floor could never be retired

A native link is charged `LINK_WEIGHT` (two permits) before anyone has
measured it. That guess is deliberate — links are the out-of-memory class, so
they start heavy rather than waiting for history to say so — but it was also
permanent, because `ledger_peak` discarded any measurement at or under one
permit:

```rust
(measured > bytes_per_permit).then_some(measured)
```

A link that really uses less than a permit therefore never got a ledger entry,
so `plan` had nothing but the floor to go on, forever. Since `plan` also took
`recorded.max(link_bytes)`, even a *recorded* light link kept being charged
two. The tail of a build is where the links are, and it was running at half
the concurrency its real memory justified.

Links are now recorded whatever they measure, and history replaces the floor
rather than only raising it. The direction that matters is still safe: a
recorded peak never shrinks, and an OOM kill is still escalated past what it
measured, so a link that dies reaching for memory comes back heavier.

## Waiters slept on a timer

A permit is released the instant its compiler exits, and nothing woke anyone —
a refused waiter backed off 2ms→25ms and rechecked. That is a core sitting
idle with work queued for it, once per release, several thousand times across
a build.

A release *is* the deletion of a lease file, so on Linux the leases directory
is watched through inotify and a refused waiter sleeps on the watch instead.
Deliberately conservative:

- **armed after the first refusal**, not before the first attempt, since most
  admissions succeed immediately and should not pay for a watch;
- **the timer stays underneath as the backstop** — arming races the release it
  would have caught, and inotify instances are a bounded per-user resource a
  large enough build can exhaust;
- **every other platform is unchanged**, sleeping the way it does today.

Failing to watch, for any reason, just means waiting the way it did before.

## Measurements

Being straight about these: this is a shared box that idles at load ~30, and
the contention scenario's wall time is noisy enough on it that I would not
publish a single-round claim. Numbers and a verdict go in a comment below once
the paired rounds finish; the hit count (1877) is identical across every cell
either way, so nothing here changes what gets cached — only how fast the pool
hands out the right to compile.

## Verification

- 2 new unit tests (a light link's measurement retiring its floor; a released
  permit waking a waiter rather than leaving it to the timeout), and the
  `ledger_peak` cases extended for the link and killed-link paths.
- `mise run ci` green, including the bats suites and the wasm e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes machine-wide admission weights and ledger semantics shared across builds; incorrect recording could admit more concurrent compiles than the memory budget intends, though failed-link and OOM rules aim to prevent unsafe cheapening.
> 
> **Overview**
> Improves the compile **permit pool** so link-heavy builds can use more concurrency and waiters stop polling idle cores on Linux.
> 
> **Link weights:** Ledger entries are keyed separately for metadata vs **`[link]`** invocations, so a `cargo check` peak cannot shrink the two-permit link guess. **`plan`** now uses measured history **instead of** `max(recorded, link_floor)`, so a light successful link can drop to one permit. **`ledger_peak`** always records successful links (even under one permit) to retire the floor, while failed “link” crate types that never reached the linker cannot record a cheap peak.
> 
> **Waiters:** After the first refused admission, **`admit`** arms **`ReleaseWake`** on Linux (inotify on lease file deletes) with the existing jittered sleep as fallback; other platforms unchanged.
> 
> Docs in **`configuration.md`** describe the first measurement replacing the link guess in either direction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdfeb276ce2d91c34b13f76b7b07889ca73e8ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->