### PR TITLE
feat(release): add GNU Linux artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+            bin: mbx
+            cross: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
             bin: mbx
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+            bin: mbx
+            cross: true
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
             runner: namespace-profile-endev-linux-arm64
@@ -88,6 +98,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
+        if: matrix.cross
+        with:
+          tool: cross
+
       - name: Import macOS signing certificate
         if: runner.os == 'macOS'
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
@@ -113,6 +128,7 @@ jobs:
           sudo apt-get install -y musl-tools
 
       - name: Build
+        if: ${{ !matrix.cross }}
         shell: bash
         # rustls brings in aws-lc-sys, which compiles C: cc-rs looks for a
         # target-prefixed compiler, and Debian's musl-tools only ships
@@ -125,6 +141,13 @@ jobs:
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
         run: ./target/mbx-bootstrap/mbx${{ runner.os == 'Windows' && '.exe' || '' }} build --release --locked --package mbx --target ${{ matrix.target }}
+
+      # Cross's pinned images give GNU artifacts a deliberate glibc 2.23
+      # baseline. Building them directly on the rolling runner would silently
+      # raise that floor whenever the runner image changes.
+      - name: Build GNU release
+        if: matrix.cross
+        run: cross build --release --locked --package mbx --target ${{ matrix.target }}
 
       - name: Sign macOS binary
         if: runner.os == 'macOS'
@@ -209,8 +232,15 @@ jobs:
           spctl --assess --type exec -vv "$BINARY" || true
 
       - name: Check the binary runs
+        if: ${{ !matrix.cross }}
         shell: bash
         run: ./target/${{ matrix.target }}/release/${{ matrix.bin }} --version
+
+      # The ARM64 GNU artifact is cross-compiled on the AMD64 release runner;
+      # let cross provide its matching execution environment for the smoke test.
+      - name: Check the GNU binary runs
+        if: matrix.cross
+        run: cross run --release --locked --package mbx --target ${{ matrix.target }} -- --version
 
       # The archive is flat and holds only the binary, so extracting it
       # straight into a directory on PATH is the whole install. Names carry no

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+# Pin the GNU release images to an old userspace rather than inheriting the
+# runner's glibc floor. These are the same 0.2.5 images mise uses for its GNU
+# release artifacts and remain compatible with glibc 2.23 and newer.
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Or install the latest Linux x86-64 release archive:
 
 ```sh
 mkdir -p ~/.local/bin
-archive=mbx-x86_64-unknown-linux-musl.tar.gz
+archive=mbx-x86_64-unknown-linux-gnu.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
 curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
@@ -75,8 +75,9 @@ grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
 tar -xzf "$archive" -C ~/.local/bin
 ```
 
-Release archives also cover Linux ARM64, Apple Silicon, and Windows x86-64 and
-ARM64.
+Use the corresponding `-musl` archive for a static Linux binary. Release
+archives cover both libc variants on x86-64 and ARM64, plus Apple Silicon and
+Windows x86-64 and ARM64.
 Every release includes `SHA256SUMS`.
 
 [See all installation options →](https://mr-boxington.jdx.dev/getting-started)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -75,7 +75,7 @@ promise each version line makes.
 
 The `mbx` crate is tagged `v{version}`; the three library crates are published to
 crates.io but get no GitHub release of their own. Asset names carry no version
-(`mbx-x86_64-unknown-linux-musl.tar.gz`), which is what keeps
+(`mbx-x86_64-unknown-linux-gnu.tar.gz`), which is what keeps
 `releases/latest/download/…` a stable URL.
 
 ## Setup this depends on

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ mise use -g mr-boxington
 
 ```sh
 mkdir -p ~/.local/bin
-archive=mbx-x86_64-unknown-linux-musl.tar.gz
+archive=mbx-x86_64-unknown-linux-gnu.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
 curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
@@ -27,7 +27,7 @@ tar -xzf "$archive" -C ~/.local/bin
 
 ```sh
 mkdir -p ~/.local/bin
-archive=mbx-aarch64-unknown-linux-musl.tar.gz
+archive=mbx-aarch64-unknown-linux-gnu.tar.gz
 release=https://github.com/jdx/mr-boxington/releases/latest/download
 curl -fsSLO "$release/$archive"
 curl -fsSLO "$release/SHA256SUMS"
@@ -83,6 +83,8 @@ Add `%LOCALAPPDATA%\Programs\mbx` to `PATH`.
 
 Every release publishes its archives and `SHA256SUMS` on
 [GitHub Releases](https://github.com/jdx/mr-boxington/releases).
+Linux also has `-musl` archives for a static binary that does not depend on a
+host glibc.
 
 ### Cargo
 
@@ -94,7 +96,7 @@ cargo install mbx
 
 Release binaries cover:
 
-- Linux x86-64 and ARM64 (static musl builds)
+- Linux x86-64 and ARM64 (GNU and static musl builds)
 - macOS on Apple Silicon
 - Windows x86-64 and ARM64
 


### PR DESCRIPTION
## Summary

- publish x86_64 and ARM64 GNU Linux archives alongside the existing static musl builds
- build GNU artifacts through pinned cross-rs 0.2.5 images for a glibc 2.23 baseline
- make GNU the documented default while retaining explicit musl archives
- smoke-test cross-built artifacts inside cross, including ARM64 under emulation

The existing musl assets remain unchanged.

## Local measurements

Same source, Rust 1.97.1, fat LTO, `panic = "abort"`. This box is noisy; I ran the end-to-end measurement twice in alternating order.

| libc | binary size | cold check | warm cached check | `--help` mean |
| --- | ---: | ---: | ---: | ---: |
| GNU | 10,974,416 B | 15.80 / 15.06 s | 7.51 / 7.50 s | 818 us |
| musl | 11,126,672 B | 13.78 / 15.60 s | 7.92 / 8.30 s | 509 us |

The cold numbers are noise-dominated and mostly measure rustc. The useful signal is that GNU was consistently about 5-10% faster in the warm, 530-hit restore workload despite musl having the much cheaper isolated process startup. That makes both artifacts worthwhile: GNU for the common glibc host and subsequent profile/layout optimization, musl for static portability and the lower startup floor.

The local GNU artifact uses this host glibc and was used only for the A/B. Release builds use the pinned cross images instead so runner updates cannot raise the compatibility floor.

## Validation

- two alternating `benchmarks/measure_builds.py` runs per libc
- 1,000-run Hyperfine startup comparison
- same-source release builds and `--help` smoke tests for x86_64 GNU and musl
- `actionlint` (the only diagnostic is the pre-existing `windows-11-arm` label absent from the checked-in allowlist)
- `git diff --check`

*AI-assisted — Tool: Codex; model: GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI release packaging and install documentation; no runtime application code or security-sensitive paths are modified.
> 
> **Overview**
> **Adds glibc (GNU) Linux release binaries** for x86-64 and ARM64 alongside the existing static musl builds, without changing musl artifact names or behavior.
> 
> The release workflow gains two matrix targets flagged with `cross: true`, installs **cross** for those jobs, builds GNU artifacts via **`cross build`** (instead of the bootstrap `mbx build` path), and smoke-tests them with **`cross run`** so ARM64 GNU can be validated on the AMD64 runner. Native build and direct `--version` checks are gated off when `matrix.cross` is set.
> 
> New **`Cross.toml`** pins **cross-rs 0.2.5** images for both GNU targets so release binaries keep a **glibc 2.23** compatibility floor instead of tracking the rolling CI runner.
> 
> **Docs** (`README`, `RELEASING`, getting-started) now treat **`-gnu` archives as the default** install examples and call out **`-musl`** for fully static Linux binaries; supported platforms lists both libc variants on Linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7cd599ff02a343664c9518fef0b722b77f585fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->