### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "blake3",
  "eyre",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.7...mbx-cache-cargo-v0.1.8) - 2026-08-30
+
+### Added
+
+- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
+- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
+
+### Other
+
+- *(mbx)* split CLI commands into modules ([#212](https://github.com/jdx/mr-boxington/pull/212))
+
 ## [0.1.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.6...mbx-cache-cargo-v0.1.7) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.7"
+version = "0.1.8"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.4...mbx-cache-cc-v0.10.0) - 2026-08-30
+
+### Added
+
+- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
+- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
+- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
+- *(mbx)* prescribe fixes for cache bypasses ([#222](https://github.com/jdx/mr-boxington/pull/222))
+
+### Other
+
+- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
+
 ## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.3...mbx-cache-cc-v0.9.4) - 2026-08-29
 
 ### Fixed

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.9.4"
+version = "0.10.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.4...mbx-cache-core-v0.10.0) - 2026-08-30
+
+### Added
+
+- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
+- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
+- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
+- *(cache)* export portable build closures ([#227](https://github.com/jdx/mr-boxington/pull/227))
+
+### Other
+
+- *(cache)* start prediction prefetch earlier ([#220](https://github.com/jdx/mr-boxington/pull/220))
+- remove pre-v1 format fallbacks ([#219](https://github.com/jdx/mr-boxington/pull/219))
+- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
+- *(core)* split cache agent modules ([#217](https://github.com/jdx/mr-boxington/pull/217))
+
 ## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.3...mbx-cache-core-v0.9.4) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.9.4"
+version = "0.10.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.7" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.8" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.7...mbx-cache-protocol-v0.5.8) - 2026-08-30
+
+### Added
+
+- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
+- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
+
 ## [0.5.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.6...mbx-cache-protocol-v0.5.7) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.7"
+version = "0.5.8"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.4...mbx-cache-rustc-v0.10.0) - 2026-08-30
+
+### Added
+
+- cache build script execution ([#225](https://github.com/jdx/mr-boxington/pull/225))
+- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
+- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
+- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
+- *(mbx)* prescribe fixes for cache bypasses ([#222](https://github.com/jdx/mr-boxington/pull/222))
+
+### Fixed
+
+- *(rustc)* compact large action predictions ([#218](https://github.com/jdx/mr-boxington/pull/218))
+
+### Other
+
+- remove pre-v1 format fallbacks ([#219](https://github.com/jdx/mr-boxington/pull/219))
+- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
+
 ## [0.9.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.3...mbx-cache-rustc-v0.9.4) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.9.4"
+version = "0.10.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.7...mbx-cache-store-v0.1.8) - 2026-08-30
+
+### Added
+
+- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
+- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
+- *(cache)* export portable build closures ([#227](https://github.com/jdx/mr-boxington/pull/227))
+
+### Fixed
+
+- *(cache)* import exported sparse files ([#228](https://github.com/jdx/mr-boxington/pull/228))
+
 ## [0.1.7](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.6...mbx-cache-store-v0.1.7) - 2026-08-29
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.7"
+version = "0.1.8"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/jdx/mr-boxington/compare/v1.0.1...v1.1.0) - 2026-08-30
+
+### Added
+
+- cache build script execution ([#225](https://github.com/jdx/mr-boxington/pull/225))
+- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
+- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
+- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
+- *(cache)* export portable build closures ([#227](https://github.com/jdx/mr-boxington/pull/227))
+- *(mbx)* prescribe fixes for cache bypasses ([#222](https://github.com/jdx/mr-boxington/pull/222))
+
+### Fixed
+
+- *(rustc)* compact large action predictions ([#218](https://github.com/jdx/mr-boxington/pull/218))
+
+### Other
+
+- remove pre-v1 format fallbacks ([#219](https://github.com/jdx/mr-boxington/pull/219))
+- *(mbx)* split session responsibilities ([#216](https://github.com/jdx/mr-boxington/pull/216))
+- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
+- *(mbx)* split CLI commands into modules ([#212](https://github.com/jdx/mr-boxington/pull/212))
+
 ## [1.0.1](https://github.com/jdx/mr-boxington/compare/v1.0.0...v1.0.1) - 2026-08-29
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.0.1"
+version = "1.1.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.7", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.4", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.4", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.7", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.8", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.8", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.0.1
+**Version:** 1.1.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.7 -> 0.5.8 (✓ API compatible changes)
* `mbx-cache-core`: 0.9.4 -> 0.10.0 (⚠ API breaking changes)
* `mbx-cache-cargo`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `mbx-cache-cc`: 0.9.4 -> 0.10.0 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.9.4 -> 0.10.0 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `mbx`: 1.0.1 -> 1.1.0 (✓ API compatible changes)

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:ActionPromise in /tmp/.tmpx179px/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:339
  variant AgentResponse:ActionPromiseCompleted in /tmp/.tmpx179px/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:346
  variant AgentRequest:JoinActionPromise in /tmp/.tmpx179px/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:160
  variant AgentRequest:CompleteActionPromise in /tmp/.tmpx179px/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:167
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.7...mbx-cache-protocol-v0.5.8) - 2026-08-30

### Added

- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.4...mbx-cache-core-v0.10.0) - 2026-08-30

### Added

- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
- *(cache)* export portable build closures ([#227](https://github.com/jdx/mr-boxington/pull/227))

### Other

- *(cache)* start prediction prefetch earlier ([#220](https://github.com/jdx/mr-boxington/pull/220))
- remove pre-v1 format fallbacks ([#219](https://github.com/jdx/mr-boxington/pull/219))
- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
- *(core)* split cache agent modules ([#217](https://github.com/jdx/mr-boxington/pull/217))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.7...mbx-cache-cargo-v0.1.8) - 2026-08-30

### Added

- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))

### Other

- *(mbx)* split CLI commands into modules ([#212](https://github.com/jdx/mr-boxington/pull/212))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.4...mbx-cache-cc-v0.10.0) - 2026-08-30

### Added

- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
- *(mbx)* prescribe fixes for cache bypasses ([#222](https://github.com/jdx/mr-boxington/pull/222))

### Other

- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.4...mbx-cache-rustc-v0.10.0) - 2026-08-30

### Added

- cache build script execution ([#225](https://github.com/jdx/mr-boxington/pull/225))
- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
- *(mbx)* prescribe fixes for cache bypasses ([#222](https://github.com/jdx/mr-boxington/pull/222))

### Fixed

- *(rustc)* compact large action predictions ([#218](https://github.com/jdx/mr-boxington/pull/218))

### Other

- remove pre-v1 format fallbacks ([#219](https://github.com/jdx/mr-boxington/pull/219))
- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.7...mbx-cache-store-v0.1.8) - 2026-08-30

### Added

- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
- *(cache)* export portable build closures ([#227](https://github.com/jdx/mr-boxington/pull/227))

### Fixed

- *(cache)* import exported sparse files ([#228](https://github.com/jdx/mr-boxington/pull/228))
</blockquote>

## `mbx`

<blockquote>

## [1.1.0](https://github.com/jdx/mr-boxington/compare/v1.0.1...v1.1.0) - 2026-08-30

### Added

- cache build script execution ([#225](https://github.com/jdx/mr-boxington/pull/225))
- *(cache)* deduplicate in-flight work across runners ([#223](https://github.com/jdx/mr-boxington/pull/223))
- cache Windows links and MSVC compiles ([#224](https://github.com/jdx/mr-boxington/pull/224))
- cache rustdoc actions ([#226](https://github.com/jdx/mr-boxington/pull/226))
- *(cache)* export portable build closures ([#227](https://github.com/jdx/mr-boxington/pull/227))
- *(mbx)* prescribe fixes for cache bypasses ([#222](https://github.com/jdx/mr-boxington/pull/222))

### Fixed

- *(rustc)* compact large action predictions ([#218](https://github.com/jdx/mr-boxington/pull/218))

### Other

- remove pre-v1 format fallbacks ([#219](https://github.com/jdx/mr-boxington/pull/219))
- *(mbx)* split session responsibilities ([#216](https://github.com/jdx/mr-boxington/pull/216))
- share cache path mapping ([#215](https://github.com/jdx/mr-boxington/pull/215))
- *(mbx)* split CLI commands into modules ([#212](https://github.com/jdx/mr-boxington/pull/212))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly release metadata, but publishing `mbx-cache-core` 0.10.0 breaks Rust API matches on agent wire enums and bundles cache-format and behavior changes from the listed PRs.
> 
> **Overview**
> Release-plz **version bump** for **mbx 1.1.0** and aligned workspace crates (`mbx-cache-core` **0.10.0**, `mbx-cache-cc` / `mbx-cache-rustc` **0.10.0**, `mbx-cache-protocol` **0.5.8**, `mbx-cache-cargo` / `mbx-cache-store` **0.1.8**), with matching `Cargo.lock` path dependency pins and **1.1.0** in generated CLI docs.
> 
> Each crate gets a dated **2026-08-30** changelog section documenting what ships in this tag: broader caching (build scripts, rustdoc, Windows link/MSVC), **in-flight action deduplication** across runners, portable build closure export/import (plus sparse import fix), cache-bypass prescriptions, removal of pre-v1 format fallbacks, and internal refactors (CLI modules, session/agent splits, shared path mapping).
> 
> **`mbx-cache-core` 0.10.0** is called out as semver-breaking for embedders: new exhaustive **`AgentRequest` / `AgentResponse`** variants for action promises (`JoinActionPromise`, `CompleteActionPromise`, `ActionPromise`, `ActionPromiseCompleted`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc19f5ebfd51f9fbff675679c4a01a196eb58fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->