### PR TITLE
perf(scheduler): weigh an unmeasured link by what this machine's links cost

### DIFF
--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -100,6 +100,18 @@ const MAX_FLIGHT_PAYLOAD: usize = 4 * 1024 * 1024;
 const LEDGER_VERSION: u8 = 1;
 /// Most crates the ledger retains; the smallest are dropped first.
 const MAX_LEDGER_ENTRIES: usize = 1024;
+/// Link measurements the window keeps, newest last.
+///
+/// Small on purpose: it stands for what *this* machine's links cost lately,
+/// and a window long enough to remember a toolchain ago would keep quoting a
+/// number nothing here produces any more.
+const MAX_LINK_SAMPLES: usize = 16;
+/// Measurements the window needs before it may speak for an unmeasured link.
+///
+/// One link is an anecdote -- the first one on a machine is as likely to be a
+/// trivial build script as the program itself -- so the static floor stands
+/// until a few have been seen.
+const MIN_LINK_SAMPLES: usize = 3;
 /// Permits a native link costs before it has ever been measured.
 ///
 /// Links are the out-of-memory class -- rust-lang/cargo#12912 is about little
@@ -400,6 +412,12 @@ fn flight_at(pool_dir: &Path, adapter: &'static str, invocation: &str) -> Result
 struct MemoryLedger {
     version: u8,
     crates: BTreeMap<String, u64>,
+    /// Recent link measurements, newest last, whatever crate they came from.
+    ///
+    /// Defaulted rather than versioned: a ledger written before this existed
+    /// reads as one with no link history, which is exactly what it is.
+    #[serde(default)]
+    link_peaks: Vec<u64>,
 }
 
 /// The machine-wide permit pool one process draws from.
@@ -594,11 +612,25 @@ impl Pool {
         if self.bytes_per_permit == 0 {
             return (link_floor.unwrap_or(1).min(self.capacity), None);
         }
-        let recorded = read_ledger(&self.ledger_path())
+        let ledger = read_ledger(&self.ledger_path());
+        let recorded = ledger
             .crates
             .get(&ledger_key(&demand.name, demand.links))
             .copied();
-        let link_bytes = link_floor.map(|weight| weight.saturating_mul(self.bytes_per_permit));
+        let link_bytes = link_floor.map(|weight| {
+            // What this machine's links have actually cost beats a constant
+            // chosen before anyone had seen one. Every test binary is its own
+            // crate name, so a cold `cargo test --no-run` never gets to reuse
+            // the measurement of the link it just made -- the per-crate entry
+            // is always missing for the one in front of it -- and this is the
+            // history it can use instead. The heaviest of the window rather
+            // than its average, because the cost of guessing low is an
+            // out-of-memory kill and the cost of guessing high is a wait.
+            let measured = (ledger.link_peaks.len() >= MIN_LINK_SAMPLES)
+                .then(|| ledger.link_peaks.iter().copied().max())
+                .flatten();
+            measured.unwrap_or_else(|| weight.saturating_mul(self.bytes_per_permit))
+        });
         // History replaces the floor rather than merely raising it. The floor
         // is a guess for links the pool has never seen; once one has been
         // measured, charging it the guess anyway would hold the tail of every
@@ -762,7 +794,9 @@ impl Pool {
         ) else {
             return;
         };
-        if let Err(error) = self.record_peak(&ledger_key(&demand.name, demand.links), peak) {
+        if let Err(error) =
+            self.record_peak(&ledger_key(&demand.name, demand.links), peak, demand.links)
+        {
             debug!("compiler memory was not recorded: {error:#}");
         }
     }
@@ -772,7 +806,7 @@ impl Pool {
     }
 
     /// Raise the recorded peak for one crate; never lower it.
-    fn record_peak(&self, name: &str, peak: u64) -> Result<()> {
+    fn record_peak(&self, name: &str, peak: u64, links: bool) -> Result<()> {
         std::fs::create_dir_all(&self.dir)
             .wrap_err_with(|| format!("failed to create {}", self.dir.display()))?;
         let mut lock = fslock::LockFile::open(&self.dir.join(LEDGER_LOCK))?;
@@ -780,8 +814,20 @@ impl Pool {
         let path = self.ledger_path();
         let mut ledger = read_ledger(&path);
         ledger.version = LEDGER_VERSION;
-        if ledger.crates.get(name).is_some_and(|known| *known >= peak) {
-            return Ok(());
+        // The window records every link, including one whose per-crate entry
+        // is already higher: it says what links cost around here lately, which
+        // a measurement no worse than the last one still answers.
+        if links {
+            ledger.link_peaks.push(peak);
+            let surplus = ledger.link_peaks.len().saturating_sub(MAX_LINK_SAMPLES);
+            ledger.link_peaks.drain(..surplus);
+        }
+        let known = ledger.crates.get(name).is_some_and(|known| *known >= peak);
+        if known {
+            // Still written: the window moved even though the entry did not.
+            let mut contents = serde_json::to_vec(&ledger)?;
+            contents.push(b'\n');
+            return crate::util::write_atomic(&path, &contents);
         }
         ledger.crates.insert(name.to_string(), peak);
         while ledger.crates.len() > MAX_LEDGER_ENTRIES {

--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -805,7 +805,8 @@ impl Pool {
         self.dir.join(LEDGER_FILE)
     }
 
-    /// Raise the recorded peak for one crate; never lower it.
+    /// Raise the recorded peak for one crate, never lowering it, and add a
+    /// link's measurement to the machine-wide window whatever the entry does.
     fn record_peak(&self, name: &str, peak: u64, links: bool) -> Result<()> {
         std::fs::create_dir_all(&self.dir)
             .wrap_err_with(|| format!("failed to create {}", self.dir.display()))?;
@@ -823,13 +824,15 @@ impl Pool {
             ledger.link_peaks.drain(..surplus);
         }
         let known = ledger.crates.get(name).is_some_and(|known| *known >= peak);
-        if known {
-            // Still written: the window moved even though the entry did not.
-            let mut contents = serde_json::to_vec(&ledger)?;
-            contents.push(b'\n');
-            return crate::util::write_atomic(&path, &contents);
+        if known && !links {
+            // Nothing moved: the entry already stands higher and there is no
+            // window entry to add. Rewriting the file identically would cost
+            // every repeat compilation a write under this lock.
+            return Ok(());
         }
-        ledger.crates.insert(name.to_string(), peak);
+        if !known {
+            ledger.crates.insert(name.to_string(), peak);
+        }
         while ledger.crates.len() > MAX_LEDGER_ENTRIES {
             let smallest = ledger
                 .crates

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -181,7 +181,7 @@ fn a_predicted_heavy_compile_does_not_wait_out_the_gate_on_an_idle_machine() {
     // Through `plan`, because that is the only weight production ever asks
     // for -- and it clamps to the capacity, so a rule written against
     // heavier-than-capacity weights would never fire for a real compilation.
-    pool.record_peak(&ledger_key("enormous", true), bytes_per_permit * 1000)
+    pool.record_peak(&ledger_key("enormous", true), bytes_per_permit * 1000, true)
         .unwrap();
     let (weight, predicted) = pool.plan(&Demand::new("enormous", true));
     assert_eq!(
@@ -272,8 +272,8 @@ fn plans_weigh_history_links_and_nothing() {
     let directory = tempfile::tempdir().unwrap();
     let bytes_per_permit = 1024;
     let pool = pool_at(directory.path(), 8, bytes_per_permit);
-    pool.record_peak("heavy", 3500).unwrap();
-    pool.record_peak("enormous", 1024 * 1024).unwrap();
+    pool.record_peak("heavy", 3500, false).unwrap();
+    pool.record_peak("enormous", 1024 * 1024, false).unwrap();
 
     let (weight, predicted) = pool.plan(&Demand::new("unseen", false));
     assert_eq!((weight, predicted), (1, None));
@@ -303,7 +303,8 @@ fn plans_weigh_history_links_and_nothing() {
 
     // A link measured *as a link* is weighted by what it used, whichever
     // side of the floor that falls on -- above it,
-    pool.record_peak(&ledger_key("heavy", true), 9000).unwrap();
+    pool.record_peak(&ledger_key("heavy", true), 9000, true)
+        .unwrap();
     let (weight, predicted) = pool.plan(&Demand::new("heavy", true));
     assert_eq!(
         (weight, predicted),
@@ -311,7 +312,7 @@ fn plans_weigh_history_links_and_nothing() {
         "a link's own history above the floor wins"
     );
     // and below it, which is the floor being retired rather than raised.
-    pool.record_peak(&ledger_key("light-link", true), 700)
+    pool.record_peak(&ledger_key("light-link", true), 700, true)
         .unwrap();
     let (weight, predicted) = pool.plan(&Demand::new("light-link", true));
     assert_eq!(
@@ -339,6 +340,110 @@ fn plans_weigh_history_links_and_nothing() {
     );
 }
 
+/// Every test binary is its own crate name, so a cold `cargo test --no-run`
+/// never finds a per-crate entry for the link in front of it. What the machine
+/// has learned about links in general is what it has to go on instead.
+#[test]
+fn an_unmeasured_link_is_weighed_by_what_this_machine_s_links_have_cost() {
+    let directory = tempfile::tempdir().unwrap();
+    let bytes_per_permit = 1000;
+    let pool = pool_at(directory.path(), 8, bytes_per_permit);
+
+    // Below the sample floor, one measurement is an anecdote: the static
+    // weight still stands.
+    pool.record_peak(&ledger_key("first", true), 5000, true)
+        .unwrap();
+    pool.record_peak(&ledger_key("second", true), 4000, true)
+        .unwrap();
+    assert_eq!(
+        pool.plan(&Demand::new("unseen", true)),
+        (LINK_WEIGHT, Some(LINK_WEIGHT * bytes_per_permit)),
+        "two measurements are not yet history"
+    );
+
+    // The third makes it history, and the heaviest of them is the guess.
+    pool.record_peak(&ledger_key("third", true), 3000, true)
+        .unwrap();
+    assert_eq!(
+        pool.plan(&Demand::new("unseen", true)),
+        (5, Some(5000)),
+        "an unmeasured link is weighed by the heaviest link this machine made"
+    );
+
+    // A link this machine has actually measured still speaks for itself.
+    pool.record_peak(&ledger_key("known", true), 1500, true)
+        .unwrap();
+    assert_eq!(
+        pool.plan(&Demand::new("known", true)),
+        (2, Some(1500)),
+        "a crate's own history outranks the machine's"
+    );
+
+    // And nothing about this reaches a compilation that never links.
+    assert_eq!(pool.plan(&Demand::new("unseen", false)), (1, None));
+}
+
+/// The window is what links cost *lately*, so it forgets in order and keeps
+/// recording even when the crate's own entry has nothing to learn.
+#[test]
+fn the_link_window_is_bounded_and_records_every_link() {
+    let directory = tempfile::tempdir().unwrap();
+    let pool = pool_at(directory.path(), 8, 1000);
+
+    for index in 0..MAX_LINK_SAMPLES + 4 {
+        pool.record_peak(&ledger_key("crate", true), 1000 + index as u64, true)
+            .unwrap();
+    }
+    let ledger = read_ledger(&pool.ledger_path());
+    assert_eq!(ledger.link_peaks.len(), MAX_LINK_SAMPLES);
+    assert_eq!(
+        ledger.link_peaks.first().copied(),
+        Some(1000 + 4),
+        "the oldest measurements are the ones dropped"
+    );
+
+    // A measurement no higher than the crate's recorded peak leaves the entry
+    // alone, but the window still saw a link happen.
+    let before = read_ledger(&pool.ledger_path()).link_peaks.len();
+    pool.record_peak(&ledger_key("crate", true), 1, true)
+        .unwrap();
+    let after = read_ledger(&pool.ledger_path());
+    assert_eq!(after.link_peaks.len(), before);
+    assert_eq!(after.link_peaks.last().copied(), Some(1));
+    assert_eq!(
+        after.crates.get(&ledger_key("crate", true)).copied(),
+        Some(1000 + MAX_LINK_SAMPLES as u64 + 3),
+        "a lower measurement never shrinks the recorded peak"
+    );
+}
+
+/// A ledger written before the window existed reads as one with no link
+/// history, which is what it is.
+#[test]
+fn a_ledger_without_a_link_window_still_loads() {
+    let directory = tempfile::tempdir().unwrap();
+    let pool = pool_at(directory.path(), 8, 1000);
+    std::fs::create_dir_all(directory.path()).unwrap();
+    std::fs::write(
+        pool.ledger_path(),
+        br#"{"version":1,"crates":{"widget [link]":4000}}"#,
+    )
+    .unwrap();
+
+    let ledger = read_ledger(&pool.ledger_path());
+    assert!(ledger.link_peaks.is_empty());
+    assert_eq!(
+        pool.plan(&Demand::new("widget", true)),
+        (4, Some(4000)),
+        "the entries it does carry still count"
+    );
+    assert_eq!(
+        pool.plan(&Demand::new("unseen", true)),
+        (LINK_WEIGHT, Some(LINK_WEIGHT * 1000)),
+        "and an empty window leaves the static weight standing"
+    );
+}
+
 #[test]
 fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
     let directory = tempfile::tempdir().unwrap();
@@ -352,8 +457,8 @@ fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
     // retires its floor.
     assert_eq!(ledger_peak(900, false, true, true, 1000), Some(900));
 
-    pool.record_peak("crate", 1500).unwrap();
-    pool.record_peak("crate", 1200).unwrap();
+    pool.record_peak("crate", 1500, false).unwrap();
+    pool.record_peak("crate", 1200, false).unwrap();
     assert_eq!(
         read_ledger(&pool.ledger_path()).crates.get("crate"),
         Some(&1500),
@@ -363,7 +468,7 @@ fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
     let garbage = pool.ledger_path();
     std::fs::write(&garbage, b"not json").unwrap();
     assert!(read_ledger(&garbage).crates.is_empty());
-    pool.record_peak("crate", 1500).unwrap();
+    pool.record_peak("crate", 1500, false).unwrap();
     assert_eq!(read_ledger(&garbage).crates.get("crate"), Some(&1500));
 }
 
@@ -402,7 +507,7 @@ fn the_ledger_drops_its_smallest_entries_at_the_cap() {
     let pool = pool_at(directory.path(), 4, 1);
 
     for index in 0..MAX_LEDGER_ENTRIES + 10 {
-        pool.record_peak(&format!("crate-{index}"), 100 + index as u64)
+        pool.record_peak(&format!("crate-{index}"), 100 + index as u64, false)
             .unwrap();
     }
     let ledger = read_ledger(&pool.ledger_path());

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -417,6 +417,38 @@ fn the_link_window_is_bounded_and_records_every_link() {
     );
 }
 
+/// A repeat compilation that teaches the ledger nothing writes nothing: the
+/// file is rewritten under a lock, and every crate in a build would otherwise
+/// pay for it on every build after the first.
+#[test]
+fn a_measurement_that_changes_nothing_leaves_the_ledger_alone() {
+    let directory = tempfile::tempdir().unwrap();
+    let pool = pool_at(directory.path(), 8, 1000);
+    pool.record_peak("crate", 4000, false).unwrap();
+
+    let written = || {
+        std::fs::metadata(pool.ledger_path())
+            .and_then(|metadata| metadata.modified())
+            .unwrap()
+    };
+    let before = written();
+    // Coarse filesystem timestamps would hide a rewrite that happened within
+    // the same tick, so the check is on the bytes as well.
+    let bytes = std::fs::read(pool.ledger_path()).unwrap();
+    pool.record_peak("crate", 1000, false).unwrap();
+    assert_eq!(std::fs::read(pool.ledger_path()).unwrap(), bytes);
+    assert_eq!(written().duration_since(before).unwrap().as_nanos(), 0);
+
+    // A link, though, always has a window entry to add.
+    pool.record_peak(&ledger_key("crate", true), 1, true)
+        .unwrap();
+    assert_eq!(
+        read_ledger(&pool.ledger_path()).link_peaks,
+        vec![1],
+        "a link's measurement lands in the window even when it teaches the entry nothing"
+    );
+}
+
 /// A ledger written before the window existed reads as one with no link
 /// history, which is what it is.
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,8 +124,16 @@ running stays inside the budget. The two-permit start is a guess for links
 nobody has measured yet, and the first measurement replaces it in either
 direction: a link that turns out to fit in one permit stops being charged for
 two, which is what keeps the link-heavy tail of a build from running at half
-concurrency. A compilation the Linux OOM killer stops is recorded heavier than
-it measured, so its retry runs with more room instead of repeating the crash.
+concurrency.
+
+A link mbx has never seen is weighed by what this machine's recent links have
+cost rather than by that constant, once a few have been measured — the
+heaviest of them, since guessing low costs an out-of-memory kill and guessing
+high costs a wait. Test binaries are why: each one is its own crate name, so a
+cold `cargo test --no-run` has no per-crate history for any of the links in
+front of it and would otherwise spend the whole run on a guess. A compilation
+the Linux OOM killer stops is recorded heavier than it measured, so its retry
+runs with more room instead of repeating the crash.
 
 `priority = "low"` (`MBX_SCHEDULER_PRIORITY`) is for builds nobody is sitting
 at — CI on a shared box, an editor's background check. While a normal-priority


### PR DESCRIPTION
`LINK_WEIGHT` is a constant chosen before anyone had seen a link, and since
#174 the ledger retires it the first time that crate is measured. For test
binaries that first time never comes: **every test target is its own crate
name**, so a cold `cargo test --no-run` looks up each link in front of it,
finds nothing, and spends the entire run on the guess. The crates whose links
matter most are exactly the ones a per-crate ledger cannot learn in time.

The ledger now also keeps what links have cost *lately* — a bounded window of
the last sixteen measurements, machine-wide, whatever crate they came from —
and an unmeasured link is weighed by the heaviest of them instead of by the
constant.

## The choices in it

- **The heaviest of the window, not the average.** Guessing low costs an
  out-of-memory kill; guessing high costs a wait. Those are not the same
  mistake, and the arithmetic should not pretend they are.
- **Three measurements before it may speak.** One link is an anecdote — the
  first on a machine is as likely to be a trivial build script as the program
  itself, and a window answering from it would replace a conservative constant
  with an optimistic sample. Below the floor, nothing changes at all.
- **It records every link, including ones that teach the per-crate entry
  nothing.** The window says what links cost around here lately, which a
  measurement no worse than the last one still answers. The per-crate peak
  keeps its own rule of never shrinking.
- **A crate mbx has measured still speaks for itself.** This is only for the
  ones it has not, and it never reaches a compilation that does not link.
- **It can push the guess up as well as down.** On a machine whose links are
  heavier than two permits, an unmeasured link now starts heavy enough,
  which the constant never did.

## Compatibility

The field is `#[serde(default)]`, so a ledger written before it existed reads
as one with no link history — which is what it is. No version bump, and the
ledger stays readable in both directions.

## Verification

Three new unit tests: the window feeds the prior only past the sample floor
and yields its heaviest entry; a crate's own history outranks the machine's;
non-linking compilations are untouched; the window is bounded and drops oldest
first; a measurement below the recorded peak still lands in the window while
leaving the entry alone; a ledger with no window still loads and still uses
the entries it does carry.

`mise run ci` green. The behavioural change only appears on a machine with
measured-link history, so the unit tests are the evidence here rather than a
benchmark cell — this box's contention numbers move by less than their own
run-to-run spread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permit admission and memory prediction for links on shared scheduler state; mistakes could cause OOM or unnecessary throttling, though behavior is conservative (max-of-window) and gated until three samples.
> 
> **Overview**
> **Unmeasured native links** no longer always use the static two-permit floor once the machine has enough link history. The memory ledger gains a bounded **`link_peaks`** window (last 16 link measurements, machine-wide) and **`plan`** uses the **heaviest** sample after at least **three** links have been recorded; per-crate link entries still win when present.
> 
> **Recording** passes a **`links`** flag into **`record_peak`**: every link appends to the window (even when the per-crate peak does not rise), the window drops oldest entries at the cap, and repeat non-link measurements that would not change the crate map **skip rewriting** `memory.json`. Older ledgers without **`link_peaks`** deserialize as empty via **`serde(default)`**.
> 
> Docs and unit tests cover the sample floor, window bounds, no-op writes, and backward-compatible ledger load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95934528e84e0cead8b79465c8d5e0de7016eed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->