### PR TITLE
docs: render target tagline in monospace

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -120,6 +120,15 @@ body::after {
   letter-spacing: -0.03em;
 }
 
+.VPHero .text code {
+  background: none;
+  color: inherit;
+  font-family: var(--vp-font-family-mono);
+  font-size: inherit;
+  font-weight: inherit;
+  padding: 0;
+}
+
 .VPHero .name .clip {
   position: relative;
   z-index: 0;

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: "mr boxington"
-  text: "fix target/"
+  text: "fix <code>target/</code>"
   tagline: Put mbx in front of any cargo command. One cache warms every worktree and CI run, and prunes itself to a size budget.
   image:
     src: /logo.svg


### PR DESCRIPTION
## Summary

- mark `target/` in the landing-page hero as code
- preserve the hero typography while using the configured monospace font

## Testing

- `cd docs && aube run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and CSS with no runtime, auth, or data impact.
> 
> **Overview**
> The landing hero tagline now wraps **`target/`** in `<code>` so it reads as a path rather than plain prose.
> 
> New **`.VPHero .text code`** rules strip the default inline-code pill (no background or padding) and switch only the font to **`var(--vp-font-family-mono)`**, while keeping the hero display type’s size, weight, and color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f5bd80d5e2db7496a373e9ce47c766cf0c3198. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation landing page hero text to visually distinguish `target/` as inline code.
  * Adjusted inline code styling so it matches the surrounding hero text while preserving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->