### PR TITLE
perf(cache): start prediction prefetch earlier

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -522,6 +522,23 @@ impl CacheAgent {
 
     async fn begin_task_with_remote_errors(&self, task: &str, strict: bool) -> Result<String> {
         validate_task_identity(task)?;
+        // The local manifest is already enough to start useful work. Do not
+        // leave those predictions idle while a high-latency remote answers the
+        // manifest lookup; the authoritative snapshot is loaded again below
+        // before it is merged, so another process can still update it while
+        // this request is in flight.
+        let early_predictions = {
+            let _write_guard = self.manifest_write_lock.lock().unwrap();
+            let _file_guard = self.lock_task_manifest(task)?;
+            self.load_task_manifest(task)?
+                .map(|manifest| manifest.predictions)
+                .unwrap_or_default()
+        };
+        let early_actions: BTreeSet<_> = early_predictions
+            .iter()
+            .map(|prediction| prediction.action.clone())
+            .collect();
+        self.spawn_prefetch_predictions(early_predictions);
         let (remote_manifest, mut remote_etag) = if self.remote_mode.reads() {
             match self.get_remote_task_manifest(task).await {
                 Ok(Some((manifest, etag))) => (Some(manifest), Some(etag)),
@@ -591,7 +608,15 @@ impl CacheAgent {
             state.predictions.len().try_into().unwrap_or(u64::MAX),
             Ordering::Relaxed,
         );
-        let predictions = state.predictions.values().cloned().collect();
+        // The early local wave already owns these actions. Only launch a
+        // second wave for predictions learned from the remote or from a local
+        // writer that committed while its lookup was in flight.
+        let predictions = state
+            .predictions
+            .values()
+            .filter(|prediction| !early_actions.contains(&prediction.action))
+            .cloned()
+            .collect();
         self.task_actions.lock().unwrap().insert(run.clone(), state);
         self.spawn_prefetch_predictions(predictions);
         Ok(run)

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -99,12 +99,6 @@ impl CacheAgent {
         &self,
         actions: &BTreeMap<CacheDigest, String>,
     ) -> Result<bool> {
-        let Some(remote) = self.remote.as_deref() else {
-            return Ok(false);
-        };
-        let Some(limit) = remote.action_batch_limit().await? else {
-            return Ok(false);
-        };
         let wanted: Vec<CacheDigest> = actions
             .keys()
             .filter(|action| !self.action_is_staged(action))
@@ -113,6 +107,16 @@ impl CacheAgent {
         if wanted.is_empty() {
             return Ok(true);
         }
+        // A warm local store needs no remote capability negotiation. Keep this
+        // check ahead of the first await: on a high-latency cache, asking what
+        // batch shape it supports can otherwise add a full network round trip
+        // to a build that has nothing left to download.
+        let Some(remote) = self.remote.as_deref() else {
+            return Ok(false);
+        };
+        let Some(limit) = remote.action_batch_limit().await? else {
+            return Ok(false);
+        };
         let mut chunks: Vec<Vec<CacheDigest>> = Vec::new();
         for chunk in wanted.chunks(limit) {
             chunks.push(chunk.to_vec());

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1279,6 +1279,95 @@ async fn prefetch_does_not_block_task_initialization() {
 }
 
 #[tokio::test]
+async fn local_predictions_start_prefetching_while_the_remote_manifest_loads() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    mock_agent_capabilities(&mut server, serde_json::json!({})).await;
+    let task = "5".repeat(64);
+    let action_bytes = b"locally predicted action";
+    let action = CacheDigest::blake3(action_bytes);
+    let prediction = ActionPrediction {
+        invocation: CacheDigest::blake3(b"local invocation"),
+        action: action.clone(),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let manifest_value = TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.clone(),
+        predictions: vec![prediction],
+    };
+    let manifest_bytes = canonical_json(&manifest_value).unwrap();
+    let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+    let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+    let release = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let response_release = release.clone();
+    let remote_manifest = server
+        .mock("GET", action_manifest_path(&selector).as_str())
+        .with_status(200)
+        .with_header("etag", &format!("\"{manifest_etag}\""))
+        .with_chunked_body(move |writer| {
+            while !response_release.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            std::io::Write::write_all(writer, &manifest_bytes)
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let response_started = started.clone();
+    let result = RemoteActionResult {
+        action: action.clone(),
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+    let action_result = server
+        .mock("GET", action_path(&action).as_str())
+        .with_status(200)
+        .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+        .with_chunked_body(move |writer| {
+            response_started.store(true, Ordering::Release);
+            std::io::Write::write_all(writer, &serde_json::to_vec(&result).unwrap())
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let action_blob = server
+        .mock("GET", blob_path(&action).as_str())
+        .with_status(200)
+        .with_body(action_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+    agent.persist_task_manifest(&manifest_value).unwrap();
+
+    let begin_agent = agent.clone();
+    let begin_task = tokio::spawn(async move { begin_agent.begin_task(&task).await });
+    let prefetched_before_manifest = tokio::time::timeout(Duration::from_secs(2), async {
+        while !started.load(Ordering::Acquire) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    release.store(true, Ordering::Release);
+    prefetched_before_manifest.expect("local prefetch waited for the remote manifest");
+    begin_task.await.unwrap().unwrap();
+    agent.wait_for_prefetches().await;
+
+    remote_manifest.assert_async().await;
+    action_result.assert_async().await;
+    action_blob.assert_async().await;
+    assert!(agent.actions.find(&action).unwrap().is_some());
+}
+
+#[tokio::test]
 async fn prefetches_complete_actions_in_directory_wave_blob_packs() {
     let directory = tempfile::tempdir().unwrap();
     let mut server = mockito::Server::new_async().await;
@@ -2433,6 +2522,32 @@ async fn prefetch_resolves_predicted_actions_in_one_lookup() {
         assert!(agent.actions.find(&result.action).unwrap().is_some());
     }
     assert_eq!(agent.stats().remote_action_lookups, 1);
+}
+
+#[tokio::test]
+async fn prefetch_skips_remote_negotiation_when_every_action_is_local() {
+    let directory = tempfile::tempdir().unwrap();
+    let server = mockito::Server::new_async().await;
+    let action = CacheDigest::blake3(b"already local action");
+    let result = RemoteActionResult {
+        action: action.clone(),
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+    let action_source = directory.path().join("already-local-action");
+    fs::write(&action_source, b"already local action").unwrap();
+    agent.cas.store_file(&action, &action_source).unwrap();
+    agent.actions.store(&result).unwrap();
+    let actions = BTreeMap::from([(action, "rustc".into())]);
+
+    assert!(agent.prefetch_action_batches(&actions).await.unwrap());
+    assert_eq!(agent.stats().remote_action_lookups, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- start downloading actions from the local prediction manifest while the remote manifest lookup is still in flight
- launch a second prefetch wave only for newly merged predictions
- skip remote batch-capability negotiation when every predicted action is already local

## Tests

- `cargo test -p mbx-cache-core`
- `cargo clippy -p mbx-cache-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task-start ordering and duplicate prefetch deduplication; incorrect filtering could skip needed downloads, though manifest locks and action-level staging limit exposure and new tests cover the timing paths.
> 
> **Overview**
> Improves remote-cache warmup by overlapping prediction prefetch with slow manifest I/O instead of waiting for the authoritative merge to finish.
> 
> **`begin_task`** now reads the on-disk task manifest under the existing manifest lock, starts prefetch for those predictions immediately, then still fetches and merges the remote manifest. After merge, a **second prefetch wave** runs only for actions that were not already covered by that early local set (remote-only or locally updated while the remote lookup was in flight).
> 
> **`prefetch_action_batches`** checks whether anything still needs fetching (`action_is_staged`) **before** the first `await` for remote batch-capability negotiation, so a fully warm local store avoids an extra round trip.
> 
> New tests assert local prefetch begins while the remote manifest response is held open, and that batch prefetch does not hit the remote when every action is already local.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91217f62d3d5ed2df905968a539792a7f3be06ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->