### PR TITLE
fix(release): forward cross smoke-test flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,9 +263,10 @@ jobs:
 
       # The ARM64 GNU artifact is cross-compiled on the AMD64 release runner;
       # let cross provide its matching execution environment for the smoke test.
+      # cross 0.2.5 consumes a trailing --version instead of forwarding it.
       - name: Check the GNU binary runs
         if: ${{ matrix.cross && !matrix.pgo }}
-        run: cross run --release --locked --package mbx --target ${{ matrix.target }} -- --version
+        run: cross run --release --locked --package mbx --target ${{ matrix.target }} -- --help
 
       # The archive is flat and holds only the binary, so extracting it
       # straight into a directory on PATH is the whole install. Names carry no


### PR DESCRIPTION
## Summary

- use `--help` for the cross-executed release smoke test
- document why `--version` cannot be used with cross 0.2.5

`cross` 0.2.5 consumes a trailing `--version` as its own flag, so mbx was launched without arguments and exited 2 after printing help.

## Verification

- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a post-build smoke command; no runtime or release artifact logic is affected.
> 
> **Overview**
> Fixes the **cross-compiled GNU** release smoke test in `release.yml` so the flag after `--` is actually passed to `mbx`.
> 
> The step now runs `cross run … -- --help` instead of `--version`, with an inline note that **cross 0.2.5** treats a trailing `--version` as its own flag, so the binary was starting with no args and failing the check. Host-run and PGO paths still smoke-test with `--version` on the built artifact directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef59858d33fbad3c930f318f71b75a02c6362528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the cross-compiled smoke test to verify the binary’s help output.
  * Improved compatibility with the cross-compilation test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->