### PR TITLE
perf: abort on release panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,7 @@ readme = "README.md"
 # every invocation cheaper, including the rustc shim and CLI startup paths.
 lto = "fat"
 codegen-units = 1
+# A panic is already fatal at every CLI and shim boundary. Omitting unwind
+# tables keeps the frequently-started binary smaller without changing recovery.
+panic = "abort"
 strip = "symbols"


### PR DESCRIPTION
## Summary

- compile release binaries with `panic = "abort"`
- remove unwind machinery from CLI and compiler-shim artifacts
- leave dev and test profiles unchanged

Every panic already crosses a process boundary: the CLI, rustc shim, and cc shim all terminate on an uncaught panic. The TUI panic hook still prints and restores the terminal before the abort. There is no `catch_unwind` in the workspace.

## Local measurements

Same source and Rust 1.97.1, fat LTO, stripped. This host is noisy, so wall-time numbers are directional; sizes and Callgrind instruction counts are deterministic.

| target | unwind size | abort size | change | `--help` instructions |
| --- | ---: | ---: | ---: | ---: |
| x86_64 GNU | 12,056,352 B | 10,974,416 B | -9.0% | 831,686 -> 825,148 (-0.8%) |
| x86_64 musl | 12,216,208 B | 11,126,672 B | -8.9% | 415,687 -> 422,595 (+1.7%) |

Hyperfine (`-N`, 1,000 runs) put GNU at 896 us -> 818 us and musl at 495 us -> 509 us, with large overlapping variance and outliers. I do not treat that as a wall-time claim. The reliable result is roughly 1.1 MB removed from both release binaries; instruction movement is small and mixed.

## Validation

- `mise run lint`
- release builds for x86_64-unknown-linux-gnu and x86_64-unknown-linux-musl
- smoke-tested `--help` under both artifacts
- `git diff --check`

*AI-assisted — Tool: Codex; model: GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Cargo profile knob with no application logic changes; risk is limited to release-only panic semantics if anything relied on unwinding (none found in the workspace).
> 
> **Overview**
> **Release builds** now use `panic = "abort"` in the workspace `[profile.release]` (alongside existing fat LTO and `strip = "symbols"`). Uncaught panics in release artifacts no longer carry unwind tables or stack-unwinding machinery; behavior stays “process exits on panic” for the CLI and compiler shims, with dev/test profiles unchanged.
> 
> The goal is a smaller, slightly leaner frequently-started binary (~9% smaller per PR measurements) without adding a panic-recovery path in release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d4085f9f6bffb9596735a2343f9b6d7c93396e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->