### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "mbx-cache-core",
  "mbx-cache-rustc",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "blake3",
  "eyre",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.4...mbx-cache-cargo-v0.1.5) - 2026-08-29
+
+### Fixed
+
+- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
+
 ## [0.1.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.3...mbx-cache-cargo-v0.1.4) - 2026-08-29
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.4"
+version = "0.1.5"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.1...mbx-cache-cc-v0.9.2) - 2026-08-29
+
+### Fixed
+
+- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
+
 ## [0.9.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.0...mbx-cache-cc-v0.9.1) - 2026-08-29
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.9.1"
+version = "0.9.2"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.1", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.2", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.1...mbx-cache-core-v0.9.2) - 2026-08-29
+
+### Fixed
+
+- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
+
 ## [0.9.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.0...mbx-cache-core-v0.9.1) - 2026-08-29
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.9.1"
+version = "0.9.2"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.4" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.5" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.4...mbx-cache-protocol-v0.5.5) - 2026-08-29
+
+### Fixed
+
+- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
+
 ## [0.5.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.3...mbx-cache-protocol-v0.5.4) - 2026-08-29
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.4"
+version = "0.5.5"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.1...mbx-cache-rustc-v0.9.2) - 2026-08-29
+
+### Fixed
+
+- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
+
 ## [0.9.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.0...mbx-cache-rustc-v0.9.1) - 2026-08-29
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.9.1"
+version = "0.9.2"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.4...mbx-cache-store-v0.1.5) - 2026-08-29
+
+### Fixed
+
+- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
+
 ## [0.1.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.3...mbx-cache-store-v0.1.4) - 2026-08-29
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.4"
+version = "0.1.5"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/jdx/mr-boxington/compare/v0.7.1...v0.7.2) - 2026-08-29
+
+### Fixed
+
+- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
+
 ## [0.7.1](https://github.com/jdx/mr-boxington/compare/v0.7.0...v0.7.1) - 2026-08-29
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "0.7.1"
+version = "0.7.2"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.1", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.4", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.1", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.1", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.2", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.5", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.2", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.2", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.5", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 0.7.1
+**Version:** 0.7.2
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `mbx-cache-core`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `mbx-cache-cc`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `mbx`: 0.7.1 -> 0.7.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.4...mbx-cache-protocol-v0.5.5) - 2026-08-29

### Fixed

- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.9.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.1...mbx-cache-core-v0.9.2) - 2026-08-29

### Fixed

- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.4...mbx-cache-cargo-v0.1.5) - 2026-08-29

### Fixed

- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.9.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.1...mbx-cache-rustc-v0.9.2) - 2026-08-29

### Fixed

- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.9.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.1...mbx-cache-cc-v0.9.2) - 2026-08-29

### Fixed

- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.4...mbx-cache-store-v0.1.5) - 2026-08-29

### Fixed

- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
</blockquote>

## `mbx`

<blockquote>

## [0.7.2](https://github.com/jdx/mr-boxington/compare/v0.7.1...v0.7.2) - 2026-08-29

### Fixed

- allow caching release-marked builds ([#194](https://github.com/jdx/mr-boxington/pull/194))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump with no code changes in this PR; risk is limited to publishing/version alignment.
> 
> **Overview**
> **Release-only PR** (release-plz) that publishes **0.7.2** for `mbx` and coordinated patch versions for the workspace cache crates (`mbx-cache-protocol` 0.5.5, `mbx-cache-core` / `mbx-cache-rustc` / `mbx-cache-cc` 0.9.2, `mbx-cache-cargo` / `mbx-cache-store` 0.1.5).
> 
> There is **no application source change** in the diff: updates are `Cargo.toml` / `Cargo.lock` version pins, new **CHANGELOG** sections for 2026-08-29, and the generated CLI docs version string (**0.7.2**). The noted user-facing fix in those changelogs is **allow caching release-marked builds** ([#194](https://github.com/jdx/mr-boxington/pull/194)), which this release tags rather than implements here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9344d487f682afa58ab70e7ac4cfaaa47b416b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->