### PR TITLE
docs: use monospace for hero command

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -114,16 +114,20 @@ body::after {
     radial-gradient(52rem 32rem at 0% 18%, rgb(var(--mbx-teal-rgb) / 0.12), transparent 60%);
 }
 
-.VPHero .name,
-.VPHero .text {
+.VPHero .name {
   font-family: var(--mbx-display);
   letter-spacing: -0.03em;
+}
+
+.VPHero .text {
+  font-family: var(--vp-font-family-mono);
+  letter-spacing: normal;
 }
 
 .VPHero .text code {
   background: none;
   color: inherit;
-  font-family: var(--vp-font-family-mono);
+  font-family: inherit;
   font-size: inherit;
   font-weight: inherit;
   padding: 0;


### PR DESCRIPTION
## Summary

- render the full `fix target/` hero command in the monospace font
- reset display-font letter spacing so the command remains fixed-width
- keep the nested `code` element inheriting the hero command font

## Testing

- `cd docs && mise exec -- aube run docs:build`
- verified the landing page in Chromium at 1134×1072

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress theme CSS on the home hero; no runtime or build behavior changes.
> 
> **Overview**
> The docs landing hero **splits typography** so the product name keeps the display font (`Space Grotesk`) while the **`fix target/` command line** uses the site monospace stack (`JetBrains Mono`).
> 
> **Letter spacing** on `.VPHero .text` is reset to normal so the command reads as fixed-width, and the nested `<code>` span **inherits** that font instead of re-declaring monospace on its own.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b3e027e147c48a9197f9a1cd602cbfa3bc709d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->