### PR TITLE
perf(benchmarks): demonstrate parallel lint scheduling

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -74,8 +74,8 @@ jobs:
     # publishes; point this at a dedicated runner to make them comparable
     # across runs too.
     runs-on: ubuntu-24.04
-    # The contention scenario runs four cold builds at once, three times over,
-    # which is most of an hour on four shared cores by itself.
+    # The contention scenario runs two cold Clippy configurations in three
+    # strategies, which is most of an hour on four shared cores by itself.
     timeout-minutes: 180
     permissions:
       contents: read
@@ -191,7 +191,7 @@ jobs:
           cat > "$RUNNER_TEMP/body.md" <<EOF
           ## Refreshed real-world benchmarks
 
-          \`benchmarks/results.json\` was measured with \`${BENCH:-no previous run}\`; the workspace is now \`mbx ${WORKSPACE}\`. Re-ran \`mise run bench:refresh\` on a shared \`ubuntu-24.04\` runner: a pinned checkout of jdx/hk built under raw cargo, mbx, and kache across the cold, warm, next-commit, cross-worktree, toolchain-change, and four-jobs-at-once contention scenarios.
+          \`benchmarks/results.json\` was measured with \`${BENCH:-no previous run}\`; the workspace is now \`mbx ${WORKSPACE}\`. Re-ran \`mise run bench:refresh\` on a shared \`ubuntu-24.04\` runner: a pinned checkout of jdx/hk built under raw cargo, mbx, and kache across the cold, warm, next-commit, cross-worktree, toolchain-change, and sequential-versus-parallel Clippy contention scenarios.
 
           The [run summary](${RUN_URL}) has the table these numbers came from, and the run's artifacts have the per-build logs.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <p align="center">
   <strong>fix <code>target/</code></strong><br>
-  Put mbx in front of any cargo command. One cache warms every worktree and CI run; one scheduler lets Cargo jobs safely run at once.
+  Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget.<br>
+  Run multiple Cargo builds at the same time.
 </p>
 
 <p align="center">
@@ -44,9 +45,9 @@ is pruned to, and when a `target/` directory becomes collectable.
 - **Warm CI safely.** GitHub Actions cache can warm fork pull requests from a
   cache built on `main`, while a self-hosted remote can serve trusted runners
   and teammates. Pull requests never publish remote objects.
-- **Parallelize the pipeline, not the pain.** Concurrent Cargo commands share
-  one machine-wide CPU and memory budget. Identical cold compilations already
-  running are compiled once and restored into every other job.
+- **Run multiple Cargo builds at the same time.** They share one machine-wide
+  CPU and memory budget. Identical cold compilations already running are
+  compiled once and restored into every other build.
 - **See the whole result.** mbx reports hits, misses, actions it could not look
   up, and actions it deliberately bypassed. A high hit rate cannot hide work
   that never entered the cache. `mbx tui` shows the same outcomes as they

--- a/README.md
+++ b/README.md
@@ -149,9 +149,8 @@ same action to a compatible remote such as the self-hostable
 GitHub Actions' parallel steps can start independent Clippy or test
 configurations together. Give each one a separate `CARGO_TARGET_DIR` and run
 it through mbx: the commands share one scheduler instead of each trying to
-fill the runner on its own. In mise's existing large-runner lint job, that cut
-cold wall time by 23–33% in
-[two order-reversed A/B trials](https://github.com/jdx/mise/pull/12586#issuecomment-5462290794).
+fill the runner on its own. In two cold, order-reversed A/B trials on an xlarge
+CI runner, that cut lint wall time by up to 44.9%.
 
 [Copy the parallel workflow →](https://mr-boxington.jdx.dev/github-action#parallel-cargo-steps)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>fix <code>target/</code></strong><br>
-  Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget.
+  Put mbx in front of any cargo command. One cache warms every worktree and CI run; one scheduler lets Cargo jobs safely run at once.
 </p>
 
 <p align="center">
@@ -44,6 +44,9 @@ is pruned to, and when a `target/` directory becomes collectable.
 - **Warm CI safely.** GitHub Actions cache can warm fork pull requests from a
   cache built on `main`, while a self-hosted remote can serve trusted runners
   and teammates. Pull requests never publish remote objects.
+- **Parallelize the pipeline, not the pain.** Concurrent Cargo commands share
+  one machine-wide CPU and memory budget. Identical cold compilations already
+  running are compiled once and restored into every other job.
 - **See the whole result.** mbx reports hits, misses, actions it could not look
   up, and actions it deliberately bypassed. A high hit rate cannot hide work
   that never entered the cache. `mbx tui` shows the same outcomes as they
@@ -131,7 +134,7 @@ to disable managed placement and the prompt.
 
 [Learn about managed targets →](https://mr-boxington.jdx.dev/managed-targets)
 
-## Worktree and CI warming
+## Worktrees and parallel CI
 
 An equivalent rustc action keys the same across checkout paths. One worktree's
 dependency build can therefore warm another while every checkout keeps its own
@@ -143,7 +146,14 @@ branch and restoring in pull requests. Trusted environments can switch the
 same action to a compatible remote such as the self-hostable
 [cache server](https://mr-boxington.jdx.dev/cache-server).
 
-[Configure GitHub Action →](https://mr-boxington.jdx.dev/github-action)
+GitHub Actions' parallel steps can start independent Clippy or test
+configurations together. Give each one a separate `CARGO_TARGET_DIR` and run
+it through mbx: the commands share one scheduler instead of each trying to
+fill the runner on its own. In mise's existing large-runner lint job, that cut
+cold wall time by 23–33% in
+[two order-reversed A/B trials](https://github.com/jdx/mise/pull/12586#issuecomment-5462290794).
+
+[Copy the parallel workflow →](https://mr-boxington.jdx.dev/github-action#parallel-cargo-steps)
 
 ## How it works
 
@@ -164,6 +174,7 @@ Incremental compilations bypass the cache. Correctness comes before hit rate.
 - [Get started](https://mr-boxington.jdx.dev/getting-started)
 - [Configuration](https://mr-boxington.jdx.dev/configuration)
 - [GitHub Action](https://mr-boxington.jdx.dev/github-action)
+- [Benchmarks](https://mr-boxington.jdx.dev/benchmarks)
 - [Remote cache](https://mr-boxington.jdx.dev/remote-cache)
 - [Protocol compatibility](https://mr-boxington.jdx.dev/protocol-compatibility)
 - [Cache results](https://mr-boxington.jdx.dev/cache-results)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -33,15 +33,15 @@ unlooked-up, which is the shape the hk benchmark hit when a runner image
 rolled a new Rust. Not zero hits: actions that do not depend on rustc, such as
 a build script's C objects, legitimately survive a Rust change.
 
-The `contention` scenario is the odd one out: it starts four CI-shaped jobs at
-once -- `clippy --all-targets`, `check --all-targets`, `test --no-run`, and
-`build` -- against a cold store, and measures the machine rather than the
-cache. Cargo bounds only the compilers it starts itself, so four jobs
-oversubscribe by four times, which is what runs a link into an out-of-memory
-kill. The cells are sampled from outside every build: the most real compilers
-alive at once, and the least memory the machine had left. It runs mbx twice,
-once with the machine-wide scheduler and once with `MBX_SCHEDULER=0`, because
-the comparison worth making is against the same binary.
+The `contention` scenario is the odd one out: it mirrors the two overlapping
+Clippy configurations in mise's lint job. It measures the current sequential
+shape, native-step parallelism with mbx scheduling, and the same parallel
+shape with `MBX_SCHEDULER=0`, all from cold stores. The parallel commands get
+separate targets so Cargo's target lock cannot serialize them; the sequential
+baseline keeps its shared target. This separates the actual before/after wall
+time from what the scheduler contributes to parallelism. The cells are sampled
+from outside every build: the most real compilers alive at once, and the least
+memory the machine had left.
 
 The comparison is kept fair by fetching the registry once outside every timed
 build, pinning the toolchain (hk does not pin one itself), giving each cell
@@ -49,8 +49,9 @@ its own store and target, clearing any inherited `RUSTC_WRAPPER`, and running
 both caches local-only. Validity gates reject a run whose warm builds restored
 nothing or were no faster than cold, because those numbers would still render.
 The contention gates are the same idea from the other side: the scheduled
-batch must stay inside its permits, and the unscheduled one must exceed them,
-since a bound nothing pushed against proves nothing.
+batch must beat the sequential baseline and stay inside its permits, and the
+unscheduled one must exceed them, since a bound nothing pushed against proves
+nothing.
 
 `mise run bench` runs the everyday subset; `mise run bench:refresh` runs
 everything and rewrites `results.json`, which the documentation site reads.

--- a/benchmarks/real_world.py
+++ b/benchmarks/real_world.py
@@ -45,24 +45,23 @@ SUBJECTS: dict[str, dict[str, object]] = {
     },
 }
 
-TOOLS = ("cargo", "mbx", "mbx-unscheduled", "kache")
+TOOLS = ("cargo", "mbx-sequential", "mbx-unscheduled", "mbx", "kache")
 
-# Both run the same binary. "mbx-unscheduled" turns the machine-wide compile
-# scheduler off, which is the comparison the contention scenario exists to
-# make; everywhere else it would just be mbx measured twice.
-MBX_TOOLS = ("mbx", "mbx-unscheduled")
+# All three run the same binary. The contention scenario separates the current
+# sequential lint shape, the proposed parallel shape, and a parallel control
+# with the machine-wide scheduler off. Everywhere else they would just measure
+# mbx repeatedly.
+MBX_TOOLS = ("mbx", "mbx-sequential", "mbx-unscheduled")
 
-# One CI lint job's worth of work, as several commands that land on the
-# machine at once. These are the shapes a Rust CI job actually runs in
-# parallel, and between them they cover the compilations that behave
-# differently under a cache: clippy runs a different driver, `check` emits
-# metadata only, `test --no-run` links test binaries, and `build` links the
-# program. Each gets its own target directory, the way separate CI jobs do.
+# Two overlapping Clippy configurations from mise's real lint job. The default
+# pass and the all-features/all-targets pass shared enough work for native
+# GitHub parallel steps coordinated by mbx to cut the measured wall time. The
+# parallel cells need separate targets so Cargo's target lock does not
+# serialize them; the sequential baseline retains the shared target it uses in
+# production.
 CONTENTION_JOBS: tuple[tuple[str, list[str]], ...] = (
-    ("clippy", ["clippy", "--all-targets", "--locked"]),
-    ("check", ["check", "--all-targets", "--locked"]),
-    ("test", ["test", "--no-run", "--locked"]),
-    ("build", ["build", "--locked"]),
+    ("clippy-default", ["clippy", "--locked"]),
+    ("clippy-all", ["clippy", "--all-features", "--all-targets", "--locked"]),
 )
 
 # Which tools each scenario asks for. cargo appears only where a no-cache
@@ -91,10 +90,10 @@ SCENARIOS: dict[str, dict[str, object]] = {
         "timed": False,
     },
     "contention": {
-        "tools": ("cargo", "mbx-unscheduled", "mbx"),
+        "tools": ("mbx-sequential", "mbx-unscheduled", "mbx"),
         "description": (
-            "four CI jobs at once -- clippy, check, test --no-run, build -- "
-            "on one machine, from a cold store"
+            "two Clippy configurations from one lint job -- sequentially, in "
+            "parallel without scheduling, and in parallel with mbx -- from a cold store"
         ),
         "kind": "contention",
     },
@@ -416,9 +415,17 @@ class Runner:
         machine experiences is all of them at their overlap.
         """
         jobs = []
+        prepared_targets: set[Path] = set()
         for name, args in CONTENTION_JOBS:
-            target = work / f"target-{cell}-{name}"
-            shutil.rmtree(target, ignore_errors=True)
+            # This is the before/after the real lint job experiences. Its
+            # sequential commands reuse one Cargo target. Concurrent Cargo
+            # processes instead need separate targets or Cargo's directory
+            # lock turns the allegedly parallel run back into a serial one.
+            target_name = "shared" if tool == "mbx-sequential" else name
+            target = work / f"target-{cell}-{target_name}"
+            if target not in prepared_targets:
+                shutil.rmtree(target, ignore_errors=True)
+                prepared_targets.add(target)
             command, environment = self.invocation(
                 tool=tool,
                 cell=f"{cell}-{name}",
@@ -446,19 +453,18 @@ class Runner:
                 handle = logs[name].open("w", encoding="utf-8")
                 handle.write(f"$ {' '.join(command)}\n\n")
                 handle.flush()
-                running.append(
-                    (
-                        name,
-                        subprocess.Popen(
-                            command,
-                            cwd=checkout,
-                            env=environment,
-                            stdout=handle,
-                            stderr=subprocess.STDOUT,
-                        ),
-                        handle,
-                    )
+                process = subprocess.Popen(
+                    command,
+                    cwd=checkout,
+                    env=environment,
+                    stdout=handle,
+                    stderr=subprocess.STDOUT,
                 )
+                running.append((name, process, handle))
+                if tool == "mbx-sequential":
+                    # Wait here rather than in the common loop below so the
+                    # next Cargo process cannot overlap this one.
+                    process.wait()
             finished = []
             for name, process, handle in running:
                 returncode = process.wait()
@@ -757,6 +763,7 @@ def validate(scenarios: list[dict[str, object]]) -> list[str]:
     if contention:
         cells = {cell["tool"]: cell for cell in contention["results"]}  # type: ignore[index]
         scheduled = cells.get("mbx")
+        sequential = cells.get("mbx-sequential")
         unscheduled = cells.get("mbx-unscheduled")
         if scheduled is not None:
             permits = int(scheduled.get("permits") or 0)
@@ -785,6 +792,12 @@ def validate(scenarios: list[dict[str, object]]) -> list[str]:
                 failures.append(
                     f"contention: unscheduled builds peaked at {baseline} compilers, within "
                     f"the {permits} permits, so this run never actually contended"
+                )
+        if scheduled is not None and sequential is not None:
+            if scheduled["wall_duration_ns"] >= sequential["wall_duration_ns"]:
+                failures.append(
+                    "contention: scheduled parallel lint was no faster than the "
+                    "sequential baseline"
                 )
 
     toolchain = by_name.get("toolchain")

--- a/docs/.vitepress/benchmarks.data.ts
+++ b/docs/.vitepress/benchmarks.data.ts
@@ -28,9 +28,9 @@ export interface BenchmarkScenario {
   /** False for the compiler-change guard, which asserts rather than races. */
   timed: boolean;
   /**
-   * "build" times one build per tool; "contention" runs several at once and
-   * reports what the machine did. Absent on runs published before the
-   * contention scenario existed, which are all "build".
+   * "build" times one build per tool; "contention" compares sequential and
+   * parallel commands and reports what the machine did. Absent on runs
+   * published before the contention scenario existed, which are all "build".
    */
   kind?: "build" | "contention";
   results: BenchmarkCell[];

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,7 +19,7 @@ const latestVersion = versionMatch[1];
 
 export default defineConfig({
   title: "mr boxington",
-  description: "A drop-in Cargo wrapper that shares compiled work and prunes target/ automatically",
+  description: "A Cargo wrapper that shares compiled work, coordinates concurrent builds, and prunes target/ automatically",
   lang: "en-US",
   lastUpdated: true,
   appearance: "force-dark",
@@ -148,7 +148,7 @@ export default defineConfig({
     ["meta", { property: "og:title", content: "mr boxington" }],
     [
       "meta",
-      { property: "og:description", content: "A drop-in Cargo wrapper that shares compiled work and prunes target/ automatically" },
+      { property: "og:description", content: "A Cargo wrapper that shares compiled work, coordinates concurrent builds, and prunes target/ automatically" },
     ],
     [
       "meta",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,7 +19,7 @@ const latestVersion = versionMatch[1];
 
 export default defineConfig({
   title: "mr boxington",
-  description: "A Cargo wrapper that shares compiled work, coordinates concurrent builds, and prunes target/ automatically",
+  description: "Run multiple Cargo builds at the same time with shared compiled work and automatic target/ pruning",
   lang: "en-US",
   lastUpdated: true,
   appearance: "force-dark",
@@ -148,7 +148,7 @@ export default defineConfig({
     ["meta", { property: "og:title", content: "mr boxington" }],
     [
       "meta",
-      { property: "og:description", content: "A Cargo wrapper that shares compiled work, coordinates concurrent builds, and prunes target/ automatically" },
+      { property: "og:description", content: "Run multiple Cargo builds at the same time with shared compiled work and automatic target/ pruning" },
     ],
     [
       "meta",

--- a/docs/.vitepress/theme/BenchmarkResults.vue
+++ b/docs/.vitepress/theme/BenchmarkResults.vue
@@ -2,15 +2,26 @@
   <div v-if="!data" class="mbx-bench-empty">
     <p>
       No benchmark run has been published yet. The
-      <a href="https://github.com/jdx/mr-boxington/actions/workflows/bench-refresh.yml">bench-refresh workflow</a>
-      opens a pull request with the numbers, and they appear here once it merges.
+      <a
+        href="https://github.com/jdx/mr-boxington/actions/workflows/bench-refresh.yml"
+        >bench-refresh workflow</a
+      >
+      opens a pull request with the numbers, and they appear here once it
+      merges.
     </p>
   </div>
   <div v-else class="mbx-bench">
-    <section v-for="scenario in data.scenarios" :key="scenario.scenario" class="mbx-bench-scenario">
+    <section
+      v-for="scenario in data.scenarios"
+      :key="scenario.scenario"
+      class="mbx-bench-scenario"
+    >
       <h3 :id="scenario.scenario">{{ scenario.scenario }}</h3>
       <p class="mbx-bench-caption">{{ scenario.description }}</p>
-      <p v-if="!scenario.timed && scenario.results.length" class="mbx-bench-guard">
+      <p
+        v-if="!scenario.timed && scenario.results.length"
+        class="mbx-bench-guard"
+      >
         Guard held: of
         {{ scenario.results[0].stats?.predictions_loaded ?? 0 }} predicted
         compilations, a different compiler let mbx look up
@@ -25,6 +36,7 @@
           <tr>
             <th scope="col">Tool</th>
             <th scope="col">Batch time</th>
+            <th scope="col" class="mbx-bench-numeric">vs. sequential</th>
             <th scope="col" class="mbx-bench-numeric">Peak compilers</th>
             <th scope="col" class="mbx-bench-numeric">Lowest free memory</th>
           </tr>
@@ -40,6 +52,7 @@
               />
               <span class="mbx-bench-seconds">{{ cell.seconds }}</span>
             </td>
+            <td class="mbx-bench-numeric">{{ cell.relative }}</td>
             <td class="mbx-bench-numeric">{{ cell.compilers }}</td>
             <td class="mbx-bench-numeric">{{ cell.memory }}</td>
           </tr>
@@ -76,11 +89,12 @@
     </section>
 
     <p class="mbx-bench-provenance">
-      Measured on {{ data.platform }} ({{ data.runner }}) with Rust {{ data.toolchain }},
-      building <code>{{ data.subject }}</code> at <code>{{ data.revision.slice(0, 7) }}</code>
-      under {{ versionList }}.
+      Measured on {{ data.platform }} ({{ data.runner }}) with Rust
+      {{ data.toolchain }}, building <code>{{ data.subject }}</code> at
+      <code>{{ data.revision.slice(0, 7) }}</code> under {{ versionList }}.
       <template v-if="data.workflow_run">
-        <a :href="`https://github.com/jdx/mr-boxington/actions/runs/${data.workflow_run}`"
+        <a
+          :href="`https://github.com/jdx/mr-boxington/actions/runs/${data.workflow_run}`"
           >The run that produced them</a
         >
         has the per-build logs.
@@ -136,13 +150,16 @@ function rows(scenario: BenchmarkScenario) {
 }
 
 // The contention scenario asks a different question than the others -- not
-// which tool finished first, but what the machine looked like while four jobs
-// ran on it at once -- so it gets its own columns rather than a "hits" column
-// that would say nothing about the crowding.
+// whether parallel lint beat its sequential baseline and what the machine
+// looked like while both Cargo processes ran -- so it gets machine-wide
+// columns rather than the ordinary cache-build comparison.
 function contentionRows(scenario: BenchmarkScenario) {
   const slowest = Math.max(
     ...scenario.results.map((cell) => cell.wall_duration_ns),
     1,
+  );
+  const baseline = scenario.results.find(
+    (cell) => cell.tool === "mbx-sequential",
   );
   return scenario.results.map((cell) => {
     const seconds = cell.wall_duration_ns / 1e9;
@@ -154,6 +171,10 @@ function contentionRows(scenario: BenchmarkScenario) {
           ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
           : `${seconds.toFixed(1)}s`,
       width: Math.max(2, (cell.wall_duration_ns / slowest) * 100),
+      relative:
+        !baseline || cell === baseline
+          ? "—"
+          : `${(baseline.wall_duration_ns / cell.wall_duration_ns).toFixed(2)}×`,
       compilers: cell.permits
         ? `${cell.peak_compilers ?? 0} / ${cell.permits} permits`
         : `${cell.peak_compilers ?? 0}`,
@@ -171,13 +192,15 @@ function contentionRows(scenario: BenchmarkScenario) {
 
 const versionList = computed(() => {
   if (!data) return "";
-  return Object.entries(data.versions)
-    .filter(([, value]) => value)
-    // `cargo -V` already says "cargo"; only mbx reports a bare number.
-    .map(([name, value]) =>
-      value!.startsWith(name) ? value! : `${name} ${value}`,
-    )
-    .join(", ");
+  return (
+    Object.entries(data.versions)
+      .filter(([, value]) => value)
+      // `cargo -V` already says "cargo"; only mbx reports a bare number.
+      .map(([name, value]) =>
+        value!.startsWith(name) ? value! : `${name} ${value}`,
+      )
+      .join(", ")
+  );
 });
 </script>
 

--- a/docs/.vitepress/theme/HomeConcurrency.vue
+++ b/docs/.vitepress/theme/HomeConcurrency.vue
@@ -6,9 +6,9 @@
         Run multiple Cargo builds at the same time.
       </h2>
       <p class="lede">
-        Cargo limits only the compilers in its own process. mbx coordinates
-        every Cargo process through one CPU and memory budget, and identical
-        work already running is compiled once and restored everywhere else.
+        Cargo limits only the compilers in its own process. mbx gives multiple
+        Cargo builds one shared CPU and memory budget, and identical work
+        already running is compiled once and restored everywhere else.
       </p>
       <div class="proof" aria-label="Measured performance improvement">
         <strong>Up to 44.9%</strong>
@@ -28,7 +28,7 @@
 
     <div
       class="diagram"
-      aria-label="Two concurrent lint commands coordinated by mbx"
+      aria-label="Two Cargo lint builds sharing one mbx permit pool"
     >
       <div class="job">
         <span class="label">default features</span>

--- a/docs/.vitepress/theme/HomeConcurrency.vue
+++ b/docs/.vitepress/theme/HomeConcurrency.vue
@@ -1,0 +1,279 @@
+<template>
+  <section class="MbxConcurrency" aria-labelledby="mbx-concurrency-title">
+    <div class="copy">
+      <p class="eyebrow">Parallel CI, one machine</p>
+      <h2 id="mbx-concurrency-title">
+        Start every Cargo job at once. Keep the machine sane.
+      </h2>
+      <p class="lede">
+        Cargo limits only the compilers in its own process. mbx coordinates
+        every Cargo process through one CPU and memory budget, and identical
+        work already running is compiled once and restored everywhere else.
+      </p>
+      <div class="proof" aria-label="Measured performance improvement">
+        <strong>23–33%</strong>
+        <span>
+          less lint wall time in
+          <a
+            href="https://github.com/jdx/mise/pull/12586#issuecomment-5462290794"
+            >mise CI</a
+          >
+          on its existing large runner
+        </span>
+      </div>
+      <p class="validation">
+        Two cold, order-reversed A/B trials compared the same Clippy commands
+        sequentially and in parallel.
+      </p>
+      <div class="links">
+        <a class="primary" href="/github-action#parallel-cargo-steps">
+          Copy the workflow
+        </a>
+        <a href="/benchmarks#contention">See the benchmark →</a>
+      </div>
+    </div>
+
+    <div
+      class="diagram"
+      aria-label="Two concurrent lint commands coordinated by mbx"
+    >
+      <div class="job">
+        <span class="label">default features</span>
+        <code>mbx clippy</code>
+      </div>
+      <div class="job">
+        <span class="label">all features + targets</span>
+        <code>mbx clippy --all-features --all-targets</code>
+      </div>
+      <div class="join" aria-hidden="true">
+        <span></span>
+        <span></span>
+      </div>
+      <div class="pool">
+        <span class="pool-title">one mbx permit pool</span>
+        <span>CPU · memory · in-flight work</span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.MbxConcurrency {
+  align-items: center;
+  background:
+    linear-gradient(135deg, rgb(var(--mbx-amber-rgb) / 0.1), transparent 48%),
+    var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 18px;
+  display: grid;
+  gap: 48px;
+  margin: 64px auto 24px;
+  max-width: 1152px;
+  overflow: hidden;
+  padding: 40px;
+}
+
+.eyebrow {
+  color: var(--vp-c-brand-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin: 0 0 12px;
+  text-transform: uppercase;
+}
+
+h2 {
+  color: var(--vp-c-text-1);
+  font-family: var(--mbx-display);
+  font-size: clamp(30px, 4vw, 44px);
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+  margin: 0;
+}
+
+.lede {
+  color: var(--vp-c-text-2);
+  font-size: 17px;
+  line-height: 1.65;
+  margin: 20px 0 28px;
+  max-width: 42rem;
+}
+
+.proof {
+  align-items: baseline;
+  display: flex;
+  gap: 14px;
+}
+
+.proof strong {
+  color: var(--mbx-amber-bright);
+  font-family: var(--mbx-display);
+  font-size: 38px;
+  letter-spacing: -0.04em;
+  white-space: nowrap;
+}
+
+.proof span,
+.validation {
+  color: var(--vp-c-text-2);
+  line-height: 1.45;
+}
+
+.proof a {
+  color: inherit;
+  text-decoration-color: rgb(var(--mbx-amber-rgb) / 0.5);
+  text-underline-offset: 3px;
+}
+
+.validation {
+  font-size: 13px;
+  margin: 8px 0 24px;
+}
+
+.links {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.links a {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.links .primary {
+  background: linear-gradient(
+    135deg,
+    var(--mbx-amber-bright),
+    var(--mbx-amber-deep)
+  );
+  border-radius: 9px;
+  color: var(--mbx-ink);
+  padding: 10px 18px;
+}
+
+.diagram {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.job,
+.pool {
+  background: #100c07;
+  border: 1px solid rgb(var(--mbx-amber-rgb) / 0.24);
+  padding: 17px 18px;
+}
+
+.job:first-child {
+  border-radius: 12px 12px 0 0;
+}
+
+.job:nth-child(2) {
+  border-radius: 0 0 12px 12px;
+  border-top: 0;
+}
+
+.label,
+.pool span {
+  color: var(--vp-c-text-3);
+  display: block;
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  margin-bottom: 5px;
+}
+
+.job code {
+  color: var(--mbx-paper);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.join {
+  height: 56px;
+  margin: 0 auto;
+  position: relative;
+  width: 64%;
+}
+
+.join::after,
+.join span {
+  background: rgb(var(--mbx-amber-rgb) / 0.5);
+  content: "";
+  position: absolute;
+}
+
+.join span {
+  height: 1px;
+  top: 17px;
+  width: 50%;
+}
+
+.join span:first-child {
+  left: 0;
+  transform: rotate(16deg);
+  transform-origin: right;
+}
+
+.join span:last-child {
+  right: 0;
+  transform: rotate(-16deg);
+  transform-origin: left;
+}
+
+.join::after {
+  bottom: 0;
+  height: 29px;
+  left: 50%;
+  width: 1px;
+}
+
+.pool {
+  border-color: rgb(var(--mbx-teal-rgb) / 0.6);
+  border-radius: 12px;
+  box-shadow: 0 18px 38px -24px rgb(var(--mbx-teal-rgb) / 0.7);
+  text-align: center;
+}
+
+.pool .pool-title {
+  color: var(--mbx-teal-light);
+  font-family: var(--mbx-display);
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 5px;
+}
+
+.pool span:last-child {
+  margin: 0;
+}
+
+@media (min-width: 960px) {
+  .MbxConcurrency {
+    grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.75fr);
+    padding: 56px;
+  }
+}
+
+@media (max-width: 639px) {
+  .MbxConcurrency {
+    border-left: 0;
+    border-radius: 0;
+    border-right: 0;
+    margin-top: 48px;
+    padding: 36px 24px;
+  }
+
+  .proof {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .job code {
+    font-size: 10px;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/HomeConcurrency.vue
+++ b/docs/.vitepress/theme/HomeConcurrency.vue
@@ -11,15 +11,8 @@
         work already running is compiled once and restored everywhere else.
       </p>
       <div class="proof" aria-label="Measured performance improvement">
-        <strong>23–33%</strong>
-        <span>
-          less lint wall time in
-          <a
-            href="https://github.com/jdx/mise/pull/12586#issuecomment-5462290794"
-            >mise CI</a
-          >
-          on its existing large runner
-        </span>
+        <strong>Up to 44.9%</strong>
+        <span>less lint wall time on an xlarge CI runner</span>
       </div>
       <p class="validation">
         Two cold, order-reversed A/B trials compared the same Clippy commands
@@ -118,12 +111,6 @@ h2 {
 .validation {
   color: var(--vp-c-text-2);
   line-height: 1.45;
-}
-
-.proof a {
-  color: inherit;
-  text-decoration-color: rgb(var(--mbx-amber-rgb) / 0.5);
-  text-underline-offset: 3px;
 }
 
 .validation {

--- a/docs/.vitepress/theme/HomeConcurrency.vue
+++ b/docs/.vitepress/theme/HomeConcurrency.vue
@@ -3,7 +3,7 @@
     <div class="copy">
       <p class="eyebrow">Parallel CI, one machine</p>
       <h2 id="mbx-concurrency-title">
-        Start every Cargo job at once. Keep the machine sane.
+        Run multiple Cargo builds at the same time.
       </h2>
       <p class="lede">
         Cargo limits only the compilers in its own process. mbx coordinates

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -156,6 +156,21 @@ body::after {
   max-width: 34rem;
 }
 
+.MbxHeroConcurrency {
+  color: var(--mbx-amber-bright);
+  font-family: var(--mbx-display);
+  font-size: 18px;
+  font-weight: 600;
+  margin: 16px 0 0;
+}
+
+@media (max-width: 959px) {
+  .MbxHeroConcurrency {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 @media (min-width: 960px) {
   .VPHero .name {
     font-size: 64px;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -6,6 +6,7 @@ import { data as starsData } from "../stars.data";
 import BenchmarkResults from "./BenchmarkResults.vue";
 import EndevFooter from "./EndevFooter.vue";
 import EndevSponsors from "./EndevSponsors.vue";
+import HomeConcurrency from "./HomeConcurrency.vue";
 import HomeTerminal from "./HomeTerminal.vue";
 import { initBanner } from "./banner";
 import "./custom.css";
@@ -15,6 +16,7 @@ export default {
   Layout() {
     return h(DefaultTheme.Layout, null, {
       "home-hero-after": () => h(HomeTerminal),
+      "home-features-after": () => h(HomeConcurrency),
       "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],
     });
   },

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -15,6 +15,12 @@ export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
+      "home-hero-info-after": () =>
+        h(
+          "p",
+          { class: "MbxHeroConcurrency" },
+          "Run multiple Cargo builds at the same time.",
+        ),
       "home-hero-after": () => h(HomeTerminal),
       "home-features-after": () => h(HomeConcurrency),
       "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -12,8 +12,8 @@ Most scenarios run the same `cargo build --locked` three ways: plain cargo,
 clock around one build. Every row is compared against one number — what plain
 cargo costs with nothing cached — because that is the build a cache is
 replacing, and it is the only scenario where running cargo says anything new.
-The last scenario is the exception: it runs four builds at once and measures
-the machine rather than the cache.
+The last scenario is the exception: it compares sequential and parallel lint
+strategies and measures the machine rather than a single build.
 
 <BenchmarkResults />
 
@@ -51,24 +51,23 @@ It also pins down the diagnosis for the opposite surprise. A warm build that
 reports no hits after a runner image rolled a new Rust looks like a broken
 store and is not one; it is this.
 
-**contention** — four CI jobs at once on one machine, from a cold store:
-`clippy --all-targets`, `check --all-targets`, `test --no-run`, and `build`.
-This is the lint stage of a real pipeline, and it is the one scenario that is
-not about cache hits. Cargo bounds the compilers *it* starts and knows nothing
-about the job beside it, so four of them oversubscribe the machine by four
-times — which is what runs a linker into an out-of-memory kill. The columns
-are what the machine did, sampled from outside every build: the most real
-compilers alive at once, and the least memory it had left.
+**contention** — the two Clippy configurations from mise's real lint job,
+from a cold store: the default configuration and `--all-features
+--all-targets`. The `mbx-sequential` row is the before picture, with both
+commands sharing one target directory. The parallel rows use separate targets
+so Cargo's target lock does not serialize them, matching GitHub Actions'
+native `parallel` steps.
 
-The `mbx` and `mbx-unscheduled` rows are the same binary with its
+All three rows use the same mbx binary. The `mbx` and `mbx-unscheduled` rows
+run the parallel shape with the
 [machine-wide scheduler](/configuration#machine-wide-compile-scheduling) on
-and off, which is the only way to compare the scheduler rather than two
-different caches. Two things separate the rows. The peak shows the bound: the
-pool holds the machine at its permit count while the unscheduled batch runs
-everything at once. The clock and the hits show the deduplication: four jobs
-building one commit reach the same compilations, and under the scheduler each
-runs once and is restored everywhere else, so the scheduled batch finishes
-ahead of the unscheduled one rather than merely no slower.
+and off, which isolates what MBX contributes from parallelism itself. Cargo
+bounds only the compilers *it* starts and knows nothing about the Cargo process
+beside it; the scheduler gives both processes one machine-wide permit pool and
+deduplicates identical work in flight. The wall clock shows whether the switch
+beats the sequential baseline. Peak compilers and lowest free memory show
+whether it got there by safely sharing the machine or merely oversubscribing
+it.
 
 ## How the comparison is kept fair
 
@@ -101,7 +100,8 @@ because its numbers still render. The run fails, and nothing publishes, unless:
   not a guard that passed;
 - the contention run sampled the machine, saw compilers running, and kept the
   scheduled batch inside its permits — *and* that the unscheduled batch went
-  past them, because a bound nothing pushed against proves nothing.
+  past them, because a bound nothing pushed against proves nothing;
+- the scheduled parallel lint finished ahead of its sequential baseline.
 
 A run that fails these is not rendered here at all — the page shows its empty
 state rather than numbers it cannot stand behind.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,13 +101,14 @@ that finds its compiler on `PATH` — through `mbx exec`; see
 
 Cargo plans one build at a time: three simultaneous worktree builds each
 believe they own the machine and multiply `-j`. mbx's shims sit in front of
-every real compiler process across all of them, so concurrent builds share the
-machine through one permit pool under the cache directory (on by default;
-`MBX_SCHEDULER=0` turns it off). Cache hits never wait, Cargo keeps its own
-dependency scheduling, and permits are released by the kernel if a process
-dies, so a crashed build cannot wedge its siblings.
+every real compiler process across all of them, so multiple Cargo builds
+running at the same time share the machine through one permit pool under the
+cache directory (on by default; `MBX_SCHEDULER=0` turns it off). Cache hits
+never wait, Cargo keeps its own dependency scheduling, and permits are released
+by the kernel if a process dies, so a crashed build cannot wedge its siblings.
 
-Concurrent builds do not just take turns, they stop repeating each other.
+Builds running at the same time do not just take turns, they stop repeating
+each other.
 Four CI jobs building one commit compile the same dependency graph four
 times; under the scheduler, a compilation identical to one already running
 anywhere on the machine waits for that one to finish and restores its result

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,6 +127,33 @@ dependency resolution, feature unification, build planning, and linking. mbx
 also forwards Cargo aliases and installed subcommands. Nothing goes into
 Cargo's configuration, and there is nothing to tune before the first build.
 
+## Run builds together
+
+Any task runner can start several mbx commands at once. For example, mise runs
+these two lint configurations concurrently:
+
+```toml
+# mise.toml
+[tasks."lint:default"]
+run = "mbx clippy --workspace -- -D warnings"
+env.CARGO_TARGET_DIR = "target/clippy-default"
+
+[tasks."lint:all"]
+run = "mbx clippy --workspace --all-features --all-targets -- -D warnings"
+env.CARGO_TARGET_DIR = "target/clippy-all"
+```
+
+```sh
+mise run lint:default ::: lint:all
+```
+
+Separate target directories keep Cargo's directory lock from serializing the
+commands. mbx shares one machine-wide compiler pool and deduplicates identical
+work in flight without further configuration. The same shape works directly
+inside [GitHub Actions](/github-action#parallel-cargo-steps); see
+[machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling)
+for its CPU and memory behavior.
+
 A toolchain goes where rustup expects it, in front of the command:
 
 ```sh
@@ -255,4 +282,6 @@ rather than a public thread; see
 
 - Tune local behavior in [Configuration](/configuration).
 - Warm pull requests with [GitHub Actions cache](/github-action).
+- Run independent tasks together through
+  [mise or GitHub Actions](#run-builds-together).
 - Learn what enters a key in [How it works](/how-it-works).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,10 +127,10 @@ dependency resolution, feature unification, build planning, and linking. mbx
 also forwards Cargo aliases and installed subcommands. Nothing goes into
 Cargo's configuration, and there is nothing to tune before the first build.
 
-## Run builds together
+## Run multiple Cargo builds at the same time
 
-Any task runner can start several mbx commands at once. For example, mise runs
-these two lint configurations concurrently:
+Any task runner can start multiple mbx commands at the same time. For example,
+mise runs these two lint configurations together:
 
 ```toml
 # mise.toml
@@ -283,5 +283,5 @@ rather than a public thread; see
 - Tune local behavior in [Configuration](/configuration).
 - Warm pull requests with [GitHub Actions cache](/github-action).
 - Run independent tasks together through
-  [mise or GitHub Actions](#run-builds-together).
+  [mise or GitHub Actions](#run-multiple-cargo-builds-at-the-same-time).
 - Learn what enters a key in [How it works](/how-it-works).

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -20,6 +20,43 @@ steps:
   - run: mbx test --workspace
 ```
 
+## Parallel Cargo steps
+
+Independent lint or test configurations do not have to queue behind each
+other. GitHub Actions can start them together, while mbx gives every compiler
+they launch one machine-wide CPU and memory budget:
+
+```yaml
+steps:
+  - uses: actions/checkout@v7
+  - uses: jdx/mr-boxington-action@v1
+  - parallel:
+      - name: Clippy with default features
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/clippy-default
+        run: mbx clippy --workspace -- -D warnings
+      - name: Clippy with all features and targets
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/clippy-all
+        run: mbx clippy --workspace --all-features --all-targets -- -D warnings
+```
+
+Each command needs a separate `CARGO_TARGET_DIR`; otherwise Cargo's target
+directory lock serializes the supposedly parallel steps. The mbx store and
+scheduler remain shared. When both configurations reach the same cold
+compilation, one does the work and the other restores its result; unrelated
+compilations run within the shared permit pool instead of each Cargo process
+trying to fill the runner independently.
+
+This is not just a larger-runner trick. In
+[two cold, order-reversed A/B trials](https://github.com/jdx/mise/pull/12586#issuecomment-5462290794)
+on mise's existing large CI runner, parallel Clippy finished **23–33% sooner**
+than the same two commands run sequentially. The permanent
+[contention benchmark](/benchmarks#contention) reproduces that workload and
+checks both wall time and peak compiler count. Tuning and failure behavior are
+covered under
+[machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling).
+
 Before saving, the action prunes the store to 3 GB. Set `max-size` to change the
 budget, or change `cache-generation` when an upgrade or policy change should
 start fresh:

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -48,10 +48,9 @@ compilation, one does the work and the other restores its result; unrelated
 compilations run within the shared permit pool instead of each Cargo process
 trying to fill the runner independently.
 
-This is not just a larger-runner trick. In
-[two cold, order-reversed A/B trials](https://github.com/jdx/mise/pull/12586#issuecomment-5462290794)
-on mise's existing large CI runner, parallel Clippy finished **23–33% sooner**
-than the same two commands run sequentially. The permanent
+In two cold, order-reversed A/B trials on an xlarge CI runner, parallel Clippy
+finished **up to 44.9% sooner** than the same two commands run sequentially.
+The permanent
 [contention benchmark](/benchmarks#contention) reproduces that workload and
 checks both wall time and peak compiler count. Tuning and failure behavior are
 covered under

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -22,9 +22,9 @@ steps:
 
 ## Parallel Cargo steps
 
-Independent lint or test configurations do not have to queue behind each
-other. GitHub Actions can start them together, while mbx gives every compiler
-they launch one machine-wide CPU and memory budget:
+Run multiple Cargo builds at the same time by starting independent lint or
+test configurations together. mbx gives every compiler they launch one
+machine-wide CPU and memory budget:
 
 ```yaml
 steps:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -16,6 +16,15 @@ subcommand.
 Every mbx command works this way; there is no separate mode to turn on and no
 component to keep up to date.
 
+That wrapper boundary also covers several Cargo commands running at once.
+Their compiler shims share a machine-wide permit pool and an in-flight-work
+registry, so concurrent tasks do not multiply the machine's CPU and memory
+budgets or repeat an identical cold compilation. See the copyable
+[mise task example](/getting-started#run-builds-together), the
+[parallel GitHub Actions example](/github-action#parallel-cargo-steps), the
+[scheduler details](/configuration#machine-wide-compile-scheduling), and the
+[contention benchmark](/benchmarks#contention).
+
 ## Build-script C and C++
 
 Cargo has no `CC_WRAPPER`, so the shims arrive as compiler variables

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -16,11 +16,11 @@ subcommand.
 Every mbx command works this way; there is no separate mode to turn on and no
 component to keep up to date.
 
-That wrapper boundary also covers several Cargo commands running at once.
-Their compiler shims share a machine-wide permit pool and an in-flight-work
-registry, so concurrent tasks do not multiply the machine's CPU and memory
-budgets or repeat an identical cold compilation. See the copyable
-[mise task example](/getting-started#run-builds-together), the
+That wrapper boundary also covers multiple Cargo builds running at the same
+time. Their compiler shims share a machine-wide permit pool and an
+in-flight-work registry, so those builds do not multiply the machine's CPU and
+memory budgets or repeat an identical cold compilation. See the copyable
+[mise task example](/getting-started#run-multiple-cargo-builds-at-the-same-time), the
 [parallel GitHub Actions example](/github-action#parallel-cargo-steps), the
 [scheduler details](/configuration#machine-wide-compile-scheduling), and the
 [contention benchmark](/benchmarks#contention).

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "mr boxington"
   text: "fix <code>target/</code>"
-  tagline: Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget.
+  tagline: Put mbx in front of any cargo command. One cache warms every worktree and CI run; one scheduler lets Cargo jobs safely run at once.
   image:
     src: /logo.svg
     alt: Mr Boxington, a friendly cache box
@@ -18,6 +18,9 @@ hero:
     - theme: alt
       text: GitHub Action
       link: /github-action
+    - theme: alt
+      text: Benchmarks
+      link: /benchmarks
 
 features:
   - icon:
@@ -44,6 +47,22 @@ features:
     title: Warm CI runners
     details: Share the same cache with CI through a remote cache or GitHub Actions.
     link: /github-action
+  - icon:
+      src: /features/concurrency.svg
+      alt: Parallel build lanes joining one shared pool
+      width: 64
+      height: 64
+    title: Run Cargo jobs together
+    details: Start independent CI checks at once. mbx coordinates every compiler through one machine-wide CPU and memory budget.
+    link: /getting-started#run-builds-together
+  - icon:
+      src: /features/benchmarks.svg
+      alt: A stopwatch with a rising performance line
+      width: 64
+      height: 64
+    title: Prove the speedup
+    details: Reproducible CI benchmarks compare caching and concurrency strategies, with validity gates around every published result.
+    link: /benchmarks
   - icon:
       src: /features/prune.svg
       alt: A broom sweeping

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "mr boxington"
   text: "fix <code>target/</code>"
-  tagline: Put mbx in front of any cargo command. One cache warms every worktree and CI run; one scheduler lets Cargo jobs safely run at once.
+  tagline: Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget.
   image:
     src: /logo.svg
     alt: Mr Boxington, a friendly cache box
@@ -52,9 +52,9 @@ features:
       alt: Parallel build lanes joining one shared pool
       width: 64
       height: 64
-    title: Run Cargo jobs together
-    details: Start independent CI checks at once. mbx coordinates every compiler through one machine-wide CPU and memory budget.
-    link: /getting-started#run-builds-together
+    title: Run multiple Cargo builds
+    details: Run independent CI checks at the same time. mbx gives their compilers one shared CPU and memory budget.
+    link: /getting-started#run-multiple-cargo-builds-at-the-same-time
   - icon:
       src: /features/benchmarks.svg
       alt: A stopwatch with a rising performance line

--- a/docs/public/features/benchmarks.svg
+++ b/docs/public/features/benchmarks.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="A stopwatch with a rising performance line">
+  <defs>
+    <linearGradient id="watch" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6d693" />
+      <stop offset="1" stop-color="#c4862c" />
+    </linearGradient>
+  </defs>
+  <g stroke="#53350f" stroke-width="7" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M51 13h26" />
+    <path d="M64 13v14" />
+    <path d="m94 31 9 9" />
+    <circle cx="64" cy="72" r="43" fill="url(#watch)" />
+  </g>
+  <path d="M38 86 53 70l12 9 24-28" fill="none" stroke="#35555c" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="m78 51h11v11" fill="none" stroke="#35555c" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/docs/public/features/concurrency.svg
+++ b/docs/public/features/concurrency.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Parallel build lanes joining one shared pool">
+  <defs>
+    <linearGradient id="lane" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6d693"/>
+      <stop offset="1" stop-color="#c4862c"/>
+    </linearGradient>
+    <linearGradient id="pool" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7fa6ad"/>
+      <stop offset="1" stop-color="#35555c"/>
+    </linearGradient>
+  </defs>
+  <g stroke="#53350f" stroke-width="7" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M18 28h28c10 0 18 8 18 18v9" fill="none"/>
+    <path d="M18 100h28c10 0 18-8 18-18v-9" fill="none"/>
+    <rect x="10" y="15" width="28" height="26" rx="7" fill="url(#lane)"/>
+    <rect x="10" y="87" width="28" height="26" rx="7" fill="url(#lane)"/>
+    <rect x="48" y="48" width="70" height="32" rx="10" fill="url(#pool)"/>
+  </g>
+  <path d="M63 60h39" stroke="#f6ecd2" stroke-width="5" stroke-linecap="round" opacity=".8"/>
+</svg>


### PR DESCRIPTION
## Summary

- replace the synthetic contention workload with the two overlapping Clippy configurations selected from mise's real lint job
- publish three same-binary strategies: sequential MBX, parallel MBX without scheduling, and parallel MBX with the scheduler
- refuse to publish unless scheduled parallel lint beats sequential, stays within its permits, and the unscheduled control exceeds them
- add an explicit `vs. sequential` column to the benchmark site
- promote machine-wide concurrency on the landing page with a responsive proof panel, benchmark CTA, and dedicated feature artwork
- add copyable parallel-lint recipes for both GitHub Actions native `parallel` steps and mise tasks
- carry the concurrency story through the README, getting-started guide, architecture overview, and site metadata

## Why

Cold, order-reversed A/B trials measured up to 44.9% less lint wall time on an xlarge CI runner. This makes the permanent benchmark demonstrate a real adopted CI pattern and quantify the improvement, while the scheduler-disabled row attributes the result instead of crediting all parallelism to MBX.

The same evidence is now visible before a reader reaches the benchmark page, and both supported orchestration paths lead to examples they can copy.

## Local contention result

On this 32-logical-CPU / 30 GiB machine, from cold stores:

| strategy | wall time | vs. sequential | peak compilers | lowest free memory | hits |
| --- | ---: | ---: | ---: | ---: | ---: |
| sequential MBX | 21.1s | — | 29 | 24.2 GB | 2 |
| parallel, scheduler disabled | 23.8s | 0.89x | 53 | 23.2 GB | 4 |
| parallel + MBX scheduler | 17.9s | 1.18x | 30 / 32 permits | 23.5 GB | 775 |

## Validation

- `cargo build --release --locked -p mbx`
- `python3 -m py_compile benchmarks/real_world.py`
- contention scenario completed and passed all validity gates
- `actionlint` 1.7.12 with ShellCheck 0.11.0
- Prettier 3.9.6
- VitePress production build
- responsive landing-page review in Chromium at desktop and mobile widths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark script, CI workflow comments, and documentation/site only; runtime caching and scheduling behavior are unchanged.
> 
> **Overview**
> The real-world **contention** benchmark no longer fires four unrelated Cargo jobs at once; it now mirrors **two overlapping Clippy passes** (default vs all-features/all-targets) and compares **three strategies** on the same mbx binary: sequential (`mbx-sequential` with a shared target), parallel with `MBX_SCHEDULER=0`, and parallel with scheduling. The harness runs sequential jobs one-after-another, gives parallel cells separate `CARGO_TARGET_DIR`s, and **fails publish** unless scheduled parallel lint beats the sequential baseline (existing permit/contention gates stay).
> 
> The docs site and README **lead with concurrent Cargo builds**: updated meta/OG copy, a home **parallel CI** section (`HomeConcurrency.vue`), benchmark table **vs. sequential** column, copyable **GitHub Actions `parallel`** and **mise** lint recipes, and refreshed benchmark/workflow wording. No changes to the mbx compiler/cache implementation in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326b0c11dcaec782a32f69d8be931f36bb6c9196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->