### PR TITLE
refactor: remove pre-v1 format fallbacks

### DIFF
--- a/crates/mbx-cache-core/src/agent/wire.rs
+++ b/crates/mbx-cache-core/src/agent/wire.rs
@@ -62,7 +62,6 @@ pub enum AgentRequest {
         /// Restoration work performed by the adapter.
         restore: RestoreStats,
         /// Compiler crate name, when the invocation supplied one.
-        #[serde(default)]
         crate_name: Option<String>,
     },
     /// A compilation the adapter declined to cache, grouped by reason.

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -958,7 +958,7 @@ impl RustcInputPrediction {
         path_mappings: &[PathMapping],
         digests: &dyn FileDigestCache,
     ) -> Result<DiscoveredInputs, BypassReason> {
-        if !matches!(self.version, 1..=4) {
+        if !matches!(self.version, 2..=4) {
             return Err(BypassReason::UnsupportedPrediction);
         }
         if self.inputs.len() > MAX_PREDICTED_INPUTS || self.environment.len() > 4 * 1024 {

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -763,15 +763,19 @@ fn a_native_search_directory_is_predicted_by_name_not_by_its_contents() {
 }
 
 #[test]
-fn reads_prediction_v1_without_timing_hints() {
-    let payload = r#"{"environment":[],"inputs":[],"version":1}"#;
-    let prediction: RustcInputPrediction = serde_json::from_str(payload).unwrap();
-    assert_eq!(prediction.compiler_duration_ns, 0);
-    assert!(prediction.crate_name.is_empty());
+fn prediction_v1_is_unsupported() {
+    let prediction: RustcInputPrediction =
+        serde_json::from_str(r#"{"environment":[],"inputs":[],"version":1}"#).unwrap();
     assert_eq!(
-        String::from_utf8(canonical_json(&prediction).unwrap()).unwrap(),
-        payload,
-        "pre-timing canonical predictions must remain canonical"
+        prediction
+            .discover(
+                Path::new("/work/one"),
+                &[],
+                &mbx_cache_core::NoFileDigestCache,
+            )
+            .unwrap_err()
+            .kind(),
+        "unsupported-prediction"
     );
 }
 

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -884,7 +884,6 @@ fn record_prediction(
         )?;
         let invocation_digest = invocation.invocation_digest(&context)?;
         let mut prediction = invocation.prediction(&context, discovered)?;
-        prediction.version = prediction.version.max(2);
         prediction.compiler_duration_ns = timing.duration_ns;
         prediction.crate_name.clone_from(&timing.crate_name);
         let payload = String::from_utf8(canonical_json(&prediction)?)?;
@@ -1005,7 +1004,6 @@ fn refresh_prediction(
     // build just saved any less real.
     let recorded = (|| {
         let mut prediction = compilation.invocation.prediction(&context, discovered)?;
-        prediction.version = prediction.version.max(2);
         prediction.compiler_duration_ns = timing.duration_ns;
         prediction.crate_name.clone_from(&timing.crate_name);
         let payload = String::from_utf8(canonical_json(&prediction)?)?;
@@ -1036,7 +1034,7 @@ fn decode_prediction_timing(
         bail!("cache agent returned an incompatible rustc timing prediction");
     }
     let timing: RustcInputPrediction = serde_json::from_str(&prediction.payload)?;
-    if !matches!(timing.version, 1..=4)
+    if !matches!(timing.version, 2..=4)
         || timing.crate_name.len() > 256
         || timing.crate_name.contains(['\0', '\n', '\r'])
         || String::from_utf8(canonical_json(&timing)?)? != prediction.payload

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -100,6 +100,26 @@ fn compiler_timing_survives_a_changed_action_key() {
     assert_eq!(decoded.duration_ns, 42);
 }
 
+#[test]
+fn prediction_v1_does_not_supply_timing() {
+    let invocation = CacheDigest::blake3(b"invocation");
+    let timing = RustcInputPrediction {
+        version: 1,
+        inputs: Vec::new(),
+        environment: Vec::new(),
+        compiler_duration_ns: 42,
+        crate_name: "demo".into(),
+    };
+    let prediction = ActionPrediction {
+        invocation: invocation.clone(),
+        action: CacheDigest::blake3(b"old action"),
+        adapter: "rustc".into(),
+        payload: String::from_utf8(canonical_json(&timing).unwrap()).unwrap(),
+    };
+
+    assert!(decode_prediction_timing(&prediction, &invocation).is_err());
+}
+
 /// `--remap-path-prefix` covers the paths rustc writes itself, so most
 /// artifacts come out clean. A crate that keeps the value as a string does
 /// not, and that is the case the outputs are read to catch.

--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -428,10 +428,6 @@ struct MemoryLedger {
     version: u8,
     crates: BTreeMap<String, u64>,
     /// Recent link measurements, newest last, whatever crate they came from.
-    ///
-    /// Defaulted rather than versioned: a ledger written before this existed
-    /// reads as one with no link history, which is exactly what it is.
-    #[serde(default)]
     link_peaks: Vec<u64>,
 }
 

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -449,33 +449,6 @@ fn a_measurement_that_changes_nothing_leaves_the_ledger_alone() {
     );
 }
 
-/// A ledger written before the window existed reads as one with no link
-/// history, which is what it is.
-#[test]
-fn a_ledger_without_a_link_window_still_loads() {
-    let directory = tempfile::tempdir().unwrap();
-    let pool = pool_at(directory.path(), 8, 1000);
-    std::fs::create_dir_all(directory.path()).unwrap();
-    std::fs::write(
-        pool.ledger_path(),
-        br#"{"version":1,"crates":{"widget [link]":4000}}"#,
-    )
-    .unwrap();
-
-    let ledger = read_ledger(&pool.ledger_path());
-    assert!(ledger.link_peaks.is_empty());
-    assert_eq!(
-        pool.plan(&Demand::new("widget", true)),
-        (4, Some(4000)),
-        "the entries it does carry still count"
-    );
-    assert_eq!(
-        pool.plan(&Demand::new("unseen", true)),
-        (LINK_WEIGHT, Some(LINK_WEIGHT * 1000)),
-        "and an empty window leaves the static weight standing"
-    );
-}
-
 #[test]
 fn the_ledger_only_remembers_what_matters_and_never_shrinks_a_peak() {
     let directory = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- retire Rust prediction schema v1 while retaining v2, v3, and current v4
- remove the now-redundant runtime upgrade from prediction v1 to v2
- require the current agent v5 `record_action_hit` shape to include `crate_name`
- stop loading scheduler ledgers from before the link-peak window existed
- keep all shipped protocol, action-key, and current prediction version numbers unchanged

These are strict-reader cleanups, not Rust API or current wire-format breaks. Active v1 CLI releases write Rust predictions v2/v3, agent protocol v5 requires an exact protocol and application-version handshake, and v1 scheduler ledgers always contain `link_peaks`. Current main writes prediction v4.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p mbx-cache-rustc --all-features`
- `cargo test -p mbx --lib rustc::tests`
- `cargo test -p mbx --lib scheduler::tests`
- `cargo test -p mbx-cache-core --all-features`
- `cargo test -p mbx-cache-core --test agent_protocol`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Strict deserialization can break very old cached predictions, agent requests, or scheduler ledger files still in use; current writers already emit v2+ predictions, v5 hits with crate_name, and ledgers with link_peaks.
> 
> **Overview**
> Removes **backward-compatibility paths** for older on-disk and wire shapes now that current releases only emit supported formats.
> 
> **Rust input predictions** no longer accept schema **v1**: `discover` and `decode_prediction_timing` only allow **v2–v4**, and the runtime no longer bumps stored predictions with `version.max(2)`. v1 payloads fail as unsupported or invalid timing rather than being upgraded in place.
> 
> **Agent protocol v5** treats `RecordActionHit.crate_name` as a normal field (drops `#[serde(default)]`), so requests must deserialize with the current shape.
> 
> **Scheduler memory ledgers** drop `#[serde(default)]` on `link_peaks` and the test that loaded pre-window ledger JSON; ledgers without `link_peaks` are no longer accepted as empty history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5c94cce6336d8b67f7f1c924a29ee8fdd99655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->