### PR TITLE
feat(mbx): prescribe fixes for cache bypasses

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -161,6 +161,15 @@ fn bypass_kinds_are_stable_and_field_independent() {
     }
 }
 
+#[test]
+fn actionable_bypasses_carry_remediation() {
+    let remediation = CcBypassReason::UnsupportedEnvironment("CPATH".into())
+        .remediation()
+        .unwrap();
+    assert!(remediation.contains("Unset"));
+    assert!(CcBypassReason::CompilerQuery.remediation().is_none());
+}
+
 fn argv(values: &[&str]) -> Vec<OsString> {
     values.iter().map(OsString::from).collect()
 }

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -219,6 +219,36 @@ impl CcBypassReason {
     pub fn kind(&self) -> &'static str {
         self.into()
     }
+
+    /// A concrete change that can make this invocation cacheable, when one is
+    /// available.
+    ///
+    /// Expected compiler probes and failures that require adapter support
+    /// return `None`; callers can still explain those from
+    /// [`CcBypassReason::kind`].
+    pub fn remediation(&self) -> Option<&'static str> {
+        match self {
+            Self::UnsupportedEnvironment(_) => Some(
+                "Unset the reported environment variable for this build so the compiler invocation describes all of its inputs.",
+            ),
+            Self::LocalCpuTarget(_) => Some(
+                "Replace the reported local-CPU option with an explicit architecture or CPU name.",
+            ),
+            Self::EmbeddedTimestampMacro(_) => Some(
+                "Remove the reported timestamp macro, or keep this compilation uncached if its changing value is intentional.",
+            ),
+            Self::SearchPathModifiedDuringCompilation(_) => Some(
+                "Generate headers before compilation instead of changing an include directory while the compiler is running.",
+            ),
+            Self::UnknownFlag(_) | Self::ToolPassthrough(_) => Some(
+                "Remove the reported compiler option, or upgrade mbx if the option should be modeled.",
+            ),
+            Self::UnmappedAbsolutePath(_) => Some(
+                "Move the input under a mapped project or system root, or keep this compilation uncached.",
+            ),
+            _ => None,
+        }
+    }
 }
 
 /// Reason a C or C++ invocation cannot safely use the action cache.

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -72,6 +72,9 @@ impl BypassReason {
             Self::Incremental => Some(
                 "Set `MBX_INCREMENTAL=0`; mbx will then disable Cargo incremental state and cache the compilation.",
             ),
+            Self::UnportableNativeLink(detail) if detail.contains("linker") => Some(
+                "Make the native linker resolvable on `PATH`, or configure a linker mbx can identify for this target.",
+            ),
             Self::UnportableNativeLink(_) => Some(
                 "Remove the reported `-C` option from the active Cargo profile or `RUSTFLAGS` to make these links cacheable.",
             ),

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -61,6 +61,32 @@ impl BypassReason {
     pub fn kind(&self) -> &'static str {
         self.into()
     }
+
+    /// A concrete change that can make this invocation cacheable, when one is
+    /// available.
+    ///
+    /// Expected probes and failures that require adapter support return
+    /// `None`; callers can still explain those from [`BypassReason::kind`].
+    pub fn remediation(&self) -> Option<&'static str> {
+        match self {
+            Self::Incremental => Some(
+                "Set `MBX_INCREMENTAL=0`; mbx will then disable Cargo incremental state and cache the compilation.",
+            ),
+            Self::UnportableNativeLink(_) => Some(
+                "Remove the reported `-C` option from the active Cargo profile or `RUSTFLAGS` to make these links cacheable.",
+            ),
+            Self::UnknownFlag(_) | Self::UnknownCodegenOption(_) => Some(
+                "Remove the reported compiler option, or upgrade mbx if the option should be modeled.",
+            ),
+            Self::UnmodeledLinkArgument(_) => Some(
+                "Remove the reported linker argument, or keep these links uncached if the argument is required.",
+            ),
+            Self::UnmappedAbsolutePath(_) => Some(
+                "Move the input under the workspace, target, Cargo, toolchain, or home roots so mbx can give it a portable cache name.",
+            ),
+            _ => None,
+        }
+    }
 }
 
 impl From<PathNormalizationError> for BypassReason {

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -37,11 +37,18 @@ fn bypass_kinds_are_stable_and_field_independent() {
 
 #[test]
 fn actionable_bypasses_carry_remediation() {
-    let remediation = BypassReason::UnportableNativeLink("split-debuginfo=packed".into())
+    let codegen_remediation = BypassReason::UnportableNativeLink("split-debuginfo=packed".into())
         .remediation()
         .unwrap();
-    assert!(remediation.contains("Cargo profile"));
-    assert!(remediation.contains("RUSTFLAGS"));
+    assert!(codegen_remediation.contains("Cargo profile"));
+    assert!(codegen_remediation.contains("RUSTFLAGS"));
+
+    let linker_remediation =
+        BypassReason::UnportableNativeLink("the linker could not be identified".into())
+            .remediation()
+            .unwrap();
+    assert!(linker_remediation.contains("linker"));
+    assert!(!linker_remediation.contains("RUSTFLAGS"));
     assert!(BypassReason::CompilerQuery.remediation().is_none());
 }
 

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -35,6 +35,16 @@ fn bypass_kinds_are_stable_and_field_independent() {
     );
 }
 
+#[test]
+fn actionable_bypasses_carry_remediation() {
+    let remediation = BypassReason::UnportableNativeLink("split-debuginfo=packed".into())
+        .remediation()
+        .unwrap();
+    assert!(remediation.contains("Cargo profile"));
+    assert!(remediation.contains("RUSTFLAGS"));
+    assert!(BypassReason::CompilerQuery.remediation().is_none());
+}
+
 #[cfg(unix)]
 #[test]
 fn path_mappings_resolve_symlinked_roots_for_missing_outputs() {

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -33,20 +33,32 @@ fn finish(log: &Path, status: ExitCode) -> Result<ExitCode> {
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
-struct Records(BTreeMap<String, BTreeMap<String, u64>>);
+struct Records {
+    bypasses: BTreeMap<String, BypassGroup>,
+    observations: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct BypassGroup {
+    details: BTreeMap<String, u64>,
+    remediation: Option<String>,
+}
 
 impl Records {
-    fn add(&mut self, kind: &str, detail: &str) {
-        *self
-            .0
-            .entry(kind.to_string())
-            .or_default()
-            .entry(detail.to_string())
-            .or_default() += 1;
+    fn add(&mut self, kind: &str, detail: &str, remediation: Option<&str>) {
+        let group = self.bypasses.entry(kind.to_string()).or_default();
+        *group.details.entry(detail.to_string()).or_default() += 1;
+        if group.remediation.is_none() {
+            group.remediation = remediation.map(str::to_string);
+        }
     }
 
     fn total(&self) -> u64 {
-        self.0.values().flat_map(BTreeMap::values).copied().sum()
+        self.bypasses
+            .values()
+            .flat_map(|group| group.details.values())
+            .copied()
+            .sum()
     }
 }
 
@@ -64,38 +76,57 @@ fn read_records(path: &Path) -> Result<Records> {
 fn parse_records(contents: &str) -> Result<Records> {
     let mut records = Records::default();
     for (index, line) in contents.lines().enumerate() {
-        let (kind, detail) = line
-            .split_once('\t')
+        let mut fields = line.splitn(3, '\t');
+        let kind = fields.next().unwrap_or_default();
+        let detail = fields
+            .next()
             .ok_or_else(|| eyre::eyre!("invalid bypass record on line {}", index + 1))?;
+        if kind == "@observation" {
+            let observation = fields.next().ok_or_else(|| {
+                eyre::eyre!("invalid cacheability observation on line {}", index + 1)
+            })?;
+            records
+                .observations
+                .insert(detail.to_string(), observation.to_string());
+            continue;
+        }
         if kind.is_empty() || detail.is_empty() {
             eyre::bail!("invalid bypass record on line {}", index + 1);
         }
-        records.add(kind, detail);
+        records.add(kind, detail, fields.next());
     }
     Ok(records)
 }
 
 fn display(records: &Records) {
-    if records.0.is_empty() {
+    if records.bypasses.is_empty() {
         crate::session::note("\ncache explanation: no compilations bypassed the cache");
-        return;
-    }
-    crate::session::note(&format!(
-        "\ncache explanation: {} compilations bypassed the cache",
-        records.total()
-    ));
-    for (kind, details) in &records.0 {
-        let count: u64 = details.values().sum();
-        crate::session::note(&format!("\n{kind} ({count})"));
-        crate::session::note(guidance(kind));
-        for (detail, occurrences) in details {
-            let suffix = if *occurrences > 1 {
-                format!(" ({occurrences} times)")
-            } else {
-                String::new()
-            };
-            crate::session::note(&format!("  - {detail}{suffix}"));
+    } else {
+        crate::session::note(&format!(
+            "\ncache explanation: {} compilations bypassed the cache",
+            records.total()
+        ));
+        for (kind, group) in &records.bypasses {
+            let count: u64 = group.details.values().sum();
+            crate::session::note(&format!("\n{kind} ({count})"));
+            crate::session::note(
+                group
+                    .remediation
+                    .as_deref()
+                    .unwrap_or_else(|| guidance(kind)),
+            );
+            for (detail, occurrences) in &group.details {
+                let suffix = if *occurrences > 1 {
+                    format!(" ({occurrences} times)")
+                } else {
+                    String::new()
+                };
+                crate::session::note(&format!("  - {detail}{suffix}"));
+            }
         }
+    }
+    for observation in records.observations.values() {
+        crate::session::note(&format!("\ncacheability warning\n{observation}"));
     }
 }
 
@@ -187,7 +218,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(records.total(), 3);
-        assert_eq!(records.0["unsupported-crate-type"].values().sum::<u64>(), 2);
+        assert_eq!(
+            records.bypasses["unsupported-crate-type"]
+                .details
+                .values()
+                .sum::<u64>(),
+            2
+        );
         assert!(guidance("incremental").contains("MBX_INCREMENTAL=0"));
     }
 
@@ -220,5 +257,23 @@ mod tests {
     fn rejects_partial_records_instead_of_guessing() {
         let error = parse_records("missing a tab\n").unwrap_err();
         assert!(error.to_string().contains("line 1"));
+    }
+
+    #[test]
+    fn reads_remediations_and_non_bypass_observations() {
+        let records = parse_records(
+            "unportable-native-link\tnative link is not reproducible: split-debuginfo=packed\tRemove the reported option.\n\
+             @observation\tcc-compiler-override\tCC is already set, so C compiles are invisible.\n",
+        )
+        .unwrap();
+
+        assert_eq!(records.total(), 1);
+        assert_eq!(
+            records.bypasses["unportable-native-link"]
+                .remediation
+                .as_deref(),
+            Some("Remove the reported option.")
+        );
+        assert!(records.observations["cc-compiler-override"].contains("invisible"));
     }
 }

--- a/crates/mbx/src/explain.rs
+++ b/crates/mbx/src/explain.rs
@@ -40,23 +40,22 @@ struct Records {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct BypassGroup {
-    details: BTreeMap<String, u64>,
-    remediation: Option<String>,
+    records: BTreeMap<(String, Option<String>), u64>,
 }
 
 impl Records {
     fn add(&mut self, kind: &str, detail: &str, remediation: Option<&str>) {
         let group = self.bypasses.entry(kind.to_string()).or_default();
-        *group.details.entry(detail.to_string()).or_default() += 1;
-        if group.remediation.is_none() {
-            group.remediation = remediation.map(str::to_string);
-        }
+        *group
+            .records
+            .entry((detail.to_string(), remediation.map(str::to_string)))
+            .or_default() += 1;
     }
 
     fn total(&self) -> u64 {
         self.bypasses
             .values()
-            .flat_map(|group| group.details.values())
+            .flat_map(|group| group.records.values())
             .copied()
             .sum()
     }
@@ -107,21 +106,25 @@ fn display(records: &Records) {
             records.total()
         ));
         for (kind, group) in &records.bypasses {
-            let count: u64 = group.details.values().sum();
+            let count: u64 = group.records.values().sum();
             crate::session::note(&format!("\n{kind} ({count})"));
-            crate::session::note(
-                group
-                    .remediation
-                    .as_deref()
-                    .unwrap_or_else(|| guidance(kind)),
-            );
-            for (detail, occurrences) in &group.details {
-                let suffix = if *occurrences > 1 {
-                    format!(" ({occurrences} times)")
-                } else {
-                    String::new()
-                };
-                crate::session::note(&format!("  - {detail}{suffix}"));
+            let mut sections: BTreeMap<Option<&str>, Vec<(&str, u64)>> = BTreeMap::new();
+            for ((detail, remediation), occurrences) in &group.records {
+                sections
+                    .entry(remediation.as_deref())
+                    .or_default()
+                    .push((detail, *occurrences));
+            }
+            for (remediation, details) in sections {
+                crate::session::note(remediation.unwrap_or_else(|| guidance(kind)));
+                for (detail, occurrences) in details {
+                    let suffix = if occurrences > 1 {
+                        format!(" ({occurrences} times)")
+                    } else {
+                        String::new()
+                    };
+                    crate::session::note(&format!("  - {detail}{suffix}"));
+                }
             }
         }
     }
@@ -220,7 +223,7 @@ mod tests {
         assert_eq!(records.total(), 3);
         assert_eq!(
             records.bypasses["unsupported-crate-type"]
-                .details
+                .records
                 .values()
                 .sum::<u64>(),
             2
@@ -268,12 +271,33 @@ mod tests {
         .unwrap();
 
         assert_eq!(records.total(), 1);
-        assert_eq!(
+        assert!(
             records.bypasses["unportable-native-link"]
-                .remediation
-                .as_deref(),
-            Some("Remove the reported option.")
+                .records
+                .keys()
+                .any(|(_, remediation)| remediation.as_deref()
+                    == Some("Remove the reported option."))
         );
         assert!(records.observations["cc-compiler-override"].contains("invisible"));
+    }
+
+    #[test]
+    fn one_kind_keeps_distinct_remediations_with_their_details() {
+        let records = parse_records(
+            "unportable-native-link\tnative link: split-debuginfo=packed\tRemove the option.\n\
+             unportable-native-link\tthe linker could not be identified\tConfigure the linker.\n",
+        )
+        .unwrap();
+
+        let group = &records.bypasses["unportable-native-link"];
+        assert_eq!(group.records.len(), 2);
+        assert!(group.records.contains_key(&(
+            "native link: split-debuginfo=packed".into(),
+            Some("Remove the option.".into())
+        )));
+        assert!(group.records.contains_key(&(
+            "the linker could not be identified".into(),
+            Some("Configure the linker.".into())
+        )));
     }
 }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -267,6 +267,18 @@ impl CacheSession {
         match host_chosen {
             Some(name) => {
                 debug!("{name} is already set; host C and C++ compilations are not cached");
+                let value = environment
+                    .get(*name)
+                    .cloned()
+                    .or_else(|| std::env::var(name).ok())
+                    .unwrap_or_else(|| "<non-UTF-8 value>".into());
+                append_cacheability_observation(
+                    environment,
+                    "cc-compiler-override",
+                    &format!(
+                        "{name} is already set to `{value}`, so host C and C++ compilations do not pass through mbx; unset it for this build to make them visible to the cache"
+                    ),
+                );
             }
             // `HOST_CC` rather than `CC`, because of where each sits in the
             // `cc` crate's lookup order: it reads `CC_<target>`, then
@@ -1131,10 +1143,13 @@ pub(crate) fn learned_incremental_requested() -> bool {
 /// outside a debug build. Reported by reason kind rather than message, since
 /// several reasons carry a path or a flag.
 fn record_bypass(error: &eyre::Report) {
-    let kind = error
-        .downcast_ref::<mbx_cache_rustc::BypassReason>()
-        .map_or("other", mbx_cache_rustc::BypassReason::kind);
-    append_bypass_log(kind, error);
+    let reason = error.downcast_ref::<mbx_cache_rustc::BypassReason>();
+    let kind = reason.map_or("other", mbx_cache_rustc::BypassReason::kind);
+    append_bypass_log(
+        kind,
+        error,
+        reason.and_then(mbx_cache_rustc::BypassReason::remediation),
+    );
     // A shim running outside a session has nowhere to report, which is fine.
     let _ = request_agent(&[AgentRequest::RecordBypass { kind: kind.into() }]);
 }
@@ -1144,13 +1159,16 @@ fn record_bypass(error: &eyre::Report) {
 /// Kinds are prefixed so that a reason the two adapters share by name, such as
 /// an unmodeled flag, does not merge into one statistic covering both.
 fn record_cc_bypass(error: &eyre::Report) {
-    let kind = error
-        .downcast_ref::<mbx_cache_cc::CcBypassReason>()
-        .map_or_else(
-            || "cc-other".to_string(),
-            |reason| format!("cc-{}", reason.kind()),
-        );
-    append_bypass_log(&kind, error);
+    let reason = error.downcast_ref::<mbx_cache_cc::CcBypassReason>();
+    let kind = reason.map_or_else(
+        || "cc-other".to_string(),
+        |reason| format!("cc-{}", reason.kind()),
+    );
+    append_bypass_log(
+        &kind,
+        error,
+        reason.and_then(mbx_cache_cc::CcBypassReason::remediation),
+    );
     // A shim running outside a session has nowhere to report, which is fine.
     let _ = request_agent(&[AgentRequest::RecordBypass { kind }]);
 }
@@ -1179,7 +1197,7 @@ pub(crate) fn record_compiler_invocation(
 /// or path caused each one. It exists because stderr cannot be relied on:
 /// cargo swallows the output of its own probe invocations, so some bypasses are
 /// invisible there.
-fn append_bypass_log(kind: &str, error: &eyre::Report) {
+fn append_bypass_log(kind: &str, error: &eyre::Report, remediation: Option<&str>) {
     let Some(path) = std::env::var_os(BYPASS_LOG_ENV).filter(|path| !path.is_empty()) else {
         return;
     };
@@ -1187,7 +1205,8 @@ fn append_bypass_log(kind: &str, error: &eyre::Report) {
     // record is what keeps parallel shims from splicing their lines together.
     // Records are a single short line for that reason: a write the kernel had
     // to break up could still interleave, and nothing here can prevent it.
-    let line = format!("{kind}\t{error:#}\n");
+    let suffix = remediation.map_or_else(String::new, |text| format!("\t{text}"));
+    let line = format!("{kind}\t{error:#}{suffix}\n");
     if let Err(problem) = append_line(&path, &line) {
         // Say so once. This runs per compilation and a destination that cannot
         // be written now will fail for every later record too, so warning each
@@ -1203,7 +1222,27 @@ fn append_bypass_log(kind: &str, error: &eyre::Report) {
     }
 }
 
-fn append_line(path: &OsString, line: &str) -> std::io::Result<()> {
+/// Record a cacheability problem that prevents compiler invocations from ever
+/// reaching a shim. It is separate from bypasses because there is no observed
+/// compilation to count.
+fn append_cacheability_observation(
+    environment: &BTreeMap<String, String>,
+    kind: &str,
+    detail: &str,
+) {
+    let Some(path) = environment
+        .get(BYPASS_LOG_ENV)
+        .filter(|path| !path.is_empty())
+    else {
+        return;
+    };
+    let line = format!("@observation\t{kind}\t{detail}\n");
+    if let Err(problem) = append_line(OsStr::new(path), &line) {
+        debug!("cacheability observation was not recorded: {problem}");
+    }
+}
+
+fn append_line(path: &OsStr, line: &str) -> std::io::Result<()> {
     use std::io::Write as _;
     let mut file = std::fs::OpenOptions::new()
         .create(true)

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -51,6 +51,17 @@ Categories marked expected appear on every build and cost nothing; here the
 `incremental` group is the one the build could act on. The command preserves
 Cargo's exit status after printing the explanation.
 
+Actionable bypasses carry their remediation with the reason that produced
+them. For example, links rejected because of `split-debuginfo=packed` point to
+the active Cargo profile or `RUSTFLAGS`, while C compilations affected by
+`CPATH` name the environment variable to unset.
+
+`mbx explain` also reports cacheability problems that prevent a compilation
+from reaching mbx at all. If `CC`, `CXX`, `HOST_CC`, or `HOST_CXX` was already
+set when the build began, the report names the variable and value and explains
+that host C and C++ compiles are invisible to the cache. These are warnings,
+not bypass counts, because mbx never observed the compiler invocations.
+
 ## Remote failure
 
 A remote cache request failed and the build carried on without it: unreachable


### PR DESCRIPTION
## Summary

- attach remediation advice to actionable Rust and C/C++ bypass reasons
- include remediation in `mbx explain` while preserving existing two-column bypass logs
- report preselected host C/C++ compilers as cacheability warnings, separate from bypass counts
- document the actionable report and invisible-compiler warning

## Validation

- `cargo test -p mbx-cache-rustc -p mbx-cache-cc --lib`
- `cargo test -p mbx --lib`
- `cargo clippy -p mbx-cache-rustc -p mbx-cache-cc -p mbx --all-targets -- -D warnings`
- manual `CC=cc mbx explain check` smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing diagnostics and log format extensions only; bypass counting and cache behavior are unchanged aside from richer explain output.
> 
> **Overview**
> Adds **per-reason remediation text** on Rust and C/C++ cache bypass enums so actionable cases (flags, env vars, paths, incremental, etc.) can suggest a concrete fix; expected probes still return none.
> 
> **`mbx explain`** now reads an optional third tab-separated remediation field on bypass log lines, groups details under that text (falling back to existing kind-level `guidance` when absent), and prints separate **cacheability warnings** from `@observation` rows. Session logging writes remediations into `MBX_BYPASS_LOG` and records when `CC`/`CXX`/`HOST_CC`/`HOST_CXX` is already set so host C/C++ compiles never hit the shims.
> 
> Docs describe actionable bypass output and the pre-set compiler warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f78dc6eaf0beb97f1f5092d0fac4a0c3f981f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->