### PR TITLE
refactor: share cache path mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,6 @@ name = "mbx-cache-cc"
 version = "0.9.4"
 dependencies = [
  "mbx-cache-core",
- "mbx-cache-rustc",
  "serde",
  "serde_json",
  "strum",

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 
 [dependencies]
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
@@ -27,9 +26,6 @@ tempfile = "3"
 
 [features]
 default = ["rustls"]
-native-tls = ["mbx-cache-core/native-tls", "mbx-cache-rustc/native-tls"]
-rustls = ["mbx-cache-core/rustls", "mbx-cache-rustc/rustls"]
-rustls-native-roots = [
-  "mbx-cache-core/rustls-native-roots",
-  "mbx-cache-rustc/rustls-native-roots",
-]
+native-tls = ["mbx-cache-core/native-tls"]
+rustls = ["mbx-cache-core/rustls"]
+rustls-native-roots = ["mbx-cache-core/rustls-native-roots"]

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -17,8 +17,10 @@
 //! roots are checkout-specific.
 #![deny(missing_docs)]
 
-use mbx_cache_core::{CacheDigest, FileDigestCache, canonical_json};
-use mbx_cache_rustc::{BypassReason as RustcBypassReason, PathMapping, normalize_mapped_path};
+use mbx_cache_core::{
+    CacheDigest, FileDigestCache, PathMapping, PathNormalizationError, canonical_json,
+    normalize_mapped_path,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
@@ -385,14 +387,11 @@ pub enum CcBypassReason {
     Serialization(String),
 }
 
-impl From<RustcBypassReason> for CcBypassReason {
-    /// Translate the shared path-normalization errors into this adapter's own
-    /// reasons, so a cc bypass never reports a rustc kind.
-    fn from(reason: RustcBypassReason) -> Self {
+impl From<PathNormalizationError> for CcBypassReason {
+    fn from(reason: PathNormalizationError) -> Self {
         match reason {
-            RustcBypassReason::UnmappedAbsolutePath(path) => Self::UnmappedAbsolutePath(path),
-            RustcBypassReason::NonUtf8Path(path) => Self::NonUtf8Path(path),
-            other => Self::UnknownFlag(other.kind().into()),
+            PathNormalizationError::UnmappedAbsolutePath(path) => Self::UnmappedAbsolutePath(path),
+            PathNormalizationError::NonUtf8Path(path) => Self::NonUtf8Path(path),
         }
     }
 }

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -39,6 +39,7 @@ use url::Url;
 mod agent;
 mod client;
 mod local;
+mod path_mapping;
 mod remote_http;
 mod remote_s3;
 mod sigv4;
@@ -62,6 +63,10 @@ pub use mbx_cache_protocol::{
     DirectoryNode as CacheDirectoryNode, FileNode as CacheFileNode, MAX_ACTION_PREDICTION_PAYLOAD,
     NAMESPACE_HEADER, PROTOCOL_HEADER, PROTOCOL_VERSION, RustcMetadata,
     SymlinkNode as CacheSymlinkNode, TASK_ACTION_MANIFEST_MEDIA_TYPE, TaskActionManifest,
+};
+pub use path_mapping::{
+    PathMapping, PathNormalizationError, normalize_mapped_path, normalize_resolved_mapped_path,
+    resolve_path_mappings,
 };
 use remote_http::HttpRemoteCache;
 #[cfg(feature = "fuzzing")]

--- a/crates/mbx-cache-core/src/path_mapping.rs
+++ b/crates/mbx-cache-core/src/path_mapping.rs
@@ -1,0 +1,186 @@
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+/// Mapping from a host-specific absolute root to a stable key placeholder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathMapping {
+    /// Absolute host path to replace.
+    pub root: PathBuf,
+    /// Placeholder name without the surrounding `${...}` syntax.
+    pub placeholder: String,
+}
+
+impl PathMapping {
+    /// Map an absolute host path to a stable cache-key placeholder.
+    pub fn new(root: impl Into<PathBuf>, placeholder: impl Into<String>) -> Self {
+        Self {
+            root: root.into(),
+            placeholder: placeholder.into(),
+        }
+    }
+
+    /// Order mappings deepest root first, which is what normalization needs.
+    pub fn ordered(mappings: &[PathMapping]) -> Vec<PathMapping> {
+        let mut ordered = mappings.to_vec();
+        ordered.sort_by_key(|mapping| std::cmp::Reverse(mapping.root.components().count()));
+        ordered
+    }
+}
+
+/// Why a path could not be represented with the configured mappings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathNormalizationError {
+    /// An absolute path has no matching stable placeholder.
+    UnmappedAbsolutePath(PathBuf),
+    /// A path component cannot be represented in the UTF-8 cache key.
+    NonUtf8Path(PathBuf),
+}
+
+impl fmt::Display for PathNormalizationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnmappedAbsolutePath(path) => {
+                write!(
+                    formatter,
+                    "absolute path has no stable cache mapping: {}",
+                    path.display()
+                )
+            }
+            Self::NonUtf8Path(path) => {
+                write!(
+                    formatter,
+                    "cache key paths must be valid UTF-8: {}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PathNormalizationError {}
+
+/// Map an absolute path to its cache-key placeholder form.
+///
+/// `mappings` must already be ordered by [`PathMapping::ordered`]. Existing
+/// path aliases are resolved while a not-yet-created suffix is preserved.
+pub fn normalize_mapped_path(
+    path: &Path,
+    working_dir: &Path,
+    mappings: &[PathMapping],
+) -> Result<String, PathNormalizationError> {
+    let mappings = resolve_path_mappings(mappings);
+    normalize_resolved_mapped_path(path, working_dir, &mappings)
+}
+
+/// Resolve filesystem aliases in mapping roots once for repeated lookups.
+///
+/// The returned mappings retain the caller's order and can be passed to
+/// [`normalize_resolved_mapped_path`].
+pub fn resolve_path_mappings(mappings: &[PathMapping]) -> Vec<PathMapping> {
+    mappings
+        .iter()
+        .map(|mapping| PathMapping {
+            root: resolve_mapping_root(&mapping.root),
+            placeholder: mapping.placeholder.clone(),
+        })
+        .collect()
+}
+
+/// Normalize a path against mapping roots already resolved by
+/// [`resolve_path_mappings`].
+pub fn normalize_resolved_mapped_path(
+    path: &Path,
+    working_dir: &Path,
+    mappings: &[PathMapping],
+) -> Result<String, PathNormalizationError> {
+    let absolute = if path.is_absolute() {
+        normalize_components(path)
+    } else {
+        normalize_components(&working_dir.join(path))
+    };
+    let resolved = if absolute.is_absolute() {
+        resolve_path_aliases(&absolute)
+    } else {
+        absolute.clone()
+    };
+    for mapping in mappings {
+        if let Ok(relative) = resolved.strip_prefix(&mapping.root) {
+            let suffix = slash_path(relative)?;
+            return Ok(if suffix.is_empty() {
+                format!("${{{}}}", mapping.placeholder)
+            } else {
+                format!("${{{}}}/{suffix}", mapping.placeholder)
+            });
+        }
+    }
+    Err(PathNormalizationError::UnmappedAbsolutePath(absolute))
+}
+
+#[cfg(unix)]
+fn resolve_path_aliases(path: &Path) -> PathBuf {
+    let mut existing = path;
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::canonicalize(existing) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return normalize_components(&resolved);
+            }
+            Err(_) => {
+                let Some(name) = existing.file_name() else {
+                    return path.to_path_buf();
+                };
+                missing.push(name.to_os_string());
+                let Some(parent) = existing.parent() else {
+                    return path.to_path_buf();
+                };
+                existing = parent;
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn resolve_path_aliases(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+fn resolve_mapping_root(root: &Path) -> PathBuf {
+    let root = normalize_components(root);
+    if root.is_absolute() {
+        resolve_path_aliases(&root)
+    } else {
+        root
+    }
+}
+
+fn normalize_components(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn slash_path(path: &Path) -> Result<String, PathNormalizationError> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(
+                value
+                    .to_str()
+                    .map(ToOwned::to_owned)
+                    .ok_or_else(|| PathNormalizationError::NonUtf8Path(path.to_path_buf())),
+            ),
+            _ => None,
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|components| components.join("/"))
+}

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -28,7 +28,11 @@
 //! ```
 #![deny(missing_docs)]
 
-use mbx_cache_core::{CacheDigest, FileDigestCache, canonical_json};
+use mbx_cache_core::{
+    CacheDigest, FileDigestCache, PathNormalizationError, canonical_json,
+    normalize_mapped_path as normalize_shared_path,
+    normalize_resolved_mapped_path as normalize_resolved_shared_path, resolve_path_mappings,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
@@ -38,6 +42,7 @@ use thiserror::Error;
 mod dep_info;
 
 pub use dep_info::{DepInfoCommand, DiscoveredInputs, RustcDepInfo};
+pub use mbx_cache_core::PathMapping;
 
 /// Schema version embedded in canonical rustc action descriptors.
 pub const ACTION_SCHEMA_VERSION: u8 = 1;
@@ -56,6 +61,15 @@ impl BypassReason {
     /// aggregated; statistics group by this instead.
     pub fn kind(&self) -> &'static str {
         self.into()
+    }
+}
+
+impl From<PathNormalizationError> for BypassReason {
+    fn from(reason: PathNormalizationError) -> Self {
+        match reason {
+            PathNormalizationError::UnmappedAbsolutePath(path) => Self::UnmappedAbsolutePath(path),
+            PathNormalizationError::NonUtf8Path(path) => Self::NonUtf8Path(path),
+        }
     }
 }
 
@@ -678,33 +692,6 @@ impl RustcOutputs {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// Mapping from a host-specific absolute root to a stable key placeholder.
-pub struct PathMapping {
-    /// Absolute host path to replace.
-    pub root: PathBuf,
-    /// Placeholder name without the surrounding `${...}` syntax.
-    pub placeholder: String,
-}
-
-impl PathMapping {
-    /// Map an absolute host path to a stable cache-key placeholder.
-    pub fn new(root: impl Into<PathBuf>, placeholder: impl Into<String>) -> Self {
-        Self {
-            root: root.into(),
-            placeholder: placeholder.into(),
-        }
-    }
-
-    /// Order mappings deepest root first, which is what normalization needs:
-    /// a target directory inside the workspace has to win over the workspace.
-    pub fn ordered(mappings: &[PathMapping]) -> Vec<PathMapping> {
-        let mut ordered = mappings.to_vec();
-        ordered.sort_by_key(|mapping| std::cmp::Reverse(mapping.root.components().count()));
-        ordered
-    }
-}
-
 /// Map an absolute path to its cache-key placeholder form.
 ///
 /// `mappings` must already be ordered by [`PathMapping::ordered`]. Exposed for
@@ -716,86 +703,7 @@ pub fn normalize_mapped_path(
     working_dir: &Path,
     mappings: &[PathMapping],
 ) -> Result<String, BypassReason> {
-    let mappings = mappings
-        .iter()
-        .map(|mapping| PathMapping {
-            root: resolve_mapping_root(&mapping.root),
-            placeholder: mapping.placeholder.clone(),
-        })
-        .collect::<Vec<_>>();
-    normalize_resolved_mapped_path(path, working_dir, &mappings)
-}
-
-fn normalize_resolved_mapped_path(
-    path: &Path,
-    working_dir: &Path,
-    mappings: &[PathMapping],
-) -> Result<String, BypassReason> {
-    let absolute = if path.is_absolute() {
-        normalize_components(path)
-    } else {
-        normalize_components(&working_dir.join(path))
-    };
-    let resolved = if absolute.is_absolute() {
-        resolve_path_aliases(&absolute)
-    } else {
-        absolute.clone()
-    };
-    for mapping in mappings {
-        if let Ok(relative) = resolved.strip_prefix(&mapping.root) {
-            let suffix = slash_path(relative)?;
-            return Ok(if suffix.is_empty() {
-                format!("${{{}}}", mapping.placeholder)
-            } else {
-                format!("${{{}}}/{suffix}", mapping.placeholder)
-            });
-        }
-    }
-    Err(BypassReason::UnmappedAbsolutePath(absolute))
-}
-
-/// Resolve aliases in the existing prefix while preserving a not-yet-created
-/// output suffix. Cargo and rustc may spell the same macOS temporary directory
-/// as `/var/...` and `/private/var/...`; comparing only lexical paths makes a
-/// target mapping miss even though both names identify the same directory.
-#[cfg(unix)]
-fn resolve_path_aliases(path: &Path) -> PathBuf {
-    let mut existing = path;
-    let mut missing = Vec::new();
-    loop {
-        match std::fs::canonicalize(existing) {
-            Ok(mut resolved) => {
-                for component in missing.iter().rev() {
-                    resolved.push(component);
-                }
-                return normalize_components(&resolved);
-            }
-            Err(_) => {
-                let Some(name) = existing.file_name() else {
-                    return path.to_path_buf();
-                };
-                missing.push(name.to_os_string());
-                let Some(parent) = existing.parent() else {
-                    return path.to_path_buf();
-                };
-                existing = parent;
-            }
-        }
-    }
-}
-
-#[cfg(not(unix))]
-fn resolve_path_aliases(path: &Path) -> PathBuf {
-    path.to_path_buf()
-}
-
-fn resolve_mapping_root(root: &Path) -> PathBuf {
-    let root = normalize_components(root);
-    if root.is_absolute() {
-        resolve_path_aliases(&root)
-    } else {
-        root
-    }
+    normalize_shared_path(path, working_dir, mappings).map_err(Into::into)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1677,14 +1585,7 @@ struct ActionBuilder<'a> {
 impl<'a> ActionBuilder<'a> {
     fn new(invocation: &'a RustcInvocation, mut context: ActionContext) -> Self {
         context.path_mappings = PathMapping::ordered(&context.path_mappings);
-        let mappings = context
-            .path_mappings
-            .iter()
-            .map(|mapping| PathMapping {
-                root: resolve_mapping_root(&mapping.root),
-                placeholder: mapping.placeholder.clone(),
-            })
-            .collect();
+        let mappings = resolve_path_mappings(&context.path_mappings);
         Self {
             linker: None,
             invocation,
@@ -1893,7 +1794,8 @@ impl<'a> ActionBuilder<'a> {
     }
 
     fn normalize_path(&self, path: &Path) -> Result<String, BypassReason> {
-        normalize_resolved_mapped_path(path, &self.context.working_dir, &self.mappings)
+        normalize_resolved_shared_path(path, &self.context.working_dir, &self.mappings)
+            .map_err(Into::into)
     }
 }
 
@@ -1955,21 +1857,6 @@ fn absolute_path(path: &Path, working_dir: &Path) -> PathBuf {
     } else {
         normalize_components(&working_dir.join(path))
     }
-}
-
-fn slash_path(path: &Path) -> Result<String, BypassReason> {
-    path.components()
-        .filter_map(|component| match component {
-            Component::Normal(value) => Some(
-                value
-                    .to_str()
-                    .map(ToOwned::to_owned)
-                    .ok_or_else(|| BypassReason::NonUtf8Path(path.to_path_buf())),
-            ),
-            _ => None,
-        })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|components| components.join("/"))
 }
 
 #[cfg(test)]

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -29,8 +29,8 @@
 #![deny(missing_docs)]
 
 use mbx_cache_core::{
-    CacheDigest, FileDigestCache, PathNormalizationError, canonical_json,
-    normalize_mapped_path as normalize_shared_path,
+    CacheDigest, FileDigestCache, PathMapping as SharedPathMapping, PathNormalizationError,
+    canonical_json, normalize_mapped_path as normalize_shared_path,
     normalize_resolved_mapped_path as normalize_resolved_shared_path, resolve_path_mappings,
 };
 use serde::{Deserialize, Serialize};
@@ -42,7 +42,6 @@ use thiserror::Error;
 mod dep_info;
 
 pub use dep_info::{DepInfoCommand, DiscoveredInputs, RustcDepInfo};
-pub use mbx_cache_core::PathMapping;
 
 /// Schema version embedded in canonical rustc action descriptors.
 pub const ACTION_SCHEMA_VERSION: u8 = 1;
@@ -692,6 +691,40 @@ impl RustcOutputs {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Mapping from a host-specific absolute root to a stable key placeholder.
+pub struct PathMapping {
+    /// Absolute host path to replace.
+    pub root: PathBuf,
+    /// Placeholder name without the surrounding `${...}` syntax.
+    pub placeholder: String,
+}
+
+impl PathMapping {
+    /// Map an absolute host path to a stable cache-key placeholder.
+    pub fn new(root: impl Into<PathBuf>, placeholder: impl Into<String>) -> Self {
+        Self {
+            root: root.into(),
+            placeholder: placeholder.into(),
+        }
+    }
+
+    /// Order mappings deepest root first, which is what normalization needs:
+    /// a target directory inside the workspace has to win over the workspace.
+    pub fn ordered(mappings: &[PathMapping]) -> Vec<PathMapping> {
+        let mut ordered = mappings.to_vec();
+        ordered.sort_by_key(|mapping| std::cmp::Reverse(mapping.root.components().count()));
+        ordered
+    }
+}
+
+fn shared_path_mappings(mappings: &[PathMapping]) -> Vec<SharedPathMapping> {
+    mappings
+        .iter()
+        .map(|mapping| SharedPathMapping::new(&mapping.root, &mapping.placeholder))
+        .collect()
+}
+
 /// Map an absolute path to its cache-key placeholder form.
 ///
 /// `mappings` must already be ordered by [`PathMapping::ordered`]. Exposed for
@@ -703,7 +736,7 @@ pub fn normalize_mapped_path(
     working_dir: &Path,
     mappings: &[PathMapping],
 ) -> Result<String, BypassReason> {
-    normalize_shared_path(path, working_dir, mappings).map_err(Into::into)
+    normalize_shared_path(path, working_dir, &shared_path_mappings(mappings)).map_err(Into::into)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1578,14 +1611,14 @@ fn parse_emits(value: &str) -> Vec<Emit> {
 struct ActionBuilder<'a> {
     invocation: &'a RustcInvocation,
     context: ActionContext,
-    mappings: Vec<PathMapping>,
+    mappings: Vec<SharedPathMapping>,
     linker: Option<LinkerIdentity>,
 }
 
 impl<'a> ActionBuilder<'a> {
     fn new(invocation: &'a RustcInvocation, mut context: ActionContext) -> Self {
         context.path_mappings = PathMapping::ordered(&context.path_mappings);
-        let mappings = resolve_path_mappings(&context.path_mappings);
+        let mappings = resolve_path_mappings(&shared_path_mappings(&context.path_mappings));
         Self {
             linker: None,
             invocation,

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -25,10 +25,9 @@ use mbx_cache_cc::{
 };
 use mbx_cache_core::{
     ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode,
-    CcMetadata, FileDigestScope, FileIdentity, RecordedFileDigest, RemoteActionResult,
-    RestoreStats, canonical_json,
+    CcMetadata, FileDigestScope, FileIdentity, PathMapping, RecordedFileDigest, RemoteActionResult,
+    RestoreStats, canonical_json, normalize_mapped_path,
 };
-use mbx_cache_rustc::{PathMapping, normalize_mapped_path};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};
@@ -547,6 +546,13 @@ fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
     mappings
 }
 
+fn rustc_path_mappings(mappings: &[PathMapping]) -> Vec<mbx_cache_rustc::PathMapping> {
+    mappings
+        .iter()
+        .map(|mapping| mbx_cache_rustc::PathMapping::new(&mapping.root, &mapping.placeholder))
+        .collect()
+}
+
 fn session_path(name: &str) -> Option<PathBuf> {
     std::env::var_os(name)
         .filter(|value| !value.is_empty())
@@ -742,6 +748,7 @@ fn restore_result(
     restore_outputs: bool,
     mappings: &[PathMapping],
 ) -> Result<Option<CachedCompilation>> {
+    let text_mappings = rustc_path_mappings(mappings);
     let responses = session::request_agent(&[AgentRequest::FindActionResult {
         action: action.digest.clone(),
     }])?;
@@ -793,11 +800,11 @@ fn restore_result(
     // that belong to the checkout that published it.
     let stdout = denormalize_output_text(
         &read_verified_blob(&blobs[0], &metadata.stdout, "stdout")?,
-        mappings,
+        &text_mappings,
     );
     let stderr = denormalize_output_text(
         &read_verified_blob(&blobs[1], &metadata.stderr, "stderr")?,
-        mappings,
+        &text_mappings,
     );
 
     let materialization_started = Instant::now();
@@ -902,6 +909,7 @@ fn publish_result(
     output: &Output,
     mappings: &[PathMapping],
 ) -> Result<()> {
+    let text_mappings = rustc_path_mappings(mappings);
     let object = invocation.output();
     let metadata = std::fs::metadata(object)
         .wrap_err_with(|| format!("failed to inspect cc output {}", object.display()))?;
@@ -913,12 +921,12 @@ fn publish_result(
     let stdout = staged_bytes(
         staging.path(),
         "stdout",
-        &normalize_output_text(&output.stdout, mappings),
+        &normalize_output_text(&output.stdout, &text_mappings),
     )?;
     let stderr = staged_bytes(
         staging.path(),
         "stderr",
-        &normalize_output_text(&output.stderr, mappings),
+        &normalize_output_text(&output.stderr, &text_mappings),
     )?;
     blobs.extend([stdout.clone(), stderr.clone()]);
 


### PR DESCRIPTION
Move host-path normalization into `mbx-cache-core` with a compiler-neutral error type. The rustc adapter retains its existing public wrapper and error behavior, while the C/C++ adapter now depends directly on the shared primitive instead of importing and translating Rust-specific bypass reasons.

This removes the `mbx-cache-cc -> mbx-cache-rustc` dependency and its feature forwarding.

Checks:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change is mostly a lift-and-shift of cache-key path logic shared by cc and rustc; incorrect wiring could change action keys or bypass reasons, but the refactor is structural with explicit error translation rather than new semantics.
> 
> **Overview**
> **Host path normalization for cache keys** now lives in `mbx-cache-core` (`path_mapping` module) with a compiler-neutral `PathNormalizationError`, instead of being owned by the rustc adapter.
> 
> The **C/C++ adapter** (`mbx-cache-cc`) drops its dependency on `mbx-cache-rustc` and uses the shared API directly; TLS feature flags on `mbx-cache-cc` only forward to `mbx-cache-core` now. The **rustc adapter** keeps its public `PathMapping` / `normalize_mapped_path` surface and maps core errors into `BypassReason` via delegation. The **mbx cc shim** builds mappings from core and converts them to rustc’s mapping type only where cached stdout/stderr still need rustc-shaped placeholders for denormalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a2fd03f63f986787e5200e899c94d83e0239c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->