### PR TITLE
fix(cc): deduplicate recursive include manifests

### DIFF
--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -315,16 +315,61 @@ impl CcDiscoveredInputs {
 /// the manifest-entry budget even though the ancestor already names every
 /// includable file below it.
 fn minimal_manifest_directories(directories: BTreeSet<PathBuf>) -> Vec<PathBuf> {
-    let mut minimal = Vec::<PathBuf>::new();
-    for directory in directories {
+    let mut directories = directories
+        .into_iter()
+        .map(|directory| {
+            let normalized = normalize_components(&directory);
+            (directory, normalized)
+        })
+        .collect::<Vec<_>>();
+    directories.sort_by(|(left, left_normalized), (right, right_normalized)| {
+        left_normalized
+            .components()
+            .count()
+            .cmp(&right_normalized.components().count())
+            .then_with(|| left_normalized.cmp(right_normalized))
+            .then_with(|| left.cmp(right))
+    });
+
+    let mut minimal = Vec::<(PathBuf, PathBuf)>::new();
+    for (directory, normalized) in directories {
         if !minimal
             .iter()
-            .any(|ancestor| directory.starts_with(ancestor))
+            .any(|(_, ancestor)| manifest_covers(ancestor, &normalized))
         {
-            minimal.push(directory);
+            minimal.push((directory, normalized));
         }
     }
     minimal
+        .into_iter()
+        .map(|(directory, _)| directory)
+        .collect()
+}
+
+/// Whether walking `ancestor` recursively is guaranteed to visit `descendant`.
+///
+/// Component-aware normalization rejects a lexical prefix that escapes through
+/// `..`. Directory symlinks need an explicit check because `read_dir` follows
+/// the directory it starts at but the recursive walk deliberately does not
+/// follow symlink entries beneath it.
+fn manifest_covers(ancestor: &Path, descendant: &Path) -> bool {
+    let Ok(relative) = descendant.strip_prefix(ancestor) else {
+        return false;
+    };
+    if relative.as_os_str().is_empty() {
+        return false;
+    }
+    let mut current = ancestor.to_path_buf();
+    for component in relative.components() {
+        current.push(component);
+        let Ok(metadata) = std::fs::symlink_metadata(&current) else {
+            return false;
+        };
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return false;
+        }
+    }
+    true
 }
 
 fn is_manifest_input(path: &Path) -> bool {

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -160,6 +160,7 @@ impl CcDiscoveredInputs {
                 working_dir.to_path_buf(),
             ));
         }
+        let directories = minimal_manifest_directories(directories);
         if files.len() + directories.len() > MAX_PREDICTED_INPUTS {
             return Err(CcBypassReason::TooManyInputs);
         }
@@ -306,6 +307,26 @@ impl CcDiscoveredInputs {
     }
 }
 
+/// Drop include directories already covered by an ancestor's recursive manifest.
+///
+/// Discovered headers often contribute hundreds of nested parent directories,
+/// especially for amalgamated C sources. Keeping both an ancestor and its
+/// descendants walks and hashes the same subtree repeatedly, and can exhaust
+/// the manifest-entry budget even though the ancestor already names every
+/// includable file below it.
+fn minimal_manifest_directories(directories: BTreeSet<PathBuf>) -> Vec<PathBuf> {
+    let mut minimal = Vec::<PathBuf>::new();
+    for directory in directories {
+        if !minimal
+            .iter()
+            .any(|ancestor| directory.starts_with(ancestor))
+        {
+            minimal.push(directory);
+        }
+    }
+    minimal
+}
+
 fn is_manifest_input(path: &Path) -> bool {
     path.to_str()
         .is_some_and(|path| path.starts_with(INCLUDE_MANIFEST_PREFIX))
@@ -322,10 +343,10 @@ pub fn manifest_snapshot(
     directories: &BTreeSet<PathBuf>,
 ) -> Result<BTreeMap<PathBuf, CacheDigest>, CcBypassReason> {
     let mut budget = 0_usize;
-    directories
-        .iter()
+    minimal_manifest_directories(directories.iter().cloned().collect())
+        .into_iter()
         .map(|directory| {
-            include_manifest(directory, &mut budget).map(|digest| (directory.clone(), digest))
+            include_manifest(&directory, &mut budget).map(|digest| (directory, digest))
         })
         .collect()
 }

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -57,6 +57,22 @@ fn write(directory: &Path, name: &str, contents: &str) -> PathBuf {
 }
 
 #[test]
+fn recursive_manifests_drop_directories_an_ancestor_already_covers() {
+    let root = PathBuf::from("/workspace/include");
+    let directories = BTreeSet::from([
+        root.join("crypto/fipsmodule"),
+        root.clone(),
+        root.join("crypto"),
+        PathBuf::from("/workspace/generated"),
+    ]);
+
+    assert_eq!(
+        minimal_manifest_directories(directories),
+        [PathBuf::from("/workspace/generated"), root]
+    );
+}
+
+#[test]
 fn timestamp_macro_tokens_in_any_read_file_bypass() {
     let directory = tempfile::tempdir().expect("tempdir");
     let root = directory.path();

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -58,17 +58,52 @@ fn write(directory: &Path, name: &str, contents: &str) -> PathBuf {
 
 #[test]
 fn recursive_manifests_drop_directories_an_ancestor_already_covers() {
-    let root = PathBuf::from("/workspace/include");
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let root = workspace.path().join("include");
+    let generated = workspace.path().join("generated");
+    std::fs::create_dir_all(root.join("crypto/fipsmodule")).expect("nested include directory");
+    std::fs::create_dir_all(&generated).expect("separate include directory");
     let directories = BTreeSet::from([
         root.join("crypto/fipsmodule"),
         root.clone(),
         root.join("crypto"),
-        PathBuf::from("/workspace/generated"),
+        generated.clone(),
     ]);
 
+    assert_eq!(minimal_manifest_directories(directories), [generated, root]);
+}
+
+#[test]
+fn a_parent_path_does_not_cover_a_directory_that_escapes_through_dot_dot() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let include = workspace.path().join("include");
+    let sibling = workspace.path().join("sibling");
+    std::fs::create_dir_all(&include).expect("include directory");
+    std::fs::create_dir_all(&sibling).expect("sibling directory");
+    let escaped = include.join("../sibling");
+
     assert_eq!(
-        minimal_manifest_directories(directories),
-        [PathBuf::from("/workspace/generated"), root]
+        minimal_manifest_directories(BTreeSet::from([include.clone(), escaped.clone()])),
+        [include, escaped]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_parent_manifest_does_not_claim_a_directory_reached_through_a_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let include = workspace.path().join("include");
+    let generated = workspace.path().join("generated");
+    std::fs::create_dir_all(&include).expect("include directory");
+    std::fs::create_dir_all(generated.join("nested")).expect("generated directory");
+    symlink(&generated, include.join("linked")).expect("directory symlink");
+    let linked = include.join("linked/nested");
+
+    assert_eq!(
+        minimal_manifest_directories(BTreeSet::from([include.clone(), linked.clone()])),
+        [include, linked]
     );
 }
 


### PR DESCRIPTION
## Summary

- collapse nested include directories when an ancestor recursive manifest already covers them
- apply the same reduction to pre-compilation search-path snapshots
- prevent amalgamated C builds from exhausting the manifest-entry budget on repeated subtree walks

## Benchmark

Fresh hk checkouts sharing only `MBX_CACHE_DIR`, with managed target views disabled to match GitHub Actions:

- before: 781 hits, 9 unconsulted; ~2.1s compiler work; ~6.5s session
- after learning the new key: 782 hits, 8 unconsulted; ~0.44s compiler work; ~5.0s session
- `aws-lc-sys` `bcm.c` changes from a repeated ~1.7s uncached compile to a hit

## Validation

- `cargo test --workspace`
- repeated local hk cold-runner benchmark

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CC cache key inputs (include manifests); incorrect deduplication could weaken shadow-header detection, though `..` and symlink guards aim to stay conservative.
> 
> **Overview**
> **Collapses redundant include-directory manifests** when a shallower directory’s recursive walk already covers nested search paths, so amalgamated C builds stop walking and hashing the same subtree many times and are less likely to hit manifest-entry / predicted-input limits.
> 
> `CcDiscoveredInputs::collect` and `manifest_snapshot` now run discovered directories through `minimal_manifest_directories` before budgeting and digesting. Coverage uses normalized path components plus a `manifest_covers` walk that rejects `..` escape prefixes and (on Unix) paths reached through directory symlinks, so parents are not dropped when they would not actually subsume a descendant.
> 
> Tests lock in keeping only `generated` and root for a nested tree, preserving both paths for `../sibling`, and keeping both parent and symlink-linked nested dirs on Unix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa618fd235eadd0293f5bb2ef40eade35db15ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced redundant processing when generating recursive include-directory manifests.
  * Improved predicted-input counting by avoiding repeated hashing of directories already covered by an ancestor.

* **Bug Fixes**
  * Ensured nested include directories are correctly omitted when their parent directory is already included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->