### PR TITLE
fix(cc): make an object independent of the directory it was built in

### DIFF
--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -291,6 +291,15 @@ pub enum CcBypassReason {
     /// ran, so the manifest recorded after it is not what the compilation saw.
     #[error("include search directory changed during the compilation: {0}")]
     SearchPathModifiedDuringCompilation(PathBuf),
+
+    /// The object kept a path the key normalized away.
+    ///
+    /// Remapping covers what the compiler records itself; a path the source
+    /// keeps as a string survives it, and publishing such an object would
+    /// share this checkout's directory under a key that says it does not
+    /// matter.
+    #[error("compilation output records a path its key normalized away: {0}")]
+    UnportableOutput(PathBuf),
     /// The object depends on the machine's own CPU rather than on named inputs.
     #[error("compiler flag tunes for the local CPU: {0}")]
     LocalCpuTarget(String),

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -28,7 +28,8 @@ use mbx_cache_core::{
     CcMetadata, FileDigestScope, FileIdentity, RecordedFileDigest, RemoteActionResult,
     RestoreStats, canonical_json,
 };
-use mbx_cache_rustc::PathMapping;
+use mbx_cache_rustc::{PathMapping, normalize_mapped_path};
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -43,14 +44,20 @@ const ADAPTER: &str = "cc";
 /// a successful compile is ever published, so a compiler error always reaches
 /// the build exactly as it would have without mbx.
 pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -> Result<ExitCode> {
-    let invocation = CcInvocation::parse(arguments)?;
     let working_dir = std::env::current_dir()?;
+    let mappings = path_mappings(&working_dir);
+    // Appended before anything parses, so the flag is part of the key the same
+    // way the caller's own prefix maps are.
+    let portable = Portable::detect(&mappings);
+    let arguments = portable.applied_to(arguments);
+    let arguments = arguments.as_ref();
+    let invocation = CcInvocation::parse(arguments)?;
     let environment = environment_inputs(|name| std::env::var(name).ok(), invocation.sysroot())?;
     let identity = compiler_identity(compiler, language)?;
     let mut context = CcActionContext {
         compiler: identity,
         working_dir: working_dir.clone(),
-        path_mappings: path_mappings(&working_dir),
+        path_mappings: mappings,
         environment,
         inputs: Vec::new(),
     };
@@ -223,6 +230,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         &searchable,
         before,
         flight.as_ref(),
+        &portable,
     ) {
         #[cfg(debug_assertions)]
         session::report_shim_warning(&format!("cc result was not published: {error:#}"));
@@ -247,12 +255,20 @@ fn publish(
     searchable: &BTreeSet<PathBuf>,
     before: Option<BTreeMap<PathBuf, CacheDigest>>,
     flight: Option<&crate::scheduler::Flight>,
+    portable: &Portable,
 ) -> Result<()> {
     let discovered = discover(invocation, context, depfile)?;
     discovered.verify_not_modified_since(compilation_started)?;
     verify_search_path_unchanged(searchable, before)?;
     discovered.verify()?;
     discovered.apply_to(context)?;
+    // The key says this object does not depend on where the build script put
+    // its headers. Publishing one that names the directory anyway would make
+    // that claim false for every checkout that restored it, so a compilation
+    // whose output kept the value is left uncached rather than shared wrong.
+    if !portable.outputs_are_clean(invocation.output()) {
+        return Err(CcBypassReason::UnportableOutput(invocation.output().to_path_buf()).into());
+    }
     let action = invocation.action(context.clone())?;
     publish_result(&action, invocation, output, &context.path_mappings)?;
     let prediction = invocation.prediction(context, duration_ns)?;
@@ -298,6 +314,102 @@ fn restore_flight_prediction(
     record_prediction(task, invocation_digest, &action.digest, &prediction, None);
     Ok(Some((action.digest, cached)))
 }
+
+/// The environment values whose absolute paths a compilation is made
+/// independent of, and the check that says it really was.
+///
+/// This is the C and C++ half of what [`crate::rustc::Portable`] does, and it
+/// exists for the same reason. `OUT_DIR` differs per checkout and per target
+/// directory, a build script that generates headers there passes it as an
+/// include directory, and the compiler records that directory in the debug
+/// information of every object it produces. The key already normalizes those
+/// paths, so without this the cache serves an object naming a directory it
+/// was not built in -- equivalent, but not the artifact this compilation
+/// would have written, and every qualification run says so once per object.
+///
+/// Two things must hold, exactly as they must for rustc.
+/// `-fdebug-prefix-map` makes the compiler record the placeholder instead of
+/// the real path, covering the debug information it writes itself. It does
+/// not cover a path the source keeps as a string, so the object is read
+/// before publishing and a compilation whose output still carries the value
+/// is not published at all.
+///
+/// `-fdebug-prefix-map` rather than `-ffile-prefix-map`: the latter also
+/// rewrites `__FILE__`, which a C program can print or assert on, and
+/// changing what a program says at runtime is not this cache's business.
+struct Portable {
+    /// Flags appended to the real compiler invocation, one per value.
+    arguments: Vec<OsString>,
+    /// The literal values, for the check before publishing.
+    values: Vec<String>,
+}
+
+impl Portable {
+    fn detect(mappings: &[PathMapping]) -> Self {
+        let mut portable = Self {
+            arguments: Vec::new(),
+            values: Vec::new(),
+        };
+        if !session::share_out_dir_requested() {
+            return portable;
+        }
+        for name in PORTABLE_ENVIRONMENT {
+            let Some(value) = std::env::var(name)
+                .ok()
+                .filter(|value| Path::new(value).is_absolute())
+            else {
+                continue;
+            };
+            // A value under no known root is one no key could agree on
+            // anyway, so there is nothing to remap and nothing to promise.
+            let Ok(placeholder) =
+                normalize_mapped_path(Path::new(&value), Path::new("/"), mappings)
+            else {
+                continue;
+            };
+            let mut flag = OsString::from("-fdebug-prefix-map=");
+            flag.push(&value);
+            flag.push("=");
+            flag.push(&placeholder);
+            portable.arguments.push(flag);
+            portable.values.push(value);
+        }
+        portable
+    }
+
+    fn applied_to<'a>(&self, arguments: &'a [OsString]) -> Cow<'a, [OsString]> {
+        if self.arguments.is_empty() {
+            return Cow::Borrowed(arguments);
+        }
+        let mut applied = arguments.to_vec();
+        applied.extend(self.arguments.iter().cloned());
+        Cow::Owned(applied)
+    }
+
+    /// Whether an output is free of every value the flags normalized away.
+    fn outputs_are_clean(&self, path: &Path) -> bool {
+        if self.values.is_empty() {
+            return true;
+        }
+        let Ok(contents) = std::fs::read(path) else {
+            // Unreadable is not evidence of cleanliness.
+            return false;
+        };
+        !self.values.iter().any(|value| {
+            memchr::memmem::find(&contents, value.as_bytes()).is_some()
+                || (value.contains('\\')
+                    && memchr::memmem::find(&contents, value.replace('\\', "/").as_bytes())
+                        .is_some())
+        })
+    }
+}
+
+/// The environment values a C or C++ compilation may be made independent of.
+///
+/// `OUT_DIR` alone, for the same reason the rustc adapter names only that one:
+/// it is what a build script hands its own compilations, and what differs
+/// between two checkouts and two target directories.
+const PORTABLE_ENVIRONMENT: &[&str] = &["OUT_DIR"];
 
 /// Read the dependency list and turn it into digested inputs.
 fn discover(

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -192,3 +192,51 @@ fn success_status() -> std::process::ExitStatus {
     use std::os::windows::process::ExitStatusExt as _;
     std::process::ExitStatus::from_raw(0)
 }
+
+/// The flags are the half that makes the compiler record a placeholder; the
+/// output check is the half that refuses when something recorded the path
+/// anyway. Either alone is wrong -- one silently, one unsoundly.
+#[test]
+fn a_portable_compilation_remaps_its_paths_and_refuses_an_output_that_kept_one() {
+    let directory = tempfile::tempdir().unwrap();
+    let out_dir = "/checkout/target/debug/build/widget-1234/out";
+    let portable = Portable {
+        arguments: vec![OsString::from(format!(
+            "-fdebug-prefix-map={out_dir}=${{target}}/debug/build/widget-1234/out"
+        ))],
+        values: vec![out_dir.to_string()],
+    };
+
+    // The flag is appended, so it lands in the key like any other argument.
+    let arguments = vec![OsString::from("-c"), OsString::from("src/hello.c")];
+    let applied = portable.applied_to(&arguments);
+    assert_eq!(applied.len(), 3);
+    assert!(
+        applied[2]
+            .to_string_lossy()
+            .starts_with("-fdebug-prefix-map="),
+        "the remap is appended: {applied:?}"
+    );
+
+    let clean = directory.path().join("clean.o");
+    std::fs::write(&clean, b"nothing here names a checkout").unwrap();
+    assert!(portable.outputs_are_clean(&clean));
+
+    // A path the source kept as a string survives the remap, and an object
+    // carrying one must not be published under a key that normalized it.
+    let dirty = directory.path().join("dirty.o");
+    std::fs::write(&dirty, format!("built in {out_dir} and says so").as_bytes()).unwrap();
+    assert!(!portable.outputs_are_clean(&dirty));
+
+    // An unreadable output is not evidence of cleanliness.
+    assert!(!portable.outputs_are_clean(&directory.path().join("absent.o")));
+
+    // With nothing remapped there is nothing to promise, and every output
+    // passes -- which is what a build with OUT_DIR sharing off looks like.
+    let inert = Portable {
+        arguments: Vec::new(),
+        values: Vec::new(),
+    };
+    assert!(inert.outputs_are_clean(&dirty));
+    assert!(matches!(inert.applied_to(&arguments), Cow::Borrowed(_)));
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,9 @@ accepted from a repository-owned file. mbx reports an error instead of applying
 an unsafe or misspelled workspace setting.
 
 `share_out_dir = true` is the global default. A workspace may set it to false
-when generated source paths must remain literal in debug information.
+when generated source paths must remain literal in debug information -- for
+C and C++ objects as well as Rust artifacts, since a build script's generated
+headers reach both.
 
 ## Build-script C and C++
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -73,12 +73,16 @@ object compiled with debug information does the same, recording the directory
 the compiler ran in.
 
 A C or C++ object also records the absolute include directories it was given,
-so an object differs between two *target* directories -- not only two
-checkouts -- when a build script generates headers into `OUT_DIR` and compiles
-against them. That is the ordinary shape of a `-sys` crate, and it is why a
-qualification run over one reports a divergence for every object it builds.
-The object path alone does not do this on Linux or macOS; on Windows it does,
-because the debug information records where the object was written as well.
+which is how a `-sys` crate whose build script generates headers into
+`OUT_DIR` used to produce a different object in every target directory. With
+[`OUT_DIR` sharing](/configuration#out-dir-sharing) on -- the default -- mbx
+passes the compiler `-fdebug-prefix-map` for that directory, so the object
+records the same placeholder the key does and two target directories produce
+the same bytes. An object that keeps the path anyway, in a string the source
+holds rather than in debug information, is not published at all rather than
+shared under a key that says the path does not matter. The object path alone
+never did this on Linux or macOS; on Windows it does, because the debug
+information records where the object was written as well.
 
 None of these changes what the artifact does. All of them are visible to
 `MBX_VERIFY=1`, which compares bytes: a divergence it reports for a
@@ -148,6 +152,13 @@ generated sources then appear in debug info under a placeholder path. It cannot
 detect a value derived from the path without embedding the path itself. Set
 `MBX_SHARE_OUT_DIR=0` to keep generated source paths literal at the cost of
 cross-checkout cache sharing for their dependent crates.
+
+This covers C and C++ as well as Rust. A build script that generates headers
+into `OUT_DIR` passes that directory to its own compilations, which record it
+in debug information, so the same remapping applies -- rustc is told
+`--remap-path-prefix` and the C compiler `-fdebug-prefix-map`, and in both
+cases an output that kept the literal path is left uncached rather than
+shared. `MBX_SHARE_OUT_DIR=0` turns both off together.
 
 ## Incremental output reduces sharing
 


### PR DESCRIPTION
Follow-up to #182, which made the C adapter's divergences legible but left
their cause in place. This is the fix. (It was meant to be a second commit on
#182 and lost the race with the merge, so it arrives on its own.)

## What the divergences were

#182's divergence reasons answered it in one run: every one was an object's
contents, and every one came from a build script that generates headers into
`OUT_DIR` and compiles against them. The compiler records absolute include
directories in debug information, so the same source compiled under two target
directories produced two different objects. Plain `cargo build`, no mbx,
reproduces it:

| | result |
| :--- | :--- |
| two target dirs, only the **output path** differs | identical |
| two target dirs, absolute **`-I`** differs | **differ** |
| same, plus `-fdebug-prefix-map` to a shared placeholder | identical |

The key already normalized those paths, so the cache served an object naming a
directory it was not built in.

## The fix

The rustc adapter has always closed exactly this: under `OUT_DIR` sharing it
appends `--remap-path-prefix` for the values a key normalizes, and refuses the
portable key if an output kept one anyway. The C adapter did neither half. It
now does both, on the same setting — not a new knob, an existing decision
finally applied to the adapter that was missing it:

- **`-fdebug-prefix-map`**, so the compiler records the placeholder the key
  already assumes. Not `-ffile-prefix-map`, which also rewrites `__FILE__` —
  a C program can print or assert on that, and changing what a program says at
  runtime is not this cache's business.
- **An output check before publishing.** Remapping covers what the compiler
  writes itself, not a path the source keeps as a string, so the object is read
  and one that kept the value is left uncached rather than shared under a key
  that says the path does not matter. Either half alone is wrong — one
  silently, one unsoundly.

## Measured

`MBX_VERIFY=1` over hk's `check --all-targets`, on current `main`:

| | verifications | divergences |
| :--- | ---: | ---: |
| before | 700 | **150** |
| after | **774** | **0** |

The same object compiled under two target directories is byte-identical, its
debug information names `${target}/…` rather than another build's path, and
nothing newly bypasses — no object failed the output check. Verified both ways:
with `MBX_SHARE_OUT_DIR=0` the flags are not passed and two freshly compiled
objects differ, which is the trade that setting has always described.

**Every C and C++ key changes**, since the flag is part of the invocation. One
cold build pays for it.

## Verification

New unit test covering the remap and the output check together: a clean object
passes, one that kept the path is refused, an unreadable output is not evidence
of cleanliness, and a build with sharing off promises nothing and borrows its
arguments unchanged. `docs/limits.md` and `docs/configuration.md` updated —
the `OUT_DIR` sharing section now covers C and C++ alongside Rust, since a
build script's generated headers reach both. `mise run ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes C/C++ cache key material and publish eligibility for every cached compile when OUT_DIR sharing is enabled; incorrect remapping or output scanning could cause bypasses or stale sharing, but behavior is gated on an existing setting and aligned with the rustc path.
> 
> **Overview**
> When **`share_out_dir`** is on (the default), the C/C++ shim now mirrors the rustc adapter: it appends **`-fdebug-prefix-map`** for absolute **`OUT_DIR`** so debug info uses the same placeholder the cache key already assumes, instead of baking in per-target-directory include paths from `-sys` build scripts.
> 
> Before publishing, it **scans the object file** for any literal remapped path still embedded as a string (which prefix maps do not fix). If found, publication is skipped via new **`CcBypassReason::UnportableOutput`** rather than sharing an object under a key that claims the path does not matter. **`MBX_SHARE_OUT_DIR=0`** disables both the flags and the check, matching rustc.
> 
> **All C/C++ cache keys change** because the injected flags become part of the parsed invocation. Docs note that OUT_DIR sharing applies to C/C++ as well as Rust; a unit test covers flag injection, clean/dirty output detection, and the inert path when sharing is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4aae4ee1705a0dc10bb500c489a1b0d83ac8bf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - C/C++ builds now support portable path remapping across different checkout locations.
  - Outputs containing unsafe, location-specific paths are automatically excluded from caching.

- **Bug Fixes**
  - Prevented cached C/C++ artifacts from differing when generated files are stored in different directories.

- **Documentation**
  - Clarified how generated paths are remapped for C/C++ and Rust builds.
  - Documented behavior when output paths cannot be safely remapped and how to disable sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->