### PR TITLE
fix(docs): redesign benchmark comparisons

### DIFF
--- a/benchmarks/real_world.py
+++ b/benchmarks/real_world.py
@@ -74,15 +74,24 @@ SCENARIOS: dict[str, dict[str, object]] = {
     },
     "warm": {
         "tools": ("mbx", "kache"),
-        "description": "warm store, fresh target -- CI restoring a cache for the same commit",
+        "description": (
+            "warm store, fresh target -- CI restoring the same commit; "
+            "plain Cargo has no cache to restore"
+        ),
     },
     "commit": {
         "tools": ("cargo", "mbx", "kache"),
-        "description": "store warmed at the parent commit, build the child -- push-to-push CI",
+        "description": (
+            "cache tools warmed at the parent commit, build the child -- "
+            "Cargo is the uncached push-to-push baseline"
+        ),
     },
     "worktree": {
         "tools": ("mbx", "kache"),
-        "description": "warm store, second checkout at a different path",
+        "description": (
+            "warm store, second checkout at a different path; "
+            "plain Cargo cannot reuse the first checkout's target"
+        ),
     },
     "toolchain": {
         "tools": ("mbx",),

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -144,7 +144,7 @@
     },
     {
       "scenario": "warm",
-      "description": "warm store, fresh target -- CI restoring a cache for the same commit",
+      "description": "warm store, fresh target -- CI restoring the same commit; plain Cargo has no cache to restore",
       "timed": true,
       "kind": "build",
       "results": [
@@ -270,7 +270,7 @@
     },
     {
       "scenario": "commit",
-      "description": "store warmed at the parent commit, build the child -- push-to-push CI",
+      "description": "cache tools warmed at the parent commit, build the child -- Cargo is the uncached push-to-push baseline",
       "timed": true,
       "kind": "build",
       "results": [
@@ -400,7 +400,7 @@
     },
     {
       "scenario": "worktree",
-      "description": "warm store, second checkout at a different path",
+      "description": "warm store, second checkout at a different path; plain Cargo cannot reuse the first checkout's target",
       "timed": true,
       "kind": "build",
       "results": [

--- a/docs/.vitepress/theme/BenchmarkResults.vue
+++ b/docs/.vitepress/theme/BenchmarkResults.vue
@@ -93,7 +93,7 @@
           </div>
           <strong class="mbx-bench-seconds">{{ cell.seconds }}</strong>
           <div class="mbx-bench-meta">
-            <span v-if="cell.relative !== '—'">{{ cell.relative }} vs. cold cargo</span>
+            <span v-if="cell.comparison">{{ cell.comparison }}</span>
             <span v-if="cell.hits !== '—'">{{ cell.hits }} cache hits</span>
           </div>
         </div>
@@ -123,18 +123,6 @@ import { computed } from "vue";
 import { data } from "../benchmarks.data";
 import type { BenchmarkScenario } from "../benchmarks.data";
 
-// Every scenario compares against the same number: what plain cargo costs
-// with nothing cached. Only the cold scenario runs cargo -- with a wiped
-// target/ the others would just repeat it -- so a per-scenario baseline would
-// leave the warm and cross-worktree rows with nothing to compare to, which is
-// exactly the comparison a reader wants.
-const coldCargo = computed(
-  () =>
-    data?.scenarios
-      .find((scenario) => scenario.scenario === "cold")
-      ?.results.find((cell) => cell.tool === "cargo") ?? null,
-);
-
 // Bars are scaled within a scenario, never across them: each card answers
 // which tool was faster on that workload, not how the workloads compare to
 // each other. The bar has its own fixed-width track beside the duration label,
@@ -151,9 +139,15 @@ function rows(scenario: BenchmarkScenario) {
   const fastest = Math.min(
     ...scenario.results.map((cell) => cell.wall_duration_ns),
   );
-  const baseline = coldCargo.value;
+  // A Cargo result is meaningful only inside the scenario that measured it.
+  // In the commit case it is deliberately an uncached control: Cargo has no
+  // portable store to seed from the parent commit, and its target is fresh.
+  const baseline = scenario.results.find((cell) => cell.tool === "cargo");
   return scenario.results.map((cell) => {
     const seconds = cell.wall_duration_ns / 1e9;
+    const ratio = baseline
+      ? baseline.wall_duration_ns / cell.wall_duration_ns
+      : null;
     return {
       tool: cell.tool,
       fastest: cell.wall_duration_ns === fastest,
@@ -162,12 +156,14 @@ function rows(scenario: BenchmarkScenario) {
           ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
           : `${seconds.toFixed(1)}s`,
       width: barWidth(cell.wall_duration_ns, slowest),
-      relative:
-        // Two decimals: a cache that costs 3% on a cold build rounds to
-        // "1.0x" at one, which reads as free.
-        !baseline || cell === baseline
-          ? "—"
-          : `${(baseline.wall_duration_ns / cell.wall_duration_ns).toFixed(2)}×`,
+      comparison:
+        !baseline
+          ? null
+          : cell === baseline
+            ? "uncached baseline"
+            : ratio! >= 1
+              ? `${ratio!.toFixed(2)}× faster than cargo`
+              : `${(1 / ratio!).toFixed(2)}× slower than cargo`,
       hits: cell.stats?.hits ?? "—",
     };
   });

--- a/docs/.vitepress/theme/BenchmarkResults.vue
+++ b/docs/.vitepress/theme/BenchmarkResults.vue
@@ -62,7 +62,7 @@
           <strong class="mbx-bench-seconds">{{ cell.seconds }}</strong>
           <div class="mbx-bench-meta">
             <span v-if="cell.relative !== '—'">{{ cell.relative }} vs. sequential</span>
-            <span>{{ cell.compilers }} compilers</span>
+            <span>{{ cell.compilers }}</span>
             <span>{{ cell.memory }} free</span>
           </div>
         </div>
@@ -204,8 +204,8 @@ function contentionRows(scenario: BenchmarkScenario) {
           ? "—"
           : `${(baseline.wall_duration_ns / cell.wall_duration_ns).toFixed(2)}×`,
       compilers: cell.permits
-        ? `${cell.peak_compilers ?? 0} / ${cell.permits} permits`
-        : `${cell.peak_compilers ?? 0}`,
+        ? `${cell.peak_compilers ?? 0} peak / ${cell.permits} permits`
+        : `${cell.peak_compilers ?? 0} peak compilers`,
       // Only Linux reports it, and only Linux runs the published benchmark.
       // Zero is a real reading -- a machine that ran itself out -- and it is
       // the single most interesting cell on the page, so it must not be
@@ -392,11 +392,21 @@ const versionList = computed(() => {
     grid-template-columns: minmax(0, 1fr) auto;
     padding: 15px 16px;
   }
-  .mbx-bench-bar-track,
-  .mbx-bench-meta {
+  .mbx-bench-tool {
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .mbx-bench-seconds {
+    grid-column: 2;
+    grid-row: 1;
+  }
+  .mbx-bench-bar-track {
     grid-column: 1 / -1;
+    grid-row: 2;
   }
   .mbx-bench-meta {
+    grid-column: 1 / -1;
+    grid-row: 3;
     margin-top: -2px;
   }
 }

--- a/docs/.vitepress/theme/BenchmarkResults.vue
+++ b/docs/.vitepress/theme/BenchmarkResults.vue
@@ -45,11 +45,13 @@
           <tr v-for="cell in contentionRows(scenario)" :key="cell.tool">
             <th scope="row">{{ cell.tool }}</th>
             <td>
-              <span
-                class="mbx-bench-bar"
-                :class="{ 'is-subject': cell.tool === 'mbx' }"
-                :style="{ width: `${cell.width}%` }"
-              />
+              <span class="mbx-bench-bar-track" aria-hidden="true">
+                <span
+                  class="mbx-bench-bar"
+                  :class="{ 'is-subject': cell.tool === 'mbx' }"
+                  :style="{ width: `${cell.width}%` }"
+                />
+              </span>
               <span class="mbx-bench-seconds">{{ cell.seconds }}</span>
             </td>
             <td class="mbx-bench-numeric">{{ cell.relative }}</td>
@@ -71,11 +73,13 @@
           <tr v-for="cell in rows(scenario)" :key="cell.tool">
             <th scope="row">{{ cell.tool }}</th>
             <td>
-              <span
-                class="mbx-bench-bar"
-                :class="{ 'is-subject': cell.tool === 'mbx' }"
-                :style="{ width: `${cell.width}%` }"
-              />
+              <span class="mbx-bench-bar-track" aria-hidden="true">
+                <span
+                  class="mbx-bench-bar"
+                  :class="{ 'is-subject': cell.tool === 'mbx' }"
+                  :style="{ width: `${cell.width}%` }"
+                />
+              </span>
               <span class="mbx-bench-seconds">{{ cell.seconds }}</span>
             </td>
             <td class="mbx-bench-numeric">{{ cell.relative }}</td>
@@ -122,7 +126,12 @@ const coldCargo = computed(
 
 // Bars are scaled within a scenario, never across them: each table answers
 // which tool was faster on that workload, not how the workloads compare to
-// each other.
+// each other. The bar has its own fixed-width track beside the duration label,
+// so the slowest result fills the track and every other result is proportional.
+function barWidth(duration: number, slowest: number) {
+  return Math.max(2, (duration / slowest) * 100);
+}
+
 function rows(scenario: BenchmarkScenario) {
   const slowest = Math.max(
     ...scenario.results.map((cell) => cell.wall_duration_ns),
@@ -137,7 +146,7 @@ function rows(scenario: BenchmarkScenario) {
         seconds >= 60
           ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
           : `${seconds.toFixed(1)}s`,
-      width: Math.max(2, (cell.wall_duration_ns / slowest) * 100),
+      width: barWidth(cell.wall_duration_ns, slowest),
       relative:
         // Two decimals: a cache that costs 3% on a cold build rounds to
         // "1.0x" at one, which reads as free.
@@ -170,7 +179,7 @@ function contentionRows(scenario: BenchmarkScenario) {
         seconds >= 60
           ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
           : `${seconds.toFixed(1)}s`,
-      width: Math.max(2, (cell.wall_duration_ns / slowest) * 100),
+      width: barWidth(cell.wall_duration_ns, slowest),
       relative:
         !baseline || cell === baseline
           ? "—"
@@ -224,14 +233,19 @@ const versionList = computed(() => {
 .mbx-bench-numeric {
   text-align: right;
 }
-.mbx-bench-bar {
-  background: var(--vp-c-divider);
+.mbx-bench-bar-track {
   border-radius: 3px;
   display: inline-block;
   height: 10px;
   margin-right: 8px;
-  max-width: 60%;
   vertical-align: middle;
+  width: 60%;
+}
+.mbx-bench-bar {
+  background: var(--vp-c-divider);
+  border-radius: inherit;
+  display: block;
+  height: 100%;
 }
 .mbx-bench-bar.is-subject {
   background: var(--vp-c-brand-1);

--- a/docs/.vitepress/theme/BenchmarkResults.vue
+++ b/docs/.vitepress/theme/BenchmarkResults.vue
@@ -16,8 +16,15 @@
       :key="scenario.scenario"
       class="mbx-bench-scenario"
     >
-      <h3 :id="scenario.scenario">{{ scenario.scenario }}</h3>
-      <p class="mbx-bench-caption">{{ scenario.description }}</p>
+      <header class="mbx-bench-header">
+        <div>
+          <h3 :id="scenario.scenario">{{ scenario.scenario }}</h3>
+          <p class="mbx-bench-caption">{{ scenario.description }}</p>
+        </div>
+        <span v-if="scenario.timed" class="mbx-bench-direction">
+          lower is better
+        </span>
+      </header>
       <p
         v-if="!scenario.timed && scenario.results.length"
         class="mbx-bench-guard"
@@ -28,65 +35,69 @@
         {{ scenario.results[0].stats?.lookups ?? 0 }} — the ones that do not
         depend on rustc at all.
       </p>
-      <table
+      <div
         v-else-if="scenario.kind === 'contention' && scenario.results.length"
-        class="mbx-bench-table"
+        class="mbx-bench-chart"
+        role="list"
+        aria-label="Contention benchmark results"
       >
-        <thead>
-          <tr>
-            <th scope="col">Tool</th>
-            <th scope="col">Batch time</th>
-            <th scope="col" class="mbx-bench-numeric">vs. sequential</th>
-            <th scope="col" class="mbx-bench-numeric">Peak compilers</th>
-            <th scope="col" class="mbx-bench-numeric">Lowest free memory</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="cell in contentionRows(scenario)" :key="cell.tool">
-            <th scope="row">{{ cell.tool }}</th>
-            <td>
-              <span class="mbx-bench-bar-track" aria-hidden="true">
-                <span
-                  class="mbx-bench-bar"
-                  :class="{ 'is-subject': cell.tool === 'mbx' }"
-                  :style="{ width: `${cell.width}%` }"
-                />
-              </span>
-              <span class="mbx-bench-seconds">{{ cell.seconds }}</span>
-            </td>
-            <td class="mbx-bench-numeric">{{ cell.relative }}</td>
-            <td class="mbx-bench-numeric">{{ cell.compilers }}</td>
-            <td class="mbx-bench-numeric">{{ cell.memory }}</td>
-          </tr>
-        </tbody>
-      </table>
-      <table v-else-if="scenario.results.length" class="mbx-bench-table">
-        <thead>
-          <tr>
-            <th scope="col">Tool</th>
-            <th scope="col">Build time</th>
-            <th scope="col" class="mbx-bench-numeric">vs. cold cargo</th>
-            <th scope="col" class="mbx-bench-numeric">Hits</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="cell in rows(scenario)" :key="cell.tool">
-            <th scope="row">{{ cell.tool }}</th>
-            <td>
-              <span class="mbx-bench-bar-track" aria-hidden="true">
-                <span
-                  class="mbx-bench-bar"
-                  :class="{ 'is-subject': cell.tool === 'mbx' }"
-                  :style="{ width: `${cell.width}%` }"
-                />
-              </span>
-              <span class="mbx-bench-seconds">{{ cell.seconds }}</span>
-            </td>
-            <td class="mbx-bench-numeric">{{ cell.relative }}</td>
-            <td class="mbx-bench-numeric">{{ cell.hits }}</td>
-          </tr>
-        </tbody>
-      </table>
+        <div
+          v-for="cell in contentionRows(scenario)"
+          :key="cell.tool"
+          class="mbx-bench-row"
+          :class="{ 'is-subject': cell.tool === 'mbx' }"
+          role="listitem"
+        >
+          <div class="mbx-bench-tool">
+            <code>{{ cell.tool }}</code>
+            <span v-if="cell.fastest" class="mbx-bench-fastest">fastest</span>
+          </div>
+          <div class="mbx-bench-bar-track" aria-hidden="true">
+            <span
+              class="mbx-bench-bar"
+              :class="{ 'is-subject': cell.tool === 'mbx' }"
+              :style="{ width: `${cell.width}%` }"
+            />
+          </div>
+          <strong class="mbx-bench-seconds">{{ cell.seconds }}</strong>
+          <div class="mbx-bench-meta">
+            <span v-if="cell.relative !== '—'">{{ cell.relative }} vs. sequential</span>
+            <span>{{ cell.compilers }} compilers</span>
+            <span>{{ cell.memory }} free</span>
+          </div>
+        </div>
+      </div>
+      <div
+        v-else-if="scenario.results.length"
+        class="mbx-bench-chart"
+        role="list"
+        :aria-label="`${scenario.scenario} benchmark results`"
+      >
+        <div
+          v-for="cell in rows(scenario)"
+          :key="cell.tool"
+          class="mbx-bench-row"
+          :class="{ 'is-subject': cell.tool === 'mbx' }"
+          role="listitem"
+        >
+          <div class="mbx-bench-tool">
+            <code>{{ cell.tool }}</code>
+            <span v-if="cell.fastest" class="mbx-bench-fastest">fastest</span>
+          </div>
+          <div class="mbx-bench-bar-track" aria-hidden="true">
+            <span
+              class="mbx-bench-bar"
+              :class="{ 'is-subject': cell.tool === 'mbx' }"
+              :style="{ width: `${cell.width}%` }"
+            />
+          </div>
+          <strong class="mbx-bench-seconds">{{ cell.seconds }}</strong>
+          <div class="mbx-bench-meta">
+            <span v-if="cell.relative !== '—'">{{ cell.relative }} vs. cold cargo</span>
+            <span v-if="cell.hits !== '—'">{{ cell.hits }} cache hits</span>
+          </div>
+        </div>
+      </div>
       <p v-if="scenario.skipped.length" class="mbx-bench-skipped">
         Not measured: {{ scenario.skipped.join("; ") }}
       </p>
@@ -124,7 +135,7 @@ const coldCargo = computed(
       ?.results.find((cell) => cell.tool === "cargo") ?? null,
 );
 
-// Bars are scaled within a scenario, never across them: each table answers
+// Bars are scaled within a scenario, never across them: each card answers
 // which tool was faster on that workload, not how the workloads compare to
 // each other. The bar has its own fixed-width track beside the duration label,
 // so the slowest result fills the track and every other result is proportional.
@@ -137,11 +148,15 @@ function rows(scenario: BenchmarkScenario) {
     ...scenario.results.map((cell) => cell.wall_duration_ns),
     1,
   );
+  const fastest = Math.min(
+    ...scenario.results.map((cell) => cell.wall_duration_ns),
+  );
   const baseline = coldCargo.value;
   return scenario.results.map((cell) => {
     const seconds = cell.wall_duration_ns / 1e9;
     return {
       tool: cell.tool,
+      fastest: cell.wall_duration_ns === fastest,
       seconds:
         seconds >= 60
           ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
@@ -167,6 +182,9 @@ function contentionRows(scenario: BenchmarkScenario) {
     ...scenario.results.map((cell) => cell.wall_duration_ns),
     1,
   );
+  const fastest = Math.min(
+    ...scenario.results.map((cell) => cell.wall_duration_ns),
+  );
   const baseline = scenario.results.find(
     (cell) => cell.tool === "mbx-sequential",
   );
@@ -175,6 +193,7 @@ function contentionRows(scenario: BenchmarkScenario) {
     const available = cell.min_available_bytes;
     return {
       tool: cell.tool,
+      fastest: cell.wall_duration_ns === fastest,
       seconds:
         seconds >= 60
           ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
@@ -215,51 +234,141 @@ const versionList = computed(() => {
 
 <style scoped>
 .mbx-bench-scenario {
-  margin: 32px 0;
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--vp-c-bg-soft) 96%, var(--vp-c-brand-1) 4%),
+      var(--vp-c-bg-soft)
+    );
+  border: 1px solid color-mix(in srgb, var(--vp-c-divider) 80%, var(--vp-c-brand-1) 20%);
+  border-radius: 14px;
+  margin: 28px 0;
+  overflow: hidden;
+}
+.mbx-bench-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  padding: 20px 22px 18px;
+}
+.mbx-bench-header h3 {
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 .mbx-bench-caption {
   color: var(--vp-c-text-2);
   font-size: 14px;
-  margin-top: -8px;
+  line-height: 1.5;
+  margin: 5px 0 0;
 }
-.mbx-bench-table {
-  display: table;
-  width: 100%;
+.mbx-bench-direction {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  color: var(--vp-c-text-2);
+  flex: none;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  padding: 6px 9px;
+  text-transform: uppercase;
 }
-.mbx-bench-table th[scope="row"] {
-  font-family: var(--vp-font-family-mono);
-  font-weight: 500;
+.mbx-bench-chart {
+  border-top: 1px solid var(--vp-c-divider);
 }
-.mbx-bench-numeric {
-  text-align: right;
+.mbx-bench-row {
+  align-items: center;
+  display: grid;
+  gap: 8px 18px;
+  grid-template-columns: minmax(120px, 0.8fr) minmax(180px, 2fr) auto;
+  padding: 16px 22px;
+}
+.mbx-bench-row + .mbx-bench-row {
+  border-top: 1px solid var(--vp-c-divider);
+}
+.mbx-bench-row.is-subject {
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 58%, transparent);
+}
+.mbx-bench-tool {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.mbx-bench-tool code {
+  background: transparent;
+  color: var(--vp-c-text-1);
+  font-size: 14px;
+  font-weight: 650;
+  padding: 0;
+}
+.mbx-bench-fastest {
+  background: color-mix(in srgb, var(--vp-c-brand-1) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--vp-c-brand-1) 32%, transparent);
+  border-radius: 999px;
+  color: var(--vp-c-brand-1);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  padding: 4px 6px;
+  text-transform: uppercase;
 }
 .mbx-bench-bar-track {
-  border-radius: 3px;
-  display: inline-block;
-  height: 10px;
-  margin-right: 8px;
-  vertical-align: middle;
-  width: 60%;
+  background: color-mix(in srgb, var(--vp-c-divider) 58%, transparent);
+  border-radius: 999px;
+  display: block;
+  height: 12px;
+  overflow: hidden;
+  width: 100%;
 }
 .mbx-bench-bar {
-  background: var(--vp-c-divider);
+  background: var(--vp-c-text-3);
   border-radius: inherit;
   display: block;
   height: 100%;
+  min-width: 3px;
 }
 .mbx-bench-bar.is-subject {
-  background: var(--vp-c-brand-1);
+  background: linear-gradient(90deg, var(--vp-c-brand-2), var(--vp-c-brand-1));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--vp-c-brand-1) 32%, transparent);
 }
 .mbx-bench-seconds {
+  color: var(--vp-c-text-1);
   font-family: var(--vp-font-family-mono);
-  font-size: 13px;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  justify-self: end;
   white-space: nowrap;
+}
+.mbx-bench-meta {
+  color: var(--vp-c-text-2);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 11px;
+  gap: 6px;
+  grid-column: 2 / 4;
+}
+.mbx-bench-meta span {
+  background: color-mix(in srgb, var(--vp-c-bg) 72%, transparent);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  line-height: 1;
+  padding: 5px 7px;
 }
 .mbx-bench-guard,
 .mbx-bench-skipped,
 .mbx-bench-provenance {
   color: var(--vp-c-text-2);
   font-size: 13px;
+}
+.mbx-bench-guard,
+.mbx-bench-skipped {
+  border-top: 1px solid var(--vp-c-divider);
+  margin: 0;
+  padding: 16px 22px;
 }
 .mbx-bench-empty {
   border: 1px solid var(--vp-c-divider);
@@ -268,5 +377,27 @@ const versionList = computed(() => {
 }
 .mbx-bench-empty p {
   margin: 0;
+}
+@media (max-width: 640px) {
+  .mbx-bench-header {
+    display: block;
+    padding: 18px 16px 16px;
+  }
+  .mbx-bench-direction {
+    display: inline-block;
+    margin-top: 12px;
+  }
+  .mbx-bench-row {
+    gap: 10px 14px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 15px 16px;
+  }
+  .mbx-bench-bar-track,
+  .mbx-bench-meta {
+    grid-column: 1 / -1;
+  }
+  .mbx-bench-meta {
+    margin-top: -2px;
+  }
 }
 </style>

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -5,14 +5,14 @@ dependencies, pinned to a fixed commit — rather than mbx's own workspace, whic
 is too small to measure anything useful against. Every scenario is one CI
 actually hits.
 
-Most scenarios run the same `cargo build --locked` three ways: plain cargo,
-[mbx](/), and [kache](https://github.com/kunobi-ninja/kache). Timings are wall
-clock around one build. Every row is compared against one number — what plain
-cargo costs with nothing cached — because that is the build a cache is
-replacing. cargo is not re-run in the other scenarios: with a fresh `target/`
-it would only repeat that time. The last scenario is the exception, comparing
-sequential and parallel lint strategies and measuring the machine rather than a
-single build.
+The build scenarios run the same `cargo build --locked` through plain Cargo,
+[mbx](/), and [kache](https://github.com/kunobi-ninja/kache), where each tool
+can make a meaningful comparison. Timings are wall clock around one build.
+When Cargo appears, it is an uncached baseline measured in that same scenario;
+cache rows compare only with that result. The warm and worktree scenarios omit
+Cargo because a fresh `target/` or a different checkout gives it nothing to
+reuse. The contention scenario is the exception, comparing sequential and
+parallel lint strategies and measuring the machine rather than a single build.
 
 <BenchmarkResults />
 


### PR DESCRIPTION
## Summary

Replaces the benchmark data tables with responsive comparison cards built from semantic HTML. Each scenario now has:

- one shared proportional bar scale;
- an explicit “lower is better” cue;
- a fastest-result badge;
- prominent wall time with secondary speedup, cache-hit, and contention metrics;
- a mobile layout that stacks bars and metadata instead of squeezing table columns.

This also fixes the original clipping bug where normalized widths above 60% were visually capped to the same length.

## Validation

- `mise run build:docs`
- Rendered locally with VitePress and captured in Chromium at 1280×1600.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and benchmark presentation only; no changes to build, cache, or auth paths.
> 
> **Overview**
> **Redesigns published benchmark results** from HTML tables into per-scenario **card layouts** with list-based chart rows, a **“lower is better”** cue, **fastest** badges, and a **mobile stack** for bars and metadata. Bars now use a **dedicated track** so within-scenario scaling is proportional (fixing the old **60% max-width cap** that clipped longer bars).
> 
> **Fixes how Cargo is compared:** drops the global **cold-scenario cargo** baseline and instead uses **cargo measured in the same scenario** when present (`uncached baseline`, `× faster/slower than cargo`). **Warm** and **worktree** rows no longer show a misleading cargo column because those scenarios do not run cargo.
> 
> **Copy stays aligned** with the UI: scenario descriptions in `benchmarks/real_world.py`, `benchmarks/results.json`, and `docs/benchmarks.md` explain when cargo is omitted and what each baseline means.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3e0739293a678ba85d00b2d26d7be5ebd68e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Benchmark results now display as responsive visual charts instead of tables.
  * Added scenario-specific details, performance bars, fastest-result badges, and “lower is better” indicators for timed benchmarks.
  * Updated the layout with card-based styling optimized for mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

![Benchmark comparison cards at 1280px](https://github.com/user-attachments/assets/231cea01-4dde-4618-bbd4-f19924d87b29)