### PR TITLE
fix(rustc): compact large action predictions

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -33,7 +33,7 @@ use mbx_cache_core::{
     canonical_json, normalize_mapped_path as normalize_shared_path,
     normalize_resolved_mapped_path as normalize_resolved_shared_path, resolve_path_mappings,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
@@ -109,6 +109,10 @@ const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
 
 const NATIVE_DIRECTORY_PREDICTION_PREFIX: &str = "@native-directory:";
 const MAX_PREDICTED_INPUTS: usize = 16 * 1024;
+// A compact payload is capped on the wire by the protocol. Bound its expanded
+// form too, so a hostile prefix chain cannot turn a small manifest into an
+// unreasonable allocation while it is being decoded.
+const MAX_DECODED_PREDICTION_BYTES: usize = 16 * 1024 * 1024;
 const MAX_NATIVE_INPUT_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
 /// Built-in WebAssembly targets whose default linkers and CRT inputs ship in
@@ -658,14 +662,13 @@ impl RustcInvocation {
                 inputs.insert(normalized);
             }
         }
-        let has_native_directory = !native_directories.is_empty();
         inputs.extend(
             native_directories
                 .into_iter()
                 .map(|directory| format!("{NATIVE_DIRECTORY_PREDICTION_PREFIX}{directory}")),
         );
         Ok(RustcInputPrediction {
-            version: if has_native_directory { 3 } else { 1 },
+            version: 4,
             inputs: inputs.into_iter().collect(),
             environment: discovered.environment.keys().cloned().collect(),
             compiler_duration_ns: 0,
@@ -821,8 +824,7 @@ pub struct RustcAction {
 
 /// Normalized input names from the last successful execution of one modeled
 /// rustc invocation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustcInputPrediction {
     /// Prediction schema version.
     pub version: u8,
@@ -832,11 +834,115 @@ pub struct RustcInputPrediction {
     pub environment: Vec<String>,
     /// Compiler wall time from the successful invocation that produced this
     /// prediction. Zero means no timing hint was recorded.
-    #[serde(default, skip_serializing_if = "is_zero")]
     pub compiler_duration_ns: u64,
     /// Crate name associated with the timing hint.
-    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub crate_name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RustcInputPredictionWire {
+    version: u8,
+    inputs: Vec<String>,
+    environment: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    compiler_duration_ns: u64,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    crate_name: String,
+}
+
+impl Serialize for RustcInputPrediction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        RustcInputPredictionWire {
+            version: self.version,
+            inputs: if self.version == 4 {
+                compact_prediction_inputs(&self.inputs)
+            } else {
+                self.inputs.clone()
+            },
+            environment: self.environment.clone(),
+            compiler_duration_ns: self.compiler_duration_ns,
+            crate_name: self.crate_name.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RustcInputPrediction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = RustcInputPredictionWire::deserialize(deserializer)?;
+        let inputs = if wire.version == 4 {
+            expand_prediction_inputs(&wire.inputs).map_err(serde::de::Error::custom)?
+        } else {
+            wire.inputs
+        };
+        Ok(Self {
+            version: wire.version,
+            inputs,
+            environment: wire.environment,
+            compiler_duration_ns: wire.compiler_duration_ns,
+            crate_name: wire.crate_name,
+        })
+    }
+}
+
+fn compact_prediction_inputs(inputs: &[String]) -> Vec<String> {
+    let mut previous = "";
+    inputs
+        .iter()
+        .map(|input| {
+            let mut shared = previous
+                .bytes()
+                .zip(input.bytes())
+                .take_while(|(left, right)| left == right)
+                .count();
+            while !input.is_char_boundary(shared) {
+                shared -= 1;
+            }
+            let compact = format!("{shared}:{}", &input[shared..]);
+            previous = input;
+            compact
+        })
+        .collect()
+}
+
+fn expand_prediction_inputs(inputs: &[String]) -> Result<Vec<String>, &'static str> {
+    let mut expanded: Vec<String> = Vec::with_capacity(inputs.len());
+    let mut decoded_bytes = 0_usize;
+    for input in inputs {
+        let (shared_text, suffix) = input
+            .split_once(':')
+            .ok_or("compact rustc prediction input has no prefix length")?;
+        let shared: usize = shared_text
+            .parse()
+            .map_err(|_| "compact rustc prediction prefix length is invalid")?;
+        if shared.to_string() != shared_text
+            || shared > expanded.last().map_or(0, String::len)
+            || expanded
+                .last()
+                .is_some_and(|previous| !previous.is_char_boundary(shared))
+        {
+            return Err("compact rustc prediction prefix is not canonical");
+        }
+        let mut path = expanded
+            .last()
+            .map_or_else(String::new, |previous| previous[..shared].to_string());
+        path.push_str(suffix);
+        decoded_bytes = decoded_bytes
+            .checked_add(path.len())
+            .ok_or("compact rustc prediction is too large")?;
+        if decoded_bytes > MAX_DECODED_PREDICTION_BYTES {
+            return Err("compact rustc prediction is too large");
+        }
+        expanded.push(path);
+    }
+    Ok(expanded)
 }
 
 fn is_zero(value: &u64) -> bool {
@@ -852,7 +958,7 @@ impl RustcInputPrediction {
         path_mappings: &[PathMapping],
         digests: &dyn FileDigestCache,
     ) -> Result<DiscoveredInputs, BypassReason> {
-        if !matches!(self.version, 1..=3) {
+        if !matches!(self.version, 1..=4) {
             return Err(BypassReason::UnsupportedPrediction);
         }
         if self.inputs.len() > MAX_PREDICTED_INPUTS || self.environment.len() > 4 * 1024 {

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -195,7 +195,7 @@ fn tracks_native_search_path_contents_but_still_rejects_native_libraries() {
         ..context(&[])
     };
     let prediction = invocation.prediction(&action_context, &discovered).unwrap();
-    assert_eq!(prediction.version, 3);
+    assert_eq!(prediction.version, 4);
     std::fs::write(native.join("added.lib"), "second").unwrap();
     let predicted = prediction
         .discover(
@@ -773,6 +773,56 @@ fn reads_prediction_v1_without_timing_hints() {
         payload,
         "pre-timing canonical predictions must remain canonical"
     );
+}
+
+#[test]
+fn compact_prediction_keeps_large_source_lists_recordable() {
+    let inputs = (0..4_000)
+        .map(|index| {
+            format!(
+                "${{workspace}}/src/commands/very_long_module_name_{index:0>5}/implementation.rs"
+            )
+        })
+        .collect::<Vec<_>>();
+    let prediction = RustcInputPrediction {
+        version: 4,
+        inputs,
+        environment: vec!["OUT_DIR".into()],
+        compiler_duration_ns: 42,
+        crate_name: "mise".into(),
+    };
+
+    let mut uncompressed = prediction.clone();
+    uncompressed.version = 3;
+    let uncompressed_payload = canonical_json(&uncompressed).unwrap();
+    assert!(
+        uncompressed_payload.len() > mbx_cache_core::MAX_ACTION_PREDICTION_PAYLOAD,
+        "the fixture must reproduce the old payload rejection"
+    );
+    let payload = canonical_json(&prediction).unwrap();
+    assert!(
+        payload.len() <= mbx_cache_core::MAX_ACTION_PREDICTION_PAYLOAD,
+        "a compact prediction must fit the protocol payload limit, got {} bytes",
+        payload.len()
+    );
+    assert!(
+        payload.len() * 2 < uncompressed_payload.len(),
+        "front coding should materially reduce a source-heavy prediction"
+    );
+    assert_eq!(
+        serde_json::from_slice::<RustcInputPrediction>(&payload).unwrap(),
+        prediction
+    );
+}
+
+#[test]
+fn rejects_noncanonical_compact_prediction_prefixes() {
+    for payload in [
+        r#"{"version":4,"inputs":["1:path"],"environment":[]}"#,
+        r#"{"version":4,"inputs":["0:path","01:other"],"environment":[]}"#,
+    ] {
+        assert!(serde_json::from_str::<RustcInputPrediction>(payload).is_err());
+    }
 }
 
 #[test]

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1036,7 +1036,7 @@ fn decode_prediction_timing(
         bail!("cache agent returned an incompatible rustc timing prediction");
     }
     let timing: RustcInputPrediction = serde_json::from_str(&prediction.payload)?;
-    if !matches!(timing.version, 1..=3)
+    if !matches!(timing.version, 1..=4)
         || timing.crate_name.len() > 256
         || timing.crate_name.contains(['\0', '\n', '\r'])
         || String::from_utf8(canonical_json(&timing)?)? != prediction.payload


### PR DESCRIPTION
## Summary

- front-code sorted rustc input paths in prediction schema v4
- expand v4 paths before action-key reconstruction while retaining exact v1-v3 compatibility
- bound decoded prediction size and reject malformed/noncanonical prefix references

## Why

The mise Windows unit job produces genuine dep-info for the `mise` crate whose canonical prediction is 262,752–263,393 bytes, just over the 262,144-byte protocol limit. mbx rejects that entire prediction, preventing later runners from deriving an action key. This keeps the protocol limit in place while making large, source-heavy predictions substantially cheaper.

## Validation

- `cargo test -p mbx-cache-rustc`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- all 30 Bats end-to-end tests
- two local mise workspace checks with isolated target directories and a shared cache

The regression fixture is deliberately too large for the old format, verifies the compact payload fits, requires at least a 2x reduction, and round-trips the expanded prediction.

The local mise run recorded its prediction without the oversized-payload warning. On the second empty target, mbx derived an action key for `mise` (it was reported as a miss rather than unconsulted), while restoring 1,486 other compilations. The `mise` action itself had changed, so this validates the fixed prediction/lookup path but does not claim a `mise` hit or a measured end-to-end speedup yet.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*