### PR TITLE
perf: cache linked proc macros

### DIFF
--- a/benchmarks/real_world.py
+++ b/benchmarks/real_world.py
@@ -387,7 +387,7 @@ class Runner:
             # and stops a draining daemon from writing into a tree that is
             # about to be removed.
             subprocess.run(
-                [kache, "daemon", "stop"],
+                [shutil.which("kache") or "kache", "daemon", "stop"],
                 cwd=checkout,
                 env=environment,
                 text=True,

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -323,6 +323,7 @@ enum LinkOutput {
     Library,
     WasmExecutable,
     NativeExecutable,
+    NativeProcMacro,
 }
 
 /// What the caller is prepared to model beyond the default tier.
@@ -333,8 +334,8 @@ enum LinkOutput {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub struct ParseOptions {
-    /// Admit natively linked test binaries and executables, given a linker
-    /// identity in the action key. Off by default.
+    /// Admit natively linked test binaries, executables, and proc macros,
+    /// given a linker identity in the action key. Off by default.
     pub cache_native_links: bool,
 }
 
@@ -378,10 +379,13 @@ impl RustcInvocation {
         Parser::new(&expanded.arguments, options).parse()
     }
 
-    /// Whether this invocation links a native program, whose key must therefore
-    /// describe the linker that produced it.
+    /// Whether this invocation links a native artifact, whose key must
+    /// therefore describe the linker that produced it.
     pub fn links_natively(&self) -> bool {
-        self.link_output == LinkOutput::NativeExecutable
+        matches!(
+            self.link_output,
+            LinkOutput::NativeExecutable | LinkOutput::NativeProcMacro
+        )
     }
 
     /// Whether the contents of native search directories cannot reach this
@@ -515,9 +519,11 @@ impl RustcInvocation {
                 "link" => match self.link_output {
                     LinkOutput::Library => ("lib", "rlib"),
                     LinkOutput::WasmExecutable => ("", "wasm"),
-                    // A linked native program has no extension of its own on
-                    // the platforms this tier admits.
                     LinkOutput::NativeExecutable => ("", ""),
+                    LinkOutput::NativeProcMacro => (
+                        std::env::consts::DLL_PREFIX,
+                        std::env::consts::DLL_SUFFIX.trim_start_matches('.'),
+                    ),
                 },
                 "metadata" => ("lib", "rmeta"),
                 _ => continue,
@@ -1429,9 +1435,13 @@ impl<'a> Parser<'a> {
             // and libc shipped in the Rust toolchain. Unlike native linking,
             // there are no implicit host inputs outside compiler identity.
             LinkOutput::WasmExecutable
-        } else if self.options.cache_native_links && self.links_a_native_program() {
+        } else if self.options.cache_native_links && self.links_a_native_artifact() {
             self.check_native_link_is_portable()?;
-            LinkOutput::NativeExecutable
+            if matches!(self.crate_types.as_slice(), [kind] if kind == "proc-macro") {
+                LinkOutput::NativeProcMacro
+            } else {
+                LinkOutput::NativeExecutable
+            }
         } else if self.test {
             return Err(BypassReason::UnsupportedCrateType("test".into()));
         } else {
@@ -1461,7 +1471,7 @@ impl<'a> Parser<'a> {
         // adapter cannot vouch for, exactly like the arguments above.
         if !matches!(
             link_output,
-            LinkOutput::Library | LinkOutput::NativeExecutable
+            LinkOutput::Library | LinkOutput::NativeExecutable | LinkOutput::NativeProcMacro
         ) && self
             .parsed
             .iter()
@@ -1537,13 +1547,13 @@ impl Parser<'_> {
         })
     }
 
-    /// Whether this invocation links a program for the host.
+    /// Whether this invocation links an artifact for the host.
     ///
     /// An explicit `--target` bypasses even when it spells the host triple:
     /// rustc without one links for the host by construction, which is the
     /// cheapest description of "the linker this adapter can identify", and
     /// cargo omits it for host builds anyway.
-    fn links_a_native_program(&self) -> bool {
+    fn links_a_native_artifact(&self) -> bool {
         self.target.is_none()
             // A compilation that emits no linked artifact did not link, so it
             // needs no linker to describe it. `cargo check --tests` asks for
@@ -1551,7 +1561,7 @@ impl Parser<'_> {
             // for a linker identity and refusing flags no linker ever saw.
             && self.emits.iter().any(|emit| emit.kind == "link")
             && ((self.test && self.crate_types.is_empty())
-                || matches!(self.crate_types.as_slice(), [kind] if kind == "bin"))
+                || matches!(self.crate_types.as_slice(), [kind] if matches!(kind.as_str(), "bin" | "proc-macro")))
     }
 
     /// Reject a native link whose result depends on something the key cannot
@@ -1604,8 +1614,18 @@ impl Parser<'_> {
                 "debuginfo" if cfg!(target_os = "macos") => {
                     !matches!(value, Some("0" | "none")) && !self.oso_prefix_covers_outputs()
                 }
-                // Both embed this checkout's absolute target directory.
-                "rpath" | "prefer-dynamic" => is_enabled(value),
+                // An rpath and a dynamically linked native program embed this
+                // checkout's absolute target directory. Cargo also passes
+                // `prefer-dynamic` to proc macros, but their dynamic runtime
+                // is rustc's own sysroot (already pinned by compiler identity),
+                // while Cargo's dependencies are linked into the macro. There
+                // is no checkout rpath to carry; keep rejecting an explicit
+                // `rpath` independently.
+                "rpath" => is_enabled(value),
+                "prefer-dynamic" => {
+                    is_enabled(value)
+                        && !matches!(self.crate_types.as_slice(), [kind] if kind == "proc-macro")
+                }
                 // The CRT objects a self-contained link uses come from
                 // somewhere other than where the driver reports.
                 "link-self-contained" => true,

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1492,20 +1492,62 @@ fn linked_artifacts_still_bypass_when_nothing_admits_them() {
         ])),
         Err(BypassReason::UnsupportedCrateType("bin".into()))
     );
-    // Even with native links modeled, a proc macro is a dylib nobody admits.
+}
+
+#[test]
+fn linked_proc_macro_uses_the_native_link_tier() {
+    let invocation = RustcInvocation::parse_with(
+        &args(&[
+            "--crate-name=widget",
+            "--crate-type=proc-macro",
+            "--emit=dep-info,metadata,link",
+            "--out-dir=target/debug/deps",
+            "src/lib.rs",
+        ]),
+        native_links(),
+    )
+    .unwrap();
+
+    assert!(invocation.links_natively());
     assert_eq!(
-        RustcInvocation::parse_with(
-            &args(&[
-                "--crate-name=widget",
-                "--crate-type=proc-macro",
-                "--emit=dep-info,metadata,link",
-                "--out-dir=target/debug/deps",
-                "src/lib.rs",
+        invocation.outputs(&absolute(&["workspace"])).unwrap().files,
+        [
+            absolute(&[
+                "workspace",
+                "target",
+                "debug",
+                "deps",
+                &format!(
+                    "{}widget{}",
+                    std::env::consts::DLL_PREFIX,
+                    std::env::consts::DLL_SUFFIX
+                ),
             ]),
-            native_links()
-        ),
-        Err(BypassReason::UnsupportedCrateType("proc-macro".into()))
+            absolute(&["workspace", "target", "debug", "deps", "libwidget.rmeta"]),
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn proc_macro_prefer_dynamic_is_pinned_by_the_compiler_identity() {
+    let invocation = RustcInvocation::parse_with(
+        &args(&[
+            "--crate-name=widget",
+            "--crate-type=proc-macro",
+            "--emit=dep-info,metadata,link",
+            "--codegen=prefer-dynamic",
+            "--out-dir=target/debug/deps",
+            "src/lib.rs",
+        ]),
+        native_links(),
+    )
+    .unwrap();
+
+    assert!(invocation.links_natively());
 }
 
 /// A native library is a linker input, and the reason it bypasses -- mbx does

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -132,7 +132,7 @@ pub(crate) struct RawConfig {
         choices("quips", "plain", "off")
     )]
     savings: String,
-    /// Cache natively linked test binaries and executables. On macOS this
+    /// Cache natively linked test binaries, executables, and proc macros. On macOS this
     /// also passes ld64 `-oso_prefix` so a debug-info link's debug map stops
     /// naming this checkout, which is what lets it cache. Linux and macOS
     /// only, and a link mbx cannot describe exactly still links normally.

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -80,10 +80,10 @@ A build can report a high hit rate among attempted lookups while spending most
 of its time on actions that were not looked up or were bypassed. Read all three
 summary lines together, and compare wall-clock time when evaluating the cache.
 
-A link mbx cannot describe always runs, so a warm build of such a binary still
-has work to do. Host binaries and tests on Linux and macOS, and binaries,
-tests, and `cdylib`s for supported self-contained WebAssembly targets, may be
-restored as hits; see
+A link mbx cannot describe always runs, so its downstream crates may have work
+to do on an otherwise warm build. Native executables, tests, and proc macros on
+Linux and macOS, plus binaries, tests, and `cdylib`s for supported self-contained
+WebAssembly targets, may be restored as hits; see
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 
 ## Troubleshooting a low hit rate
@@ -104,11 +104,11 @@ The usual causes, roughly in the order they show up:
   members compile incrementally, those compilations bypass the cache, and the
   changed artifacts make crates above them miss too. See
   [limits](/limits#incremental-compilations-are-not-cached).
-- **Undescribed links always run.** Host binaries and tests are cached on
-  Linux and macOS, and self-contained WebAssembly targets everywhere, but a
-  link naming a native library, a custom linker, or built on Windows re-links
-  even when every compilation hit, so a warm build of such a binary still
-  takes time. See
+- **A link could not be described.** Native executables, tests, and proc macros
+  are cached on Linux and macOS, and self-contained WebAssembly targets
+  everywhere, but native links with custom or unmodeled inputs and links built
+  on Windows still run. A rebuilt dylib can also change the keys of its
+  downstream crates. `mbx explain` reports why the link bypassed; see
   [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 - **The inputs actually differ.** A different toolchain, feature set, profile,
   or `RUSTFLAGS` between two checkouts is a different key, and the summary

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -31,7 +31,7 @@ Cache root.
 - **Scope:** only from the environment or the command line
 - **Set with:** `MBX_CACHE_LINKS`
 
-Cache natively linked test binaries and executables. On macOS this also passes ld64 `-oso_prefix` so a debug-info link's debug map stops naming this checkout, which is what lets it cache. Linux and macOS only, and a link mbx cannot describe exactly still links normally.
+Cache natively linked test binaries, executables, and proc macros. On macOS this also passes ld64 `-oso_prefix` so a debug-info link's debug map stops naming this checkout, which is what lets it cache. Linux and macOS only, and a link mbx cannot describe exactly still links normally.
 
 ### `cc`
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -128,11 +128,11 @@ Unsupported crate types, unmodeled search paths, and incremental compilations
 bypass the shared action cache. A compilation that links nothing is cached
 whatever its crate type — `cargo check` and clippy compile every binary and
 test target that way, and metadata is metadata. A native link is admitted only
-when its linker can be described: host binaries and tests on Linux and macOS,
-where mbx puts the resolved linker, startup objects, libc, and SDK into the
-key, and a fixed allowlist of built-in WebAssembly targets whose default
-linker and system inputs ship with rustc. Everything else — native libraries,
-custom linkers, Windows — links as it always did; see
+when its linker can be described: host binaries, tests, and proc macros on Linux
+and macOS, where mbx puts the resolved linker, startup objects, libc, and SDK
+into the key, and a fixed allowlist of built-in WebAssembly targets whose
+default linker and system inputs ship with rustc. Everything else — native
+libraries, custom linkers, Windows — links as it always did; see
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 `MBX_VERIFY=1` compiles while also consulting the cache and compares the result,
 providing a deliberately expensive qualification mode.


### PR DESCRIPTION
## Summary

- admit linked proc-macro dylibs to the existing native-link cache tier
- model platform dylib output names and allow Cargo's proc-macro `prefer-dynamic` mode while retaining linker identity and portability checks
- fix the real-world benchmark's kache daemon shutdown and update native-link documentation

## Performance

Pinned `hk` benchmark on Linux, Rust 1.97.1, kache 0.16.0:

| Scenario | Before | After | kache |
| --- | ---: | ---: | ---: |
| warm | 5.8s | 5.9s | 7.5s |
| worktree | 11.6s | 5.9s | 7.5s |

The worktree run increases mbx from 756 hits / 1,293 restored files to 781 hits / 1,344 restored files and removes the proc-macro rebuild cascade into `arc_swap` and the final `hk` link.

## Validation

- `cargo test --workspace --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 benchmarks/real_world.py --mbx target/release/mbx --scenarios warm`
- `python3 benchmarks/real_world.py --mbx target/release/mbx --scenarios worktree`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native-link classification and portability rules for proc-macro dylibs; incorrect modeling could restore wrong macro binaries, though it reuses the existing linker-identity path and adds targeted tests.
> 
> **Overview**
> **Linked proc-macro crates** are now admitted to the same native-link cache tier as host binaries and tests when `MBX_CACHE_LINKS` / `cache_links` is enabled, instead of bypassing as an unsupported crate type.
> 
> The rustc adapter introduces a **`NativeProcMacro`** link output: it models platform **dylib** names for `link` emits, treats proc macros as natively linked (linker identity required), and **allows Cargo’s `prefer-dynamic`** for proc macros while still rejecting checkout-specific **`rpath`**. Portability and `-oso_prefix` rules apply to this tier alongside executables.
> 
> The real-world benchmark **resolves `kache` via `shutil.which`** when stopping the daemon (matching stats). Docs and config text now mention proc macros alongside executables and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748f19edcb56c5d3520f25a46c08ea40c68daa60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->