### PR TITLE
perf(release): train binaries with PGO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,14 +255,16 @@ jobs:
           spctl --assess --type exec -vv "$BINARY" || true
 
       - name: Check the binary runs
-        if: ${{ !matrix.cross }}
+        # The x86_64 GNU PGO binary is host-runnable too. Execute the finished
+        # artifact directly so a smoke-test build cannot replace it.
+        if: ${{ !matrix.cross || matrix.pgo }}
         shell: bash
         run: ./target/${{ matrix.target }}/release/${{ matrix.bin }} --version
 
       # The ARM64 GNU artifact is cross-compiled on the AMD64 release runner;
       # let cross provide its matching execution environment for the smoke test.
       - name: Check the GNU binary runs
-        if: matrix.cross
+        if: ${{ matrix.cross && !matrix.pgo }}
         run: cross run --release --locked --package mbx --target ${{ matrix.target }} -- --version
 
       # The archive is flat and holds only the binary, so extracting it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,12 @@ jobs:
             runner: namespace-profile-endev-linux-amd64
             bin: mbx
             cross: true
+            pgo: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
             bin: mbx
+            pgo: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
@@ -76,10 +78,12 @@ jobs:
             os: ubuntu-24.04-arm
             runner: namespace-profile-endev-linux-arm64
             bin: mbx
+            pgo: true
           - target: aarch64-apple-darwin
             os: macos-latest
             runner: namespace-profile-endev-macos-arm64
             bin: mbx
+            pgo: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             runner: windows-latest
@@ -102,6 +106,10 @@ jobs:
         if: matrix.cross
         with:
           tool: cross
+
+      - name: Install LLVM profiling tools
+        if: matrix.pgo
+        run: rustup component add llvm-tools
 
       - name: Import macOS signing certificate
         if: runner.os == 'macOS'
@@ -128,7 +136,7 @@ jobs:
           sudo apt-get install -y musl-tools
 
       - name: Build
-        if: ${{ !matrix.cross }}
+        if: ${{ !matrix.cross && !matrix.pgo }}
         shell: bash
         # rustls brings in aws-lc-sys, which compiles C: cc-rs looks for a
         # target-prefixed compiler, and Debian's musl-tools only ships
@@ -146,8 +154,23 @@ jobs:
       # baseline. Building them directly on the rolling runner would silently
       # raise that floor whenever the runner image changes.
       - name: Build GNU release
-        if: matrix.cross
+        if: ${{ matrix.cross && !matrix.pgo }}
         run: cross build --release --locked --package mbx --target ${{ matrix.target }}
+
+      - name: Build PGO release
+        if: matrix.pgo
+        shell: bash
+        env:
+          MBX_PGO_BUILD_TOOL: ${{ matrix.cross && 'cross' || 'cargo' }}
+          MBX_PGO_TARGET: ${{ matrix.target }}
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
+          # cc-rs mirrors Rust's PGO flags into the C compiler. Apple clang's
+          # profiling ABI follows Xcode rather than rustc, so keep vendored C
+          # dependencies out of this Rust profile on macOS.
+          CFLAGS: ${{ runner.os == 'macOS' && '-fno-profile-generate -fno-profile-use' || '' }}
+          CXXFLAGS: ${{ runner.os == 'macOS' && '-fno-profile-generate -fno-profile-use' || '' }}
+        run: benchmarks/pgo.bash
 
       - name: Sign macOS binary
         if: runner.os == 'macOS'

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,5 +4,11 @@
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
+[target.x86_64-unknown-linux-gnu.env]
+passthrough = ["RUSTFLAGS"]
+
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"
+
+[target.aarch64-unknown-linux-gnu.env]
+passthrough = ["RUSTFLAGS"]

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Build, train, and rebuild mbx with rustc profile-guided optimization.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+pgo_target="${MBX_PGO_TARGET:-}"
+pgo_build_tool="${MBX_PGO_BUILD_TOOL:-cargo}"
+pgo_profile="${MBX_PGO_PROFILE:-release}"
+pgo_data_dir="$repo_root/target/pgo-data"
+profraw_dir="$pgo_data_dir/profraw"
+merged_profile="$pgo_data_dir/merged.profdata"
+base_rustflags="${RUSTFLAGS:-}"
+
+target_arg=""
+target_dir_part=""
+if [ -n "$pgo_target" ]; then
+	target_arg="--target=$pgo_target"
+	target_dir_part="$pgo_target/"
+fi
+
+rustc_host="$(rustc -vV | sed -n 's/^host: //p')"
+rustc_sysroot="$(rustc --print sysroot)"
+llvm_profdata="$rustc_sysroot/lib/rustlib/$rustc_host/bin/llvm-profdata"
+if [ ! -x "$llvm_profdata" ]; then
+	echo "llvm-profdata is missing; install rustup component llvm-tools" >&2
+	exit 1
+fi
+
+mkdir -p "$profraw_dir"
+rm -f "$profraw_dir"/*.profraw "$merged_profile"
+
+# cross mounts the repository at another path. Make the host spelling of the
+# merged profile visible there too, because rustc reads it during phase three.
+if [ "$pgo_build_tool" = cross ]; then
+	export CROSS_CONTAINER_OPTS="${CROSS_CONTAINER_OPTS:-} -v $pgo_data_dir:$pgo_data_dir:rw"
+fi
+
+echo ">>> [1/3] building instrumented mbx"
+# shellcheck disable=SC2086 # An empty target_arg must disappear.
+RUSTFLAGS="${base_rustflags:+$base_rustflags }-Cprofile-generate=$profraw_dir" \
+	"$pgo_build_tool" build --profile "$pgo_profile" $target_arg --locked --package mbx
+
+instrumented="$repo_root/target/${target_dir_part}${pgo_profile}/mbx"
+if [ ! -x "$instrumented" ]; then
+	echo "instrumented binary missing: $instrumented" >&2
+	exit 1
+fi
+
+echo ">>> [2/3] training mbx"
+export LLVM_PROFILE_FILE="$profraw_dir/mbx-%m-%p.profraw"
+"$script_dir/train-pgo.bash" "$instrumented"
+unset LLVM_PROFILE_FILE
+
+profraw_count="$(find "$profraw_dir" -maxdepth 1 -name '*.profraw' -type f | wc -l | tr -d ' ')"
+if [ "$profraw_count" -eq 0 ]; then
+	echo "training produced no profile data" >&2
+	exit 1
+fi
+echo ">>> collected $profraw_count raw profiles"
+
+echo ">>> [3/3] merging profiles and rebuilding mbx"
+"$llvm_profdata" merge -o "$merged_profile" "$profraw_dir"
+test -s "$merged_profile"
+
+# shellcheck disable=SC2086 # An empty target_arg must disappear.
+RUSTFLAGS="${base_rustflags:+$base_rustflags }-Cprofile-use=$merged_profile -Cllvm-args=-pgo-warn-missing-function=false" \
+	"$pgo_build_tool" build --profile "$pgo_profile" $target_arg --locked --package mbx
+
+"$instrumented" --version
+ls -lh "$instrumented"

--- a/benchmarks/train-pgo.bash
+++ b/benchmarks/train-pgo.bash
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Hermetic training workload shared by rustc PGO and post-link optimization.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [ ! -x "$1" ]; then
+	echo "usage: $0 /path/to/mbx" >&2
+	exit 2
+fi
+
+mbx="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+train_dir="$(mktemp -d "${TMPDIR:-/tmp}/mbx-pgo.XXXXXX")"
+cleanup() {
+	case "$train_dir" in
+	"${TMPDIR:-/tmp}"/mbx-pgo.*) rm -rf "$train_dir" ;;
+	*) echo "refusing to remove unexpected training directory: $train_dir" >&2 ;;
+	esac
+}
+trap cleanup EXIT
+
+project="$train_dir/project"
+mkdir -p "$project/src"
+
+cat >"$project/Cargo.toml" <<'EOF'
+[package]
+name = "mbx-pgo-subject"
+version = "0.0.0"
+edition = "2024"
+build = "build.rs"
+
+[[bin]]
+name = "mbx-pgo-subject"
+path = "src/main.rs"
+EOF
+
+cat >"$project/src/lib.rs" <<'EOF'
+pub fn digest(seed: u64) -> u64 {
+    (0..4096).fold(seed, |value, byte| value.rotate_left(7) ^ byte)
+}
+EOF
+
+cat >"$project/src/main.rs" <<'EOF'
+fn main() {
+    println!("{}", mbx_pgo_subject::digest(42));
+}
+EOF
+
+cat >"$project/build.rs" <<'EOF'
+use std::{env, process::Command};
+
+fn main() {
+    let compiler = env::var_os("CC").unwrap_or_else(|| "cc".into());
+    let output = std::path::PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("native.o");
+    let status = Command::new(compiler)
+        .args(["-c", "native.c", "-o"])
+        .arg(output)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    println!("cargo:rerun-if-changed=native.c");
+}
+EOF
+
+cat >"$project/native.c" <<'EOF'
+unsigned long mbx_pgo_native(unsigned long value) {
+    return (value << 5) ^ (value >> 3);
+}
+EOF
+
+export MBX_CACHE_DIR="$train_dir/cache"
+export MBX_TARGET_VIEWS=0
+export CARGO_TARGET_DIR="$train_dir/target"
+
+# Weight short-lived dispatch because Cargo reaches the rustc and cc shims far
+# more often than a person reaches a subcommand.
+for _ in $(seq 1 30); do
+	"$mbx" --help >/dev/null
+	"$mbx" --version >/dev/null
+done
+
+# First-touch compilation trains misses and publication. Removing only the
+# throwaway target then trains prediction lookup, blob reads, decompression,
+# and output materialization from a warm action store.
+(
+	cd "$project"
+	"$mbx" build --offline
+	for _ in $(seq 1 8); do
+		rm -rf "$CARGO_TARGET_DIR"
+		"$mbx" build --offline
+	done
+	"$mbx" check --offline
+	"$mbx" cache stats >/dev/null
+	"$mbx" gc --dry-run >/dev/null
+)

--- a/mise.toml
+++ b/mise.toml
@@ -111,6 +111,10 @@ run_windows = "git diff --exit-code -- docs/cli; if (git status --porcelain --un
 description = "Build the fixed benchmark subject"
 run = "cargo build --release --locked -p mbx"
 
+[tasks."build:pgo"]
+description = "Build a profile-guided mbx release binary"
+run = "benchmarks/pgo.bash"
+
 [tasks.perf]
 description = "Measure instruction-counted performance benchmarks"
 depends = ["perf:prepare"]


### PR DESCRIPTION
## Summary

- build release binaries twice with rustc instrumentation/profile-use
- train against repeated CLI startup plus cold and cache-warm Rust builds
- enable PGO for native/training-compatible GNU, musl, and macOS targets
- keep a local `mise run build:pgo` entry point for reproducing the release build

This is stacked on #181 because the x86_64 GNU release is one of the measured targets.

## Local results

Same source, `panic = "abort"`, 1,000 `mbx --version` samples plus deterministic Callgrind instruction counts:

| target | instruction count | startup mean | binary size |
| --- | ---: | ---: | ---: |
| GNU plain | 825,148 | 747.9 µs | 10,974,416 B |
| GNU PGO | 799,679 (-3.1%) | 731.5 µs (-2.2%) | 11,168,648 B (+1.8%) |
| musl plain | 217,234 | 385.7 µs | 11,134,864 B |
| musl PGO | 212,373 (-2.2%) | 382.6 µs (-0.8%) | 11,339,664 B (+1.8%) |

Alternating GNU end-to-end `cargo check --workspace --all-targets --locked` runs:

- plain: cold 12.42/12.24 s, warm 5.22/5.19 s
- PGO: cold 14.08/12.96 s, warm 5.25/5.04 s

Alternating musl runs:

- plain: cold 14.28/12.07 s, warm 5.24/5.21 s
- PGO: cold 15.19/15.63 s, warm 5.33/5.35 s

The box is noisy, but the deterministic instruction reduction is repeatable. My read is that this is technically real but marginal: isolated startup improves a little, application-level timings are effectively flat here, binaries grow ~1.8%, and releases pay for a second full LTO build. It is useful infrastructure for evaluating BOLT, but not an obvious must-merge on its own.

## Validation

- full GNU and musl instrument/train/profile-use builds
- `mise run lint`
- `bash -n benchmarks/pgo.bash benchmarks/train-pgo.bash`
- ShellCheck 0.11.0
- actionlint 1.7.7 (only the pre-existing unregistered `windows-11-arm` label diagnostic)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release binaries are produced and lengthens CI; failures or profile mismatches could block assets for PGO-enabled targets, but runtime behavior is build/perf infrastructure rather than auth or data handling.
> 
> **Overview**
> **Release artifacts for several Linux and macOS targets are now built with profile-guided optimization** instead of a single plain `cargo`/`cross` release compile.
> 
> The release workflow marks **x86_64 GNU (via cross), x86_64/aarch64 musl, and aarch64 macOS** with `pgo: true`, installs **`llvm-tools`**, and runs a new **`benchmarks/pgo.bash`** step (instrument → **`train-pgo.bash`** workload → merge → profile-use rebuild). Plain bootstrap/cross build steps are skipped when PGO is enabled. **Windows** and **aarch64 GNU** stay on the non-PGO path. Smoke tests run the **finished PGO binary directly** for host-runnable PGO targets (e.g. x86_64 GNU) so a follow-up build cannot overwrite the artifact.
> 
> **`Cross.toml`** passes **`RUSTFLAGS`** into GNU cross images so PGO flags reach the container build. macOS sets **`-fno-profile-generate/use`** on C/C++ flags so vendored C deps are not profiled with mismatched Apple clang.
> 
> **`mise run build:pgo`** mirrors the release PGO pipeline locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1afd890a7debb575a2d7d88de968d3056f53e2d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->