### PR TITLE
docs: corrections, editorial rebalance, and a CI anchor check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mise run check:docs
-          mise run build:docs
+          mise run check:links
 
   lint:
     runs-on: namespace-profile-endev-linux-amd64

--- a/README.md
+++ b/README.md
@@ -158,14 +158,16 @@ CI runner, that cut lint wall time by up to 44.9%.
 ## How it works
 
 An `mbx` Cargo command starts an in-process cache agent, points Cargo at a rustc shim with
-`RUSTC_WRAPPER`, and exits the agent with the build—there is no daemon. The shim
+`RUSTC_WRAPPER`, and exits the agent with the build — there is no daemon. The shim
 derives an action key, restores cached outputs when possible, or runs the real
 compiler and publishes a successful result.
 
-Anything mbx cannot model exactly bypasses the cache. Native linking is not
-cached; built-in WebAssembly targets with self-contained linkers are the narrow
-exception because their linker, CRT, and libc inputs ship in the Rust toolchain.
-Incremental compilations bypass the cache. Correctness comes before hit rate.
+Anything mbx cannot model exactly bypasses the cache. A native link is cached
+only when the linker itself can enter the key: host binaries and tests on Linux
+and macOS, where mbx resolves the linker, startup objects, and libc, and
+self-contained WebAssembly targets everywhere, whose linker and libc ship in
+the Rust toolchain. Incremental compilations bypass the cache. Correctness
+comes before hit rate.
 
 [Read the architecture and limits →](https://mr-boxington.jdx.dev/how-it-works)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,9 +52,10 @@ The crates do not share a version. `mbx` and `mbx-cache-protocol` each have an
 independent one, because each carries a stability promise the other should not
 be able to break: the CLI's surface is its commands and JSON output, and the
 protocol crate's is the remote cache wire contract that `jdx/mbx-cache` depends
-on. `mbx-cache-core` and `mbx-cache-rustc` are internals; they share the
-`mbx-internals` version group, move together, and stay on `0.x` so semver
-itself says a minor bump may break them.
+on. `mbx-cache-core`, `mbx-cache-rustc`, and `mbx-cache-cc` are internals;
+they share the `mbx-internals` version group, move together, and stay on `0.x`
+so semver itself says a minor bump may break them. `mbx-cache-cargo` and
+`mbx-cache-store` release independently on `0.x`.
 
 Nobody edits a version in a feature pull request. release-plz owns every
 number, and one written by hand either collides with its calculation or is
@@ -73,7 +74,7 @@ promise each version line makes.
 
 ## Tags and asset names
 
-The `mbx` crate is tagged `v{version}`; the three library crates are published to
+The `mbx` crate is tagged `v{version}`; the library crates are published to
 crates.io but get no GitHub release of their own. Asset names carry no version
 (`mbx-x86_64-unknown-linux-gnu.tar.gz`), which is what keeps
 `releases/latest/download/…` a stable URL.
@@ -109,8 +110,9 @@ successful releases:
   build annotates a warning instead of failing. What it loses is Gatekeeper
   approval for anyone who downloads the archive through a browser — see
   [Notarization](#notarization).
-- **A crates.io Trusted Publisher for each of `mbx`, `mbx-cache-core`,
-  `mbx-cache-protocol`, and `mbx-cache-rustc`**, naming this repository and the
+- **A crates.io Trusted Publisher for every published crate** — `mbx`,
+  `mbx-cache-cargo`, `mbx-cache-cc`, `mbx-cache-core`, `mbx-cache-protocol`,
+  `mbx-cache-rustc`, and `mbx-cache-store` — naming this repository and the
   workflow file `release-plz.yml`. Publishing is OIDC-only; no registry token
   exists anywhere. **Renaming `release-plz.yml` breaks publishing** until the
   trusted publishers are updated to match. A crate that does not exist on

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,6 +64,19 @@ require; it is not a request for a bump. Either the break is unintended, and
 the API is what to fix, or it is intended, and the pull request should say so
 and leave the version alone.
 
+An intended break is declared on the commit — `feat!:`, or a `BREAKING
+CHANGE:` footer — and leaves the `public API compatibility` check red, because
+the version it compares against cannot move until the release PR exists. That
+red check is the expected state of an honest breaking change, not a problem to
+solve inside the pull request.
+
+Read that job's output as a list of what broke, not as an instruction. Its
+summary says "semver requires new major version" whatever the crate's
+position, so for the crates on `0.x` it names a bump Cargo does not want —
+there, a break is a minor. The lint names above the summary are the useful
+part: they say which items changed shape, which is what a reviewer needs to
+judge whether the break was intended.
+
 release-plz computes each line from the commits that touched it and updates the
 path dependencies' version requirements, so a release can move one crate and
 leave the rest alone. When `mbx` reaches `1.0`, the internal crates stay on

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -27,8 +27,8 @@ clones a pinned checkout of [jdx/hk](https://github.com/jdx/hk) and runs the
 same `cargo build --locked` under raw cargo, mbx, and kache across the
 situations CI actually hits: a cold store, a warm store with a fresh target,
 the next commit on the branch, a second checkout at a different path, and a
-compiler change. The last of those is a correctness cell rather than a timing
--- it fails unless a different rustc leaves almost every predicted compilation
+compiler change. The last of those is a correctness cell rather than a timing —
+it fails unless a different rustc leaves almost every predicted compilation
 unlooked-up, which is the shape the hk benchmark hit when a runner image
 rolled a new Rust. Not zero hits: actions that do not depend on rustc, such as
 a build script's C objects, legitimately survive a Rust change.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
         items: [
           { text: "Introduction", link: "/" },
           { text: "Install and run", link: "/getting-started" },
+          { text: "FAQ", link: "/faq" },
         ],
       },
       {
@@ -74,6 +75,10 @@ export default defineConfig({
         text: "Cookbook",
         items: [
           { text: "CI with fork pull requests", link: "/cookbook/fork-prs" },
+          {
+            text: "Migrate from rust-cache or sccache",
+            link: "/cookbook/migrate",
+          },
         ],
       },
       {

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -108,7 +108,7 @@ state rather than numbers it cannot stand behind.
 
 ## Running it yourself
 
-```bash
+```sh
 mise run bench
 ```
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,27 +19,37 @@ strategies and measures the machine rather than a single build.
 
 ## What each scenario reproduces
 
-**cold** — an empty store and a fresh `target/`. What a new machine, or a CI
+### cold
+
+An empty store and a fresh `target/`. What a new machine, or a CI
 job with no cache to restore, actually does. There is nothing to hit, so this
 is where a cache can only cost time; a cache that is slower than cargo here is
 charging rent on the first build.
 
-**warm** — the store from the cold build, a fresh `target/`. This is the
+### warm
+
+The store from the cold build, a fresh `target/`. This is the
 common CI shape: a runner restores a cache, then builds a commit it has
 already seen. cargo is not run, because with a wiped `target/` it would just
 repeat its cold number.
 
-**commit** — the store is warmed at one commit and the build runs at the next
+### commit
+
+The store is warmed at one commit and the build runs at the next
 one. Push-to-push CI: most of the dependency graph is unchanged, a few crates
 are not. cargo's baseline here is a cold build, because that is what cargo
 does with an empty `target/`.
 
-**worktree** — the store is warmed in one checkout, and the timed build runs
+### worktree
+
+The store is warmed in one checkout, and the timed build runs
 in a second checkout at a different path. This is the claim that absolute
 paths did not enter the keys. A cache that keys on paths reports a cold build
 here.
 
-**toolchain** — not a timing. The store is warmed on the pinned Rust and the
+### toolchain
+
+Not a timing. The store is warmed on the pinned Rust and the
 build reruns on a different one, and the run fails unless essentially none of
 the predicted compilations were even looked up. A compiler change invalidates
 every invocation digest at once; the failure mode worth guarding against is a
@@ -51,7 +61,9 @@ It also pins down the diagnosis for the opposite surprise. A warm build that
 reports no hits after a runner image rolled a new Rust looks like a broken
 store and is not one; it is this.
 
-**contention** — the two Clippy configurations from mise's real lint job,
+### contention
+
+The two Clippy configurations from mise's real lint job,
 from a cold store: the default configuration and `--all-features
 --all-targets`. The `mbx-sequential` row is the before picture, with both
 commands sharing one target directory. The parallel rows use separate targets

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -52,8 +52,8 @@ on a cache that has quietly stopped serving.
 ## Watching a build instead
 
 Everything above describes the summary printed after a build. To see the same
-outcomes as they are decided -- one row per compilation, with the crate it
-belongs to -- run [`mbx tui`](/tui) in another terminal. It reads every build on
+outcomes as they are decided — one row per compilation, with the crate it
+belongs to — run [`mbx tui`](/tui) in another terminal. It reads every build on
 the machine, including ones already running.
 
 ## Reading the hit rate
@@ -62,9 +62,11 @@ A build can report a high hit rate among attempted lookups while spending most
 of its time on actions that were not looked up or were bypassed. Read all three
 summary lines together, and compare wall-clock time when evaluating the cache.
 
-Native link steps always run, so an otherwise warm native binary build still
-has work to do. Binaries, tests, and `cdylib`s for supported self-contained
-WebAssembly targets are the exception and may be restored as hits.
+A link mbx cannot describe always runs, so a warm build of such a binary still
+has work to do. Host binaries and tests on Linux and macOS, and binaries,
+tests, and `cdylib`s for supported self-contained WebAssembly targets, may be
+restored as hits; see
+[limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 
 ## Troubleshooting a low hit rate
 
@@ -84,9 +86,12 @@ The usual causes, roughly in the order they show up:
   members compile incrementally, those compilations bypass the cache, and the
   changed artifacts make crates above them miss too. See
   [limits](/limits#incremental-compilations-are-not-cached).
-- **Link steps always run.** Native binaries, tests, and dylibs re-link even
-  when every compilation hit, so a warm build of a large binary still takes
-  time. Self-contained WebAssembly targets are the exception.
+- **Undescribed links always run.** Host binaries and tests are cached on
+  Linux and macOS, and self-contained WebAssembly targets everywhere, but a
+  link naming a native library, a custom linker, or built on Windows re-links
+  even when every compilation hit, so a warm build of such a binary still
+  takes time. See
+  [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 - **The inputs actually differ.** A different toolchain, feature set, profile,
   or `RUSTFLAGS` between two checkouts is a different key, and the summary
   reports it as an ordinary miss. `cargo tree` and comparing the two commands
@@ -94,12 +99,12 @@ The usual causes, roughly in the order they show up:
 - **Build-script output paths.** A crate that embeds its `OUT_DIR` produces
   checkout-specific inputs for its dependents. mbx remaps this by default;
   `MBX_SHARE_OUT_DIR=0` disables that sharing. See
-  [limits](/limits#out_dir-sharing-remaps-generated-source-paths).
+  [limits](/limits#out-dir-sharing-remaps-generated-source-paths).
 - **A build chose its own C compiler, or is cross-compiling.** Setting `CC`,
   `HOST_CC`, or a target-specific variant leaves that build's C and C++
   compilations uncached, and so does `--target`. Bypass kinds beginning `cc-`
   report anything the C adapter declined to model. See
-  [limits](/limits#c-and-c-caching-covers-build-script-compiles-only).
+  [limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
 - **CI restored nothing.** On GitHub Actions, check that the cache step
   actually restored an entry — a changed `cache-generation` or a fresh
   repository starts empty by design. With a remote cache configured, check the

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -31,7 +31,25 @@ group identical causes, and print guidance for every bypass category:
 mbx explain build --workspace
 ```
 
-The command preserves Cargo's exit status after printing the explanation.
+```text
+cache explanation: 8 compilations bypassed the cache
+
+compiler-query (2)
+Expected: Cargo asks rustc for toolchain information; there is no compilation to cache.
+  - rustc invocation is a compiler query, not a compilation (2 times)
+
+incremental (5)
+Cargo compiled this incrementally, which mbx cannot cache. `MBX_INCREMENTAL=0` makes it cacheable again; mbx already gives a crate you are editing its own incremental state without giving up the rest of the cache.
+  - incremental compilation cannot be combined with action caching (5 times)
+
+standard-input (1)
+Expected for Cargo probes: source supplied on standard input cannot be rediscovered later.
+  - rustc invocation reads source from standard input
+```
+
+Categories marked expected appear on every build and cost nothing; here the
+`incremental` group is the one the build could act on. The command preserves
+Cargo's exit status after printing the explanation.
 
 ## Remote failure
 
@@ -114,11 +132,18 @@ The usual causes, roughly in the order they show up:
 ## Compiler time
 
 The session summary reports real compiler time by outcome and an estimate of
-the compiler time avoided by cache hits. The estimate comes from the duration
-recorded with the successful compilation that populated the action prediction;
-older predictions without a timing hint contribute zero rather than being
-guessed. The five crates with the largest cumulative uncached compiler time are
-listed so optimization work can target wall-clock cost instead of action count.
+the compiler time avoided by cache hits:
+
+```text
+mbx[cache]: compiler time: 252.90s estimated avoided; 38.20s spent (161 miss in 31.00s, 7 unconsulted in 7.20s)
+mbx[cache]: slowest uncached crates: syn 8.90s, regex-syntax 4.90s, serde_derive 3.90s
+```
+
+The estimate comes from the duration recorded with the successful compilation
+that populated the action prediction; older predictions without a timing hint
+contribute zero rather than being guessed. The five crates with the largest
+cumulative uncached compiler time are listed so optimization work can target
+wall-clock cost instead of action count.
 
 The version 2 JSON statistics report exposes the same data in
 `estimated_compiler_duration_avoided_ns`, `compiler`, and

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -6,8 +6,9 @@
 cache, and it aims wider: it caches CUDA alongside Rust, C, and C++, and can
 distribute compilation across machines. mbx caches rustc, the C and C++ that
 cargo build scripts compile, the C and C++ of builds outside cargo through
-[`mbx exec`](/standalone-builds), and native links. It spends a
-scope still narrower than sccache's on problems sccache does not attempt:
+[`mbx exec`](/standalone-builds), and native links. That scope is still
+narrower than sccache's, and mbx spends it on problems sccache does not
+attempt:
 
 - **No daemon.** sccache runs a background server that builds talk to. mbx
   starts an in-process agent for each command and exits with it; there is

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -58,12 +58,10 @@ hits — do not match. The differences are in the mechanics:
   into place, so each checkout's `target/` shares disk with the store but
   stays where it is, pruned by `kache gc`. mbx owns the directories it
   creates: outputs live once in the store, appear in each checkout by
-  reflink, and directories whose checkout is gone are collected
-  automatically.
-- **Restores never hardlink.** A hardlinked output shares an inode with the
-  cache — the two names are the same file. mbx restores by reflink, a
-  copy-on-write clone that diverges on first write, and falls back to a
-  plain byte copy where the filesystem cannot clone, never to a hardlink.
+  reflink — a copy-on-write clone that diverges on first write, never a
+  hardlink sharing the cache's inode — and directories whose checkout is
+  gone are collected automatically. Where the filesystem cannot clone, mbx
+  falls back to a plain byte copy, still never a hardlink.
 - **CI write policy.** kache's README states no policy on what may publish
   from pull requests — whatever the credentials allow, any build can write.
   mbx's client refuses to publish from pull requests, unprotected branches,
@@ -78,16 +76,12 @@ hits — do not match. The differences are in the mechanics:
   results but never rewrite or remove what an earlier build published. Fork
   pull requests hold no credentials at all and fall back to a read-only
   platform cache; see [fork PRs](/cookbook/fork-prs).
-- **How the C and C++ shims arrive.** Both put shims on `PATH`, and cover
-  make, CMake, or anything else that resolves its compiler there. kache
-  installs them alongside its service, so every build on the machine finds
-  them. mbx keeps its shim directory in the cache, but puts it on `PATH` for
-  one [`mbx exec`](/standalone-builds) command at a time: a build is cached
-  when it asks to be and untouched otherwise, and a shim reached through a
-  path some configure step recorded runs the real compiler and stands aside.
-  mbx also shims only the plain driver names (`cc`, `c++`, `gcc`, `g++`,
-  `clang`, `clang++`) on Unix, leaving a versioned or cross toolchain to the
-  build that chose it; kache covers Windows as well.
+- **How the C and C++ shims arrive.** Both put shims on `PATH` for make,
+  CMake, or anything else that resolves its compiler there. kache installs
+  them alongside its service, so every build on the machine finds them; mbx
+  puts them on `PATH` for one [`mbx exec`](/standalone-builds) command at a
+  time, so a build is cached when it asks to be and untouched otherwise.
+  kache covers Windows as well; mbx shims only the plain Unix driver names.
 - **Executable caching.** Both cache linked binaries on Linux and macOS. In
   mbx the key includes the resolved linker, startup objects, libc, and SDK
   rather than dep-info alone, so a host mbx cannot describe that precisely

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -66,9 +66,8 @@ hits — do not match. The differences are in the mechanics:
   plain byte copy where the filesystem cannot clone, never to a hardlink.
 - **CI write policy.** kache's README states no policy on what may publish
   from pull requests — whatever the credentials allow, any build can write.
-  mbx's client refuses to publish from pull requests and unprotected
-  branches and disables caching entirely on tag builds, before the server
-  enforces anything.
+  mbx's client refuses to publish from pull requests, unprotected branches,
+  and tag or release builds, before the server enforces anything.
 - **A server, not a bucket.** kache's remotes are S3-compatible buckets
   reached through the standard AWS credential chain. mbx's remote is a
   namespaced protocol server with guardrails a bucket cannot express:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,9 +1,16 @@
 # Configuration
 
-mbx loads environment variables over `.mbx.toml` at the resolved Cargo
-workspace root, then `mbx/config.toml` in the platform configuration directory,
-then defaults. This honors platform and XDG overrides through the operating
-system's configuration-directory lookup. Unknown TOML keys are rejected, so a
+mbx reads configuration from three places; the first value found wins:
+
+1. Environment variables (`MBX_*`).
+2. `.mbx.toml` at the resolved Cargo workspace root — the
+   [build-policy switches](#workspace-policy) only.
+3. `mbx/config.toml` in the platform configuration directory:
+   - Linux: `~/.config/mbx/config.toml`, honoring `$XDG_CONFIG_HOME`
+   - macOS: `~/Library/Application Support/mbx/config.toml`
+   - Windows: `%APPDATA%\mbx\config.toml`
+
+Anything still unset takes its default. Unknown TOML keys are rejected, so a
 misspelled setting is an error rather than a silent no-op.
 
 ## Disk-scaled defaults
@@ -107,16 +114,11 @@ cache directory (on by default; `MBX_SCHEDULER=0` turns it off). Cache hits
 never wait, Cargo keeps its own dependency scheduling, and permits are released
 by the kernel if a process dies, so a crashed build cannot wedge its siblings.
 
-Builds running at the same time do not just take turns, they stop repeating
-each other.
-Four CI jobs building one commit compile the same dependency graph four
-times; under the scheduler, a compilation identical to one already running
-anywhere on the machine waits for that one to finish and restores its result
-from the cache instead of burning a core on it. The finished compilation also
-leaves its input list behind, so a job arriving after it is already done can
-build the cache key it would otherwise lack and hit where it would have
-compiled cold. Both paths rehash every input before trusting anything, so
-the worst a stale record can do is fall back to compiling.
+Builds running at the same time also stop repeating each other: a compilation
+identical to one already running anywhere on the machine waits for that one
+and restores its result instead of burning a core on it. How the pool weighs
+compilations and links — and what happens when a guess is wrong — is described
+in [how it works](/how-it-works#machine-wide-scheduling).
 
 The pool is memory-aware. `scheduler.cpus` permits (default: logical CPUs)
 divide `scheduler.memory` (default: 85% of physical memory, leaving headroom
@@ -124,22 +126,6 @@ for everything that is not a compiler; `"none"` keeps plain CPU permits). In a
 container, "physical memory" means the cgroup's limit rather than the host's
 RAM — a build in a 4 GiB container on a large machine is budgeted by the
 4 GiB, because the rest was never its to spend.
-Native links start at two permits, and every compilation is thereafter
-weighted by what it actually used, so the predicted memory of everything
-running stays inside the budget. The two-permit start is a guess for links
-nobody has measured yet, and the first measurement replaces it in either
-direction: a link that turns out to fit in one permit stops being charged for
-two, which is what keeps the link-heavy tail of a build from running at half
-concurrency.
-
-A link mbx has never seen is weighed by what this machine's recent links have
-cost rather than by that constant, once a few have been measured — the
-heaviest of them, since guessing low costs an out-of-memory kill and guessing
-high costs a wait. Test binaries are why: each one is its own crate name, so a
-cold `cargo test --no-run` has no per-crate history for any of the links in
-front of it and would otherwise spend the whole run on a guess. A compilation
-the Linux OOM killer stops is recorded heavier than it measured, so its retry
-runs with more room instead of repeating the crash.
 
 `priority = "low"` (`MBX_SCHEDULER_PRIORITY`) is for builds nobody is sitting
 at — CI on a shared box, an editor's background check. While a normal-priority
@@ -193,26 +179,15 @@ The crate you are editing misses the cache on every build, because its content
 is new every time. After three consecutive compilations whose sources changed,
 mbx compiles that crate with its own incremental state rather than from
 scratch, and keeps the result out of the shared cache — an incremental artifact
-describes one checkout's edit history, not its source, so it is never something
-another checkout should restore. The build reports those compilations as
-`incremental` and says how many were held back.
+describes one checkout's edit history, not its source. The build reports those
+compilations as `incremental` and says how many were held back.
 
-What it watches is the crate's own sources, not its cache key. A key also
-covers the artifacts a crate links against, so rebuilding one dependency
-changes the key of everything above it; watching that would send a whole
-dependency cone incremental because one crate at the bottom was edited, and
-stop all of it publishing. Crates above the one you are editing keep compiling
-and publishing normally.
-
-Unchanged sources are never churn, however the compilation got here. A miss on
-them means something else lost the result — a wiped `target/`, a first build in
-a new checkout — so it compiles normally and publishes for everyone.
-
-The record of what a crate last compiled belongs to one checkout, and lives in
-`mbx-incremental/` inside that build's target directory alongside the
-incremental state itself. A sibling worktree keeps its own, so one developer's
-edit loop cannot mark a crate hot for a worktree that is merely building it. A
-managed target reclaims both along with everything else it holds, and each
+The trigger is the crate's own sources, not its cache key, so a rebuilt
+dependency — which changes the keys of everything above it — keeps compiling
+and publishing normally, and so does a miss on unchanged sources (a wiped
+`target/`, a first build in a new checkout). The record is private to each
+checkout, living in `mbx-incremental/` inside that build's target directory
+beside the incremental state itself; a managed target reclaims both, and each
 crate's incremental state is discarded once it passes 1 GiB.
 
 CI never does this, for the same reason it never compiles incrementally: there

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,9 +10,9 @@ misspelled setting is an error rather than a silent no-op.
 
 mbx bounds its own disk use without being configured. The two size budgets
 default to a share of the disk holding the cache — 5% for the action store and
-10% for managed target directories — each from its floor (5GiB and 10GiB) up to
-100GiB, rounded down to a whole 5GiB. Managed targets are also collected after
-30 days unused.
+10% for managed target directories — each from its floor (5 GiB and 10 GiB) up
+to 100 GiB, rounded down to a whole 5 GiB. Managed targets are also collected
+after 30 days unused.
 
 Setting any of them outright overrides the scaling; `"none"` disables
 `target.max_size`, `target.max_age`, and `gc.max_total_size`. See
@@ -77,7 +77,7 @@ accepted from a repository-owned file. mbx reports an error instead of applying
 an unsafe or misspelled workspace setting.
 
 `share_out_dir = true` is the global default. A workspace may set it to false
-when generated source paths must remain literal in debug information -- for
+when generated source paths must remain literal in debug information — for
 C and C++ objects as well as Rust artifacts, since a build script's generated
 headers reach both.
 
@@ -122,8 +122,8 @@ The pool is memory-aware. `scheduler.cpus` permits (default: logical CPUs)
 divide `scheduler.memory` (default: 85% of physical memory, leaving headroom
 for everything that is not a compiler; `"none"` keeps plain CPU permits). In a
 container, "physical memory" means the cgroup's limit rather than the host's
-RAM — a build in a 4GiB container on a large machine is budgeted by the 4GiB,
-because the rest was never its to spend.
+RAM — a build in a 4 GiB container on a large machine is budgeted by the
+4 GiB, because the rest was never its to spend.
 Native links start at two permits, and every compilation is thereafter
 weighted by what it actually used, so the predicted memory of everything
 running stays inside the budget. The two-permit start is a guess for links

--- a/docs/cookbook/migrate.md
+++ b/docs/cookbook/migrate.md
@@ -1,0 +1,70 @@
+# Migrate from rust-cache or sccache
+
+Both migrations end in the same place: `mbx` in front of the Cargo command and
+nothing else standing between Cargo and rustc. What has to be removed differs.
+
+## From rust-cache or `actions/cache` over `target/`
+
+A tarball cache and mbx solve the same problem, so replace the step rather
+than stacking them — an archived `target/` restored over a managed one is
+exactly the stale, ever-growing entry mbx exists to replace (see
+[tarball CI caches](/compared#tarball-ci-caches)).
+
+Before:
+
+```yaml
+steps:
+  - uses: actions/checkout@v7
+  - uses: Swatinem/rust-cache@v2
+  - run: cargo test --workspace
+```
+
+After:
+
+```yaml
+steps:
+  - uses: actions/checkout@v7
+  - uses: jdx/mr-boxington-action@v1
+  - run: mbx test --workspace
+```
+
+One thing the swap gives up: rust-cache also cached Cargo's download caches
+under `~/.cargo`, and the plain action does not, so each run re-fetches the
+registry. To keep those cached too, use the
+[manual GitHub cache setup](/github-action#manual-github-cache-setup), which
+shares one entry between Cargo's download caches and the mbx store.
+
+Leave release jobs out of the migration entirely: a production release should
+not restore any compiler cache, mbx's or the one being removed. See the
+[release warning](/github-action#s3-compatible-bucket).
+
+## From sccache
+
+Both tools wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
+the same build. mbx does not fight for the seat: with `RUSTC_WRAPPER` already
+set it defers to the existing wrapper and warns that the build is not cached.
+Migration is therefore removal — take sccache out of:
+
+- `RUSTC_WRAPPER` in CI environments and shell profiles,
+- `build.rustc-wrapper` in `~/.cargo/config.toml`,
+- workflow steps that install or configure it (`mozilla-actions/sccache-action`,
+  `SCCACHE_GHA_ENABLED`, and similar).
+
+Then check the result:
+
+```sh
+mbx doctor
+```
+
+The `setup` check reports `no plain-cargo wrapper installed; mbx wraps cargo
+directly` once nothing else is configured, and warns
+`Cargo uses another wrapper: sccache` while the old configuration is still in
+place.
+
+## The first build measures nothing
+
+However you arrive, the first mbx build has an empty store: it restores
+nothing, stores everything, and the summary's
+[could not look up](/cache-results#could-not-look-up) line dominates. The
+second build is the honest measurement, and
+[`mbx explain`](/cache-results#bypass) says what any remaining gap is made of.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,73 @@
+# FAQ
+
+Short answers, with the page that owns each one.
+
+## Is deleting the cache safe?
+
+Always. The store is a cache of work mbx can redo: the worst case is a colder
+build, never a wrong one. See [stability](/stability#the-store-is-disposable).
+
+## Why wasn't my first build faster?
+
+A first build has an empty store — there is nothing to hit, so it can only
+cost time, and the summary's "could not look up" line dominates. The second
+build is the honest measurement. See
+[cache results](/cache-results#troubleshooting-a-low-hit-rate) and the cold
+scenario in [benchmarks](/benchmarks#cold).
+
+## Why does a fully warm build still take time?
+
+Links mbx cannot describe always run — a large binary re-links even when every
+compilation hit. Host binaries and tests are restored on Linux and macOS, and
+self-contained WebAssembly targets everywhere; the rest is
+[limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
+
+## The cache stopped hitting after a Rust update. Is it broken?
+
+No — the compiler is part of every key, so a toolchain roll invalidates every
+rustc action at once, and the build says so:
+`a manifest predicting N compilations was loaded, but none matched this build`.
+The [toolchain benchmark scenario](/benchmarks#toolchain) exists to pin down
+exactly this diagnosis. Actions that do not depend on rustc, such as a build
+script's C objects, legitimately survive.
+
+## Can I use mbx together with sccache?
+
+No. Both wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
+the same build; with `RUSTC_WRAPPER` already set, mbx defers to it and does
+not cache. See [migrate from rust-cache or sccache](/cookbook/migrate).
+
+## Are restored artifacts byte-identical to what a compile would produce?
+
+Equivalent, not always identical: rustc and C compilers record absolute
+source paths in metadata and debug information, so artifacts from two
+checkouts can differ without behaving differently.
+[`MBX_VERIFY=1`](/configuration#verify-mode) compares bytes and names what
+differed. See
+[limits](/limits#restored-artifacts-are-equivalent-not-always-identical).
+
+## Where does everything live?
+
+`mbx cache dir` prints the store's location. Managed target directories live
+under the same root ([managed targets](/managed-targets)), and configuration
+comes from the paths listed at the top of [configuration](/configuration).
+
+## How do I turn one feature off?
+
+Every feature has its own switch, so none of them has to be a package deal:
+
+| Switch | Turns off |
+| --- | --- |
+| `MBX_SCHEDULER=0` | [machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling) |
+| `MBX_CC=0` | [build-script and `mbx exec` C and C++ caching](/configuration#build-script-c-and-c) |
+| `MBX_TARGET_VIEWS=0` | [managed target directories](/managed-targets#disable-managed-targets) |
+| `MBX_CACHE_LINKS=0` | [native link caching](/limits#native-linking-is-cached-only-where-the-linker-can-be-described) |
+| `MBX_LEARNED_INCREMENTAL=0` | [learned incremental reuse](/configuration#learned-incremental-reuse) |
+| `MBX_EVENTS=0` | [per-compilation event streams](/tui#recording) |
+| `MBX_SAVINGS=off` | [the savings line](/configuration#the-savings-line) |
+
+## Something looks wrong. What should a report include?
+
+Three things describe almost any mbx problem: `mbx doctor --json`,
+`MBX_LOG=debug`, and `MBX_BYPASS_LOG`. See
+[reporting a problem](/getting-started#reporting-a-problem).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -193,7 +193,7 @@ mbx doctor
   ok  cargo        cargo 1.98.0 (797e8a9bc 2026-08-05)
   ok  rustc        rustc 1.98.0 (88d9e12ae 2026-08-18)
   ok  cache        /home/you/.cache/mbx is writable
-  ok  config       20.0 GiB budget, automatic gc enabled, managed targets enabled at /home/you/.cache/mbx/targets
+  ok  config       50.0 GiB budget, automatic gc enabled, managed targets enabled at /home/you/.cache/mbx/targets
   ok  reflink      supported by the cache filesystem
   ok  setup        no plain-cargo wrapper installed; mbx wraps cargo directly
   ok  remote       not configured; using the local cache

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,9 +108,25 @@ Reflinked output restoration needs a filesystem with copy-on-write file
 cloning: APFS on macOS, btrfs or XFS on Linux, ReFS (Dev Drive) on Windows.
 mbx probes the actual cache and target locations rather than assuming from
 the platform, and copies bytes where cloning is unavailable — caching still
-works on ext4 or NTFS, it just spends the disk twice. On Windows, managed
-target directories also need Developer Mode or a privileged process to create
-the `target` link; see [managed target directories](/managed-targets).
+works on ext4 or NTFS, it just spends the disk twice.
+
+### Windows
+
+Windows is a supported release platform with a narrower caching tier. The
+differences, which the pages they belong to also note in place:
+
+- Reflinks need ReFS, which usually means a Dev Drive; on NTFS mbx copies
+  bytes instead.
+- The managed `target` link needs Developer Mode or a privileged process;
+  where Windows refuses to create it, Cargo keeps its ordinary target
+  directory. See [managed target directories](/managed-targets).
+- rustc compilations are cached as on every platform, but there is no
+  native-link tier: host programs and tests link as they always did, and only
+  the self-contained WebAssembly targets restore linked binaries. See
+  [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
+- No C or C++ shims are installed, and MSVC invocations are never modeled, so
+  build-script C and `mbx exec` caching are Unix-only. See
+  [limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
 
 ## Run a build
 
@@ -126,6 +142,17 @@ The command and its arguments are passed to Cargo unchanged. Cargo still owns
 dependency resolution, feature unification, build planning, and linking. mbx
 also forwards Cargo aliases and installed subcommands. Nothing goes into
 Cargo's configuration, and there is nothing to tune before the first build.
+
+A toolchain goes where rustup expects it, in front of the command:
+
+```sh
+mbx +1.91 check --workspace
+```
+
+mbx reads that word rather than passing it along unexamined, so it means the
+same thing in front of mbx's own commands: `mbx +1.91 doctor` reports on 1.91,
+and `mbx +1.91 explain check` diagnoses a build under it. Commands that never
+reach a compiler, such as `mbx gc`, refuse a toolchain instead of ignoring one.
 
 ## Run multiple Cargo builds at the same time
 
@@ -149,21 +176,9 @@ mise run lint:default ::: lint:all
 
 Separate target directories keep Cargo's directory lock from serializing the
 commands. mbx shares one machine-wide compiler pool and deduplicates identical
-work in flight without further configuration. The same shape works directly
-inside [GitHub Actions](/github-action#parallel-cargo-steps); see
-[machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling)
-for its CPU and memory behavior.
-
-A toolchain goes where rustup expects it, in front of the command:
-
-```sh
-mbx +1.91 check --workspace
-```
-
-mbx reads that word rather than passing it along unexamined, so it means the
-same thing in front of mbx's own commands: `mbx +1.91 doctor` reports on 1.91,
-and `mbx +1.91 explain check` diagnoses a build under it. Commands that never
-reach a compiler, such as `mbx gc`, refuse a toolchain instead of ignoring one.
+work in flight without further configuration — see
+[how it works](/how-it-works#machine-wide-scheduling) for the mechanism and
+the same shape [inside GitHub Actions](/github-action#parallel-cargo-steps).
 
 ## The first build
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -2,7 +2,8 @@
 
 [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
 installs mbx and connects it to either GitHub Actions cache or an mbx-compatible
-server.
+server. The examples below show the inputs that matter for each backend; the
+action's repository documents the complete list.
 
 ## GitHub Actions cache
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -7,7 +7,7 @@ subcommand.
 1. mbx resolves the workspace and target roots through Cargo metadata.
 2. It starts an in-process cache agent and creates shims for the build.
 3. Cargo runs normally with the rustc shim set as `RUSTC_WRAPPER`, and build
-   scripts inherit a `HOST_CC` and `HOST_CXX` pointing at the C and C++ shims.
+   scripts inherit `HOST_CC` and `HOST_CXX` pointing at the C and C++ shims.
 4. Each shim analyzes its compiler invocation and derives a content-addressed action key.
 5. A hit restores the action's outputs; a miss runs the real compiler and publishes the result.
 6. The agent exits with the build, draining any remote uploads it still owes.
@@ -94,12 +94,15 @@ platform, including when mbx has to use the copy fallback.
 
 ## Correctness first
 
-Unsupported crate types, unmodeled search paths, native linking, and
-incremental compilations bypass the shared action cache. A compilation that
-links nothing is cached whatever its crate type -- `cargo check` and clippy
-compile every binary and test target that way, and metadata is metadata.
-Linked WebAssembly binaries, tests, and `cdylib`s are admitted only for a
-fixed allowlist of built-in targets whose default linker and system inputs
-ship with rustc.
+Unsupported crate types, unmodeled search paths, and incremental compilations
+bypass the shared action cache. A compilation that links nothing is cached
+whatever its crate type — `cargo check` and clippy compile every binary and
+test target that way, and metadata is metadata. A native link is admitted only
+when its linker can be described: host binaries and tests on Linux and macOS,
+where mbx puts the resolved linker, startup objects, libc, and SDK into the
+key, and a fixed allowlist of built-in WebAssembly targets whose default
+linker and system inputs ship with rustc. Everything else — native libraries,
+custom linkers, Windows — links as it always did; see
+[limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 `MBX_VERIFY=1` compiles while also consulting the cache and compares the result,
 providing a deliberately expensive qualification mode.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -19,11 +19,14 @@ component to keep up to date.
 That wrapper boundary also covers multiple Cargo builds running at the same
 time. Their compiler shims share a machine-wide permit pool and an
 in-flight-work registry, so those builds do not multiply the machine's CPU and
-memory budgets or repeat an identical cold compilation. See the copyable
-[mise task example](/getting-started#run-multiple-cargo-builds-at-the-same-time), the
-[parallel GitHub Actions example](/github-action#parallel-cargo-steps), the
-[scheduler details](/configuration#machine-wide-compile-scheduling), and the
-[contention benchmark](/benchmarks#contention).
+memory budgets or repeat an identical cold compilation.
+[Machine-wide scheduling](#machine-wide-scheduling) below describes the
+mechanism; the
+[mise task example](/getting-started#run-multiple-cargo-builds-at-the-same-time)
+and the
+[parallel GitHub Actions example](/github-action#parallel-cargo-steps) are
+copyable shapes, and the [contention benchmark](/benchmarks#contention)
+measures it.
 
 ## Build-script C and C++
 
@@ -44,14 +47,8 @@ key to look up yet — it is stored after compiling and warms the next build. Th
 directories the compile searched also contribute a manifest of the names in
 them that could answer an `#include`, so a header appearing where it would
 *shadow* one that was read changes the key even though every file that was read
-is unchanged. Objects and dependency files are not counted: they cannot shadow
-an include, and a build writes them into the very directory a generated header
-lives in.
-
-Those manifests are taken once before the compiler runs and again before
-publishing. A header that appeared while the compilation was in flight is one
-the compiler never saw, so recording it would claim a state that did not
-produce this object.
+is unchanged; what a manifest counts and leaves out is covered in
+[limits](/limits#shadowing-is-modeled-by-name-not-by-content).
 
 ## Portable keys
 
@@ -91,6 +88,39 @@ the same values as `reflinked_output_files`, `reflinked_output_bytes`,
 This is filesystem copy-on-write, not a placeholder or userspace on-demand
 filesystem. Restored paths retain normal file semantics on every supported
 platform, including when mbx has to use the copy fallback.
+
+## Machine-wide scheduling
+
+Every compiler mbx starts takes a permit from one pool shared by every build
+on the machine, so simultaneous builds do not multiply the machine's CPU and
+memory budgets. Cache hits never wait, Cargo keeps its own dependency
+scheduling, and permits are released by the kernel if a process dies, so a
+crashed build cannot wedge its siblings.
+
+Concurrent builds also stop repeating each other. Four CI jobs building one
+commit compile the same dependency graph four times; under the scheduler, a
+compilation identical to one already running anywhere on the machine waits for
+that one to finish and restores its result from the cache instead of burning a
+core on it. The finished compilation also leaves its input list behind, so a
+job arriving after it is already done can build the cache key it would
+otherwise lack and hit where it would have compiled cold. Both paths rehash
+every input before trusting anything, so the worst a stale record can do is
+fall back to compiling.
+
+Permits are weighted by memory. Native links start at two permits, and every
+compilation is thereafter weighted by what it actually used, so the predicted
+memory of everything running stays inside the budget; a link that turns out to
+fit in one permit stops being charged for two, which is what keeps the
+link-heavy tail of a build from running at half concurrency. A link mbx has
+never seen is weighed by the heaviest of this machine's recent links —
+guessing low costs an out-of-memory kill and guessing high costs a wait, and
+test binaries make the case for remembering: each is its own crate name, so a
+cold `cargo test --no-run` has no per-crate history for the links in front of
+it. A compilation the Linux OOM killer stops is recorded heavier than it
+measured, so its retry runs with more room instead of repeating the crash.
+
+The pool size, memory budget, and priority are settings; see
+[machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling).
 
 ## Correctness first
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -136,6 +136,11 @@ because a build writes those into the very directory a generated header lives
 in, and counting them would make the key depend on how many sibling
 compilations had finished rather than on anything about this one.
 
+Manifests are taken once before the compiler runs and again before publishing.
+A header that appeared while the compilation was in flight is one the compiler
+never saw, so recording it would claim a state that did not produce this
+object.
+
 System roots are exempt from manifests entirely: enumerating an SDK on every
 compile costs more than the risk, and anything actually read from one is
 digested like any other input.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -62,7 +62,7 @@ links for the host by construction, and that is the only linker mbx identifies.
 ## Restored artifacts are equivalent, not always identical
 
 A restore writes this checkout's spelling of the outputs that describe where a
-compilation ran -- its dep-info and its diagnostics -- so the files cargo reads
+compilation ran — its dep-info and its diagnostics — so the files cargo reads
 name the directory it is building into.
 
 The compiled artifacts are reused as they were produced, and a few things can
@@ -75,7 +75,7 @@ the compiler ran in.
 A C or C++ object also records the absolute include directories it was given,
 which is how a `-sys` crate whose build script generates headers into
 `OUT_DIR` used to produce a different object in every target directory. With
-[`OUT_DIR` sharing](/configuration#out-dir-sharing) on -- the default -- mbx
+[`OUT_DIR` sharing](/configuration#share-out-dir) on — the default — mbx
 passes the compiler `-fdebug-prefix-map` for that directory, so the object
 records the same placeholder the key does and two target directories produce
 the same bytes. An object that keeps the path anyway, in a string the source
@@ -107,7 +107,7 @@ A cross compile is cached when the build names its own compiler, through
 `CC_<target>`, `CXX_<target>`, `TARGET_CC`, or `TARGET_CXX`: mbx wraps what
 was named rather than replacing it. A cross build that names nothing is left
 alone, because which compiler a target implies lives in the `cc` crate's own
-tables -- guessing wrong would not cost a cache hit, it would build the object
+tables — guessing wrong would not cost a cache hit, it would build the object
 with the wrong compiler. A value that is a command rather than a path, such as
 `ccache gcc`, is left alone for the same reason.
 
@@ -119,15 +119,15 @@ bypass, as does any flag the adapter does not model. A source or header that
 expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__` bypasses too: its object is
 not a function of its inputs.
 
-A flag that tunes for the machine's own processor -- `-march=native` and its
-relatives -- bypasses as well, since the object it produces is not a function
+A flag that tunes for the machine's own processor — `-march=native` and its
+relatives — bypasses as well, since the object it produces is not a function
 of anything the key names.
 
 ## Shadowing is modeled by name, not by content
 
 An include directory contributes the names in it that could answer an
-`#include`: headers, sources -- `#include "generated.c"` is unusual but legal
--- names without an extension, and precompiled headers, which GCC prefers over
+`#include`: headers, sources — `#include "generated.c"` is unusual but legal —
+names without an extension, and precompiled headers, which GCC prefers over
 the header they were built from without anything on the command line saying so.
 
 What is left out is what cannot answer an `#include` at all: an object, a
@@ -155,7 +155,7 @@ cross-checkout cache sharing for their dependent crates.
 
 This covers C and C++ as well as Rust. A build script that generates headers
 into `OUT_DIR` passes that directory to its own compilations, which record it
-in debug information, so the same remapping applies -- rustc is told
+in debug information, so the same remapping applies — rustc is told
 `--remap-path-prefix` and the C compiler `-fdebug-prefix-map`, and in both
 cases an output that kept the literal path is left uncached rather than
 shared. `MBX_SHARE_OUT_DIR=0` turns both off together.

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -74,8 +74,8 @@ existing `target` symlink keeps counting as in use, so turning placement off
 does not schedule existing outputs for deletion.
 
 Each budget is measured against the disk that actually holds it, so putting
-`target.root` on a large scratch volume sizes the target budget from that
-volume rather than from the cache disk.
+[`target.root`](/configuration#target-root) on a large scratch volume sizes
+the target budget from that volume rather than from the cache disk.
 
 ## When mbx leaves a target alone
 

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -44,11 +44,11 @@ a build server do not need the same configuration:
 
 | Budget | Default | Bounds |
 | --- | --- | --- |
-| `gc.max_size` (action store) | 5% of the disk | 5GiB to 100GiB |
-| `target.max_size` (managed targets) | 10% of the disk | 10GiB to 100GiB |
+| `gc.max_size` (action store) | 5% of the disk | 5 GiB to 100 GiB |
+| `target.max_size` (managed targets) | 10% of the disk | 10 GiB to 100 GiB |
 
-Scaled budgets are rounded down to a whole 5GiB. When the disk cannot be
-measured, mbx uses 20GiB and 30GiB respectively. Any value you set outright
+Scaled budgets are rounded down to a whole 5 GiB. When the disk cannot be
+measured, mbx uses 20 GiB and 30 GiB respectively. Any value you set outright
 wins, and `mbx gc --dry-run` previews the effect of a policy without deleting
 anything.
 

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -18,7 +18,7 @@ response variant against `tests/fixtures/agent-protocol-v5.jsonl`. Its exhaustiv
 matches make a newly added variant fail to compile until the fixture and the
 protocol-version decision are reviewed together.
 
-Agent protocol v2 added compiler-duration accounting to hits and real compiler
+Agent protocol v2 adds compiler-duration accounting to hits and real compiler
 invocations. v3 adds the crate name to a recorded hit plus `begin_task` and
 `commit_task`, allowing an embedded Cargo shim to create one prediction manifest
 for each real Cargo invocation. v4 adds `record_warning`, which is how a shim

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -98,25 +98,12 @@ protocols. Pull requests that touch workspace crates run `cargo-semver-checks`
 against the pull request's base commit with all features enabled. Wire format
 changes still require the protocol-version steps above.
 
-A breaking API change is *declared*, not numbered by hand. Mark the commit
-breaking — `feat!:`, or a `BREAKING CHANGE:` footer — and release-plz prices
-it into the version when it opens the release PR. Do not edit a crate's version
-in a pull request: release-plz owns those numbers, and it knows that a crate on
-`0.x` needs a minor bump where a `1.x` crate would need a major one.
-
-One consequence is worth knowing before it surprises you. A pull request that
-breaks an API on purpose leaves `public API compatibility` red, because the
-version it compares against cannot move until the release PR exists. The
-breaking marker on the commit is what makes the break deliberate; the red check
-is the expected state of an honest breaking change, not a problem to solve
-inside the pull request.
-
-Read that job's output as a list of what broke, not as an instruction. Its
-summary says "semver requires new major version" whatever the crate's position,
-so for the crates on `0.x` it names a bump Cargo does not want — there, a break
-is a minor. The lint names above the summary are the useful part: they say which
-items changed shape, which is what a reviewer needs to judge whether the break
-was intended.
+A breaking API change is *declared*, not numbered by hand: the commit carries
+`feat!:` or a `BREAKING CHANGE:` footer, and release-plz prices it into the
+version when it opens the release PR. What that means for contributors —
+including why a deliberate break leaves the semver check red until the release
+PR exists — is covered in
+[RELEASING.md](https://github.com/jdx/mr-boxington/blob/main/RELEASING.md).
 
 The published crates do not all share a version, because they do not promise
 the same things:

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -14,7 +14,7 @@ the handshake and do not exchange cache requests. Adding, removing, or changing
 a request or response therefore requires incrementing `AGENT_PROTOCOL_VERSION`.
 
 `crates/mbx-cache-core/tests/agent_protocol.rs` exercises every request and
-response variant against `tests/fixtures/agent-protocol-v4.jsonl`. Its exhaustive
+response variant against `tests/fixtures/agent-protocol-v5.jsonl`. Its exhaustive
 matches make a newly added variant fail to compile until the fixture and the
 protocol-version decision are reviewed together.
 
@@ -25,6 +25,8 @@ for each real Cargo invocation. v4 adds `record_warning`, which is how a shim
 reports a diagnostic at all: a C or C++ shim stands in for a compiler whose
 stderr its caller reads as an answer, so it cannot write there itself, and the
 agent prints each distinct message once from the process that owns the build.
+v5 adds `find_file_digests` and `record_file_digests`, which let a shim reuse
+the digest of a file the session already read in full instead of rehashing it.
 The client and agent still require exact protocol and application-version
 equality, including when different applications ship them.
 
@@ -97,7 +99,7 @@ against the pull request's base commit with all features enabled. Wire format
 changes still require the protocol-version steps above.
 
 A breaking API change is *declared*, not numbered by hand. Mark the commit
-breaking -- `feat!:`, or a `BREAKING CHANGE:` footer -- and release-plz prices
+breaking — `feat!:`, or a `BREAKING CHANGE:` footer — and release-plz prices
 it into the version when it opens the release PR. Do not edit a crate's version
 in a pull request: release-plz owns those numbers, and it knows that a crate on
 `0.x` needs a minor bump where a `1.x` crate would need a major one.
@@ -111,7 +113,7 @@ inside the pull request.
 
 Read that job's output as a list of what broke, not as an instruction. Its
 summary says "semver requires new major version" whatever the crate's position,
-so for the crates on `0.x` it names a bump Cargo does not want -- there, a break
+so for the crates on `0.x` it names a bump Cargo does not want — there, a break
 is a minor. The lint names above the summary are the useful part: they say which
 items changed shape, which is what a reviewer needs to judge whether the break
 was intended.
@@ -125,12 +127,13 @@ the same things:
 | `mbx-cache-protocol` | independent | The remote cache wire contract, as described above. Depend on this to speak to an mbx cache. |
 | `mbx-cache-core` | shared `0.x` | Unstable session, store, and agent primitives for coordinated embedding. |
 | `mbx-cache-rustc` | shared `0.x` | Unstable rustc action modeling for coordinated embedding. |
+| `mbx-cache-cc` | shared `0.x` | Unstable C and C++ action modeling for coordinated embedding. |
 | `mbx-cache-cargo` | independent `0.x` | Unstable Cargo invocation and shared-cache-root resolution. |
 | `mbx-cache-store` | independent `0.x` | Unstable checkout claims and disk-bounded shared-store GC. |
 
 The embedding crates stay on `0.x`, where a minor bump is allowed to break.
-`mbx-cache-core` and `mbx-cache-rustc` move together; the smaller Cargo and
-store crates release independently. Pin compatible minors and expect an
+`mbx-cache-core`, `mbx-cache-rustc`, and `mbx-cache-cc` move together; the
+smaller Cargo and store crates release independently. Pin compatible minors and expect an
 upgrade to require source changes.
 
 The Rust types mirror which wire records are open to extension and which are

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -172,44 +172,42 @@ mbx prefetch build --workspace --release
 
 The workspace's `Cargo.lock` and complete Cargo argument list select the same
 manifest as a normal mbx build. Prefetch requires a configured remote in
-`read-only` or `read-write` mode, waits for every predicted action, and returns
-an error when the manifest lookup fails.
+`read-only` or `read-write` mode, waits for every predicted action, and reports
+what it pulled:
+
+```text
+prefetched 161 actions; 214.8 MiB downloaded and 214.8 MiB stored locally
+```
+
+A workspace and command nobody has published a manifest for print
+`no recorded actions for this workspace and Cargo command` and exit
+successfully — there was nothing to fetch, which is normal for a first build.
+A lookup that *fails* — unreachable host, refused credentials — is an error,
+so CI can tell an empty cache from a broken one. A typical place for the
+command is a runner or devcontainer image's start-up hook, so the store is
+warm before anyone builds.
 
 ## Deferred publication
 
-An upload is not on the critical path of the build that produced it. A store
-request returns once the object is durable in the local content-addressed store,
-and the upload it implies is queued and performed while the build continues, so a
-compilation never waits for a round trip that only later builds benefit from.
+Uploads are not on the critical path of the build that produced them: they are
+queued while the build continues and drained before the session exits, and an
+action result is published only after every blob it references, so a reader
+never fetches a result whose outputs it cannot restore. A command killed part
+way through publishes less than it stored, which costs only hit rate — the
+next build recomputes what never landed.
 
-Two rules follow from that:
-
-- An action result is published only after every blob it references. A server
-  validates an action result's output tree before committing it, so publishing
-  one early would be rejected — and a reader that fetched it would find outputs
-  it cannot restore. A blob that fails to upload therefore withholds the action
-  result naming it, and a task manifest waits for the results it predicts.
-- The session drains its queue before exiting. Uploads belong to the build's
-  process, so a command killed part way through publishes less than it stored.
-  Nothing is lost but hit rate: the next build recomputes what never landed.
-
-A failed upload is reported, counted in `remote_failures`, and recovered from.
-The build keeps its local result either way. The session summary reports what was
-published and what the drain cost:
+A failed upload is reported, counted in `remote_failures`, and recovered from;
+the build keeps its local result either way. The session summary reports what
+was published and what the drain cost, and where the server accepts them,
+queued blobs are published several to a request rather than one at a time:
 
 ```text
-mbx[cache]: uploads: 143 published, 0 not published; 412ms waited for after the build
+mbx[cache]: uploads: 143 published (118 of them in 2 packs), 0 not published; 412.0ms waited for after the build
 ```
 
 `MBX_STATS_REPORT` carries the same figures as `background_uploads`,
-`background_upload_failures`, and `upload_drain_duration_ns`.
-
-Where the server accepts them, queued blobs are published several to a request
-rather than one at a time — rustc output is many small objects, so one request
-each spends most of its time in round trips. The summary says how many went that
-way, and `remote_blob_pack_uploads` and `remote_blob_pack_upload_blobs` report
-it. A pack the server refuses is republished blob by blob, which also says which
-blob was the problem.
+`background_upload_failures`, `upload_drain_duration_ns`,
+`remote_blob_pack_uploads`, and `remote_blob_pack_upload_blobs`.
 
 ## Batched lookups
 
@@ -224,17 +222,14 @@ has made; nothing needs configuring either way.
 
 ## Transfer behavior
 
-Remote blobs are compressed with zstd. `MBX_HTTP_DOWNLOAD_TIMEOUT` is separate
-from the normal request timeout because artifacts can be much larger than
-metadata responses. Failed requests are retried according to
-`MBX_HTTP_RETRIES`.
+Remote blobs are compressed with zstd. Failed requests are retried according
+to `MBX_HTTP_RETRIES`, and a stalled attempt is cut short by
+`MBX_HTTP_TIMEOUT`.
 
-`MBX_HTTP_DOWNLOAD_TIMEOUT` is a deadline for the whole download rather than a
-budget per attempt: it spans every retry named by `MBX_HTTP_RETRIES` and the
-backoff between them, so a download that exhausts it fails even with retries
-left. That bounds how long one blob can hold a build open, and a stalled attempt
-is separately cut short by `MBX_HTTP_TIMEOUT`. Both the protocol server and the
-bucket backend read it the same way; a packed request to a protocol server
-scales the deadline up with the bytes and object count it asks for, since the
-configured value describes a single blob. Raise `MBX_HTTP_DOWNLOAD_TIMEOUT` if a
-slow link makes large artifacts run out of time before their retries are spent.
+`MBX_HTTP_DOWNLOAD_TIMEOUT` exists separately because artifacts can be much
+larger than metadata responses. It is a deadline for the whole download, not a
+budget per attempt — it spans every retry and the backoff between them, which
+bounds how long one blob can hold a build open. A packed request scales the
+deadline up with the bytes and object count it asks for, since the configured
+value describes a single blob. Raise it if a slow link makes large artifacts
+run out of time before their retries are spent.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -41,8 +41,8 @@ versioned under `/v1/` with explicit evolution rules, and published Rust crates
 follow semantic versioning enforced by `cargo-semver-checks` in CI. See
 [protocol compatibility](/protocol-compatibility) for the details.
 
-`mbx-cache-cargo`, `mbx-cache-store`, `mbx-cache-core`, and
-`mbx-cache-rustc` are supported building blocks for coordinated embedding.
+`mbx-cache-cargo`, `mbx-cache-store`, `mbx-cache-core`, `mbx-cache-rustc`, and
+`mbx-cache-cc` are supported building blocks for coordinated embedding.
 They intentionally stay on `0.x`: their public APIs can change in a new minor
 release, and embedders should pin a compatible minor. Store and wire formats
 remain independently versioned and treat unfamiliar records as cache misses.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -66,6 +66,16 @@ or a quick look that does not take over the terminal.
 mbx tui --once
 ```
 
+```text
+store: /home/you/.cache/mbx/actions
+objects: 44 (8.6 MiB); action results: 7 (2.5 KiB)
+
+command                             state         hit   miss  unconsulted  bypass
+mbx check --workspace               live            0      0            4       3
+mbx build                           finished        3      0            0       3
+mbx build                           finished        0      0            3       3
+```
+
 ## Recording
 
 Recording is on by default. A build appends one short line per compilation

--- a/mise.lock
+++ b/mise.lock
@@ -128,6 +128,41 @@ url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-pc-windows
 url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283641"
 provenance = "github-attestations"
 
+[[tools.lychee]]
+version = "0.24.2"
+backend = "aqua:lycheeverse/lychee"
+specifiers = ["0.24.2"]
+
+[tools.lychee."platforms.linux-arm64"]
+checksum = "sha256:91a7bd65685da41b90ccb9bc867a3d649a7818042dae04ff405e55a25bddee4c"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409959442"
+
+[tools.lychee."platforms.linux-arm64-musl"]
+checksum = "sha256:5d0b0e3aeab240f41920c633a6eaf97599be6eedda034b36e858ede7dba5e535"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409958602"
+
+[tools.lychee."platforms.linux-x64"]
+checksum = "sha256:1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409959156"
+
+[tools.lychee."platforms.linux-x64-musl"]
+checksum = "sha256:73657a111819a30c47c08352896796f23d64e4eb2b3ed39b6d32149241566fc5"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409959271"
+
+[tools.lychee."platforms.macos-arm64"]
+checksum = "sha256:c9d3740ea2d891854d37116c9fba840f37b6e7c89d330e7db84ac333631c4977"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409957951"
+
+[tools.lychee."platforms.windows-x64"]
+checksum = "sha256:32975d1493ee1a975d6bb41e4fb56fe419cb442ded628bb772ba2e614acfacad"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409959491"
+
 [[tools.node]]
 version = "24.19.0"
 backend = "core:node"

--- a/mise.toml
+++ b/mise.toml
@@ -70,7 +70,7 @@ run_windows = [
 ]
 
 [tasks.ci]
-depends = ["lint", "build", "check:docs", "build:docs", "test"]
+depends = ["lint", "build", "check:docs", "check:links", "test"]
 
 [tasks.docs]
 description = "Start the documentation development server"
@@ -106,6 +106,14 @@ description = "Check that generated documentation is current"
 depends = ["render:docs"]
 run = "git diff --exit-code -- docs/cli && test -z \"$(git status --porcelain --untracked-files=all -- docs/cli)\""
 run_windows = "git diff --exit-code -- docs/cli; if (git status --porcelain --untracked-files=all -- docs/cli) { exit 1 }"
+
+# VitePress validates page links at build time but not #fragments, so a
+# renamed heading rots its inbound anchors silently. --offline keeps external
+# URLs out of it: this checks the site against itself, not the internet.
+[tasks."check:links"]
+description = "Check internal links and anchors in the built documentation"
+depends = ["build:docs"]
+run = "lychee --offline --include-fragments --root-dir \"$PWD/docs/.vitepress/dist\" --fallback-extensions html 'docs/.vitepress/dist/**/*.html'"
 
 [tasks."perf:prepare"]
 description = "Build the fixed benchmark subject"
@@ -155,6 +163,7 @@ run = "tak run --record"
 "github:jdx/tak" = "0.0.8"
 aube = "latest"
 communique = "latest"
+lychee = "0.24.2"
 node = "24"
 rust = "1.97.1"
 usage = "6.5.0"


### PR DESCRIPTION
Started as a correction pass over the hand-written docs, then grew on request into acting on a full editorial review. Generated `docs/cli/` untouched throughout.

## Corrections

- The README, how-it-works, and cache-results said native linking is never cached with WebAssembly as the sole exception — stale since `cache_links` (#129). All three now match limits.md.
- The agent-protocol page named the v4 fixture; #164 moved it to v5. Updated, with a line on what v5 added.
- `mbx-cache-cc` was missing from the crate table, stability.md, and RELEASING.md, which also under-listed the crates needing Trusted Publishers.
- compared.md said tag builds disable caching entirely — stale since #194 (local cache stays; remote goes read-only).
- Three rotted anchors fixed, and the benchmark scenario names became real headings after three pages linked `/benchmarks#contention`.

## New: `mise run check:links`

VitePress validates page links but not `#fragments` — how every one of the anchors above rotted. The task runs lychee (pinned via mise) over the built site with `--include-fragments`; `--offline` keeps external URLs out of it. Wired into `mise run ci` and the docs CI job, and verified to fail on a fabricated broken fragment. It caught the `#contention` rot during this PR's own rebase.

## Editorial pass (all examples from real runs of the bootstrap binary)

**Show, don't describe**: a genuine `mbx explain` transcript and compiler-time lines in cache-results, prefetch output — including that an absent manifest exits zero while a failed lookup errors, so CI can tell empty from broken — and a real `mbx tui --once` snapshot with a live row.

**Rebalance depth**: the scheduler's dedup and permit-weighting story moves from the configuration reference into its own how-it-works section; learned-incremental and remote-cache transfer/publication prose tightened; include-shadowing owned by limits alone; the kache comparison trimmed; the semver-check reading guide moved from the docs site to RELEASING.md.

**Fill gaps**: literal per-platform config paths; a consolidated Windows subsection; the rustup toolchain paragraph restored to "Run a build"; a new FAQ (with a per-feature kill-switch table) and a new cookbook recipe for migrating from rust-cache or sccache — mbx defers to a pre-set `RUSTC_WRAPPER`, so the migration is removal, and `mbx doctor` warns until it's done.

Site builds clean; `check:links` passes over the result (417 unique links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)