### PR TITLE
feat(rustc): cache native links by default

### DIFF
--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -621,10 +621,13 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
         return run_cargo(&cargo, arguments, BTreeMap::new());
     }
 
-    // Experimental, and only where mbx can identify the linker precisely
-    // enough to key what it produced.
+    // Only where mbx can identify the linker precisely enough to key what it
+    // produced. Said out loud only to somebody who asked for it: this is on
+    // by default now, and a platform that cannot do it would otherwise warn
+    // every build about a setting nobody chose.
     let cache_links = settings.cache_links && session::cache_links_supported();
-    if settings.cache_links && !cache_links {
+    if settings.cache_links && !cache_links && std::env::var_os(session::CACHE_LINKS_ENV).is_some()
+    {
         log::warn!("caching native links is not supported on this platform");
     }
     let working_dir = std::env::current_dir()?;

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -132,14 +132,14 @@ pub(crate) struct RawConfig {
         choices("quips", "plain", "off")
     )]
     savings: String,
-    /// Cache natively linked test binaries and executables. Experimental:
-    /// qualify it on your own workload with MBX_VERIFY=1 before relying on it.
-    /// On macOS this also passes ld64 `-oso_prefix` so a debug-info link's
-    /// debug map stops naming this checkout, which is what lets it cache.
+    /// Cache natively linked test binaries and executables. On macOS this
+    /// also passes ld64 `-oso_prefix` so a debug-info link's debug map stops
+    /// naming this checkout, which is what lets it cache. Linux and macOS
+    /// only, and a link mbx cannot describe exactly still links normally.
     #[usage(
         key = "cache_links",
         env = "MBX_CACHE_LINKS",
-        default = false,
+        default = true,
         scope = "env"
     )]
     cache_links: bool,
@@ -470,7 +470,7 @@ impl Default for CliSettings {
             retention: RetentionSettings::default(),
             savings: SavingsStyle::default(),
             learned_incremental: true,
-            cache_links: false,
+            cache_links: true,
         }
     }
 }

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -114,7 +114,7 @@ fn guidance(kind: &str) -> &'static str {
             "The invocation uses an `@response-file`; mbx does not model response-file contents yet."
         }
         "unsupported-crate-type" => {
-            "This linked artifact type is outside mbx's current cacheability tier. Compilations that link nothing -- what `cargo check` and clippy run -- are cached whatever their crate type. Dynamic libraries still link normally; `MBX_CACHE_LINKS=1` adds native test binaries and executables."
+            "This linked artifact type is outside mbx's current cacheability tier. Compilations that link nothing -- what `cargo check` and clippy run -- are cached whatever their crate type, and native test binaries and executables are cached where the linker can be identified. Dynamic libraries and proc macros still link normally."
         }
         "ambiguous-output-name" => {
             "This output is named like a library but is a program, so mbx cannot tell which permissions to restore it with."

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -2041,10 +2041,11 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
 
 /// Whether a bypassed invocation will run a linker.
 ///
-/// Read off the raw arguments because there is no parsed invocation here: this
-/// is the path a compilation takes when the cache could not model it, and
-/// native links are exactly that path today -- they bypass by default. They
-/// are also the compilations that run a machine out of memory, so the
+/// Read off the raw arguments because there is no parsed invocation here:
+/// this is the path a compilation takes when the cache could not model it,
+/// and a link mbx cannot describe exactly -- an unidentifiable linker, a
+/// native library, a flag that would embed this checkout -- still lands here.
+/// They are also the compilations that run a machine out of memory, so the
 /// scheduler has to recognize one without the parser's help.
 ///
 /// A test harness links a program whatever its crate type says, which is why
@@ -2183,16 +2184,20 @@ pub fn cache_links_supported() -> bool {
     cfg!(any(target_os = "linux", target_os = "macos"))
 }
 
-/// Whether the shim may cache a natively linked program. Read the same way as
-/// verify mode.
+/// Whether the shim may cache a natively linked program.
+///
+/// Unset means on, which is the one place this differs from verify mode: a
+/// shim installed by `mbx setup` is driven by plain cargo, with no session to
+/// have written the variable, and reading absence as "off" there would leave
+/// the persistent wrapper on a default nobody chose. A session always states
+/// the answer explicitly, so `MBX_CACHE_LINKS=0` still turns it off for both.
 ///
 /// The platform is checked here rather than trusted from whoever set the
-/// variable: a shim installed by `mbx setup` is driven by plain cargo, with no
-/// session to have applied the gate, so the value it reads is whatever the
-/// developer exported.
+/// variable, for the same reason: the standalone shim has no session to have
+/// applied the gate.
 pub(crate) fn cache_links_requested() -> bool {
     cache_links_supported()
-        && std::env::var_os(CACHE_LINKS_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+        && std::env::var_os(CACHE_LINKS_ENV).is_none_or(|value| !value.is_empty() && value != "0")
 }
 
 /// Whether the shim may make a compilation independent of its `OUT_DIR` so two

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -860,6 +860,12 @@ fn out_dir_crosses_checkouts_only_where_the_artifact_allows_it() {
 
 /// Build the same fixture in two checkouts, reporting whether the second one
 /// reused anything from the first.
+/// Whether the *crate* shares, which is what every caller here is asking.
+///
+/// Native links are left out rather than counted: a build script's own binary
+/// reads no `OUT_DIR` -- the value is handed to it when it runs, long after it
+/// compiles -- so it shares between these checkouts whatever the crate does,
+/// and counting it would answer a question nobody asked.
 fn two_checkouts_share(generated: Generated, settings: &[(&str, &str)]) -> bool {
     let store = tempfile::tempdir().unwrap();
     let first = tempfile::tempdir().unwrap();
@@ -868,17 +874,21 @@ fn two_checkouts_share(generated: Generated, settings: &[(&str, &str)]) -> bool 
     write_generated_project(first.path(), generated);
     write_generated_project(second.path(), generated);
 
+    let settings: Vec<(&str, &str)> = [("MBX_CACHE_LINKS", "0")]
+        .into_iter()
+        .chain(settings.iter().copied())
+        .collect();
     build_with(
         first.path(),
         store.path(),
         &reports.path().join("first.json"),
-        settings,
+        &settings,
     );
     let (stats, _) = build_with(
         second.path(),
         store.path(),
         &reports.path().join("second.json"),
-        settings,
+        &settings,
     );
     count(&stats, "hits") > 0
 }
@@ -1793,8 +1803,8 @@ fn objects_landing_beside_a_generated_header_still_cross_checkouts() {
     );
     assert_eq!(
         count(&warm, "hits"),
-        4,
-        "all three C compilations and the Rust one should be restored: {warm}"
+        5,
+        "all three C compilations, the Rust one, and the build script should be restored: {warm}"
     );
 }
 
@@ -1959,8 +1969,8 @@ fn a_stale_prediction_recovers_instead_of_stranding_the_compilation() {
     );
     assert_eq!(
         count(&warm, "hits"),
-        2,
-        "both the Rust and the C compilation should be restored: {warm}"
+        3,
+        "the Rust, the C, and the build script's own compilation should be restored: {warm}"
     );
 }
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -194,6 +194,9 @@ fn build_with(
         // must not read an answer out of the developer's environment.
         .env_remove("MBX_SHARE_OUT_DIR")
         .env_remove("MBX_LEARNED_INCREMENTAL")
+        // Native links are cached by default and several counts here include
+        // one, so an inherited answer would decide them.
+        .env_remove("MBX_CACHE_LINKS")
         // The C shims are on by default; a test that says nothing about them
         // must not inherit a different answer from the developer's shell. The
         // compiler variables matter just as much: this suite is itself run

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -27,11 +27,11 @@ Cache root.
 ### `cache_links`
 
 - **Type:** `bool`
-- **Default:** `false`
+- **Default:** `true`
 - **Scope:** only from the environment or the command line
 - **Set with:** `MBX_CACHE_LINKS`
 
-Cache natively linked test binaries and executables. Experimental: qualify it on your own workload with MBX_VERIFY=1 before relying on it. On macOS this also passes ld64 `-oso_prefix` so a debug-info link's debug map stops naming this checkout, which is what lets it cache.
+Cache natively linked test binaries and executables. On macOS this also passes ld64 `-oso_prefix` so a debug-info link's debug map stops naming this checkout, which is what lets it cache. Linux and macOS only, and a link mbx cannot describe exactly still links normally.
 
 ### `cc`
 

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -6,7 +6,7 @@
 cache, and it aims wider: it caches CUDA alongside Rust, C, and C++, and can
 distribute compilation across machines. mbx caches rustc, the C and C++ that
 cargo build scripts compile, the C and C++ of builds outside cargo through
-[`mbx exec`](/standalone-builds), and optionally native links. It spends a
+[`mbx exec`](/standalone-builds), and native links. It spends a
 scope still narrower than sccache's on problems sccache does not attempt:
 
 - **No daemon.** sccache runs a background server that builds talk to. mbx
@@ -89,9 +89,9 @@ hits — do not match. The differences are in the mechanics:
   `clang`, `clang++`) on Unix, leaving a versioned or cross toolchain to the
   build that chose it; kache covers Windows as well.
 - **Executable caching.** Both cache linked binaries on Linux and macOS. In
-  mbx it is opt-in (`MBX_CACHE_LINKS=1`) and experimental, and the key
-  includes the resolved linker, startup objects, libc, and SDK rather than
-  dep-info alone.
+  mbx the key includes the resolved linker, startup objects, libc, and SDK
+  rather than dep-info alone, so a host mbx cannot describe that precisely
+  links normally instead of sharing a binary it cannot stand behind.
 - **A store other tools embed.** The extraction from mise went both ways:
   mise now embeds mbx's cache crates, so a task run through mise and a
   direct mbx build fill and hit the same shared action store and speak the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,9 +164,10 @@ is whether a compilation reproduces itself rather than whether two checkouts
 embed the same paths. Anything above zero divergences is a modeling bug worth
 reporting; `MBX_BYPASS_LOG` and `mbx explain` show what was left out.
 
-This is how to qualify an experimental setting such as
-[`MBX_CACHE_LINKS`](/limits#native-linking-is-not-cached) on your own
-workload before relying on it.
+This is how to qualify a setting whose tier you want to check against your
+own workload, such as
+[native link caching](/limits#native-linking-is-cached-only-where-the-linker-can-be-described),
+before relying on it.
 
 ## The savings line
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -10,14 +10,16 @@ are the bulk of a cold build. See [incremental
 builds](/configuration#incremental-builds) for the trade `MBX_INCREMENTAL=1`
 makes.
 
-## Native linking is not cached
+## Native linking is cached only where the linker can be described
 
-Native binaries and dynamic libraries always link. Their results can depend on
-an external linker, startup objects, and system libraries that rustc dep-info
-does not enumerate, so mbx bypasses them.
+Native binaries and dynamic libraries link against an external linker, startup
+objects, and system libraries that rustc dep-info does not enumerate. mbx
+caches such a link only when it can put all of that into the key, and bypasses
+it otherwise.
 
-The narrow exception is a binary, test, or `cdylib` for one of these built-in
-targets using its compiler-bundled self-contained linker:
+WebAssembly is the case that needs nothing extra: a binary, test, or `cdylib`
+for one of these built-in targets uses its compiler-bundled self-contained
+linker, so it is cached on every platform:
 
 - `wasm32-unknown-unknown`
 - `wasm32-wasip1` and `wasm32-wasip1-threads`
@@ -31,13 +33,13 @@ identity. Custom target specifications, external WebAssembly toolchains,
 native libraries, custom linkers, disabled WASI CRT bundling, and
 non-affirmative `link-self-contained` modes remain uncached.
 
-`MBX_CACHE_LINKS=1` adds host test binaries and executables on Linux and
-macOS, by putting the rest of the link into the key: the resolved `cc` driver
-and its version, the linker it selects, the startup objects and libc it
-resolves (hashed), and on macOS the SDK. Two hosts that differ in any of those
-produce different keys and miss, rather than sharing a binary neither of them
-built. It is experimental — qualify it on your own workload as described in
-[verify mode](/configuration#verify-mode) before relying on it.
+Host test binaries and executables are cached on Linux and macOS, by putting
+the rest of the link into the key: the resolved `cc` driver and its version,
+the linker it selects, the startup objects and libc it resolves (hashed), and
+on macOS the SDK. Two hosts that differ in any of those produce different keys
+and miss, rather than sharing a binary neither of them built. `cache_links`
+(`MBX_CACHE_LINKS=0`) turns it off; Windows has no such tier, and a build
+there links its programs as it always did.
 
 Some hosts cannot be described at all. mbx asks the driver to place a startup
 object and a libc, and a host where neither resolves gets no linker identity
@@ -49,9 +51,11 @@ other bypass.
 
 Even then, a link bypasses if it names a native library, overrides the linker,
 or carries a flag that would embed this checkout's paths (`-Crpath`,
-`-Cprefer-dynamic`), leave a file beside the binary that mbx does not store
-(`-Csplit-debuginfo`), or — on macOS — record absolute object paths and their
-timestamps in the binary's debug map (`-Cdebuginfo` above `0`). An explicit
+`-Cprefer-dynamic`) or leave a file beside the binary that mbx does not store
+(`-Csplit-debuginfo`). On macOS a debug-info link records absolute object
+paths and their timestamps in the binary's debug map, so the shim passes ld64
+`-oso_prefix` for its own output directory, which is what lets those links
+cache rather than bypass. An explicit
 `--target` bypasses too, even when it spells the host triple: rustc without one
 links for the host by construction, and that is the only linker mbx identifies.
 

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -93,7 +93,9 @@ object_in() {
     MBX_STATS_REPORT="$warm_report" \
     "$MBX_BIN" build --offline --manifest-path "$PROJECT/Cargo.toml"
   assert_success
-  run grep -E '"hits"[[:space:]]*:[[:space:]]*2' "$warm_report"
+  # Three: the crate, the C object, and the build script's own binary, which
+  # is a native link and cached like any other.
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*3' "$warm_report"
   assert_success
 
   local restored
@@ -172,14 +174,14 @@ EOF
     "$MBX_BIN" build --offline --manifest-path "$PROJECT/Cargo.toml"
   assert_success
 
-  # Only the Rust compilation is cached, so the warm build has one hit rather
-  # than two.
+  # The C compilation is left alone, so the warm build hits the crate and the
+  # build script's binary rather than all three.
   run env \
     CARGO_TARGET_DIR="$second_target" \
     MBX_STATS_REPORT="$warm_report" \
     MBX_CC=0 \
     "$MBX_BIN" build --offline --manifest-path "$PROJECT/Cargo.toml"
   assert_success
-  run grep -E '"hits"[[:space:]]*:[[:space:]]*1' "$warm_report"
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*2' "$warm_report"
   assert_success
 }

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -9,7 +9,7 @@ setup() {
 
   # CC and CXX are unset for the same reason MBX_CC is: an inherited compiler
   # choice would make mbx stand aside and the fixture prove nothing.
-  unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI MBX_CC
+  unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI MBX_CC MBX_CACHE_LINKS
   unset CC CXX HOST_CC HOST_CXX TARGET_CC TARGET_CXX MBX_REAL_CC MBX_REAL_CXX
   export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store"
 

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -89,12 +89,41 @@ test_binary() {
   assert_success
 }
 
-@test "native links stay outside the cache until asked for" {
-  local target="$BATS_TEST_TMPDIR/unasked-target"
+@test "a linked test binary is cached without being asked for" {
+  local first_target="$BATS_TEST_TMPDIR/default-first"
+  local second_target="$BATS_TEST_TMPDIR/default-second"
+  local warm_report="$BATS_TEST_TMPDIR/default-warm.json"
+
+  # No MBX_CACHE_LINKS anywhere: this is what an unconfigured machine does.
+  run env \
+    CARGO_TARGET_DIR="$first_target" \
+    "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+
+  run env \
+    CARGO_TARGET_DIR="$second_target" \
+    MBX_STATS_REPORT="$warm_report" \
+    "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  # The library and the linked test binary, as in the asked-for case above.
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*[2-9]' "$warm_report"
+  assert_success
+
+  local restored
+  restored="$(test_binary "$second_target")"
+  assert_file_exists "$restored"
+  assert_file_executable "$restored"
+  run "$restored"
+  assert_success
+}
+
+@test "MBX_CACHE_LINKS=0 keeps native links outside the cache" {
+  local target="$BATS_TEST_TMPDIR/refused-target"
   local bypasses="$BATS_TEST_TMPDIR/bypasses.tsv"
 
   run env \
     CARGO_TARGET_DIR="$target" \
+    MBX_CACHE_LINKS=0 \
     MBX_BYPASS_LOG="$bypasses" \
     "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
   assert_success

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -7,7 +7,10 @@ setup() {
   export CARGO_HOME="${CARGO_HOME:-$developer_home/.cargo}"
   _common_setup
 
-  unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI
+  # MBX_CACHE_LINKS above all: two cases here state what an unconfigured
+  # machine does, and an inherited value would answer for it -- a leftover
+  # 1 hiding a regression in the default, a leftover 0 failing the counts.
+  unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI MBX_CACHE_LINKS
   export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store"
 
   export PROJECT="$BATS_TEST_TMPDIR/project"


### PR DESCRIPTION
Native links have been behind `MBX_CACHE_LINKS=1` since the tier was built,
and the machinery it gates has stopped being provisional. The key carries the
resolved `cc` driver and its version, the linker it selects, the startup
objects and libc it resolves, and on macOS the SDK, so two hosts differing
anywhere in that produce different keys and miss rather than sharing a binary
neither of them built. A host that cannot answer those probes gets no linker
identity and bypasses — the refusal that makes the rest safe.

What being off by default cost is most of a build's tail. Every build script
is a linked binary, and so is every test harness and every final program, so
four CI jobs on one machine compiled each of them four times over — the
slowest uncached crates in the contention benchmark were build scripts and the
program itself. None of that was a modeling gap; it was a default.

## What changes

1. `cache_links` defaults to `true` (`MBX_CACHE_LINKS=0` turns it off).
   Platform gate unchanged: Linux and macOS only.
2. **The standalone path follows the same rule.** `cache_links_requested` read
   an absent variable as off, which is right for a session — one always states
   the answer — but wrong for the persistent wrapper `mbx setup` installs,
   where plain cargo drives the shim and nobody writes the variable at all.
   Absent now means on.
3. **The platform warning moved behind an explicit request.** It fires where
   the tier does not exist, which is every Windows build; warning about a
   setting nobody chose is noise rather than news.
4. `ParseOptions::default()` in `mbx-cache-rustc` stays off — the library's
   contract is unchanged, only mbx's policy.

## Qualification

`MBX_VERIFY=1` over hk on Linux, seeded then re-run, against the same binary
with the tier off as a control:

| | verifications | divergences |
| :--- | ---: | ---: |
| `MBX_CACHE_LINKS=0` (control) | 682 | 150 |
| default (this PR) | **720** | **150** |

The tier adds 38 verified compilations and **no new divergences**.

I chased the 150, since a number that size sitting next to a default flip is
not something to wave past. They are **all C compilations, none of them
rustc**: with `MBX_CC=0` the same qualification reports 233 verifications and
0 divergences.

Followed all the way down in #182, and they are **not a fault** — I called
them a bug in an earlier revision of this description and that was wrong.
Every one is a libgit2-sys object whose absolute `OUT_DIR` include path is
recorded in its debug information, so the same source compiled under two
target directories yields two different objects; plain `cargo build` with no
mbx involved reproduces it. That is the documented "equivalent, not always
identical" case. It predates this PR, is untouched by it, and #182 makes the
adapter say which kind of divergence it found instead of leaving 150
identical lines in a log.

macOS is CI's to confirm; I only have Linux.

## Tests that carried the old default

Four assertions pinned exact hit counts that assumed a build script's binary
is never cached. Each rises by exactly one, with `misses: 0` throughout — the
extra hit *is* the build script:

- `cc_build_script_cache.bats`: warm hits 2 → 3, and 1 → 2 under `MBX_CC=0`.
- `a_stale_prediction_recovers_instead_of_stranding_the_compilation`: 2 → 3.
- `objects_landing_beside_a_generated_header_still_cross_checkouts`: 4 → 5.
- `two_checkouts_share` asked "did anything hit", which the build script's
  binary now answers regardless — it reads no `OUT_DIR`, since that value is
  handed to it when it *runs*, long after it compiles, so it shares between
  checkouts whatever the crate does. The helper now excludes the link tier so
  it measures the crate, which is what every caller is asking about.

The bats suite also gains the inverse of the test it lost: native links are
cached without being asked for, and `MBX_CACHE_LINKS=0` puts them back outside.

## Docs

`docs/limits.md` is rewritten for the new default, and its stale claim that a
macOS debug-info link always bypasses is corrected — the shim has passed ld64
`-oso_prefix` for its own output directory since c95e084, which is what lets
those links cache. `docs/compared.md`, `docs/configuration.md`,
`docs/how-it-works.md`, the `mbx explain` guidance, and the generated
`docs/cli/configuration.md` follow.

`mise run ci` green, including the bats suites and the wasm e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flipping the default changes which linked artifacts are shared across checkouts and CI; incorrect linker keying could theoretically serve wrong binaries, though existing bypass rules and MBX_CACHE_LINKS=0 remain as escape hatches.
> 
> **Overview**
> **Native link caching is on by default** on Linux and macOS: `cache_links` and `MBX_CACHE_LINKS` now default to enabled (`MBX_CACHE_LINKS=0` still disables it). Docs and `mbx explain` drop the “experimental / opt-in” framing and describe when links bypass instead.
> 
> The **persistent rustc shim** (`mbx setup`) now treats an **unset** `MBX_CACHE_LINKS` as **on**, matching the new default—previously absence meant off while session-driven builds always set the variable explicitly.
> 
> **CLI noise reduction:** the “caching native links is not supported on this platform” warning (e.g. Windows) only appears when **`MBX_CACHE_LINKS` is explicitly set**, not on every build with the new default.
> 
> Tests and bats fixtures **unset `MBX_CACHE_LINKS`**, bump expected cache **hit counts by one** where build-script binaries are now restored, **`two_checkouts_share` forces `MBX_CACHE_LINKS=0`** so it still measures crate sharing, and native-link bats cover default-on caching plus opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b314595b8841f4eb3925f2104f22ce18cc69205c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

