### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "mbx-cache-core",
  "mbx-cache-rustc",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "blake3",
  "eyre",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.6...mbx-cache-cargo-v0.1.7) - 2026-08-29
+
+### Other
+
+- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
+
 ## [0.1.6](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.5...mbx-cache-cargo-v0.1.6) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.6"
+version = "0.1.7"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.3...mbx-cache-cc-v0.9.4) - 2026-08-29
+
+### Fixed
+
+- *(cc)* deduplicate recursive include manifests ([#210](https://github.com/jdx/mr-boxington/pull/210))
+
+### Other
+
+- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
+
 ## [0.9.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.2...mbx-cache-cc-v0.9.3) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.9.3"
+version = "0.9.4"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.3", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.3...mbx-cache-core-v0.9.4) - 2026-08-29
+
+### Other
+
+- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
+
 ## [0.9.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.2...mbx-cache-core-v0.9.3) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.9.3"
+version = "0.9.4"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.6" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.7" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.6...mbx-cache-protocol-v0.5.7) - 2026-08-29
+
+### Other
+
+- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
+
 ## [0.5.6](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.5...mbx-cache-protocol-v0.5.6) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.6"
+version = "0.5.7"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.3...mbx-cache-rustc-v0.9.4) - 2026-08-29
+
+### Other
+
+- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
+
 ## [0.9.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.2...mbx-cache-rustc-v0.9.3) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.9.3"
+version = "0.9.4"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.6...mbx-cache-store-v0.1.7) - 2026-08-29
+
+### Other
+
+- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
+
 ## [0.1.6](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.5...mbx-cache-store-v0.1.6) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.6"
+version = "0.1.7"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/jdx/mr-boxington/compare/v1.0.0...v1.0.1) - 2026-08-29
+
+### Fixed
+
+- support Jujutsu repositories in mbx exec ([#207](https://github.com/jdx/mr-boxington/pull/207))
+
+### Other
+
+- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
+
 ## [1.0.0](https://github.com/jdx/mr-boxington/compare/v0.7.2...v1.0.0) - 2026-08-29
 
 ### Other

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.0.0"
+version = "1.0.1"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.3", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.6", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.3", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.3", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.6", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.7", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.4", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.4", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.7", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.6 -> 0.5.7 (✓ API compatible changes)
* `mbx-cache-core`: 0.9.3 -> 0.9.4 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.9.3 -> 0.9.4 (✓ API compatible changes)
* `mbx-cache-cc`: 0.9.3 -> 0.9.4 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `mbx`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.6...mbx-cache-protocol-v0.5.7) - 2026-08-29

### Other

- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.3...mbx-cache-core-v0.9.4) - 2026-08-29

### Other

- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.6...mbx-cache-cargo-v0.1.7) - 2026-08-29

### Other

- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.3...mbx-cache-rustc-v0.9.4) - 2026-08-29

### Other

- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.3...mbx-cache-cc-v0.9.4) - 2026-08-29

### Fixed

- *(cc)* deduplicate recursive include manifests ([#210](https://github.com/jdx/mr-boxington/pull/210))

### Other

- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.6...mbx-cache-store-v0.1.7) - 2026-08-29

### Other

- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
</blockquote>

## `mbx`

<blockquote>

## [1.0.1](https://github.com/jdx/mr-boxington/compare/v1.0.0...v1.0.1) - 2026-08-29

### Fixed

- support Jujutsu repositories in mbx exec ([#207](https://github.com/jdx/mr-boxington/pull/207))

### Other

- recognize Cargo, sccache, and kache ([#205](https://github.com/jdx/mr-boxington/pull/205))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The release bundles cache-key and exec environment detection changes (especially CC include manifests) that can alter hit/miss behavior; the PR diff itself is mostly versioning and changelogs.
> 
> **Overview**
> This is a **release-plz** cut that bumps crate versions, refreshes `Cargo.lock`, records dated changelog entries, and updates the generated CLI docs version string—no new application logic appears in the diff itself.
> 
> **`mbx` 1.0.0 → 1.0.1** ships **Jujutsu repo support in `mbx exec`** ([#207](https://github.com/jdx/mr-boxington/pull/207)) plus broader **recognition of Cargo, sccache, and kache** ([#205](https://github.com/jdx/mr-boxington/pull/205)). Dependent **`mbx-cache-*`** crates move in step (`mbx-cache-core` / `rustc` / `cc` **0.9.4**, `mbx-cache-protocol` **0.5.7**, `mbx-cache-cargo` / `store` **0.1.7**), with path dependency version pins updated in each `Cargo.toml`.
> 
> **`mbx-cache-cc` 0.9.4** also documents a fix to **deduplicate recursive include manifests** ([#210](https://github.com/jdx/mr-boxington/pull/210)), which affects C/C++ cache key construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972e46855a267fab682cbf3762e16a2432226525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->