### PR TITLE
perf(release): add BOLT post-link optimization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,14 +255,16 @@ jobs:
           spctl --assess --type exec -vv "$BINARY" || true
 
       - name: Check the binary runs
-        if: ${{ !matrix.cross }}
+        # The x86_64 GNU PGO binary is host-runnable too. Execute the finished
+        # artifact directly so a smoke-test build cannot replace it.
+        if: ${{ !matrix.cross || matrix.pgo }}
         shell: bash
         run: ./target/${{ matrix.target }}/release/${{ matrix.bin }} --version
 
       # The ARM64 GNU artifact is cross-compiled on the AMD64 release runner;
       # let cross provide its matching execution environment for the smoke test.
       - name: Check the GNU binary runs
-        if: matrix.cross
+        if: ${{ matrix.cross && !matrix.pgo }}
         run: cross run --release --locked --package mbx --target ${{ matrix.target }} -- --version
 
       # The archive is flat and holds only the binary, so extracting it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
             bin: mbx
             cross: true
             pgo: true
+            bolt: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
@@ -110,6 +111,10 @@ jobs:
       - name: Install LLVM profiling tools
         if: matrix.pgo
         run: rustup component add llvm-tools
+
+      - name: Install BOLT
+        if: matrix.bolt
+        run: sudo apt-get update && sudo apt-get install -y bolt-19
 
       - name: Import macOS signing certificate
         if: runner.os == 'macOS'
@@ -163,6 +168,9 @@ jobs:
         env:
           MBX_PGO_BUILD_TOOL: ${{ matrix.cross && 'cross' || 'cargo' }}
           MBX_PGO_TARGET: ${{ matrix.target }}
+          MBX_PGO_BOLT: ${{ matrix.bolt && '1' || '' }}
+          LLVM_BOLT: llvm-bolt-19
+          MERGE_FDATA: merge-fdata-19
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
           # cc-rs mirrors Rust's PGO flags into the C compiler. Apple clang's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,12 @@ jobs:
             runner: namespace-profile-endev-linux-amd64
             bin: mbx
             cross: true
+            pgo: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
             bin: mbx
+            pgo: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
@@ -76,10 +78,12 @@ jobs:
             os: ubuntu-24.04-arm
             runner: namespace-profile-endev-linux-arm64
             bin: mbx
+            pgo: true
           - target: aarch64-apple-darwin
             os: macos-latest
             runner: namespace-profile-endev-macos-arm64
             bin: mbx
+            pgo: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             runner: windows-latest
@@ -102,6 +106,10 @@ jobs:
         if: matrix.cross
         with:
           tool: cross
+
+      - name: Install LLVM profiling tools
+        if: matrix.pgo
+        run: rustup component add llvm-tools
 
       - name: Import macOS signing certificate
         if: runner.os == 'macOS'
@@ -128,7 +136,7 @@ jobs:
           sudo apt-get install -y musl-tools
 
       - name: Build
-        if: ${{ !matrix.cross }}
+        if: ${{ !matrix.cross && !matrix.pgo }}
         shell: bash
         # rustls brings in aws-lc-sys, which compiles C: cc-rs looks for a
         # target-prefixed compiler, and Debian's musl-tools only ships
@@ -146,8 +154,23 @@ jobs:
       # baseline. Building them directly on the rolling runner would silently
       # raise that floor whenever the runner image changes.
       - name: Build GNU release
-        if: matrix.cross
+        if: ${{ matrix.cross && !matrix.pgo }}
         run: cross build --release --locked --package mbx --target ${{ matrix.target }}
+
+      - name: Build PGO release
+        if: matrix.pgo
+        shell: bash
+        env:
+          MBX_PGO_BUILD_TOOL: ${{ matrix.cross && 'cross' || 'cargo' }}
+          MBX_PGO_TARGET: ${{ matrix.target }}
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
+          # cc-rs mirrors Rust's PGO flags into the C compiler. Apple clang's
+          # profiling ABI follows Xcode rather than rustc, so keep vendored C
+          # dependencies out of this Rust profile on macOS.
+          CFLAGS: ${{ runner.os == 'macOS' && '-fno-profile-generate -fno-profile-use' || '' }}
+          CXXFLAGS: ${{ runner.os == 'macOS' && '-fno-profile-generate -fno-profile-use' || '' }}
+        run: benchmarks/pgo.bash
 
       - name: Sign macOS binary
         if: runner.os == 'macOS'

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,5 +4,11 @@
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
+[target.x86_64-unknown-linux-gnu.env]
+passthrough = ["RUSTFLAGS"]
+
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"
+
+[target.aarch64-unknown-linux-gnu.env]
+passthrough = ["RUSTFLAGS"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,7 +5,7 @@
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
 [target.x86_64-unknown-linux-gnu.env]
-passthrough = ["RUSTFLAGS"]
+passthrough = ["RUSTFLAGS", "CARGO_PROFILE_RELEASE_STRIP"]
 
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"

--- a/benchmarks/bolt.bash
+++ b/benchmarks/bolt.bash
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Apply profile-guided LLVM BOLT optimizations to a linked mbx ELF binary.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [ ! -x "$1" ]; then
+	echo "usage: $0 /path/to/mbx" >&2
+	exit 2
+fi
+
+binary="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+llvm_bolt="${LLVM_BOLT:-llvm-bolt}"
+merge_fdata="${MERGE_FDATA:-merge-fdata}"
+
+for tool in "$llvm_bolt" "$merge_fdata"; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "required BOLT tool not found: $tool" >&2
+		exit 1
+	fi
+done
+
+llvm_bolt_path="$(readlink -f "$(command -v "$llvm_bolt")")"
+llvm_bolt_prefix="$(cd "$(dirname "$llvm_bolt_path")/.." && pwd)"
+runtime_lib="${BOLT_RUNTIME_INSTRUMENTATION_LIB:-$llvm_bolt_prefix/lib/libbolt_rt_instr.a}"
+if [ ! -f "$runtime_lib" ]; then
+	echo "BOLT instrumentation runtime not found: $runtime_lib" >&2
+	exit 1
+fi
+
+# Debian's BOLT resolves this option relative to /usr/lib even when given an
+# absolute path, otherwise producing /usr/lib/usr/lib/llvm-N/lib/...
+runtime_arg="$runtime_lib"
+case "$runtime_arg" in
+/usr/lib/*) runtime_arg="${runtime_arg#/usr/lib/}" ;;
+esac
+
+if ! readelf -S "$binary" | grep -q '\.rela\.text'; then
+	echo "$binary has no .rela.text section; link with --emit-relocs" >&2
+	exit 1
+fi
+
+bolt_dir="$(mktemp -d "${TMPDIR:-/tmp}/mbx-bolt.XXXXXX")"
+instrumented="$bolt_dir/mbx.instrumented"
+profile_prefix="$bolt_dir/mbx.fdata"
+merged_profile="$bolt_dir/merged.fdata"
+optimized="$binary.bolt"
+cleanup() {
+	case "$bolt_dir" in
+	"${TMPDIR:-/tmp}"/mbx-bolt.*) rm -rf "$bolt_dir" ;;
+	*) echo "refusing to remove unexpected BOLT directory: $bolt_dir" >&2 ;;
+	esac
+	rm -f "$optimized"
+}
+trap cleanup EXIT
+
+echo ">>> [1/3] instrumenting PGO-optimized binary with BOLT"
+"$llvm_bolt" "$binary" \
+	-instrument \
+	-runtime-instrumentation-lib="$runtime_arg" \
+	-instrumentation-file="$profile_prefix" \
+	-instrumentation-file-append-pid \
+	-o "$instrumented"
+
+echo ">>> [2/3] training BOLT against the hermetic workload"
+"$script_dir/train-pgo.bash" "$instrumented"
+
+profile_count="$(find "$bolt_dir" -maxdepth 1 -name 'mbx.fdata.*' -type f | wc -l | tr -d ' ')"
+if [ "$profile_count" -eq 0 ]; then
+	echo "BOLT training produced no profiles in $bolt_dir" >&2
+	exit 1
+fi
+echo ">>> collected $profile_count BOLT profiles"
+
+# BOLT appends only numeric process IDs to this controlled prefix.
+# shellcheck disable=SC2086
+"$merge_fdata" "$profile_prefix".* >"$merged_profile"
+test -s "$merged_profile"
+
+echo ">>> [3/3] reordering and splitting hot code with BOLT"
+"$llvm_bolt" "$binary" \
+	-o "$optimized" \
+	-data="$merged_profile" \
+	-reorder-blocks=ext-tsp \
+	-reorder-functions=cdsort \
+	-split-functions \
+	-split-all-cold \
+	-split-eh \
+	-use-gnu-stack \
+	-dyno-stats
+
+strip --strip-all "$optimized"
+"$optimized" --version >/dev/null
+mv "$optimized" "$binary"
+echo ">>> BOLT optimization complete: $binary"
+ls -lh "$binary"

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -10,6 +10,7 @@ cd "$repo_root"
 pgo_target="${MBX_PGO_TARGET:-}"
 pgo_build_tool="${MBX_PGO_BUILD_TOOL:-cargo}"
 pgo_profile="${MBX_PGO_PROFILE:-release}"
+pgo_bolt="${MBX_PGO_BOLT:-}"
 pgo_data_dir="$repo_root/target/pgo-data"
 profraw_dir="$pgo_data_dir/profraw"
 merged_profile="$pgo_data_dir/merged.profdata"
@@ -66,9 +67,27 @@ echo ">>> [3/3] merging profiles and rebuilding mbx"
 "$llvm_profdata" merge -o "$merged_profile" "$profraw_dir"
 test -s "$merged_profile"
 
+# BOLT needs the final link's relocation table so it can safely move blocks
+# and functions. The table is useful only on the GNU x86_64 BOLT release row.
+final_rustflags="${base_rustflags:+$base_rustflags }-Cprofile-use=$merged_profile -Cllvm-args=-pgo-warn-missing-function=false"
+if [ -n "$pgo_bolt" ]; then
+	final_rustflags="$final_rustflags -C link-arg=-Wl,--emit-relocs"
+fi
+
 # shellcheck disable=SC2086 # An empty target_arg must disappear.
-RUSTFLAGS="${base_rustflags:+$base_rustflags }-Cprofile-use=$merged_profile -Cllvm-args=-pgo-warn-missing-function=false" \
-	"$pgo_build_tool" build --profile "$pgo_profile" $target_arg --locked --package mbx
+if [ -n "$pgo_bolt" ]; then
+	# rust-lld rejects --strip-all together with --emit-relocs. BOLT strips the
+	# rewritten result after it has consumed the relocation table.
+	CARGO_PROFILE_RELEASE_STRIP=none RUSTFLAGS="$final_rustflags" \
+		"$pgo_build_tool" build --profile "$pgo_profile" $target_arg --locked --package mbx
+else
+	RUSTFLAGS="$final_rustflags" \
+		"$pgo_build_tool" build --profile "$pgo_profile" $target_arg --locked --package mbx
+fi
 
 "$instrumented" --version
 ls -lh "$instrumented"
+
+if [ -n "$pgo_bolt" ]; then
+	"$script_dir/bolt.bash" "$instrumented"
+fi

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Build, train, and rebuild mbx with rustc profile-guided optimization.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+pgo_target="${MBX_PGO_TARGET:-}"
+pgo_build_tool="${MBX_PGO_BUILD_TOOL:-cargo}"
+pgo_profile="${MBX_PGO_PROFILE:-release}"
+pgo_data_dir="$repo_root/target/pgo-data"
+profraw_dir="$pgo_data_dir/profraw"
+merged_profile="$pgo_data_dir/merged.profdata"
+base_rustflags="${RUSTFLAGS:-}"
+
+target_arg=""
+target_dir_part=""
+if [ -n "$pgo_target" ]; then
+	target_arg="--target=$pgo_target"
+	target_dir_part="$pgo_target/"
+fi
+
+rustc_host="$(rustc -vV | sed -n 's/^host: //p')"
+rustc_sysroot="$(rustc --print sysroot)"
+llvm_profdata="$rustc_sysroot/lib/rustlib/$rustc_host/bin/llvm-profdata"
+if [ ! -x "$llvm_profdata" ]; then
+	echo "llvm-profdata is missing; install rustup component llvm-tools" >&2
+	exit 1
+fi
+
+mkdir -p "$profraw_dir"
+rm -f "$profraw_dir"/*.profraw "$merged_profile"
+
+# cross mounts the repository at another path. Make the host spelling of the
+# merged profile visible there too, because rustc reads it during phase three.
+if [ "$pgo_build_tool" = cross ]; then
+	export CROSS_CONTAINER_OPTS="${CROSS_CONTAINER_OPTS:-} -v $pgo_data_dir:$pgo_data_dir:rw"
+fi
+
+echo ">>> [1/3] building instrumented mbx"
+# shellcheck disable=SC2086 # An empty target_arg must disappear.
+RUSTFLAGS="${base_rustflags:+$base_rustflags }-Cprofile-generate=$profraw_dir" \
+	"$pgo_build_tool" build --profile "$pgo_profile" $target_arg --locked --package mbx
+
+instrumented="$repo_root/target/${target_dir_part}${pgo_profile}/mbx"
+if [ ! -x "$instrumented" ]; then
+	echo "instrumented binary missing: $instrumented" >&2
+	exit 1
+fi
+
+echo ">>> [2/3] training mbx"
+export LLVM_PROFILE_FILE="$profraw_dir/mbx-%m-%p.profraw"
+"$script_dir/train-pgo.bash" "$instrumented"
+unset LLVM_PROFILE_FILE
+
+profraw_count="$(find "$profraw_dir" -maxdepth 1 -name '*.profraw' -type f | wc -l | tr -d ' ')"
+if [ "$profraw_count" -eq 0 ]; then
+	echo "training produced no profile data" >&2
+	exit 1
+fi
+echo ">>> collected $profraw_count raw profiles"
+
+echo ">>> [3/3] merging profiles and rebuilding mbx"
+"$llvm_profdata" merge -o "$merged_profile" "$profraw_dir"
+test -s "$merged_profile"
+
+# shellcheck disable=SC2086 # An empty target_arg must disappear.
+RUSTFLAGS="${base_rustflags:+$base_rustflags }-Cprofile-use=$merged_profile -Cllvm-args=-pgo-warn-missing-function=false" \
+	"$pgo_build_tool" build --profile "$pgo_profile" $target_arg --locked --package mbx
+
+"$instrumented" --version
+ls -lh "$instrumented"

--- a/benchmarks/train-pgo.bash
+++ b/benchmarks/train-pgo.bash
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Hermetic training workload shared by rustc PGO and post-link optimization.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [ ! -x "$1" ]; then
+	echo "usage: $0 /path/to/mbx" >&2
+	exit 2
+fi
+
+mbx="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+train_dir="$(mktemp -d "${TMPDIR:-/tmp}/mbx-pgo.XXXXXX")"
+cleanup() {
+	case "$train_dir" in
+	"${TMPDIR:-/tmp}"/mbx-pgo.*) rm -rf "$train_dir" ;;
+	*) echo "refusing to remove unexpected training directory: $train_dir" >&2 ;;
+	esac
+}
+trap cleanup EXIT
+
+project="$train_dir/project"
+mkdir -p "$project/src"
+
+cat >"$project/Cargo.toml" <<'EOF'
+[package]
+name = "mbx-pgo-subject"
+version = "0.0.0"
+edition = "2024"
+build = "build.rs"
+
+[[bin]]
+name = "mbx-pgo-subject"
+path = "src/main.rs"
+EOF
+
+cat >"$project/src/lib.rs" <<'EOF'
+pub fn digest(seed: u64) -> u64 {
+    (0..4096).fold(seed, |value, byte| value.rotate_left(7) ^ byte)
+}
+EOF
+
+cat >"$project/src/main.rs" <<'EOF'
+fn main() {
+    println!("{}", mbx_pgo_subject::digest(42));
+}
+EOF
+
+cat >"$project/build.rs" <<'EOF'
+use std::{env, process::Command};
+
+fn main() {
+    let compiler = env::var_os("CC").unwrap_or_else(|| "cc".into());
+    let output = std::path::PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("native.o");
+    let status = Command::new(compiler)
+        .args(["-c", "native.c", "-o"])
+        .arg(output)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    println!("cargo:rerun-if-changed=native.c");
+}
+EOF
+
+cat >"$project/native.c" <<'EOF'
+unsigned long mbx_pgo_native(unsigned long value) {
+    return (value << 5) ^ (value >> 3);
+}
+EOF
+
+export MBX_CACHE_DIR="$train_dir/cache"
+export MBX_TARGET_VIEWS=0
+export CARGO_TARGET_DIR="$train_dir/target"
+
+# Weight short-lived dispatch because Cargo reaches the rustc and cc shims far
+# more often than a person reaches a subcommand.
+for _ in $(seq 1 30); do
+	"$mbx" --help >/dev/null
+	"$mbx" --version >/dev/null
+done
+
+# First-touch compilation trains misses and publication. Removing only the
+# throwaway target then trains prediction lookup, blob reads, decompression,
+# and output materialization from a warm action store.
+(
+	cd "$project"
+	"$mbx" build --offline
+	for _ in $(seq 1 8); do
+		rm -rf "$CARGO_TARGET_DIR"
+		"$mbx" build --offline
+	done
+	"$mbx" check --offline
+	"$mbx" cache stats >/dev/null
+	"$mbx" gc --dry-run >/dev/null
+)

--- a/mise.toml
+++ b/mise.toml
@@ -115,6 +115,10 @@ run = "cargo build --release --locked -p mbx"
 description = "Build a profile-guided mbx release binary"
 run = "benchmarks/pgo.bash"
 
+[tasks."build:bolt"]
+description = "Build a PGO and BOLT optimized mbx release binary"
+run = "MBX_PGO_BOLT=1 benchmarks/pgo.bash"
+
 [tasks.perf]
 description = "Measure instruction-counted performance benchmarks"
 depends = ["perf:prepare"]

--- a/mise.toml
+++ b/mise.toml
@@ -111,6 +111,10 @@ run_windows = "git diff --exit-code -- docs/cli; if (git status --porcelain --un
 description = "Build the fixed benchmark subject"
 run = "cargo build --release --locked -p mbx"
 
+[tasks."build:pgo"]
+description = "Build a profile-guided mbx release binary"
+run = "benchmarks/pgo.bash"
+
 [tasks.perf]
 description = "Measure instruction-counted performance benchmarks"
 depends = ["perf:prepare"]


### PR DESCRIPTION
## Summary

- layer an instrumentation-based LLVM BOLT rewrite after PGO for x86_64 GNU releases
- retain relocations only for the BOLT input and defer stripping until after rewriting
- reuse the hermetic PGO workload to collect BOLT profiles without `perf` privileges
- add `mise run build:bolt` for local reproduction

This is stacked on #184 because BOLT consumes the PGO-trained binary.

## Local results

Same source and training workload, comparing PGO alone with PGO+BOLT:

| metric | PGO | PGO+BOLT | change |
| --- | ---: | ---: | ---: |
| `mbx --version`, 1,000 runs | 735.6 µs | 657.0 µs | -10.7% |
| reversed-order rerun, 2,000 runs | ~1.1 ms | ~1.1 ms | BOLT ~6% faster |
| Callgrind instructions | 678,830 | 686,541 | +1.1% |
| stripped binary size | 11,167,624 B | 15,341,944 B | +37.4% |

Alternating end-to-end `cargo check --workspace --all-targets --locked` runs were noisy and showed no reliable improvement:

- PGO: cold 12.15/12.77 s, warm 5.23/5.85 s
- PGO+BOLT: cold 12.09/13.01 s, warm 5.73/5.74 s

A later pair hit obvious host contention (PGO 19.24/9.27 s), so I excluded it from the comparison rather than cherry-picking it.

My read: BOLT produces a real isolated dispatch/layout win, but for mbx that does not translate into the application-level workload on this host. The 37% size increase and extra release machinery make this experimental rather than something I would recommend merging today.

## Validation

- full PGO instrument/train/rebuild plus BOLT instrument/train/rewrite cycle
- rewritten binary smoke test
- `mise run lint`
- `bash -n` and ShellCheck 0.11.0 for all optimization scripts
- actionlint 1.7.7 (only the pre-existing unregistered `windows-11-arm` label diagnostic)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the primary Linux x86_64 release binary is produced (larger artifacts, extra CI deps and build steps) without touching runtime auth or data paths.
> 
> **Overview**
> Adds an optional **LLVM BOLT** post-link pass on top of the existing PGO release path for **`x86_64-unknown-linux-gnu`** only.
> 
> When `MBX_PGO_BOLT` is set, the final PGO link keeps relocations (`-Wl,--emit-relocs`) and skips Cargo release stripping so BOLT can rewrite the ELF; **`benchmarks/bolt.bash`** then instruments the binary, retrains with the same **`train-pgo.bash`** workload, merges profiles, applies BOLT layout optimizations, strips, and replaces the release artifact. **Release CI** installs `bolt-19`, enables this via a new `matrix.bolt` row, and **`Cross.toml`** passes through `CARGO_PROFILE_RELEASE_STRIP` for cross GNU builds. **`mise run build:bolt`** mirrors the flow locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad63e5f051c787a7ba2df90732b88eb8b530864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->