### PR TITLE
fix: allow caching release-marked builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ branch and restoring in pull requests. Trusted environments can switch the
 same action to a compatible remote such as the self-hostable
 [cache server](https://mr-boxington.jdx.dev/cache-server).
 
-[Configure GitHub Actions →](https://mr-boxington.jdx.dev/github-actions)
+[Configure GitHub Action →](https://mr-boxington.jdx.dev/github-action)
 
 ## How it works
 
@@ -163,7 +163,7 @@ Incremental compilations bypass the cache. Correctness comes before hit rate.
 
 - [Get started](https://mr-boxington.jdx.dev/getting-started)
 - [Configuration](https://mr-boxington.jdx.dev/configuration)
-- [GitHub Actions](https://mr-boxington.jdx.dev/github-actions)
+- [GitHub Action](https://mr-boxington.jdx.dev/github-action)
 - [Remote cache](https://mr-boxington.jdx.dev/remote-cache)
 - [Protocol compatibility](https://mr-boxington.jdx.dev/protocol-compatibility)
 - [Cache results](https://mr-boxington.jdx.dev/cache-results)

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -380,7 +380,7 @@ fn strings(arguments: &[std::ffi::OsString]) -> Result<Vec<String>> {
 }
 
 fn prefetch(config: &Config, arguments: &[String]) -> Result<ExitCode> {
-    validate_prefetch_config(config, policy::release_context())?;
+    validate_prefetch_config(config)?;
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let working_dir = std::env::current_dir()?;
     let roots = resolve_roots(&cargo, arguments, &working_dir);
@@ -406,15 +406,12 @@ fn prefetch(config: &Config, arguments: &[String]) -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-fn validate_prefetch_config(config: &Config, release_context: bool) -> Result<()> {
+fn validate_prefetch_config(config: &Config) -> Result<()> {
     if config.remote.url.is_none() {
         eyre::bail!("remote prefetch requires remote.url or MBX_REMOTE_URL");
     }
     if !config.remote.mode.reads() {
         eyre::bail!("remote prefetch requires a read-capable remote.mode");
-    }
-    if release_context {
-        eyre::bail!("remote prefetch is disabled in release contexts");
     }
     Ok(())
 }
@@ -614,13 +611,6 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
 ) -> Result<ExitCode> {
     let retention = &settings.retention;
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    // Release builds publish artifacts that must not depend on a cache, and a
-    // tag build has no later build to share with anyway.
-    if policy::release_context() {
-        log::warn!("the build cache is disabled for release builds");
-        return run_cargo(&cargo, arguments, BTreeMap::new());
-    }
-
     // Only where mbx can identify the linker precisely enough to key what it
     // produced. Said out loud only to somebody who asked for it: this is on
     // by default now, and a platform that cannot do it would otherwise warn
@@ -837,13 +827,6 @@ fn exec(config: &Config, settings: &CliSettings, args: &ExecArgs) -> Result<Exit
         eyre::bail!("exec needs a command to run");
     };
     let program: std::ffi::OsString = program.into();
-    // The same two stand-asides as a cargo build: a release build must not
-    // depend on a cache, and MBX_CC=0 turns the C and C++ cache off -- which
-    // is all of what this command caches.
-    if policy::release_context() {
-        log::warn!("the build cache is disabled for release builds");
-        return run_cargo(&program, arguments, BTreeMap::new());
-    }
     let working_dir = std::env::current_dir()?;
     let project_root = match &args.project_root {
         Some(root) => absolute(&working_dir, root),

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -601,16 +601,13 @@ fn prefetch_preserves_cargo_flags_and_the_rustc_separator() {
 }
 
 #[test]
-fn prefetch_rejects_release_contexts_instead_of_succeeding_without_remote_work() {
+fn prefetch_accepts_a_read_capable_remote() {
     let directory = tempfile::tempdir().unwrap();
     let mut config = managed_target_config(directory.path());
     config.remote.url = Some("https://cache.example.test".into());
     config.remote.mode = mbx_cache_core::RemoteCacheMode::ReadOnly;
 
-    let error = validate_prefetch_config(&config, true).unwrap_err();
-
-    assert!(error.to_string().contains("disabled in release contexts"));
-    assert!(validate_prefetch_config(&config, false).is_ok());
+    assert!(validate_prefetch_config(&config).is_ok());
 }
 
 #[test]

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -309,18 +309,12 @@ fn setup_paths() -> Option<(PathBuf, PathBuf)> {
 }
 
 async fn remote_checks(config: &Config) -> Vec<Check> {
-    let release_context = policy::release_context();
-    let effective_mode = if release_context {
-        None
-    } else {
-        policy::effective_remote_cache_mode(config.remote.mode)
-    };
-    remote_checks_with_policy(config, release_context, effective_mode).await
+    let effective_mode = policy::effective_remote_cache_mode(config.remote.mode);
+    remote_checks_with_policy(config, effective_mode).await
 }
 
 async fn remote_checks_with_policy(
     config: &Config,
-    release_context: bool,
     effective_mode: Option<mbx_cache_core::RemoteCacheMode>,
 ) -> Vec<Check> {
     let Some(base_url) = config
@@ -335,14 +329,10 @@ async fn remote_checks_with_policy(
             "not configured; using the local cache",
         )];
     };
-    let effective = if release_context {
-        "disabled in this release context".to_string()
-    } else {
-        effective_mode.map_or_else(
-            || "disabled by cache write policy".to_string(),
-            |mode| mode.to_string(),
-        )
-    };
+    let effective = effective_mode.map_or_else(
+        || "disabled by cache write policy".to_string(),
+        |mode| mode.to_string(),
+    );
     let policy = Check::pass(
         "policy",
         format!("configured {}, effective {effective}", config.remote.mode),
@@ -450,7 +440,6 @@ mod tests {
             .unwrap();
         let checks = runtime.block_on(remote_checks_with_policy(
             &config,
-            false,
             Some(mbx_cache_core::RemoteCacheMode::ReadOnly),
         ));
         let failure = checks
@@ -485,7 +474,7 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let checks = runtime.block_on(remote_checks_with_policy(&config, false, None));
+        let checks = runtime.block_on(remote_checks_with_policy(&config, None));
 
         assert!(checks.iter().all(|check| check.severity == Severity::Pass));
         assert!(checks.iter().any(|check| {

--- a/crates/mbx/src/policy.rs
+++ b/crates/mbx/src/policy.rs
@@ -2,8 +2,7 @@
 //!
 //! Cache writes are only trusted from a CI context that a pull request cannot
 //! influence, so untrusted contexts read the remote cache but never publish to
-//! it. Release builds do not participate at all, and CI never compiles
-//! incrementally.
+//! it. CI never compiles incrementally.
 
 use mbx_cache_core::RemoteCacheMode;
 
@@ -25,11 +24,6 @@ fn effective_remote_cache_mode_with(
         RemoteCacheMode::ReadWrite | RemoteCacheMode::ReadOnly => Some(RemoteCacheMode::ReadOnly),
         RemoteCacheMode::WriteOnly => None,
     }
-}
-
-/// Whether this is a release build, which never uses the cache.
-pub fn release_context() -> bool {
-    release_context_with(|name| std::env::var(name).ok())
 }
 
 /// Whether incremental compilation is worth allowing here.
@@ -75,14 +69,6 @@ fn trusted_cache_writer(get_env: &impl Fn(&str) -> Option<String>) -> bool {
             && env_truthy(get_env("CI_COMMIT_REF_PROTECTED"));
     }
     false
-}
-
-fn release_context_with(get_env: impl Fn(&str) -> Option<String>) -> bool {
-    env_truthy(get_env("MBX_RELEASE"))
-        || (env_truthy(get_env("GITHUB_ACTIONS"))
-            && (get_env("GITHUB_REF_TYPE").as_deref() == Some("tag")
-                || get_env("GITHUB_EVENT_NAME").as_deref() == Some("release")))
-        || (env_truthy(get_env("GITLAB_CI")) && get_env("CI_COMMIT_TAG").is_some())
 }
 
 fn env_truthy(value: Option<String>) -> bool {
@@ -158,6 +144,31 @@ mod tests {
     }
 
     #[test]
+    fn release_markers_do_not_disable_the_cache() {
+        let release = env(&[
+            ("MBX_RELEASE", "1"),
+            ("GITHUB_ACTIONS", "true"),
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "branch"),
+            ("GITHUB_REF_PROTECTED", "true"),
+        ]);
+        assert_eq!(
+            effective_remote_cache_mode_with(RemoteCacheMode::ReadWrite, &release),
+            Some(RemoteCacheMode::ReadWrite)
+        );
+
+        let tag = env(&[
+            ("GITHUB_ACTIONS", "true"),
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "tag"),
+        ]);
+        assert_eq!(
+            effective_remote_cache_mode_with(RemoteCacheMode::ReadWrite, &tag),
+            Some(RemoteCacheMode::ReadOnly)
+        );
+    }
+
+    #[test]
     fn ci_never_compiles_incrementally() {
         assert!(!incremental_allowed_with(true, env(&[("CI", "true")])));
         assert!(incremental_allowed_with(true, env(&[])));
@@ -172,22 +183,5 @@ mod tests {
         ));
         assert!(learned_incremental_allowed_with(true, env(&[])));
         assert!(!learned_incremental_allowed_with(false, env(&[])));
-    }
-
-    #[test]
-    fn tags_and_releases_are_release_contexts() {
-        assert!(release_context_with(env(&[("MBX_RELEASE", "1")])));
-        assert!(release_context_with(env(&[
-            ("GITHUB_ACTIONS", "1"),
-            ("GITHUB_REF_TYPE", "tag"),
-        ])));
-        assert!(release_context_with(env(&[
-            ("GITLAB_CI", "1"),
-            ("CI_COMMIT_TAG", "v1.0.0"),
-        ])));
-        assert!(!release_context_with(env(&[
-            ("GITHUB_ACTIONS", "1"),
-            ("GITHUB_REF_TYPE", "branch"),
-        ])));
     }
 }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -541,12 +541,6 @@ fn action_remote_cache(config: &Config, store: &Path) -> Result<Option<AgentRemo
     let Some(client) = crate::remote::remote_client(config)? else {
         return Ok(None);
     };
-    // Release builds publish artifacts that must not depend on a cache, so they
-    // do not read one either. The CLI already skips the whole session; this
-    // keeps a library caller from reaching the remote behind its back.
-    if crate::policy::release_context() {
-        return Ok(None);
-    }
     let Some(mode) = crate::policy::effective_remote_cache_mode(config.remote.mode) else {
         return Ok(None);
     };

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -190,6 +190,7 @@ fn build_with(
         .env_remove("MBX_INCREMENTAL")
         .env_remove("CARGO_INCREMENTAL")
         .env_remove("CI")
+        .env_remove("MBX_RELEASE")
         // Same reason: a test asserting the default cross-checkout behaviour
         // must not read an answer out of the developer's environment.
         .env_remove("MBX_SHARE_OUT_DIR")
@@ -777,6 +778,34 @@ fn a_second_checkout_starts_warm() {
     assert!(
         count(&warm, "hits") > 0,
         "a checkout at another path should reuse the first build: {warm}"
+    );
+}
+
+#[test]
+fn a_release_marker_does_not_disable_the_cache() {
+    let store = tempfile::tempdir().unwrap();
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(first.path());
+    write_project(second.path());
+
+    build_with(
+        first.path(),
+        store.path(),
+        &reports.path().join("first.json"),
+        &[("MBX_RELEASE", "1")],
+    );
+    let (warm, _) = build_with(
+        second.path(),
+        store.path(),
+        &reports.path().join("second.json"),
+        &[("MBX_RELEASE", "1")],
+    );
+
+    assert!(
+        count(&warm, "hits") > 0,
+        "a release-marked build should still reuse cached output: {warm}"
     );
 }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,7 +37,7 @@ export default defineConfig({
     nav: [
       { text: "Get Started", link: "/getting-started" },
       { text: "Configuration", link: "/configuration" },
-      { text: "GitHub Actions", link: "/github-actions" },
+      { text: "GitHub Action", link: "/github-action" },
       { text: "CLI", link: "/cli/" },
       {
         text: `v${latestVersion}`,
@@ -56,7 +56,7 @@ export default defineConfig({
         text: "Use mbx",
         items: [
           { text: "Configuration", link: "/configuration" },
-          { text: "GitHub Actions", link: "/github-actions" },
+          { text: "GitHub Action", link: "/github-action" },
           { text: "Remote cache", link: "/remote-cache" },
           { text: "Cache server", link: "/cache-server" },
           { text: "Managed targets", link: "/managed-targets" },

--- a/docs/cache-server.md
+++ b/docs/cache-server.md
@@ -116,7 +116,7 @@ workflow identity should write. Symmetric JWT algorithms are never accepted.
 On the client side, mbx acquires the GitHub Actions job token itself: set
 `MBX_REMOTE_OIDC_AUDIENCE`, or use
 [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) with
-`backend: server` as shown in [GitHub Actions](/github-actions#cache-server).
+`backend: server` as shown in [GitHub Action](/github-action#cache-server).
 
 ## Operations
 

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -115,7 +115,7 @@ mbx restores exactly the actions a build needs from a store it prunes itself.
 [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) uses
 GitHub Actions cache as the transport for that store, so it composes the
 per-action granularity with the platform cache you already have. See
-[GitHub Actions](/github-actions).
+[GitHub Actions](/github-action).
 
 ## Cargo's incremental compilation
 

--- a/docs/cookbook/fork-prs.md
+++ b/docs/cookbook/fork-prs.md
@@ -56,7 +56,7 @@ jobs:
 
 - **The backend expression** treats pushes and same-repository pull requests
   as trusted — both come from people with push access — and everything else
-  as a fork. Fork runs get the [GitHub Actions cache backend](/github-actions),
+  as a fork. Fork runs get the [GitHub Actions cache backend](/github-action),
   which restores without credentials and never lets a pull request save.
 - **`id-token: write` is safe to declare at the workflow level.** GitHub
   refuses to issue OIDC tokens to fork-triggered runs regardless of the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -254,5 +254,5 @@ rather than a public thread; see
 ## Next steps
 
 - Tune local behavior in [Configuration](/configuration).
-- Warm pull requests with [GitHub Actions cache](/github-actions).
+- Warm pull requests with [GitHub Actions cache](/github-action).
 - Learn what enters a key in [How it works](/how-it-works).

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -136,8 +136,9 @@ only read. See [remote cache](/remote-cache#who-may-publish).
 
 ::: warning Do not use remote caches for production releases
 A production release may still use `mbx` and its local cache, but should not use
-a remote cache. Release jobs should also avoid restoring or saving the mbx store
-through `actions/cache`.
+a remote cache so a cache-poisoning attack cannot influence published artifacts.
+Release jobs should also avoid restoring or saving the mbx store through
+`actions/cache`.
 :::
 
 For a repository that combines both backends — the server for trusted runs, the

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -135,11 +135,10 @@ the branches allowed to assume it, and give pull request jobs a role that can
 only read. See [remote cache](/remote-cache#who-may-publish).
 
 ::: warning Do not cache production releases
-mbx permits caching in tag and release jobs so workflows can test release
-builds. A production release should run Cargo directly, without `mbx`, because
-published artifacts must not depend on any cache being correct. Release jobs
-should also avoid restoring `target/` through `actions/cache` or rust-cache and
-should not use any other compiler cache.
+A production release should run Cargo directly, without `mbx`, because published
+artifacts must not depend on any cache being correct. Release jobs should also
+avoid restoring `target/` through `actions/cache` or rust-cache and should not
+use any other compiler cache.
 :::
 
 For a repository that combines both backends — the server for trusted runs, the

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,4 +1,4 @@
-# GitHub Actions
+# GitHub Action
 
 [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
 installs mbx and connects it to either GitHub Actions cache or an mbx-compatible
@@ -90,10 +90,10 @@ steps:
   - run: mbx build --workspace --all-features
 ```
 
-Only a push to a protected branch may write. Pull requests degrade to read-only,
-and tag or release builds do not use the remote cache at all. If fork authors
-must not reach the host, use the GitHub backend for those jobs instead. A bearer
-token can be supplied with the action's `token` input when OIDC is unavailable.
+Only a push to a protected branch may write. Pull requests and tag or release
+builds degrade to read-only. If fork authors must not reach the host, use the
+GitHub backend for those jobs instead. A bearer token can be supplied with the
+action's `token` input when OIDC is unavailable.
 
 ## S3-compatible bucket
 
@@ -134,11 +134,11 @@ server to authorize anything, make IAM agree: scope the role's trust policy to
 the branches allowed to assume it, and give pull request jobs a role that can
 only read. See [remote cache](/remote-cache#who-may-publish).
 
-::: warning Release builds are never cached
-In a tag or release build (or with `MBX_RELEASE=1`), mbx runs plain Cargo —
-no local or remote cache — because published artifacts must not depend on any
-cache being correct. Hold the rest of the workflow to the same rule: release
-jobs should not restore `target/` through `actions/cache` or rust-cache, and
+::: warning Do not cache production releases
+mbx permits caching in tag and release jobs so workflows can test release
+builds. A production release should run Cargo directly, without `mbx`, because
+published artifacts must not depend on any cache being correct. Release jobs
+should also avoid restoring `target/` through `actions/cache` or rust-cache and
 should not use any other compiler cache.
 :::
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -134,11 +134,10 @@ server to authorize anything, make IAM agree: scope the role's trust policy to
 the branches allowed to assume it, and give pull request jobs a role that can
 only read. See [remote cache](/remote-cache#who-may-publish).
 
-::: warning Do not cache production releases
-A production release should run Cargo directly, without `mbx`, because published
-artifacts must not depend on any cache being correct. Release jobs should also
-avoid restoring `target/` through `actions/cache` or rust-cache and should not
-use any other compiler cache.
+::: warning Do not use remote caches for production releases
+A production release may still use `mbx` and its local cache, but should not use
+a remote cache. Release jobs should also avoid restoring or saving the mbx store
+through `actions/cache`.
 :::
 
 For a repository that combines both backends — the server for trusted runs, the

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ hero:
       text: How it works
       link: /how-it-works
     - theme: alt
-      text: GitHub Actions
-      link: /github-actions
+      text: GitHub Action
+      link: /github-action
 
 features:
   - icon:
@@ -43,7 +43,7 @@ features:
       height: 64
     title: Warm CI runners
     details: Share the same cache with CI through a remote cache or GitHub Actions.
-    link: /github-actions
+    link: /github-action
   - icon:
       src: /features/prune.svg
       alt: A broom sweeping

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -133,7 +133,7 @@ Configured mode is constrained by the environment:
 | --- | --- |
 | Protected branch push on GitHub Actions or GitLab CI | Configured mode |
 | Pull request, merge request, local shell, or unprotected branch | Read-only; `write-only` becomes disabled |
-| Tag or release build | All caching disabled — mbx runs plain Cargo |
+| Tag or release build | Read-only; `write-only` becomes disabled |
 
 This policy prevents untrusted code from publishing objects that later builds
 would trust. The server should still authenticate and authorize requests; the
@@ -143,7 +143,7 @@ client-side policy is defense in depth, not an access-control boundary.
 
 The write policy recognizes GitLab CI with the same shape as GitHub Actions: a
 push pipeline on a protected branch may write, merge requests and unprotected
-branches are read-only, and tag pipelines do not use the remote at all.
+branches are read-only, and tag pipelines cannot publish to the remote.
 
 The OIDC flow is GitHub-specific, so authenticate GitLab jobs with a bearer
 token in a masked, protected CI/CD variable:

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -68,4 +68,5 @@ across them.
 
 `MBX_CC=0` disables the C and C++ cache, which is all `mbx exec` caches, so
 the command runs plainly. Production releases may still use this local cache,
-but should not configure a remote cache.
+but should not configure a remote cache so a cache-poisoning attack cannot
+influence published artifacts.

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -67,5 +67,5 @@ across them.
 ## Turning it off
 
 `MBX_CC=0` disables the C and C++ cache, which is all `mbx exec` caches, so
-the command runs plainly. Tag and release builds run plainly always, exactly
-as cargo builds do.
+the command runs plainly. For production releases, run the build tool directly
+instead of through `mbx` so published artifacts do not depend on cached output.

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -67,5 +67,5 @@ across them.
 ## Turning it off
 
 `MBX_CC=0` disables the C and C++ cache, which is all `mbx exec` caches, so
-the command runs plainly. For production releases, run the build tool directly
-instead of through `mbx` so published artifacts do not depend on cached output.
+the command runs plainly. Production releases may still use this local cache,
+but should not configure a remote cache.


### PR DESCRIPTION
## Summary

- stop automatically bypassing local and remote caches in release-marked contexts
- keep tag and release remote access read-only while documenting that production releases should use only the local cache
- rename the GitHub Action docs page and title from github-actions to github-action

## Tests

- cargo test -p mbx
- cargo test -p mbx --test build a_release_marker_does_not_disable_the_cache
- cargo clippy -p mbx --all-features --all-targets -- -D warnings
- mise run build:docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default caching behavior for tag/release and `MBX_RELEASE` builds, which previously never used the cache; remote writes remain gated by existing CI trust policy, but teams that relied on the old hard bypass need to align workflows with the new documentation.
> 
> **Overview**
> **Release-marked builds no longer skip the cache.** The `release_context()` policy and every early exit that ran plain Cargo (or blocked prefetch and remote sessions) for `MBX_RELEASE`, GitHub tag/release events, and GitLab tag pipelines are removed. Local caching and remote **reads** now apply in those contexts; untrusted CI policy is unchanged (PRs stay read-only on the remote).
> 
> **Docs and navigation** rename the GitHub integration page from `github-actions` to `github-action` and soften the release story: tag/release pipelines are **read-only** on the remote (not “cache off”), with guidance that production releases should rely on the **local** cache and avoid remote restore/save—not that mbx disables caching entirely.
> 
> **Tests** add an integration case that `MBX_RELEASE=1` still gets cache hits across checkouts, update prefetch/doctor/policy unit tests, and strip `MBX_RELEASE` from the build test harness env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f8f77e1d8a58cb0b63d8daf7128f432bacb7db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->