### PR TITLE
docs: recognize Cargo, sccache, and kache

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,12 @@ comes before hit rate.
 - [CLI reference](https://mr-boxington.jdx.dev/cli)
 - [Current limits](https://mr-boxington.jdx.dev/limits)
 
-> [!NOTE]
-> mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
-> compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
-> [kache](https://github.com/kunobi-ninja/kache), which directly inspired its
-> design. [Read the acknowledgements](https://mr-boxington.jdx.dev/acknowledgements).
+## Acknowledgements
+
+mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
+compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
+[kache](https://github.com/kunobi-ninja/kache), which directly inspired its
+design. [Read the acknowledgements](https://mr-boxington.jdx.dev/acknowledgements).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -186,9 +186,8 @@ comes before hit rate.
 > [!NOTE]
 > mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
 > compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
-> [kache](https://github.com/kunobi-ninja/kache). kache directly inspired mbx
-> and has the longer production track record.
-> [Read the acknowledgements](https://mr-boxington.jdx.dev/acknowledgements).
+> [kache](https://github.com/kunobi-ninja/kache), which directly inspired its
+> design. [Read the acknowledgements](https://mr-boxington.jdx.dev/acknowledgements).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ supported compilations it has seen before. There is nothing to configure and
 nothing to install into Cargo: put `mbx` in front of the command you already
 run.
 
+> [!NOTE]
+> mbx is deeply inspired by [kache](https://github.com/kunobi-ninja/kache),
+> which demonstrated how a content-addressed Rust compiler cache could share
+> work across checkouts and machines. Its ideas helped shape mbx from the
+> beginning. kache has also been around longer and is the more proven choice
+> today. [Read the full acknowledgement](https://mr-boxington.jdx.dev/acknowledgements).
+
 ```sh
 mbx build                  # cargo build, with caching
 mbx test --all-features    # cargo test --all-features, with caching

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ nothing to install into Cargo: put `mbx` in front of the command you already
 run.
 
 > [!NOTE]
-> mbx is deeply inspired by [kache](https://github.com/kunobi-ninja/kache),
-> which demonstrated how a content-addressed Rust compiler cache could share
-> work across checkouts and machines. Its ideas helped shape mbx from the
-> beginning. kache has also been around longer and is the more proven choice
-> today. [Read the full acknowledgement](https://mr-boxington.jdx.dev/acknowledgements).
+> mbx stands on [Cargo](https://github.com/rust-lang/cargo), follows the
+> compiler-caching trail established by
+> [sccache](https://github.com/mozilla/sccache), and is deeply inspired by
+> [kache](https://github.com/kunobi-ninja/kache). kache has also been around
+> longer and is the more proven choice today.
+> [Read the full acknowledgement](https://mr-boxington.jdx.dev/acknowledgements).
 
 ```sh
 mbx build                  # cargo build, with caching

--- a/README.md
+++ b/README.md
@@ -21,14 +21,6 @@ supported compilations it has seen before. There is nothing to configure and
 nothing to install into Cargo: put `mbx` in front of the command you already
 run.
 
-> [!NOTE]
-> mbx stands on [Cargo](https://github.com/rust-lang/cargo), follows the
-> compiler-caching trail established by
-> [sccache](https://github.com/mozilla/sccache), and is deeply inspired by
-> [kache](https://github.com/kunobi-ninja/kache). kache has also been around
-> longer and is the more proven choice today.
-> [Read the full acknowledgement](https://mr-boxington.jdx.dev/acknowledgements).
-
 ```sh
 mbx build                  # cargo build, with caching
 mbx test --all-features    # cargo test --all-features, with caching
@@ -190,6 +182,13 @@ comes before hit rate.
 - [Watching builds](https://mr-boxington.jdx.dev/tui)
 - [CLI reference](https://mr-boxington.jdx.dev/cli)
 - [Current limits](https://mr-boxington.jdx.dev/limits)
+
+> [!NOTE]
+> mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
+> compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
+> [kache](https://github.com/kunobi-ninja/kache). kache directly inspired mbx
+> and has the longer production track record.
+> [Read the acknowledgements](https://mr-boxington.jdx.dev/acknowledgements).
 
 ## License
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,7 +55,6 @@ export default defineConfig({
         text: "Getting started",
         items: [
           { text: "Introduction", link: "/" },
-          { text: "Acknowledgements", link: "/acknowledgements" },
           { text: "Install and run", link: "/getting-started" },
           { text: "FAQ", link: "/faq" },
         ],
@@ -87,6 +86,7 @@ export default defineConfig({
         items: [
           { text: "How it works", link: "/how-it-works" },
           { text: "How mbx compares", link: "/compared" },
+          { text: "Acknowledgements", link: "/acknowledgements" },
           { text: "Benchmarks", link: "/benchmarks" },
           { text: "Stability", link: "/stability" },
           { text: "Protocol compatibility", link: "/protocol-compatibility" },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
         text: "Getting started",
         items: [
           { text: "Introduction", link: "/" },
+          { text: "Acknowledgements", link: "/acknowledgements" },
           { text: "Install and run", link: "/getting-started" },
           { text: "FAQ", link: "/faq" },
         ],

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -21,11 +21,10 @@ different tradeoffs.
 
 ## kache
 
-[kache](https://github.com/kunobi-ninja/kache) directly inspired mbx's design.
-It combines a content-addressed `RUSTC_WRAPPER` cache with C and C++ compiler
-shims, remote storage, and executable caching.
+[kache](https://github.com/kunobi-ninja/kache) predates mbx and directly
+inspired its design. It combines a content-addressed `RUSTC_WRAPPER` cache
+with C and C++ compiler shims, remote storage, and executable caching.
 
 The projects do not share code, and they make different tradeoffs. The
 [comparison with kache](/compared#kache) explains where mbx took a different
-direction and where kache may be the better fit. kache has a longer production
-track record and is the more proven option today.
+direction and where kache may be the better fit.

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,0 +1,24 @@
+# Acknowledgements
+
+## kache
+
+[kache](https://github.com/kunobi-ninja/kache) is the project that most
+directly inspired mbx. It demonstrated that a content-addressed
+`RUSTC_WRAPPER` cache could make compilations reusable across worktrees and
+machines, and it paired that Rust cache with C and C++ compiler shims, remote
+storage, and executable caching. Those ideas helped shape mbx from the
+beginning.
+
+mbx would look very different without the path kache opened. We are grateful
+to kache's maintainers for building it in public and giving the Rust community
+a strong foundation to learn from.
+
+The projects do not share code, and they make different tradeoffs. The
+[comparison with kache](/compared#kache) explains where mbx took a different
+direction and where kache may be the better fit. Most importantly, kache has
+been around longer and has more real-world history behind it. It is the more
+proven choice today, and that maturity may matter more than mbx's different
+tradeoffs.
+
+Those differences do not diminish the influence: kache is the closest
+antecedent to mbx, and that debt deserves to be visible.

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,5 +1,31 @@
 # Acknowledgements
 
+mbx stands on the work of Cargo, sccache, and kache. Each contributed
+something different: Cargo is the foundation, sccache established compiler
+caching in the Rust ecosystem, and kache most directly inspired mbx's design.
+
+## Cargo
+
+[Cargo](https://github.com/rust-lang/cargo) resolves dependencies, plans
+builds, and orchestrates rustc; mbx only restores supported work from around
+that process. Cargo's `RUSTC_WRAPPER` integration is the seam that makes mbx
+and other Rust compiler caches possible in the first place.
+
+We are grateful to the Cargo team and the wider Rust project for building and
+maintaining the foundation mbx relies on every time it runs.
+
+## sccache
+
+[sccache](https://github.com/mozilla/sccache) established compiler caching as
+a practical part of Rust development long before mbx existed. It showed that
+rustc work could be reused locally and through remote storage, while serving a
+broader set of compilers and use cases than mbx does.
+
+mbx makes different tradeoffs, but it follows a trail sccache helped create.
+We are grateful to its maintainers and contributors for proving and advancing
+compiler caching in the Rust ecosystem. See the
+[comparison with sccache](/compared#sccache) for where the projects differ.
+
 ## kache
 
 [kache](https://github.com/kunobi-ninja/kache) is the project that most

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,50 +1,31 @@
 # Acknowledgements
 
-mbx stands on the work of Cargo, sccache, and kache. Each contributed
-something different: Cargo is the foundation, sccache established compiler
-caching in the Rust ecosystem, and kache most directly inspired mbx's design.
+mbx relies on Cargo and follows earlier compiler-cache work in sccache and
+kache.
 
 ## Cargo
 
 [Cargo](https://github.com/rust-lang/cargo) resolves dependencies, plans
-builds, and orchestrates rustc; mbx only restores supported work from around
-that process. Cargo's `RUSTC_WRAPPER` integration is the seam that makes mbx
-and other Rust compiler caches possible in the first place.
-
-We are grateful to the Cargo team and the wider Rust project for building and
-maintaining the foundation mbx relies on every time it runs.
+builds, and orchestrates rustc. Its `RUSTC_WRAPPER` integration is what allows
+mbx and other Rust compiler caches to wrap compiler invocations.
 
 ## sccache
 
-[sccache](https://github.com/mozilla/sccache) established compiler caching as
-a practical part of Rust development long before mbx existed. It showed that
-rustc work could be reused locally and through remote storage, while serving a
-broader set of compilers and use cases than mbx does.
+[sccache](https://github.com/mozilla/sccache) predates mbx and established
+compiler caching in the Rust ecosystem. It reuses compiler work locally and
+through remote storage, and supports a broader set of compilers and use cases
+than mbx.
 
-mbx makes different tradeoffs, but it follows a trail sccache helped create.
-We are grateful to its maintainers and contributors for proving and advancing
-compiler caching in the Rust ecosystem. See the
-[comparison with sccache](/compared#sccache) for where the projects differ.
+See the [comparison with sccache](/compared#sccache) for where mbx makes
+different tradeoffs.
 
 ## kache
 
-[kache](https://github.com/kunobi-ninja/kache) is the project that most
-directly inspired mbx. It demonstrated that a content-addressed
-`RUSTC_WRAPPER` cache could make compilations reusable across worktrees and
-machines, and it paired that Rust cache with C and C++ compiler shims, remote
-storage, and executable caching. Those ideas helped shape mbx from the
-beginning.
-
-mbx would look very different without the path kache opened. We are grateful
-to kache's maintainers for building it in public and giving the Rust community
-a strong foundation to learn from.
+[kache](https://github.com/kunobi-ninja/kache) directly inspired mbx's design.
+It combines a content-addressed `RUSTC_WRAPPER` cache with C and C++ compiler
+shims, remote storage, and executable caching.
 
 The projects do not share code, and they make different tradeoffs. The
 [comparison with kache](/compared#kache) explains where mbx took a different
-direction and where kache may be the better fit. Most importantly, kache has
-been around longer and has more real-world history behind it. It is the more
-proven choice today, and that maturity may matter more than mbx's different
-tradeoffs.
-
-Those differences do not diminish the influence: kache is the closest
-antecedent to mbx, and that debt deserves to be visible.
+direction and where kache may be the better fit. kache has a longer production
+track record and is the more proven option today.

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -1,9 +1,9 @@
 # How mbx compares
 
-::: info An important influence
-mbx is deeply inspired by [kache](https://github.com/kunobi-ninja/kache), the
-project that most directly shaped it. See the
-[acknowledgements](/acknowledgements) for a fuller account of that debt.
+::: info Standing on earlier work
+mbx runs on Cargo, follows the compiler-caching trail established by sccache,
+and is deeply inspired by kache, the project that most directly shaped it. See
+the [acknowledgements](/acknowledgements) for a fuller account of those debts.
 :::
 
 ## sccache

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -54,11 +54,11 @@ cannot be combined for the same build.
 
 ## kache
 
-[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx, and
-it predates mbx and directly inspired its design. No code is shared between
-the projects, but the influence is real and worth saying plainly. mbx began as
-the Rust cache inside the [mise](https://github.com/jdx/mise) task runner and
-was extracted into its own CLI to chase three things: less to operate, a
+[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx: it
+predates mbx and directly inspired its design, though the projects share no
+code. mbx began as the Rust cache inside the
+[mise](https://github.com/jdx/mise) task runner and was extracted into its
+own CLI to chase three things: less to operate, a
 better day-to-day experience, and something safe to switch on in a public
 repository that takes fork pull requests. The differences below are mostly
 those three goals.

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -8,8 +8,8 @@ C++, and can distribute compilation across machines. mbx caches rustc, the C
 and C++ that cargo build scripts compile, the C and C++ of builds outside
 cargo through [`mbx exec`](/standalone-builds), and native links. That scope
 is narrower, and mbx spends the difference on the parts of caching that are
-not the cache: what it costs to operate, what it does to your disk, and what it is safe to
-let CI write.
+not the cache: what it costs to operate, what it does to your disk, and what
+it is safe to let CI write.
 
 - **No daemon.** sccache builds talk to a background server. It starts
   itself, but it outlives the build, keeps the configuration it was started
@@ -55,18 +55,17 @@ cannot be combined for the same build.
 ## kache
 
 [kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx, and
-mbx's design was directly inspired by it. No code is shared between the
-projects. mbx began as the Rust cache inside the
-[mise](https://github.com/jdx/mise) task runner and was extracted into its own
-CLI to chase three things: less to operate, a
+it predates mbx and directly inspired its design. No code is shared between
+the projects, but the influence is real and worth saying plainly. mbx began as
+the Rust cache inside the [mise](https://github.com/jdx/mise) task runner and
+was extracted into its own CLI to chase three things: less to operate, a
 better day-to-day experience, and something safe to switch on in a public
 repository that takes fork pull requests. The differences below are mostly
 those three goals.
 
 Like mbx, kache is a content-addressed `RUSTC_WRAPPER` cache built for sharing
 compilations across worktrees, with C and C++ compiler shims, S3-compatible
-and filesystem remotes, and executable caching on Linux and macOS. kache has
-a longer production track record than mbx and is the more proven option.
+and filesystem remotes, and executable caching on Linux and macOS.
 
 - **Nothing to install or keep running.** `kache init` installs an OS service
   by default, with a `--no-service` opt-out. mbx starts an in-process agent

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -1,5 +1,11 @@
 # How mbx compares
 
+::: info An important influence
+mbx is deeply inspired by [kache](https://github.com/kunobi-ninja/kache), the
+project that most directly shaped it. See the
+[acknowledgements](/acknowledgements) for a fuller account of that debt.
+:::
+
 ## sccache
 
 [sccache](https://github.com/mozilla/sccache) is the established compiler
@@ -54,18 +60,21 @@ cannot be combined for the same build.
 
 ## kache
 
-[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx, and
-parts of mbx's design were inspired by it. No code is shared between the
-projects, but the influence is real and worth saying plainly. mbx began as the
-Rust cache inside the [mise](https://github.com/jdx/mise) task runner and was
-extracted into its own CLI to chase three things: less to operate, a better
-day-to-day experience, and something safe to switch on in a public repository
-that takes fork pull requests. The differences below are mostly those three
-goals.
+[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx and
+the project that most directly inspired it. No code is shared between the
+projects, but the influence is substantial and worth saying plainly. mbx began
+as the Rust cache inside the [mise](https://github.com/jdx/mise) task runner
+and was extracted into its own CLI to chase three things: less to operate, a
+better day-to-day experience, and something safe to switch on in a public
+repository that takes fork pull requests. The differences below are mostly
+those three goals.
 
 Like mbx, kache is a content-addressed `RUSTC_WRAPPER` cache built for sharing
 compilations across worktrees, with C and C++ compiler shims, S3-compatible
-and filesystem remotes, and executable caching on Linux and macOS.
+and filesystem remotes, and executable caching on Linux and macOS. kache has
+also been around longer and has more real-world history behind it. It is the
+more proven choice today; if maturity is the deciding factor, that is its most
+important advantage over mbx.
 
 - **Nothing to install or keep running.** `kache init` installs an OS service
   by default, with a `--no-service` opt-out. mbx starts an in-process agent
@@ -123,10 +132,10 @@ and filesystem remotes, and executable caching on Linux and macOS.
   binary. On a host mbx cannot describe that precisely, it links normally
   rather than handing back one it cannot vouch for.
 
-If you build on Windows, or want the C and C++ shims installed once rather
-than wrapping the commands that should use them, kache is worth evaluating.
-Both tools wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
-the same build.
+If you value a longer track record, build on Windows, or want the C and C++
+shims installed once rather than wrapping the commands that should use them,
+kache is worth evaluating. Both tools wrap rustc through `RUSTC_WRAPPER`, so
+they cannot be combined for the same build.
 
 ## Tarball CI caches
 

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -1,20 +1,14 @@
 # How mbx compares
 
-::: info Standing on earlier work
-mbx runs on Cargo, follows the compiler-caching trail established by sccache,
-and is deeply inspired by kache, the project that most directly shaped it. See
-the [acknowledgements](/acknowledgements) for a fuller account of those debts.
-:::
-
 ## sccache
 
 [sccache](https://github.com/mozilla/sccache) is the established compiler
-cache, and it aims wider: it caches CUDA alongside Rust, C, and C++, and can
-distribute compilation across machines. mbx caches rustc, the C and C++ that
-cargo build scripts compile, the C and C++ of builds outside cargo through
-[`mbx exec`](/standalone-builds), and native links. That scope is narrower,
-and mbx spends the difference on the parts of caching that are not the cache:
-what it costs to operate, what it does to your disk, and what it is safe to
+cache and predates mbx. It aims wider: it caches CUDA alongside Rust, C, and
+C++, and can distribute compilation across machines. mbx caches rustc, the C
+and C++ that cargo build scripts compile, the C and C++ of builds outside
+cargo through [`mbx exec`](/standalone-builds), and native links. That scope
+is narrower, and mbx spends the difference on the parts of caching that are
+not the cache: what it costs to operate, what it does to your disk, and what it is safe to
 let CI write.
 
 - **No daemon.** sccache builds talk to a background server. It starts
@@ -60,11 +54,11 @@ cannot be combined for the same build.
 
 ## kache
 
-[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx and
-the project that most directly inspired it. No code is shared between the
-projects, but the influence is substantial and worth saying plainly. mbx began
-as the Rust cache inside the [mise](https://github.com/jdx/mise) task runner
-and was extracted into its own CLI to chase three things: less to operate, a
+[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx, and
+mbx's design was directly inspired by it. No code is shared between the
+projects. mbx began as the Rust cache inside the
+[mise](https://github.com/jdx/mise) task runner and was extracted into its own
+CLI to chase three things: less to operate, a
 better day-to-day experience, and something safe to switch on in a public
 repository that takes fork pull requests. The differences below are mostly
 those three goals.
@@ -72,9 +66,7 @@ those three goals.
 Like mbx, kache is a content-addressed `RUSTC_WRAPPER` cache built for sharing
 compilations across worktrees, with C and C++ compiler shims, S3-compatible
 and filesystem remotes, and executable caching on Linux and macOS. kache has
-also been around longer and has more real-world history behind it. It is the
-more proven choice today; if maturity is the deciding factor, that is its most
-important advantage over mbx.
+a longer production track record than mbx and is the more proven option.
 
 - **Nothing to install or keep running.** `kache init` installs an OS service
   by default, with a `--no-service` opt-out. mbx starts an in-process agent
@@ -132,10 +124,10 @@ important advantage over mbx.
   binary. On a host mbx cannot describe that precisely, it links normally
   rather than handing back one it cannot vouch for.
 
-If you value a longer track record, build on Windows, or want the C and C++
-shims installed once rather than wrapping the commands that should use them,
-kache is worth evaluating. Both tools wrap rustc through `RUSTC_WRAPPER`, so
-they cannot be combined for the same build.
+If you build on Windows, or want the C and C++ shims installed once rather
+than wrapping the commands that should use them, kache is worth evaluating.
+Both tools wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
+the same build.
 
 ## Tarball CI caches
 

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -58,10 +58,10 @@ cannot be combined for the same build.
 predates mbx and directly inspired its design, though the projects share no
 code. mbx began as the Rust cache inside the
 [mise](https://github.com/jdx/mise) task runner and was extracted into its
-own CLI to chase three things: less to operate, a
-better day-to-day experience, and something safe to switch on in a public
-repository that takes fork pull requests. The differences below are mostly
-those three goals.
+own CLI to chase three things: less to operate, a better day-to-day
+experience, and tight limits on what CI can write to a shared cache — the
+concern that matters most in a public repository that takes fork pull
+requests. The differences below are mostly those three goals.
 
 Like mbx, kache is a content-addressed `RUSTC_WRAPPER` cache built for sharing
 compilations across worktrees, with C and C++ compiler shims, S3-compatible

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,3 @@ hero:
       text: Benchmarks
       link: /benchmarks
 ---
-
-mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
-compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
-[kache](https://github.com/kunobi-ninja/kache), which directly inspired its
-design — [read the acknowledgements](/acknowledgements).

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,13 @@ hero:
       text: Benchmarks
       link: /benchmarks
 ---
+
+## With thanks to kache
+
+mbx is deeply inspired by [kache](https://github.com/kunobi-ninja/kache).
+kache demonstrated how a content-addressed Rust compiler cache could share
+work across checkouts and machines, and its ideas helped shape mbx from the
+beginning. It has also been around longer and is the more proven choice today.
+We are grateful to its maintainers for the path they opened.
+
+[Read about kache's influence on mbx →](/acknowledgements)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,14 +23,12 @@ hero:
       link: /benchmarks
 ---
 
-## With thanks to Cargo, sccache, and kache
+## Acknowledgements
 
-[Cargo](https://github.com/rust-lang/cargo) is the foundation mbx runs on, and
-its `RUSTC_WRAPPER` integration makes Rust compiler caches possible.
-[sccache](https://github.com/mozilla/sccache) established compiler caching in
-the Rust ecosystem. [kache](https://github.com/kunobi-ninja/kache) most
-directly inspired mbx's design; it has also been around longer and is the more
-proven choice today. We are grateful to all of their maintainers and
-contributors.
+mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
+compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
+[kache](https://github.com/kunobi-ninja/kache). kache directly inspired mbx's
+design and, with its longer production track record, is the more proven
+option.
 
 [Read the acknowledgements →](/acknowledgements)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,12 +23,14 @@ hero:
       link: /benchmarks
 ---
 
-## With thanks to kache
+## With thanks to Cargo, sccache, and kache
 
-mbx is deeply inspired by [kache](https://github.com/kunobi-ninja/kache).
-kache demonstrated how a content-addressed Rust compiler cache could share
-work across checkouts and machines, and its ideas helped shape mbx from the
-beginning. It has also been around longer and is the more proven choice today.
-We are grateful to its maintainers for the path they opened.
+[Cargo](https://github.com/rust-lang/cargo) is the foundation mbx runs on, and
+its `RUSTC_WRAPPER` integration makes Rust compiler caches possible.
+[sccache](https://github.com/mozilla/sccache) established compiler caching in
+the Rust ecosystem. [kache](https://github.com/kunobi-ninja/kache) most
+directly inspired mbx's design; it has also been around longer and is the more
+proven choice today. We are grateful to all of their maintainers and
+contributors.
 
-[Read about kache's influence on mbx →](/acknowledgements)
+[Read the acknowledgements →](/acknowledgements)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,12 +23,7 @@ hero:
       link: /benchmarks
 ---
 
-## Acknowledgements
-
 mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
 compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
-[kache](https://github.com/kunobi-ninja/kache). kache directly inspired mbx's
-design and, with its longer production track record, is the more proven
-option.
-
-[Read the acknowledgements →](/acknowledgements)
+[kache](https://github.com/kunobi-ninja/kache), which directly inspired its
+design — [read the acknowledgements](/acknowledgements).


### PR DESCRIPTION
## Summary

- prominently acknowledge Cargo as the foundation and integration point mbx relies on
- recognize sccache for establishing compiler caching in the Rust ecosystem
- recognize kache as mbx's closest design influence and the longer-established, more proven choice
- add a dedicated acknowledgement page to the primary docs navigation
- surface the acknowledgements on the docs homepage, README, and comparison page

## Testing

- `aube run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime, auth, or cache logic changes.
> 
> **Overview**
> Adds **public credit** for the projects mbx builds on and learns from, without changing product behavior.
> 
> A new **Acknowledgements** doc page explains how **Cargo** enables `RUSTC_WRAPPER` caching, how **sccache** established Rust compiler caching, and how **kache** predates mbx and inspired its design (with pointers to the existing comparison sections). That page is wired into the VitePress **Understand mbx** nav, and a matching **Acknowledgements** blurb plus link is added to the **README** before the license.
> 
> **`compared.md`** is lightly reworded so sccache and kache are framed as earlier work that predates mbx, and the kache section spells out mbx’s fork-PR / CI write-limit motivation more clearly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4612b79612bc5c3fa15f6267fd90283222d1e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->