### PR TITLE
perf: share OUT_DIR artifacts across worktrees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ dependencies = [
  "mbx-cache-core",
  "mbx-cache-rustc",
  "mbx-cache-store",
+ "memchr",
  "rand 0.10.2",
  "ratatui",
  "reflink-copy",

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -23,6 +23,7 @@ dirs = "6"
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
+memchr = "2"
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.0", default-features = false }
 mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.3", default-features = false }
 mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.0", default-features = false }

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -117,7 +117,7 @@ pub(crate) struct RawConfig {
     )]
     _learned_incremental: bool,
     /// Share eligible compilations that read `OUT_DIR`.
-    #[usage(env = "MBX_SHARE_OUT_DIR", default = false)]
+    #[usage(env = "MBX_SHARE_OUT_DIR", default = true)]
     share_out_dir: bool,
     /// Record a per-compilation event stream for `mbx tui` to watch.
     #[usage(env = "MBX_EVENTS", default = true)]
@@ -289,9 +289,9 @@ pub struct Config {
     pub incremental: bool,
     /// Let a compilation that reads `OUT_DIR` be shared between checkouts.
     ///
-    /// Off by default: it changes the compilation, remapping the generated
-    /// sources out of debug info, and its safety rests on reading the outputs
-    /// rather than on the inputs alone.
+    /// On by default: the compilation remaps generated sources to a stable
+    /// placeholder, and mbx reads the outputs before publishing to fall back
+    /// to a checkout-specific key when a crate embeds the literal path.
     pub share_out_dir: bool,
     /// Append a per-compilation event stream to the store, for `mbx tui`.
     ///
@@ -971,6 +971,7 @@ mod tests {
         assert!(config.remote.url.is_none());
         assert!(!config.verify);
         assert!(!config.incremental);
+        assert!(config.share_out_dir);
         assert!(config.store_dir().ends_with("actions"));
         assert!(config.gc.auto, "collection runs until it is turned off");
         assert_eq!(config.gc.max_bytes, 20 * GIB, "5% of a 400GiB disk");
@@ -1265,7 +1266,7 @@ mod tests {
             "incremental = true\nshare_out_dir = true\n",
         )
         .unwrap();
-        let mut config = configured(None, &[]).unwrap();
+        let mut config = configured(None, &[("MBX_SHARE_OUT_DIR", "0")]).unwrap();
 
         config
             .apply_workspace_policy_with(directory.path(), |_| true)

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -338,10 +338,9 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             let action = if learned.engaged() {
                 &candidates.literal
             } else {
-                let action = candidates.publishable(&portable, &outputs.files)?;
-                publish_result(
-                    &action.digest,
-                    &action.bytes,
+                let action = publish_result(
+                    &candidates,
+                    &portable,
                     &outputs,
                     &output,
                     &portable.mappings,
@@ -711,10 +710,10 @@ impl ActionCandidates {
     /// itself, but not one a crate reads through `env!` and keeps as a string,
     /// and nothing in the inputs distinguishes the two shapes -- so the outputs
     /// are read.
-    fn publishable(&self, portable: &Portable, outputs: &[PathBuf]) -> Result<&RustcAction> {
+    fn publishable(&self, outputs_are_clean: bool) -> &RustcAction {
         match &self.portable {
-            Some(action) if portable.outputs_are_clean(outputs)? => Ok(action),
-            _ => Ok(&self.literal),
+            Some(action) if outputs_are_clean => action,
+            _ => &self.literal,
         }
     }
 
@@ -1614,18 +1613,8 @@ impl Portable {
     /// construction, and is restored as written for every action that already
     /// shares across checkouts today. Judging the artifact by it would reject
     /// every compilation.
-    fn outputs_are_clean(&self, outputs: &[PathBuf]) -> Result<bool> {
-        if self.values.is_empty() {
-            return Ok(false);
-        }
-        for output in outputs {
-            let contents = std::fs::read(output)
-                .wrap_err_with(|| format!("failed to read rustc output {}", output.display()))?;
-            if self.values.iter().any(|value| carries(&contents, value)) {
-                return Ok(false);
-            }
-        }
-        Ok(true)
+    fn contents_are_clean(&self, contents: &[u8]) -> bool {
+        !self.values.is_empty() && !self.values.iter().any(|value| carries(contents, value))
     }
 }
 
@@ -1642,18 +1631,7 @@ fn carries(contents: &[u8], value: &str) -> bool {
 }
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
-    let Some((first, rest)) = needle.split_first() else {
-        return false;
-    };
-    let mut offset = 0;
-    while let Some(index) = haystack[offset..].iter().position(|byte| byte == first) {
-        let start = offset + index;
-        if haystack[start + 1..].starts_with(rest) {
-            return true;
-        }
-        offset = start + 1;
-    }
-    false
+    !needle.is_empty() && memchr::memmem::find(haystack, needle).is_some()
 }
 
 fn path_mappings(
@@ -1781,18 +1759,18 @@ fn replay_output(output: &Output) -> Result<()> {
     replay_bytes(&output.stdout, &output.stderr)
 }
 
-fn publish_result(
-    action: &CacheDigest,
-    action_bytes: &[u8],
+fn publish_result<'a>(
+    candidates: &'a ActionCandidates,
+    portable: &Portable,
     outputs: &RustcOutputs,
     output: &Output,
     mappings: &[PathMapping],
-) -> Result<()> {
+) -> Result<&'a RustcAction> {
     if outputs.files.is_empty() {
         bail!("rustc produced no cacheable outputs");
     }
     let staging = staging_directory()?;
-    let mut blobs = vec![staged_bytes(staging.path(), "action.json", action_bytes)?];
+    let mut blobs = Vec::new();
     let stdout = staged_bytes(
         staging.path(),
         "stdout",
@@ -1811,6 +1789,7 @@ fn publish_result(
         .chain(std::iter::once(&outputs.dep_info));
     let mut files = Vec::with_capacity(outputs.files.len() + 1);
     let mut hashed_outputs = Vec::with_capacity(outputs.files.len());
+    let mut portable_outputs_are_clean = candidates.portable.is_some();
     for path in output_paths {
         let metadata = std::fs::metadata(path)
             .wrap_err_with(|| format!("failed to inspect rustc output {}", path.display()))?;
@@ -1826,7 +1805,18 @@ fn publish_result(
             blobs.push(staged.clone());
             staged.0
         } else {
-            let digest = CacheDigest::blake3_file(path)?;
+            // When a portable key is possible, inspect the same bytes used to
+            // hash the artifact. Reading first and then calling `blake3_file`
+            // made cold builds read every output twice merely to decide which
+            // action key could safely name it.
+            let digest = if candidates.portable.is_some() {
+                let contents = std::fs::read(path)
+                    .wrap_err_with(|| format!("failed to read rustc output {}", path.display()))?;
+                portable_outputs_are_clean &= portable.contents_are_clean(&contents);
+                CacheDigest::blake3(&contents)
+            } else {
+                CacheDigest::blake3_file(path)?
+            };
             blobs.push((digest.clone(), path.clone()));
             // Freshly compiled artifacts enter the ledger too: on a cold
             // build these are exactly the rlibs every dependent is about to
@@ -1857,6 +1847,9 @@ fn publish_result(
     files.sort_by(|left, right| left.name.cmp(&right.name));
     session::record_file_digests(FileDigestScope::Content, hashed_outputs);
 
+    let action = candidates.publishable(portable_outputs_are_clean);
+    blobs.push(staged_bytes(staging.path(), "action.json", &action.bytes)?);
+
     let metadata = canonical_json(&RustcMetadata {
         version: 1,
         kind: "rustc".into(),
@@ -1883,7 +1876,7 @@ fn publish_result(
     }
     requests.push(AgentRequest::StoreActionResult {
         result: RemoteActionResult {
-            action: action.clone(),
+            action: action.digest.clone(),
             metadata: Some(metadata.0),
             output_root: Some(directory.0),
             version: 1,
@@ -1896,7 +1889,7 @@ fn publish_result(
             _ => bail!("cache agent returned an unexpected publish response"),
         }
     }
-    Ok(())
+    Ok(action)
 }
 
 fn staged_bytes(directory: &Path, name: &str, bytes: &[u8]) -> Result<(CacheDigest, PathBuf)> {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -338,14 +338,13 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             let action = if learned.engaged() {
                 &candidates.literal
             } else {
-                let action = publish_result(
+                publish_result(
                     &candidates,
                     &portable,
                     &outputs,
                     &output,
                     &portable.mappings,
-                )?;
-                action
+                )?
             };
             // The flight prediction is only left behind a *published* result:
             // an incremental artifact was withheld from the store, so a

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -117,25 +117,21 @@ fn an_output_carrying_a_normalized_value_is_not_portable() {
     std::fs::write(&carries, format!("compiled in {out_dir} at some offset")).unwrap();
 
     let portable = portable_for(&[out_dir]);
-    assert!(
-        portable
-            .outputs_are_clean(std::slice::from_ref(&clean))
-            .unwrap()
-    );
-    assert!(
-        !portable
-            .outputs_are_clean(std::slice::from_ref(&carries))
-            .unwrap()
-    );
+    assert!(portable.contents_are_clean(&std::fs::read(&clean).unwrap()));
+    assert!(!portable.contents_are_clean(&std::fs::read(&carries).unwrap()));
     // One dirty output is enough: the artifact is published as a set.
-    assert!(!portable.outputs_are_clean(&[clean, carries]).unwrap());
+    assert!(
+        ![clean, carries]
+            .iter()
+            .all(|output| portable.contents_are_clean(&std::fs::read(output).unwrap()))
+    );
 }
 
 /// Nothing was made portable, so there is no portable key to publish under
 /// and no claim to check.
 #[test]
 fn nothing_portable_is_never_clean() {
-    assert!(!portable_for(&[]).outputs_are_clean(&[]).unwrap());
+    assert!(!portable_for(&[]).contents_are_clean(b"an artifact"));
 }
 
 #[test]

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -825,21 +825,22 @@ fn write_generated_project(directory: &Path, generated: Generated) {
     assert!(status.success());
 }
 
-/// A build script alone does not stop two checkouts sharing a cache. Consuming
-/// `OUT_DIR` does, because its value is an absolute path the compilation reads
-/// and could bake into the artifact.
+/// Turning sharing off preserves the old checkout-specific behavior for a
+/// compilation that consumes `OUT_DIR`, without affecting one that only uses a
+/// build-script cfg.
 #[test]
-fn out_dir_decides_whether_two_checkouts_share() {
+fn out_dir_sharing_can_be_turned_off() {
+    let disabled = [("MBX_SHARE_OUT_DIR", "0")];
     for (generated, expect_hits) in [(Generated::Cfg, true), (Generated::Include, false)] {
         assert_eq!(
-            two_checkouts_share(generated, &[]),
+            two_checkouts_share(generated, &disabled),
             expect_hits,
-            "the default should not share a compilation that reads OUT_DIR"
+            "the opt-out changed the wrong shape"
         );
     }
 }
 
-/// With sharing on, the compilation is remapped so rustc records the
+/// By default, the compilation is remapped so rustc records the
 /// placeholder instead of the real `OUT_DIR`, and the include-only shape crosses
 /// checkouts. The shape that keeps the value in a string still does not: the
 /// remapping cannot reach into the artifact, and mbx reads the outputs rather
@@ -847,13 +848,12 @@ fn out_dir_decides_whether_two_checkouts_share() {
 ///
 /// The pair is the test. Either half alone would pass for the wrong reason.
 #[test]
-fn sharing_out_dir_crosses_checkouts_only_where_the_artifact_allows_it() {
-    let sharing = [("MBX_SHARE_OUT_DIR", "1")];
+fn out_dir_crosses_checkouts_only_where_the_artifact_allows_it() {
     for (generated, expect_hits) in [(Generated::Include, true), (Generated::Text, false)] {
         assert_eq!(
-            two_checkouts_share(generated, &sharing),
+            two_checkouts_share(generated, &[]),
             expect_hits,
-            "sharing changed the wrong shape"
+            "the default shared the wrong shape"
         );
     }
 }

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -92,8 +92,9 @@ The usual causes, roughly in the order they show up:
   reports it as an ordinary miss. `cargo tree` and comparing the two commands
   usually finds it.
 - **Build-script output paths.** A crate that embeds its `OUT_DIR` produces
-  checkout-specific inputs for its dependents. `MBX_SHARE_OUT_DIR=1` remaps
-  it; see [limits](/limits#out_dir-sharing-is-opt-in).
+  checkout-specific inputs for its dependents. mbx remaps this by default;
+  `MBX_SHARE_OUT_DIR=0` disables that sharing. See
+  [limits](/limits#out_dir-sharing-remaps-generated-source-paths).
 - **A build chose its own C compiler, or is cross-compiling.** Setting `CC`,
   `HOST_CC`, or a target-specific variant leaves that build's C and C++
   compilations uncached, and so does `--target`. Bypass kinds beginning `cc-`

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -279,7 +279,7 @@ Permit priority of this build's compilations.
 ### `share_out_dir`
 
 - **Type:** `bool`
-- **Default:** `false`
+- **Default:** `true`
 - **Set with:** `MBX_SHARE_OUT_DIR`
 
 Share eligible compilations that read `OUT_DIR`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ Every value below is optional; these are shown set explicitly.
 # <config directory>/mbx/config.toml
 cache_dir = "/var/cache/mbx"
 incremental = false
-share_out_dir = false
+share_out_dir = true
 cc = true
 savings = "quips"        # or "plain", "off"
 
@@ -75,6 +75,9 @@ Environment variables still win. Machine paths, remote-cache configuration,
 credentials, diagnostics, target placement, and garbage collection are not
 accepted from a repository-owned file. mbx reports an error instead of applying
 an unsafe or misspelled workspace setting.
+
+`share_out_dir = true` is the global default. A workspace may set it to false
+when generated source paths must remain literal in debug information.
 
 ## Build-script C and C++
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -128,13 +128,14 @@ The shims are only installed when the build has not chosen its own compiler.
 Setting `CC`, `CXX`, `HOST_CC`, `HOST_CXX`, `TARGET_CC`, or `TARGET_CXX` leaves
 that build's C compilations uncached, and `MBX_CC=0` disables the feature.
 
-## `OUT_DIR` sharing is opt-in
+## `OUT_DIR` sharing remaps generated source paths
 
 A generated source path can contain an absolute checkout-specific `OUT_DIR`.
-`MBX_SHARE_OUT_DIR=1` remaps the path and inspects outputs before choosing a
-shared key, but generated sources then appear in debug info under a placeholder
-path. It cannot detect a value derived from the path without embedding the path
-itself.
+mbx remaps the path and inspects outputs before choosing a shared key, but
+generated sources then appear in debug info under a placeholder path. It cannot
+detect a value derived from the path without embedding the path itself. Set
+`MBX_SHARE_OUT_DIR=0` to keep generated source paths literal at the cost of
+cross-checkout cache sharing for their dependent crates.
 
 ## Incremental output reduces sharing
 


### PR DESCRIPTION
## Summary

- enable the existing correctness-guarded `OUT_DIR` remapping by default
- hash and inspect compiler outputs in one read so portability checks do not penalize cold publication
- document the default and the `MBX_SHARE_OUT_DIR=0` opt-out

## Real-world hk benchmark

The checked-in worktree result is 49.8s, 683 hits, and 1,113 restored files. This branch measured 14.5s, 717 hits, and 1,215 restored files.

A paired cold run measured 30.5s both with the new default and with `MBX_SHARE_OUT_DIR=0`.

## Verification

- `cargo fmt --all --check`
- `cargo test --locked -p mbx --lib` (271 passed, 1 ignored)
- `cargo check --locked --workspace --all-targets`
- `python3 benchmarks/real_world.py --mbx target/release/mbx --tools mbx --scenarios cold ...`
- `MBX_SHARE_OUT_DIR=0 python3 benchmarks/real_world.py --mbx target/release/mbx --tools mbx --scenarios cold ...`
- `python3 benchmarks/real_world.py --mbx target/release/mbx --tools mbx --scenarios worktree ...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on OUT_DIR remapping changes cache keys and debug-info paths for build-script consumers; correctness still depends on output inspection before publishing under a portable key.
> 
> **Overview**
> **`share_out_dir` is now on by default**, so eligible rustc compilations that read `OUT_DIR` remap generated paths and can share cache keys across checkouts. **`MBX_SHARE_OUT_DIR=0`** (or workspace `share_out_dir = false`) keeps the old checkout-specific behavior. Docs and integration tests were updated to match.
> 
> **Cold publish path:** when choosing portable vs literal action keys, **`publish_result` reads each artifact once**—hash and scan for embedded `OUT_DIR` literals in the same pass—instead of reading outputs again only for the portability check. Substring search uses **`memchr`** instead of a hand-rolled matcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d28538959549ec1f6e110f4ea7818d2d1060f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->