### PR TITLE
feat(rustc): cache the compilations that never link

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -363,9 +363,10 @@ impl RustcInvocation {
     /// the first argument to `RUSTC_WRAPPER`.
     ///
     /// Any flag whose cache semantics are not modeled returns a bypass reason
-    /// instead of guessing. A successful parse only admits the initial
-    /// rlib/rmeta tier plus binaries linked by compiler-bundled WebAssembly
-    /// toolchains.
+    /// instead of guessing. A successful parse admits the rlib/rmeta tier,
+    /// every compilation that links nothing at all -- what `cargo check` and
+    /// clippy run, whatever the crate type -- and binaries linked by
+    /// compiler-bundled WebAssembly toolchains.
     pub fn parse(arguments: &[OsString]) -> Result<Self, BypassReason> {
         Self::parse_with(arguments, ParseOptions::default())
     }
@@ -1377,13 +1378,22 @@ impl<'a> Parser<'a> {
     }
 
     fn classify(&self) -> Result<LinkOutput, BypassReason> {
-        let link_output = if !self.test
+        // A compilation that emits no `link` produces exactly what an rlib's
+        // metadata emit does -- dep-info and `lib<name>.rmeta` -- whatever it
+        // calls its crate type. `cargo check` and clippy compile every binary
+        // and test target this way, and those were bypassing as an
+        // unsupported crate type for a linked artifact none of them asked
+        // for. No linker runs, so nothing downstream needs a linker identity
+        // to describe, and rustc names the metadata the same way for every
+        // crate type.
+        let never_links = !self.emits.iter().any(|emit| emit.kind == "link");
+        let builds_a_library = !self.test
             && !self.crate_types.is_empty()
             && self
                 .crate_types
                 .iter()
-                .all(|crate_type| matches!(crate_type.as_str(), "lib" | "rlib"))
-        {
+                .all(|crate_type| matches!(crate_type.as_str(), "lib" | "rlib"));
+        let link_output = if never_links || builds_a_library {
             LinkOutput::Library
         } else if self
             .target

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1405,9 +1405,124 @@ fn a_compilation_that_never_links_is_not_a_link() {
         "-Cdebuginfo=2",
         "src/lib.rs",
     ]);
+    assert!(
+        RustcInvocation::parse_with(&with_debug, native_links()).is_ok(),
+        "a debug-info flag no linker reads must not bypass a check compilation"
+    );
+    assert!(RustcInvocation::parse(&with_debug).is_ok());
+}
+
+/// `cargo check` and clippy compile every binary target this way. rustc names
+/// the metadata `lib<name>.rmeta` whatever the crate type, so there is nothing
+/// here an rlib's metadata emit does not already do.
+#[test]
+fn a_binary_that_only_emits_metadata_is_cached_like_a_library() {
+    let working_dir = absolute(&["workspace"]);
+    let invocation = RustcInvocation::parse(&args(&[
+        "--crate-name=widget",
+        "--crate-type=bin",
+        "--emit=dep-info,metadata",
+        "--out-dir=target/debug/deps",
+        "-Cextra-filename=-abc123",
+        "src/main.rs",
+    ]))
+    .unwrap();
+
+    assert!(!invocation.links_natively());
+    let outputs = invocation.outputs(&working_dir).unwrap();
     assert_eq!(
-        RustcInvocation::parse_with(&with_debug, native_links()),
-        Err(BypassReason::UnsupportedCrateType("test".into()))
+        outputs.files,
+        vec![working_dir.join("target/debug/deps/libwidget-abc123.rmeta")]
+    );
+    assert_eq!(
+        outputs.dep_info,
+        working_dir.join("target/debug/deps/widget-abc123.d")
+    );
+}
+
+/// A test target carries `--test` and no crate type at all, and cargo omits
+/// the extra filename for a unit that needs no disambiguating.
+#[test]
+fn a_test_target_that_only_emits_metadata_is_cached_like_a_library() {
+    let working_dir = absolute(&["workspace"]);
+    let invocation = RustcInvocation::parse(&args(&[
+        "--crate-name=widget",
+        "--test",
+        "--emit=dep-info,metadata",
+        "--out-dir=target/debug/deps",
+        "src/lib.rs",
+    ]))
+    .unwrap();
+
+    assert!(!invocation.links_natively());
+    let outputs = invocation.outputs(&working_dir).unwrap();
+    assert_eq!(
+        outputs.files,
+        vec![working_dir.join("target/debug/deps/libwidget.rmeta")]
+    );
+}
+
+/// The crate type describes what a *link* would produce, and nothing links
+/// here, so none of them is a reason to refuse.
+#[test]
+fn every_crate_type_is_cached_when_nothing_links() {
+    for crate_type in ["bin", "cdylib", "dylib", "staticlib", "proc-macro", "lib"] {
+        let parsed = RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            &format!("--crate-type={crate_type}"),
+            "--emit=dep-info,metadata",
+            "--out-dir=target/debug/deps",
+            "src/lib.rs",
+        ]));
+        assert!(parsed.is_ok(), "{crate_type} was refused: {parsed:?}");
+    }
+}
+
+/// The widening is about what links, not about what is named: an artifact that
+/// really is linked stays outside the tier exactly as it was.
+#[test]
+fn linked_artifacts_still_bypass_when_nothing_admits_them() {
+    assert_eq!(
+        RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--crate-type=bin",
+            "--emit=dep-info,link",
+            "--out-dir=target/debug/deps",
+            "src/main.rs",
+        ])),
+        Err(BypassReason::UnsupportedCrateType("bin".into()))
+    );
+    // Even with native links modeled, a proc macro is a dylib nobody admits.
+    assert_eq!(
+        RustcInvocation::parse_with(
+            &args(&[
+                "--crate-name=widget",
+                "--crate-type=proc-macro",
+                "--emit=dep-info,metadata,link",
+                "--out-dir=target/debug/deps",
+                "src/lib.rs",
+            ]),
+            native_links()
+        ),
+        Err(BypassReason::UnsupportedCrateType("proc-macro".into()))
+    );
+}
+
+/// A native library is a linker input, and the reason it bypasses -- mbx does
+/// not model where it came from -- does not soften because this particular
+/// compilation stopped short of the link.
+#[test]
+fn a_native_library_still_bypasses_a_check_compilation() {
+    assert_eq!(
+        RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--test",
+            "--emit=dep-info,metadata",
+            "--out-dir=target/debug/deps",
+            "-lstatic=fixture",
+            "src/lib.rs",
+        ])),
+        Err(BypassReason::NativeLibrary)
     );
 }
 

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -114,7 +114,7 @@ fn guidance(kind: &str) -> &'static str {
             "The invocation uses an `@response-file`; mbx does not model response-file contents yet."
         }
         "unsupported-crate-type" => {
-            "This artifact type is outside mbx's current cacheability tier. Dynamic libraries still link normally; `MBX_CACHE_LINKS=1` adds native test binaries and executables."
+            "This linked artifact type is outside mbx's current cacheability tier. Compilations that link nothing -- what `cargo check` and clippy run -- are cached whatever their crate type. Dynamic libraries still link normally; `MBX_CACHE_LINKS=1` adds native test binaries and executables."
         }
         "ambiguous-output-name" => {
             "This output is named like a library but is a program, so mbx cannot tell which permissions to restore it with."

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -86,8 +86,11 @@ platform, including when mbx has to use the copy fallback.
 ## Correctness first
 
 Unsupported crate types, unmodeled search paths, native linking, and
-incremental compilations bypass the shared action cache. Linked WebAssembly
-binaries, tests, and `cdylib`s are admitted only for a fixed allowlist of
-built-in targets whose default linker and system inputs ship with rustc.
+incremental compilations bypass the shared action cache. A compilation that
+links nothing is cached whatever its crate type -- `cargo check` and clippy
+compile every binary and test target that way, and metadata is metadata.
+Linked WebAssembly binaries, tests, and `cdylib`s are admitted only for a
+fixed allowlist of built-in targets whose default linker and system inputs
+ship with rustc.
 `MBX_VERIFY=1` compiles while also consulting the cache and compares the result,
 providing a deliberately expensive qualification mode.

--- a/test/check_cache.bats
+++ b/test/check_cache.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "test_helper/common_setup"
+  local developer_home="$HOME"
+  export RUSTUP_HOME="${RUSTUP_HOME:-$developer_home/.rustup}"
+  export CARGO_HOME="${CARGO_HOME:-$developer_home/.cargo}"
+  _common_setup
+
+  unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI
+  export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store"
+
+  # A library, a binary, and a test target: the three shapes `cargo check
+  # --all-targets` compiles, two of which used to bypass for naming a crate
+  # type no linker was ever going to be asked for.
+  export PROJECT="$BATS_TEST_TMPDIR/project"
+  mkdir -p "$PROJECT/src"
+  cat >"$PROJECT/Cargo.toml" <<'EOF'
+[package]
+name = "check-fixture"
+version = "0.1.0"
+edition = "2021"
+EOF
+  cat >"$PROJECT/src/lib.rs" <<'EOF'
+pub fn double(value: u32) -> u32 {
+    value * 2
+}
+
+#[test]
+fn doubles() {
+    assert_eq!(double(21), 42);
+}
+EOF
+  cat >"$PROJECT/src/main.rs" <<'EOF'
+fn main() {
+    println!("{}", check_fixture::double(21));
+}
+EOF
+
+  run cargo generate-lockfile --offline --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+}
+
+@test "a checked binary and test target restore into a distinct target directory" {
+  local first_target="$BATS_TEST_TMPDIR/first-target"
+  local second_target="$BATS_TEST_TMPDIR/second-target"
+  local cold_report="$BATS_TEST_TMPDIR/cold.json"
+  local warm_report="$BATS_TEST_TMPDIR/warm.json"
+  local bypasses="$BATS_TEST_TMPDIR/bypasses.tsv"
+
+  run env \
+    CARGO_TARGET_DIR="$first_target" \
+    MBX_STATS_REPORT="$cold_report" \
+    "$MBX_BIN" check --offline --all-targets --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*0' "$cold_report"
+  assert_success
+
+  run env \
+    CARGO_TARGET_DIR="$second_target" \
+    MBX_STATS_REPORT="$warm_report" \
+    MBX_BYPASS_LOG="$bypasses" \
+    "$MBX_BIN" check --offline --all-targets --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  # Three, not one: the library, the binary, and the test target. Before these
+  # compilations were admitted the library alone would have hit, so a laxer
+  # assertion would pass with the feature switched off.
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*[3-9]' "$warm_report"
+  assert_success
+
+  # And none of them bypassed for being named after an artifact this
+  # compilation never asked anyone to link.
+  if [ -f "$bypasses" ]; then
+    run grep -E '^unsupported-crate-type' "$bypasses"
+    assert_failure
+  fi
+}


### PR DESCRIPTION
`cargo check` and `clippy --all-targets` compile every binary and test target
with `--emit=dep-info,metadata`. No linker runs, and the only artifacts are
dep-info and `lib<name>.rmeta` — exactly what an rlib's metadata emit
produces. They bypassed anyway, as `unsupported-crate-type`, because the tier
was written around what a compilation *would* link rather than what this one
does: the arm demanded `lib` or `rlib`, and a check of a binary target says
`--crate-type=bin`.

The tier now asks the question it meant to: a compilation that emits no `link`
is a library whatever it calls itself.

## Why this is sound

- **rustc names the metadata the same way for every crate type.** `outputs()`
  already mapped a metadata emit to `lib<name><extra>.rmeta` unconditionally,
  and this workspace's own clippy artifacts confirm rustc agrees — the `bin`
  unit writes `libmbx-03ff72a50da3eca4.rmeta`, the test harnesses write
  `libmbx-1998b6bde2865a0d.rmeta` and `libbuild-389f0ee0e14cdc2c.rmeta`.
- **Nothing about a linked artifact moves.** A `bin` emitting `link` still
  bypasses unless native links are admitted, a proc macro still links its
  dylib, and `-l` still bypasses first, before classification — a native
  library is a linker input whether or not this compilation stopped short of
  the link.
- **No existing key changes.** The classification is never serialized, and the
  pinned-digest test passes unmodified; the shapes newly admitted had no keys
  to change.
- **One reclassification comes with it:** a wasm-target *check* unit was
  admitted as a linked WebAssembly binary, since its metadata emit satisfied
  the tier's final test. It is a library now, so rejections that exist for
  link time stop applying to units that never reach it. Digests identical.

## Measured

On hk, `cargo check --locked --all-targets`, cold into one target directory
then warm into a fresh one against the same store:

| | bypassed as unsupported-crate-type | warm lookups |
| :--- | ---: | ---: |
| before | 65 | 737 |
| after | **61** | 741 |

Four units per `check` job stop bypassing. It is a small number on this
subject for an honest reason worth stating: hk is one binary and a handful of
test targets against several hundred dependency libraries, and dependencies
were always cached. The shape it removes is per-workspace-target, so it grows
with the number of bins and test targets a workspace has, not with its
dependency count — a workspace of twenty binaries stops bypassing twenty
compilations in every check and clippy job.

The contention benchmark moves accordingly (65 → 61 in its check job, and the
batch's other three jobs unchanged); I would not read its wall time here,
since this box idles at load ~30.

## Verification

- New adapter tests: a metadata-only `bin` is cached as a library with the
  exact output names; a `--test` target likewise, with and without an extra
  filename; every crate type admitted when nothing links; linked bins and
  proc macros still bypass; `-l` still bypasses a check compilation.
- The existing `a_compilation_that_never_links_is_not_a_link` flips its second
  assertion — that flip is the point of the change.
- New `test/check_cache.bats`: a lib + bin + test fixture, `check
  --all-targets` cold then warm into a second target directory, asserting ≥3
  hits and no `unsupported-crate-type` in the bypass log.
- `MBX_VERIFY=1` over hk's `check --all-targets`, seeded then re-run: **700
  verifications, 150 divergences — identical to the same qualification on
  `main`**, so this admits 4 more compilations per job without changing what
  verification finds. (Those 150 are all C compilations and predate this work:
  with `MBX_CC=0` the same run reports 233 verifications and 0 divergences.
  Worth its own issue; nothing to do with this PR.)
- `mise run ci` green.

## Not in this PR: reusing `build` artifacts for `check`

The larger version of this idea — satisfying a `check` lookup from what
`cargo build` already published — does not work, and it is worth recording
why. Cargo folds the compile mode into the unit's metadata hash, so a check
unit is a *different crate identity*: for `aho_corasick` at identical
features and profile, `-Cmetadata=4869fdd0728d47f0`/`-Cextra-filename=-dc11f820b8cc44a0`
against `b788e8b15520c560`/`-11b107ed0cabeb1c`, producing a 1476841-byte rmeta
against an 1856195-byte one, with a different `StableCrateId` and different
symbol mangling. Forging the check key would need cargo-owned hashes plus every
dependency's check-mode rmeta digest, none of which a `RUSTC_WRAPPER` sees, and
restore demands byte-exact descriptor equality regardless. Serving the build
rmeta under a check key would be knowingly serving a non-reproduction. That is
[rust-lang/cargo#3501](https://github.com/rust-lang/cargo/issues/3501), and it
is not fixable from inside the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache admission logic for many rustc invocations; linked artifacts and native-library bypasses are preserved, but misclassification could cache or skip compilations incorrectly.
> 
> **Overview**
> **Rustc classification now keys on whether a compilation links, not on `--crate-type`.** Invocations with `--emit=dep-info,metadata` (no `link`) are admitted like rlib metadata emits—`cargo check` and clippy’s binary and test units stop bypassing as `unsupported-crate-type`.
> 
> `Parser::classify` adds `never_links` and treats `never_links || builds_a_library` as `LinkOutput::Library`. Linked bins, proc-macros, and `-l` still bypass the same way; output paths stay `lib<name>.rmeta` for metadata-only units.
> 
> Docs and **`mbx explain`** text note that check/clippy compilations are cached regardless of crate type. New adapter tests and **`test/check_cache.bats`** assert warm `check --all-targets` gets at least three hits (lib, bin, test) with no `unsupported-crate-type` bypasses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54b616ce0751a5ee99778b334c17ffcf4db6802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
