### PR TITLE
docs(scheduler): say why the release watch could not have paid

### DIFF
--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -123,10 +123,24 @@ const POLL_INITIAL: Duration = Duration::from_millis(2);
 ///
 /// Waking waiters on the release itself -- watching the leases directory, so
 /// the wait ends when a lease disappears -- was built and measured and did
-/// not pay, so it is deliberately not here. A build's whole idle on this is
-/// one interval per compilation, and every core is compiling while it
-/// elapses: about a second of a forty-second build. The pool is rarely what
-/// a build waits on; Cargo's dependency graph is.
+/// not pay, so it is deliberately not here. The reason is not that the win
+/// was small enough to lose in the noise: this interval is not what a waiter
+/// is waiting on. Waiters poll at independent jittered phases, so a released
+/// permit is found by whichever of them wakes first, and the more waiters
+/// there are the sooner that is.
+///
+/// Measured on hk, which is the shape that makes this look worst -- one
+/// build, permits deliberately scarce so the pool really is the constraint:
+///
+/// - at the default permit count, the whole build spends 0.2 s waiting for
+///   permits across ten admissions, so nothing here is worth reaching for;
+/// - at two permits, where admissions wait 1100 s in aggregate, cutting this
+///   interval by twelve and a half times -- to 2 ms, past what any wake could
+///   save -- moved the build from 62.5 s to 63.0 s, and the aggregate wait
+///   from 1105 s to 1073 s. Both are inside the run-to-run spread.
+///
+/// What that aggregate wait is, then, is capacity that genuinely was not
+/// free. No mechanism for noticing sooner can return it.
 const POLL_MAX: Duration = Duration::from_millis(25);
 /// How recently the stamp must have been touched to hold low priority back.
 const PRIORITY_WAIT_FRESHNESS: Duration = Duration::from_secs(2);


### PR DESCRIPTION
I was asked to re-measure the release watch #183 removed, and to restore it if
the measurement supported it. **It does not — #183 was right.** This PR is
only the record of why, because the note it left behind understates its own
case in a way that invites the next person to redo the work.

## What #183's note says, and why it invites a rematch

> A build's whole idle on this is one interval per compilation … about a
> second of a forty-second build.

That reads as *the win was too small to measure*, and the evidence behind it
was two wall-clock cells whose own spread (57.0 / 60.9 / 56.3 s) is wider than
the effect being ruled out. Someone with a quieter box will reasonably think
they can resolve it.

## There is no win, for a structural reason

Waiters poll at **independent jittered phases**, so a released permit is found
by whichever of them wakes first — and the more waiters are queued, the sooner
that is. `POLL_MAX` bounds *one waiter's* latency, not the pool's idle time.
That is why the watch could not have paid, regardless of noise.

## Measured

Instrumented admission directly rather than inferring from wall clock, on hk
with permits deliberately scarce so the pool really is the binding constraint:

| permits | contended admissions | aggregate wait |
| ---: | ---: | ---: |
| 32 (default) | 10 | **0.2 s** |
| 6 | 600–745 | 327 / 522 / 359 s |
| 2 | ~750 | ~1100 s |

At the default there is nothing to reach for at all. And the decisive test, at
two permits — **cut the poll interval 12.5×, to 2 ms, which is past anything a
wake could save**:

| | wall | aggregate wait |
| :--- | ---: | ---: |
| `POLL_MAX` = 25 ms | 62.5 s / 64.1 s | 1105 s / 1086 s |
| `POLL_MAX` = 2 ms | 63.0 s / 82.0 s | 1073 s / 1480 s |

Nothing moved. If polling 12.5× faster changes nothing, waking instantly — the
limit of what a watch can do — changes nothing either. That aggregate wait is
capacity that genuinely was not free, and noticing sooner cannot return it.

I'll note I nearly talked myself into the opposite: a per-waiter latency bound
suggested up to 16% of wall time at two permits. That bound assumes one waiter
and is badly loose with hundreds; the experiment is what corrected it, which is
the other reason this belongs in the file rather than in a thread.

## What changes

The `POLL_MAX` note only. No behavior, no tests touched — `mise run ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no behavioral or test impact.
> 
> **Overview**
> **Documentation-only** update to the `POLL_MAX` comment in `scheduler.rs` — no runtime, tests, or constants change.
> 
> The note no longer frames skipping a lease-directory release watch as “the win was too small to measure.” It explains that **`POLL_MAX` caps one waiter’s poll backoff**, not total pool idle time, because waiters sleep on **independent jittered** intervals and the first to wake picks up a freed permit.
> 
> It adds **hk benchmark numbers** (default permits vs deliberately scarce pool): at default, aggregate permit wait is ~0.2 s; at two permits, shrinking the interval 12.5× (25 ms → 2 ms) did not meaningfully move wall time or aggregate wait — so aggregate wait reflects **real lack of capacity**, not slow notification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d83ba5e1136540fa52c2a0341d6736518912ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->