### PR TITLE
fix(docs): show the mbx release version

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,11 +5,17 @@ import { defineConfig } from "vitepress";
 import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 
 const configDir = dirname(fileURLToPath(import.meta.url));
-const cargoToml = readFileSync(resolve(configDir, "../../Cargo.toml"), "utf8");
-const versionMatch = cargoToml.match(
-  /^\[workspace\.package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m,
+const cargoToml = readFileSync(
+  resolve(configDir, "../../crates/mbx/Cargo.toml"),
+  "utf8",
 );
-const latestVersion = versionMatch?.[1] ?? "0.0.0";
+const versionMatch = cargoToml.match(
+  /^\[package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m,
+);
+if (!versionMatch) {
+  throw new Error("could not read the mbx version from crates/mbx/Cargo.toml");
+}
+const latestVersion = versionMatch[1];
 
 export default defineConfig({
   title: "mr boxington",


### PR DESCRIPTION
## Summary

- read the landing-page version from `crates/mbx/Cargo.toml` now that workspace crates are independently versioned
- fail the docs build if the mbx version cannot be read instead of silently displaying `0.0.0`

## Verification

- `mise run build:docs`
- verified generated landing page contains `v0.7.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only build configuration; no runtime or security impact.
> 
> **Overview**
> Updates the VitePress docs build so the nav **release badge** reflects the **`mbx` crate version** instead of the old workspace-level version.
> 
> **`docs/.vitepress/config.mts`** now reads `crates/mbx/Cargo.toml` and parses `version` from `[package]`, matching independently versioned workspace crates. If that version is missing, the docs build **throws** rather than showing a misleading `v0.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297e6ca3e5760caca93a700d5f020e74545c608f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->