### PR TITLE
fix: support Jujutsu repositories in mbx exec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Instructions
+
+## Changelogs
+
+- Do not edit `CHANGELOG.md` files in ordinary pull requests. The release-plz
+  workflow generates changelog entries in release pull requests.
+- Only edit a changelog when the user explicitly requests it or when working on
+  the release process itself.

--- a/crates/mbx/src/cli.rs
+++ b/crates/mbx/src/cli.rs
@@ -882,15 +882,15 @@ fn exec(config: &Config, settings: &CliSettings, args: &ExecArgs) -> Result<Exit
     account_session(config, settings, session_outcome, None)
 }
 
-/// The root `mbx exec` keys paths against: the enclosing git checkout, so
-/// every subdirectory of one project agrees on it, or the working directory
-/// outside one.
+/// The root `mbx exec` keys paths against: the enclosing VCS checkout, so every
+/// subdirectory of one project agrees on it, or the working directory outside
+/// one.
 fn discover_project_root(working_dir: &Path) -> PathBuf {
     let mut directory = working_dir;
     loop {
-        // A plain file rather than a directory in linked worktrees, which are
-        // exactly the checkouts worth recognizing.
-        if directory.join(".git").exists() {
+        // `.git` may be a plain file in a linked worktree. Jujutsu's marker is
+        // a directory today, but existence is the useful distinction for both.
+        if directory.join(".git").exists() || directory.join(".jj").exists() {
             return directory.to_path_buf();
         }
         match directory.parent() {

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -43,6 +43,17 @@ fn falls_back_to_the_starting_directory() {
 }
 
 #[test]
+fn discovers_a_jujutsu_project_root() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    let nested = root.join("build").join("debug");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::create_dir(root.join(".jj")).unwrap();
+
+    assert_eq!(discover_project_root(&nested), root);
+}
+
+#[test]
 fn reads_both_flag_spellings() {
     let joined = ["build".to_string(), "--target-dir=/tmp/out".to_string()];
     let split = [

--- a/crates/mbx/src/cli_tests.rs
+++ b/crates/mbx/src/cli_tests.rs
@@ -43,6 +43,7 @@ fn falls_back_to_the_starting_directory() {
 }
 
 #[test]
+/// A non-colocated Jujutsu checkout is a project boundary.
 fn discovers_a_jujutsu_project_root() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path();
@@ -51,6 +52,20 @@ fn discovers_a_jujutsu_project_root() {
     std::fs::create_dir(root.join(".jj")).unwrap();
 
     assert_eq!(discover_project_root(&nested), root);
+}
+
+#[test]
+/// A nested Git checkout takes precedence over an enclosing Jujutsu checkout.
+fn discovers_a_nested_git_project_root() {
+    let directory = tempfile::tempdir().unwrap();
+    let outer = directory.path();
+    let inner = outer.join("vendor");
+    let nested = inner.join("src");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::create_dir(outer.join(".jj")).unwrap();
+    std::fs::create_dir(inner.join(".git")).unwrap();
+
+    assert_eq!(discover_project_root(&nested), inner);
 }
 
 #[test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -492,7 +492,7 @@ struct ExecIdentity<'a> {
 /// Worktrees of one project must share a manifest for predictions to travel --
 /// the cc adapter has no second way to build a key -- so the marker prefers
 /// content and origin over location: a `Cargo.lock` digest where one exists,
-/// then the git origin URL, and only then the directory name.
+/// then the Git or Jujutsu origin URL, and only then the directory name.
 pub fn exec_identity(project_root: &Path, command: &[String]) -> String {
     let project = exec_marker(project_root);
     let material = ExecIdentity {
@@ -508,7 +508,7 @@ fn exec_marker(project_root: &Path) -> String {
     if let Ok(lock) = std::fs::read(project_root.join("Cargo.lock")) {
         return CacheDigest::blake3(&lock).hash;
     }
-    if let Some(origin) = git_origin_marker(project_root) {
+    if let Some(origin) = project_origin_marker(project_root) {
         return origin;
     }
     project_root
@@ -519,22 +519,51 @@ fn exec_marker(project_root: &Path) -> String {
 }
 
 /// The origin URL names a project the same way in every worktree and clone,
-/// which a checkout's directory name does not.
-fn git_origin_marker(project_root: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
+/// which a checkout's directory name does not. Try Git first so colocated
+/// Jujutsu repositories keep exactly the identity they had before.
+fn project_origin_marker(project_root: &Path) -> Option<String> {
+    // Do not let Git walk above a non-colocated Jujutsu repository and borrow
+    // an unrelated enclosing checkout's remote.
+    if !project_root.join(".jj").exists() || project_root.join(".git").exists() {
+        let git = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["config", "--get", "remote.origin.url"])
+            .output();
+        if let Ok(output) = git
+            && output.status.success()
+        {
+            let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !url.is_empty() {
+                return Some(format!("origin\0{url}"));
+            }
+        }
+    }
+
+    let output = Command::new("jj")
+        .arg("-R")
         .arg(project_root)
-        .args(["config", "--get", "remote.origin.url"])
+        .arg("--ignore-working-copy")
+        .args(["git", "remote", "list"])
         .output()
         .ok()?;
     if !output.status.success() {
         return None;
     }
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if url.is_empty() {
-        return None;
-    }
+    let remotes = String::from_utf8_lossy(&output.stdout);
+    let url = jj_origin_url(&remotes)?;
     Some(format!("origin\0{url}"))
+}
+
+fn jj_origin_url(remotes: &str) -> Option<&str> {
+    remotes.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        if fields.next()? == "origin" {
+            fields.next()
+        } else {
+            None
+        }
+    })
 }
 
 fn action_remote_cache(config: &Config, store: &Path) -> Result<Option<AgentRemoteCache>> {

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -522,24 +522,34 @@ fn exec_marker(project_root: &Path) -> String {
 /// which a checkout's directory name does not. Try Git first so colocated
 /// Jujutsu repositories keep exactly the identity they had before.
 fn project_origin_marker(project_root: &Path) -> Option<String> {
-    // Do not let Git walk above a non-colocated Jujutsu repository and borrow
-    // an unrelated enclosing checkout's remote.
-    if !project_root.join(".jj").exists() || project_root.join(".git").exists() {
-        let git = Command::new("git")
-            .arg("-C")
-            .arg(project_root)
-            .args(["config", "--get", "remote.origin.url"])
-            .output();
-        if let Ok(output) = git
-            && output.status.success()
-        {
-            let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !url.is_empty() {
-                return Some(format!("origin\0{url}"));
-            }
-        }
+    if project_root.join(".jj").exists() && !project_root.join(".git").exists() {
+        jj_origin_marker(project_root)
+    } else {
+        git_origin_marker(project_root).or_else(|| jj_origin_marker(project_root))
     }
+}
 
+/// Read Git's origin without imposing a repository layout on explicit roots.
+fn git_origin_marker(project_root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["config", "--get", "remote.origin.url"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!url.is_empty()).then(|| format!("origin\0{url}"))
+}
+
+/// Read Jujutsu's origin only from a root that is itself a Jujutsu checkout.
+fn jj_origin_marker(project_root: &Path) -> Option<String> {
+    // Without this gate `jj -R` may discover an unrelated enclosing checkout.
+    if !project_root.join(".jj").exists() {
+        return None;
+    }
     let output = Command::new("jj")
         .arg("-R")
         .arg(project_root)
@@ -555,6 +565,7 @@ fn project_origin_marker(project_root: &Path) -> Option<String> {
     Some(format!("origin\0{url}"))
 }
 
+/// Extract the fetch URL for the conventionally named origin remote.
 fn jj_origin_url(remotes: &str) -> Option<&str> {
     remotes.lines().find_map(|line| {
         let mut fields = line.split_whitespace();

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -278,6 +278,20 @@ fn exec_identity_falls_back_to_the_directory_name() {
     );
 }
 
+#[test]
+fn reads_the_origin_from_jujutsu_remote_output() {
+    let remotes = "backup ssh://example.com/backup\norigin https://example.com/project.git\n";
+
+    assert_eq!(
+        jj_origin_url(remotes),
+        Some("https://example.com/project.git")
+    );
+    assert_eq!(
+        jj_origin_url("upstream https://example.com/project.git\n"),
+        None
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn a_shim_directory_never_supplies_the_real_compiler() {

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -279,6 +279,7 @@ fn exec_identity_falls_back_to_the_directory_name() {
 }
 
 #[test]
+/// Jujutsu's remote listing names each remote before its URL.
 fn reads_the_origin_from_jujutsu_remote_output() {
     let remotes = "backup ssh://example.com/backup\norigin https://example.com/project.git\n";
 
@@ -290,6 +291,19 @@ fn reads_the_origin_from_jujutsu_remote_output() {
         jj_origin_url("upstream https://example.com/project.git\n"),
         None
     );
+}
+
+#[test]
+/// A nested Git checkout must not inherit an enclosing Jujutsu remote.
+fn a_nested_git_checkout_does_not_query_jujutsu() {
+    let directory = tempfile::tempdir().unwrap();
+    let outer = directory.path();
+    let inner = outer.join("vendor");
+    std::fs::create_dir(&inner).unwrap();
+    std::fs::create_dir(outer.join(".jj")).unwrap();
+    std::fs::create_dir(inner.join(".git")).unwrap();
+
+    assert_eq!(jj_origin_marker(&inner), None);
 }
 
 #[cfg(unix)]

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -53,16 +53,16 @@ deliberately, and mbx stands aside rather than intercepting it.
 
 Compilation keys map the project root to a placeholder, so equivalent
 checkouts share objects even when their absolute paths differ. The project
-root is the enclosing git checkout (or the working directory outside one);
-`--project-root` overrides it.
+root is the enclosing Git or Jujutsu checkout (or the working directory
+outside one); `--project-root` overrides it.
 
 Warm lookups travel between checkouts through the build's manifest, and the
 manifest's identity must therefore name the *project*, not the checkout. It
-is derived from, in order: the `Cargo.lock` digest where one exists, the git
-`origin` remote URL, and the directory name as a last resort. A project with
-none of the first two still caches within each checkout; give worktrees the
-same directory name or pass `--project-root` through a stable path to share
-across them.
+is derived from, in order: the `Cargo.lock` digest where one exists, the Git or
+Jujutsu `origin` remote URL, and the directory name as a last resort. A project
+with none of the first two still caches within each checkout; give worktrees
+the same directory name or pass `--project-root` through a stable path to
+share across them.
 
 ## Turning it off
 


### PR DESCRIPTION
## Summary

- recognize `.jj` markers when discovering the `mbx exec` project root
- use the Jujutsu `origin` remote for prediction identity in non-colocated repositories
- preserve existing Git identity behavior for colocated repositories and document the support

## Testing

- `cargo test -p mbx`
- `cargo clippy -p mbx --all-features --all-targets -- -D warnings`
- `cargo fmt --all --check`
- validated `jj git remote list` output with jj 0.44.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `mbx exec` derives project roots and prediction manifests; mis-detection could split or merge caches across checkouts, and jj-only identity depends on `jj` being on PATH.
> 
> **Overview**
> **`mbx exec`** now treats Jujutsu checkouts like Git for project boundaries and cache sharing.
> 
> **Project root discovery** walks up for `.git` or **`.jj`**, so nested paths inside a jj repo resolve to the jj root. A **nested Git tree inside an outer jj checkout** still stops at the inner `.git`.
> 
> **Standalone build identity** (`exec_identity`) can use the **`origin` remote from Jujutsu** (`jj git remote list`) when there is no `Cargo.lock`, using the same `origin\0{url}` marker shape as Git. **Jj-only** repos use jj only; **colocated Git+jj** keeps **Git first** so existing identities do not change. Jj is only queried when `.jj` is present at the project root (avoids picking up an enclosing jj repo for a nested Git vendor tree).
> 
> Docs and **`AGENTS.md`** (changelog policy) are updated; tests cover jj root discovery, remote parsing, and nested-git behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d458b91f107ef35314c6ac97e8ae2e11ddf0a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Jujutsu project roots.
  * Standalone builds can now share identity across Jujutsu checkouts using the configured `origin` remote.
  * Git remains preferred for repositories that combine Git and Jujutsu.

* **Documentation**
  * Updated standalone-build guidance to cover Git and Jujutsu checkouts.

* **Tests**
  * Added coverage for Jujutsu project-root detection and remote parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->