### PR TITLE
fix(release): load helpers from workflow revision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,24 @@ jobs:
           ref: ${{ inputs.tag }}
           persist-credentials: false
 
+      # A manual recovery deliberately runs today's workflow against an older
+      # tag. Build helpers belong to the workflow revision, not necessarily to
+      # that tag: v0.7.1, for example, predates the PGO scripts. Keep the
+      # product checkout pinned to the release while loading only the trusted
+      # helpers from the commit that defined this workflow.
+      - name: Load release build helpers
+        if: matrix.pgo
+        shell: bash
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          automation_dir="$RUNNER_TEMP/mbx-release-automation"
+          git fetch --no-tags --depth=1 origin "$WORKFLOW_SHA"
+          mkdir -p "$automation_dir"
+          git show "$WORKFLOW_SHA:benchmarks/pgo.bash" > "$automation_dir/pgo.bash"
+          git show "$WORKFLOW_SHA:benchmarks/train-pgo.bash" > "$automation_dir/train-pgo.bash"
+          chmod +x "$automation_dir"/*.bash
+
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
@@ -163,6 +181,7 @@ jobs:
         env:
           MBX_PGO_BUILD_TOOL: ${{ matrix.cross && 'cross' || 'cargo' }}
           MBX_PGO_TARGET: ${{ matrix.target }}
+          MBX_PGO_REPO_ROOT: ${{ github.workspace }}
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
           # cc-rs mirrors Rust's PGO flags into the C compiler. Apple clang's
@@ -170,7 +189,8 @@ jobs:
           # dependencies out of this Rust profile on macOS.
           CFLAGS: ${{ runner.os == 'macOS' && '-fno-profile-generate -fno-profile-use' || '' }}
           CXXFLAGS: ${{ runner.os == 'macOS' && '-fno-profile-generate -fno-profile-use' || '' }}
-        run: benchmarks/pgo.bash
+        run: |
+          "$RUNNER_TEMP/mbx-release-automation/pgo.bash"
 
       - name: Sign macOS binary
         if: runner.os == 'macOS'

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -4,7 +4,10 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd "$script_dir/.." && pwd)"
+repo_root="${MBX_PGO_REPO_ROOT:-}"
+if [ -z "$repo_root" ]; then
+	repo_root="$(cd "$script_dir/.." && pwd)"
+fi
 cd "$repo_root"
 
 pgo_target="${MBX_PGO_TARGET:-}"


### PR DESCRIPTION
## Summary

- keep manual recovery source pinned to the requested release tag
- load PGO helper scripts from the trusted workflow commit
- allow the PGO driver to operate on a separately checked-out repository root

This makes `workflow_dispatch` recovery work for tags such as `v0.7.1` that predate the current release helpers, while retaining the existing draft/attach/publish idempotency guards.

## Verification

- `shellcheck benchmarks/pgo.bash benchmarks/train-pgo.bash`
- `git diff --check`
- simulated shallow `v0.7.1` checkout fetching helpers from the workflow SHA
- actionlint clean except for the pre-existing unregistered `windows-11-arm` hosted runner label

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to release CI PGO jobs; it decouples helper script version from the release tag without changing signing, attach, or publish guards.
> 
> **Overview**
> **Manual release recovery** can re-run today’s workflow against an older tag while still building that tag’s sources. PGO matrix jobs now **fetch `pgo.bash` and `train-pgo.bash` from `github.workflow_sha`** into `$RUNNER_TEMP/mbx-release-automation` and invoke that copy instead of whatever exists under `benchmarks/` on the checked-out tag (e.g. tags before PGO scripts existed).
> 
> The PGO step sets **`MBX_PGO_REPO_ROOT` to the workspace** so those helpers still compile and profile the release checkout. **`benchmarks/pgo.bash`** honors that env var and only falls back to resolving the repo from the script path when it is unset (local/mise usage unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d039e8544a72dd3a613b178b66ea1bfffae114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->