### PR TITLE
feat(cache): deduplicate in-flight work across runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ is pruned to, and when a `target/` directory becomes collectable.
   and teammates. Pull requests never publish remote objects.
 - **Run multiple Cargo builds at the same time.** They share one machine-wide
   CPU and memory budget. Identical cold compilations already running are
-  compiled once and restored into every other build.
+  compiled once and restored into every other build. With a compatible cache
+  server, the same in-flight deduplication extends across CI runners.
 - **See the whole result.** mbx reports hits, misses, actions it could not look
   up, and actions it deliberately bypassed. A high hit rate cannot hide work
   that never entered the cache. `mbx tui` shows the same outcomes as they

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1,9 +1,9 @@
 use crate::uploads::{ConnectionUploads, UploadQueue, UploadSink};
 use crate::{
-    ActionPrediction, BlobPackLimits, CacheDigest, CacheDirectory, LocalActionCache, LocalCas,
-    MAX_STAGED_BLOB_PACK_BYTES, MAX_STAGED_BLOB_PACK_ITEMS, ManifestPutOutcome, RemoteActionResult,
-    RemoteCacheClient, RemoteCacheMode, RustcMetadata, TaskActionManifest, blob_pack_chunk,
-    canonical_json,
+    ActionPrediction, ActionPromiseCompletion, ActionPromiseState, BlobPackLimits, CacheDigest,
+    CacheDirectory, LocalActionCache, LocalCas, MAX_STAGED_BLOB_PACK_BYTES,
+    MAX_STAGED_BLOB_PACK_ITEMS, ManifestPutOutcome, RemoteActionResult, RemoteCacheClient,
+    RemoteCacheMode, RustcMetadata, TaskActionManifest, blob_pack_chunk, canonical_json,
 };
 use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
@@ -14,6 +14,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime};
+
+/// Fleet claims are leases rather than correctness locks. This only bounds how
+/// long one shim waits through repeated pending responses before degrading to
+/// an ordinary compilation; the server independently expires abandoned claims.
+const ACTION_PROMISE_WAIT: Duration = Duration::from_secs(60 * 60);
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 
 mod file_digest;
@@ -1067,6 +1072,13 @@ impl CacheAgent {
             }
             AgentRequest::RecordWarning { message } => self.record_warning(message),
             AgentRequest::FindFileDigests { scope, files } => self.find_file_digests(scope, files),
+            AgentRequest::JoinActionPromise {
+                adapter,
+                invocation,
+            } => self.join_action_promise(&adapter, &invocation).await,
+            AgentRequest::CompleteActionPromise { claim, prediction } => {
+                self.complete_action_promise(&claim, &prediction).await
+            }
             AgentRequest::RecordFileDigests { scope, entries } => {
                 self.record_file_digests(scope, entries)
             }
@@ -1292,6 +1304,113 @@ impl CacheAgent {
             uploads.queue_action_result(result, connection);
         }
         Ok(AgentResponse::ActionStored { path })
+    }
+
+    async fn join_action_promise(
+        &self,
+        adapter: &str,
+        invocation: &CacheDigest,
+    ) -> Result<AgentResponse> {
+        if !self.remote_mode.reads() || !self.remote_mode.writes() {
+            return Ok(AgentResponse::ActionPromise {
+                claim: None,
+                prediction: None,
+            });
+        }
+        let Some(remote) = &self.remote else {
+            return Ok(AgentResponse::ActionPromise {
+                claim: None,
+                prediction: None,
+            });
+        };
+        let deadline = Instant::now() + ACTION_PROMISE_WAIT;
+        loop {
+            let _permit = self.remote_transfers.acquire().await?;
+            let state = remote.join_action_promise(invocation, adapter).await;
+            drop(_permit);
+            match state {
+                Ok(Some(ActionPromiseState::Claimed { claim })) => {
+                    return Ok(AgentResponse::ActionPromise {
+                        claim: Some(claim),
+                        prediction: None,
+                    });
+                }
+                Ok(Some(ActionPromiseState::Complete { prediction })) => {
+                    return Ok(AgentResponse::ActionPromise {
+                        claim: None,
+                        prediction: Some(prediction),
+                    });
+                }
+                Ok(Some(ActionPromiseState::Pending { retry_after_ms }))
+                    if Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(Duration::from_millis(retry_after_ms.clamp(10, 5_000)))
+                        .await;
+                }
+                Ok(Some(ActionPromiseState::Pending { .. }) | None) => {
+                    return Ok(AgentResponse::ActionPromise {
+                        claim: None,
+                        prediction: None,
+                    });
+                }
+                Ok(Some(_)) => {
+                    return Ok(AgentResponse::ActionPromise {
+                        claim: None,
+                        prediction: None,
+                    });
+                }
+                Err(error) => {
+                    self.note_remote_failure();
+                    warn!(
+                        "remote cache action promise failed for {}: {error}",
+                        invocation.hash
+                    );
+                    return Ok(AgentResponse::ActionPromise {
+                        claim: None,
+                        prediction: None,
+                    });
+                }
+            }
+        }
+    }
+
+    async fn complete_action_promise(
+        &self,
+        claim: &str,
+        prediction: &ActionPrediction,
+    ) -> Result<AgentResponse> {
+        prediction.validate()?;
+        let Some(remote) = &self.remote else {
+            return Ok(AgentResponse::ActionPromiseCompleted);
+        };
+        let Some(uploads) = &self.uploads else {
+            return Ok(AgentResponse::ActionPromiseCompleted);
+        };
+        if uploads
+            .wait_for_actions(std::slice::from_ref(&prediction.action))
+            .await
+            .contains(&prediction.action)
+        {
+            // Never promise an action result the server does not hold. The
+            // server lease expires and another runner gets to repair it.
+            return Ok(AgentResponse::ActionPromiseCompleted);
+        }
+        let completion = ActionPromiseCompletion {
+            claim: claim.to_string(),
+            prediction: prediction.clone(),
+        };
+        let _permit = self.remote_transfers.acquire().await?;
+        if let Err(error) = remote
+            .complete_action_promise(&prediction.invocation, &completion)
+            .await
+        {
+            self.note_remote_failure();
+            warn!(
+                "remote cache action promise completion failed for {}: {error}",
+                prediction.invocation.hash
+            );
+        }
+        Ok(AgentResponse::ActionPromiseCompleted)
     }
 
     /// Record that a remote operation failed and the build carried on without it.

--- a/crates/mbx-cache-core/src/agent/wire.rs
+++ b/crates/mbx-cache-core/src/agent/wire.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 /// Wire protocol version used between an in-process cache agent and its shims.
-pub const AGENT_PROTOCOL_VERSION: u8 = 5;
+pub const AGENT_PROTOCOL_VERSION: u8 = 6;
 /// Largest single protocol request the agent will read.
 ///
 /// Requests are small JSON objects; the largest legitimate ones carry an output
@@ -155,6 +155,20 @@ pub enum AgentRequest {
         scope: FileDigestScope,
         /// Hashed files and the identities their digests describe.
         entries: Vec<RecordedFileDigest>,
+    },
+    /// Join or claim an invocation-wide promise through the cache server.
+    JoinActionPromise {
+        /// Adapter that owns the invocation and prediction payload.
+        adapter: String,
+        /// Digest of the compiler invocation before input discovery.
+        invocation: CacheDigest,
+    },
+    /// Fulfill a claimed promise after its action result is remotely durable.
+    CompleteActionPromise {
+        /// Opaque claim token returned by [`Self::JoinActionPromise`].
+        claim: String,
+        /// Prediction through which waiters reconstruct the final action key.
+        prediction: ActionPrediction,
     },
 }
 
@@ -321,4 +335,13 @@ pub enum AgentResponse {
     },
     /// File digests were recorded.
     FileDigestsRecorded,
+    /// State of an optional server-wide compilation promise.
+    ActionPromise {
+        /// Opaque lease owned by this client, when it should compile.
+        claim: Option<String>,
+        /// Completed prediction, when another client compiled first.
+        prediction: Option<ActionPrediction>,
+    },
+    /// A server-wide compilation promise was fulfilled or safely skipped.
+    ActionPromiseCompleted,
 }

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, BLOB_PACK_BLOBS_HEADER,
-    MAX_ACTION_PREDICTION_PAYLOAD,
+    ACTION_PROMISE_MEDIA_TYPE, ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE,
+    BLOB_PACK_BLOBS_HEADER, MAX_ACTION_PREDICTION_PAYLOAD,
 };
 use std::time::Duration;
 
@@ -3133,6 +3133,199 @@ fn remote_agent_url_with_limit(
         },
         max_remote_download_bytes,
     )
+}
+
+#[tokio::test]
+async fn a_read_write_agent_claims_an_advertised_action_promise() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let invocation = CacheDigest::blake3(b"fleet invocation");
+    let capabilities = server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":{"action_promises":true}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    let promise_path = format!(
+        "/v1/action-promises/blake3/{}/{}",
+        invocation.hash, invocation.size
+    );
+    let claim = server
+        .mock("POST", promise_path.as_str())
+        .with_status(200)
+        .with_header("content-type", ACTION_PROMISE_MEDIA_TYPE)
+        .with_body(r#"{"state":"claimed","claim":"fleet-lease"}"#)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().to_path_buf(),
+        RemoteCacheMode::ReadWrite,
+    );
+
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::JoinActionPromise {
+                adapter: "rustc".into(),
+                invocation,
+            })
+            .await,
+        AgentResponse::ActionPromise {
+            claim: Some(claim),
+            prediction: None,
+        } if claim == "fleet-lease"
+    ));
+    capabilities.assert_async().await;
+    claim.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_read_only_agent_never_claims_fleet_work() {
+    let directory = tempfile::tempdir().unwrap();
+    let server = mockito::Server::new_async().await;
+    let agent = remote_agent(
+        &server,
+        directory.path().to_path_buf(),
+        RemoteCacheMode::ReadOnly,
+    );
+
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::JoinActionPromise {
+                adapter: "rustc".into(),
+                invocation: CacheDigest::blake3(b"read-only invocation"),
+            })
+            .await,
+        AgentResponse::ActionPromise {
+            claim: None,
+            prediction: None,
+        }
+    ));
+}
+
+#[tokio::test]
+async fn completing_a_fleet_promise_waits_for_its_action_upload() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let invocation = CacheDigest::blake3(b"promised invocation");
+    let action = CacheDigest::blake3(b"promised action");
+    let output_root = CacheDigest::blake3(b"promised output root");
+    let result = RemoteActionResult {
+        version: 1,
+        action: action.clone(),
+        output_root: Some(output_root.clone()),
+        metadata: None,
+    };
+    let prediction = ActionPrediction {
+        invocation: invocation.clone(),
+        action: action.clone(),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let capabilities = server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":{"action_promises":true}
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    let upload = server
+        .mock("PUT", action_path(&action).as_str())
+        .with_status(201)
+        .expect(1)
+        .create_async()
+        .await;
+    let action_blob_upload = server
+        .mock("PUT", blob_path(&action).as_str())
+        .with_status(201)
+        .expect(1)
+        .create_async()
+        .await;
+    let output_blob_upload = server
+        .mock("PUT", blob_path(&output_root).as_str())
+        .with_status(201)
+        .expect(1)
+        .create_async()
+        .await;
+    let promise_path = format!(
+        "/v1/action-promises/blake3/{}/{}",
+        invocation.hash, invocation.size
+    );
+    let complete = server
+        .mock("PUT", promise_path.as_str())
+        .match_body(mockito::Matcher::Json(
+            serde_json::to_value(ActionPromiseCompletion {
+                claim: "fleet-lease".into(),
+                prediction: prediction.clone(),
+            })
+            .unwrap(),
+        ))
+        .with_status(204)
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().to_path_buf(),
+        RemoteCacheMode::ReadWrite,
+    );
+
+    let action_source = directory.path().join("action-source");
+    let output_source = directory.path().join("output-source");
+    std::fs::write(&action_source, b"promised action").unwrap();
+    std::fs::write(&output_source, b"promised output root").unwrap();
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::StoreBlob {
+                digest: action.clone(),
+                source: action_source,
+            })
+            .await,
+        AgentResponse::Stored { .. }
+    ));
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::StoreBlob {
+                digest: output_root,
+                source: output_source,
+            })
+            .await,
+        AgentResponse::Stored { .. }
+    ));
+
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::StoreActionResult { result })
+            .await,
+        AgentResponse::ActionStored { .. }
+    ));
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::CompleteActionPromise {
+                claim: "fleet-lease".into(),
+                prediction,
+            })
+            .await,
+        AgentResponse::ActionPromiseCompleted
+    ));
+    capabilities.assert_async().await;
+    action_blob_upload.assert_async().await;
+    output_blob_upload.assert_async().await;
+    upload.assert_async().await;
+    complete.assert_async().await;
 }
 
 fn blob_path(digest: &CacheDigest) -> String {

--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -84,6 +84,93 @@ fn action_result_keys_require_blake3() {
 }
 
 #[tokio::test]
+async fn joins_an_advertised_action_promise() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({ "action_promises": true })).await;
+    let invocation = CacheDigest::blake3(b"rustc invocation");
+    let endpoint = format!(
+        "/v1/action-promises/blake3/{}/{}",
+        invocation.hash, invocation.size
+    );
+    let join = server
+        .mock("POST", endpoint.as_str())
+        .match_header(PROTOCOL_HEADER, "1")
+        .match_header(NAMESPACE_HEADER, "test")
+        .match_header("content-type", ACTION_PROMISE_MEDIA_TYPE)
+        .match_body(mockito::Matcher::Json(
+            serde_json::json!({"adapter":"rustc"}),
+        ))
+        .with_status(200)
+        .with_header("content-type", ACTION_PROMISE_MEDIA_TYPE)
+        .with_body(r#"{"state":"claimed","claim":"lease-1"}"#)
+        .create_async()
+        .await;
+
+    assert_eq!(
+        test_client(&server)
+            .join_action_promise(&invocation, "rustc")
+            .await
+            .unwrap(),
+        Some(ActionPromiseState::Claimed {
+            claim: "lease-1".into()
+        })
+    );
+    join.assert_async().await;
+}
+
+#[tokio::test]
+async fn completes_an_action_promise_with_a_bound_prediction() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({ "action_promises": true })).await;
+    let invocation = CacheDigest::blake3(b"cc invocation");
+    let prediction = ActionPrediction {
+        invocation: invocation.clone(),
+        action: CacheDigest::blake3(b"cc action"),
+        adapter: "cc".into(),
+        payload: "{}".into(),
+    };
+    let completion = ActionPromiseCompletion {
+        claim: "lease-2".into(),
+        prediction: prediction.clone(),
+    };
+    let endpoint = format!(
+        "/v1/action-promises/blake3/{}/{}",
+        invocation.hash, invocation.size
+    );
+    let complete = server
+        .mock("PUT", endpoint.as_str())
+        .match_header("content-type", ACTION_PROMISE_MEDIA_TYPE)
+        .match_body(mockito::Matcher::Json(
+            serde_json::to_value(&completion).unwrap(),
+        ))
+        .with_status(204)
+        .create_async()
+        .await;
+
+    assert!(
+        test_client(&server)
+            .complete_action_promise(&invocation, &completion)
+            .await
+            .unwrap()
+    );
+    complete.assert_async().await;
+}
+
+#[tokio::test]
+async fn does_not_probe_action_promises_without_the_capability() {
+    let mut server = mockito::Server::new_async().await;
+    mock_capabilities(&mut server, serde_json::json!({})).await;
+    let invocation = CacheDigest::blake3(b"uncoordinated invocation");
+    assert_eq!(
+        test_client(&server)
+            .join_action_promise(&invocation, "rustc")
+            .await
+            .unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
 async fn downloads_negotiated_blob_packs_and_omits_missing_objects() {
     let mut server = mockito::Server::new_async().await;
     let first_bytes = b"first packed blob";

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -54,15 +54,17 @@ pub use agent::{
 pub use client::BlockingAgentClient;
 pub use local::{LocalActionCache, LocalCas};
 pub use mbx_cache_protocol::{
-    ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, ActionPrediction,
+    ACTION_PROMISE_MEDIA_TYPE, ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE,
+    ActionPrediction, ActionPromiseCompletion, ActionPromiseJoin, ActionPromiseState,
     ActionResult as RemoteActionResult, BLOB_MEDIA_TYPE, BLOB_PACK_BLOBS_HEADER,
     BLOB_PACK_BYTES_HEADER, BLOB_PACK_HEADER_BYTES, BLOB_PACK_MAGIC, BLOB_PACK_MEDIA_TYPE,
     BLOB_PACK_RECEIPT_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, Capabilities, CapabilityFeatures,
     CapabilityLimits, CapabilityProtocol, CcMetadata, DIGEST_LIST_MEDIA_TYPE, DIRECTORY_MEDIA_TYPE,
     Digest as CacheDigest, DigestAlgorithm, Directory as CacheDirectory,
     DirectoryNode as CacheDirectoryNode, FileNode as CacheFileNode, MAX_ACTION_PREDICTION_PAYLOAD,
-    NAMESPACE_HEADER, PROTOCOL_HEADER, PROTOCOL_VERSION, RustcMetadata,
-    SymlinkNode as CacheSymlinkNode, TASK_ACTION_MANIFEST_MEDIA_TYPE, TaskActionManifest,
+    MAX_ACTION_PROMISE_CLAIM_BYTES, NAMESPACE_HEADER, PROTOCOL_HEADER, PROTOCOL_VERSION,
+    RustcMetadata, SymlinkNode as CacheSymlinkNode, TASK_ACTION_MANIFEST_MEDIA_TYPE,
+    TaskActionManifest,
 };
 pub use path_mapping::{
     PathMapping, PathNormalizationError, normalize_mapped_path, normalize_resolved_mapped_path,
@@ -374,6 +376,34 @@ impl RemoteCacheClient {
         match &self.backend {
             Backend::Http(client) => client.put_action_result(result).await,
             Backend::S3(store) => store.put_action_result(result).await,
+        }
+    }
+
+    /// Atomically join or claim a server-wide compilation promise.
+    ///
+    /// `None` means this backend does not support ephemeral coordination.
+    pub async fn join_action_promise(
+        &self,
+        invocation: &CacheDigest,
+        adapter: &str,
+    ) -> Result<Option<ActionPromiseState>> {
+        match &self.backend {
+            Backend::Http(client) => client.join_action_promise(invocation, adapter).await,
+            Backend::S3(_) => Ok(None),
+        }
+    }
+
+    /// Complete a claimed promise after its action result has been published.
+    ///
+    /// `false` means this backend does not support ephemeral coordination.
+    pub async fn complete_action_promise(
+        &self,
+        invocation: &CacheDigest,
+        completion: &ActionPromiseCompletion,
+    ) -> Result<bool> {
+        match &self.backend {
+            Backend::Http(client) => client.complete_action_promise(invocation, completion).await,
+            Backend::S3(_) => Ok(false),
         }
     }
 

--- a/crates/mbx-cache-core/src/remote_http.rs
+++ b/crates/mbx-cache-core/src/remote_http.rs
@@ -5,7 +5,8 @@
 //! batched-lookup extensions that only a protocol server offers.
 
 use crate::{
-    ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, BLOB_MEDIA_TYPE,
+    ACTION_PROMISE_MEDIA_TYPE, ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE,
+    ActionPromiseCompletion, ActionPromiseJoin, ActionPromiseState, BLOB_MEDIA_TYPE,
     BLOB_PACK_BLOBS_HEADER, BLOB_PACK_BYTES_HEADER, BLOB_PACK_HEADER_BYTES, BLOB_PACK_MAGIC,
     BLOB_PACK_MEDIA_TYPE, BLOB_PACK_RECEIPT_MEDIA_TYPE, BLOB_PACK_TIMEOUT_BYTES_PER_UNIT,
     BLOB_PACK_TIMEOUT_ITEMS_PER_UNIT, BlobPackReceipt, BlobSource, BlobUpload, CacheDigest,
@@ -133,6 +134,7 @@ struct NegotiatedCapabilities {
     blob_pack_uploads: Option<BlobPackLimits>,
     action_batches: Option<usize>,
     zstd_uploads: bool,
+    action_promises: bool,
 }
 
 #[derive(Serialize)]
@@ -165,6 +167,7 @@ pub(crate) struct HttpRemoteCache {
     blob_packs_disabled: AtomicBool,
     blob_pack_uploads_disabled: AtomicBool,
     action_batches_disabled: AtomicBool,
+    action_promises_disabled: AtomicBool,
 }
 
 impl HttpRemoteCache {
@@ -196,6 +199,7 @@ impl HttpRemoteCache {
             blob_packs_disabled: AtomicBool::new(false),
             blob_pack_uploads_disabled: AtomicBool::new(false),
             action_batches_disabled: AtomicBool::new(false),
+            action_promises_disabled: AtomicBool::new(false),
         })
     }
 
@@ -256,6 +260,17 @@ impl HttpRemoteCache {
         Ok(self
             .base_url
             .join(&format!("v{PROTOCOL_VERSION}/action-results:batch"))?)
+    }
+
+    fn action_promise_endpoint(&self, invocation: &CacheDigest) -> Result<Url> {
+        invocation.validate()?;
+        if invocation.algorithm != "blake3" {
+            bail!("remote cache invocation keys must use blake3");
+        }
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/action-promises/{}/{}/{}",
+            invocation.algorithm, invocation.hash, invocation.size
+        ))?)
     }
 
     async fn request(
@@ -359,7 +374,84 @@ impl HttpRemoteCache {
             blob_pack_uploads,
             action_batches,
             zstd_uploads,
+            action_promises: capabilities.features.action_promises,
         })
+    }
+
+    pub(crate) async fn join_action_promise(
+        &self,
+        invocation: &CacheDigest,
+        adapter: &str,
+    ) -> Result<Option<ActionPromiseState>> {
+        if self.action_promises_disabled.load(Ordering::Relaxed)
+            || !self.negotiated_capabilities().await?.action_promises
+        {
+            return Ok(None);
+        }
+        let url = self.action_promise_endpoint(invocation)?;
+        let join = ActionPromiseJoin {
+            adapter: adapter.to_string(),
+        };
+        join.validate()?;
+        let body = serde_json::to_vec(&join)?;
+        let response = self
+            .request(reqwest::Method::POST, url, ACTION_PROMISE_MEDIA_TYPE)
+            .await?
+            .header(CONTENT_TYPE, ACTION_PROMISE_MEDIA_TYPE)
+            .body(body)
+            .send()
+            .await?;
+        if matches!(
+            response.status(),
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED
+        ) {
+            self.action_promises_disabled.store(true, Ordering::Relaxed);
+            return Ok(None);
+        }
+        let bytes = read_bounded_json(response.error_for_status()?, "action promise").await?;
+        let state: ActionPromiseState = serde_json::from_slice(&bytes)?;
+        state.validate()?;
+        if let ActionPromiseState::Complete { prediction } = &state {
+            prediction.validate()?;
+            if &prediction.invocation != invocation || prediction.adapter != adapter {
+                bail!("remote cache action promise returned an incompatible prediction");
+            }
+        }
+        Ok(Some(state))
+    }
+
+    pub(crate) async fn complete_action_promise(
+        &self,
+        invocation: &CacheDigest,
+        completion: &ActionPromiseCompletion,
+    ) -> Result<bool> {
+        if self.action_promises_disabled.load(Ordering::Relaxed)
+            || !self.negotiated_capabilities().await?.action_promises
+        {
+            return Ok(false);
+        }
+        completion.validate()?;
+        if &completion.prediction.invocation != invocation {
+            bail!("remote cache action promise completion names another invocation");
+        }
+        let url = self.action_promise_endpoint(invocation)?;
+        let body = serde_json::to_vec(completion)?;
+        let response = self
+            .request(reqwest::Method::PUT, url, ACTION_PROMISE_MEDIA_TYPE)
+            .await?
+            .header(CONTENT_TYPE, ACTION_PROMISE_MEDIA_TYPE)
+            .body(body)
+            .send()
+            .await?;
+        if matches!(
+            response.status(),
+            StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED
+        ) {
+            self.action_promises_disabled.store(true, Ordering::Relaxed);
+            return Ok(false);
+        }
+        response.error_for_status()?;
+        Ok(true)
     }
 
     pub(crate) async fn get_blob_pack(

--- a/crates/mbx-cache-core/tests/agent_protocol.rs
+++ b/crates/mbx-cache-core/tests/agent_protocol.rs
@@ -1,8 +1,8 @@
 use mbx_cache_core::{
-    ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE, AGENT_PROTOCOL_VERSION,
-    ActionPrediction, AgentRequest, AgentResponse, BLOB_MEDIA_TYPE, BLOB_PACK_MEDIA_TYPE,
-    BLOB_PACK_RECEIPT_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, CacheDigest, CacheDirectory,
-    CacheFileNode, CcMetadata, DIRECTORY_MEDIA_TYPE, FileDigestScope, FileIdentity,
+    ACTION_PROMISE_MEDIA_TYPE, ACTION_RESULT_BATCH_MEDIA_TYPE, ACTION_RESULT_MEDIA_TYPE,
+    AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRequest, AgentResponse, BLOB_MEDIA_TYPE,
+    BLOB_PACK_MEDIA_TYPE, BLOB_PACK_RECEIPT_MEDIA_TYPE, CLIENT_METADATA_MEDIA_TYPE, CacheDigest,
+    CacheDirectory, CacheFileNode, CcMetadata, DIRECTORY_MEDIA_TYPE, FileDigestScope, FileIdentity,
     PROTOCOL_VERSION, RecordedFileDigest, RemoteActionResult, RestoreStats, RustcMetadata,
     TASK_ACTION_MANIFEST_MEDIA_TYPE, canonical_json,
 };
@@ -10,7 +10,7 @@ use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
-const AGENT_FIXTURE: &str = include_str!("fixtures/agent-protocol-v5.jsonl");
+const AGENT_FIXTURE: &str = include_str!("fixtures/agent-protocol-v6.jsonl");
 
 fn digest() -> CacheDigest {
     CacheDigest {
@@ -99,7 +99,7 @@ fn requests() -> Vec<(&'static str, AgentRequest)> {
         (
             "request.hello",
             AgentRequest::Hello {
-                protocol: 5,
+                protocol: 6,
                 client_version: "0.3.0".into(),
             },
         ),
@@ -225,6 +225,20 @@ fn requests() -> Vec<(&'static str, AgentRequest)> {
                 }],
             },
         ),
+        (
+            "request.join_action_promise",
+            AgentRequest::JoinActionPromise {
+                adapter: "rustc".into(),
+                invocation: digest(),
+            },
+        ),
+        (
+            "request.complete_action_promise",
+            AgentRequest::CompleteActionPromise {
+                claim: "claim-1".into(),
+                prediction: prediction(),
+            },
+        ),
     ]
 }
 
@@ -233,7 +247,7 @@ fn responses() -> Vec<(&'static str, AgentResponse)> {
         (
             "response.hello",
             AgentResponse::Hello {
-                protocol: 5,
+                protocol: 6,
                 agent_version: "0.3.0".into(),
             },
         ),
@@ -337,6 +351,31 @@ fn responses() -> Vec<(&'static str, AgentResponse)> {
             "response.file_digests_recorded",
             AgentResponse::FileDigestsRecorded,
         ),
+        (
+            "response.action_promise_claimed",
+            AgentResponse::ActionPromise {
+                claim: Some("claim-1".into()),
+                prediction: None,
+            },
+        ),
+        (
+            "response.action_promise_complete",
+            AgentResponse::ActionPromise {
+                claim: None,
+                prediction: Some(prediction()),
+            },
+        ),
+        (
+            "response.action_promise_unavailable",
+            AgentResponse::ActionPromise {
+                claim: None,
+                prediction: None,
+            },
+        ),
+        (
+            "response.action_promise_completed",
+            AgentResponse::ActionPromiseCompleted,
+        ),
     ]
 }
 
@@ -360,7 +399,7 @@ fn assert_fixture<T: Serialize>(expected: &mut BTreeMap<&str, &str>, name: &str,
 }
 
 #[test]
-fn agent_protocol_v3_shapes_match_the_conformance_fixture() {
+fn agent_protocol_v6_shapes_match_the_conformance_fixture() {
     let mut expected = fixture();
     for line in AGENT_FIXTURE.lines() {
         let (name, json) = line
@@ -438,7 +477,7 @@ fn agent_protocol_v3_shapes_match_the_conformance_fixture() {
 
 #[test]
 fn protocol_constants_match_the_contract() {
-    assert_eq!(AGENT_PROTOCOL_VERSION, 5);
+    assert_eq!(AGENT_PROTOCOL_VERSION, 6);
     assert_eq!(PROTOCOL_VERSION, 1);
     assert_eq!(
         ACTION_RESULT_MEDIA_TYPE,
@@ -464,6 +503,10 @@ fn protocol_constants_match_the_contract() {
     assert_eq!(
         ACTION_RESULT_BATCH_MEDIA_TYPE,
         "application/vnd.mbx.cache-action-result-batch.v1+json"
+    );
+    assert_eq!(
+        ACTION_PROMISE_MEDIA_TYPE,
+        "application/vnd.mbx.cache-action-promise.v1+json"
     );
     assert_eq!(
         BLOB_PACK_RECEIPT_MEDIA_TYPE,
@@ -492,6 +535,8 @@ define_variant_coverage!(request_variant_name, EXPECTED_REQUEST_VARIANTS, AgentR
     AgentRequest::StoreExecutableIdentity { .. } => "store_executable_identity",
     AgentRequest::FindFileDigests { .. } => "find_file_digests",
     AgentRequest::RecordFileDigests { .. } => "record_file_digests",
+    AgentRequest::JoinActionPromise { .. } => "join_action_promise",
+    AgentRequest::CompleteActionPromise { .. } => "complete_action_promise",
 });
 
 define_variant_coverage!(response_variant_name, EXPECTED_RESPONSE_VARIANTS, AgentResponse, {
@@ -515,4 +560,6 @@ define_variant_coverage!(response_variant_name, EXPECTED_RESPONSE_VARIANTS, Agen
     AgentResponse::Error { .. } => "error",
     AgentResponse::FileDigests { .. } => "file_digests",
     AgentResponse::FileDigestsRecorded => "file_digests_recorded",
+    AgentResponse::ActionPromise { .. } => "action_promise",
+    AgentResponse::ActionPromiseCompleted => "action_promise_completed",
 });

--- a/crates/mbx-cache-core/tests/fixtures/agent-protocol-v6.jsonl
+++ b/crates/mbx-cache-core/tests/fixtures/agent-protocol-v6.jsonl
@@ -1,4 +1,4 @@
-request.hello	{"client_version":"0.3.0","protocol":5,"type":"hello"}
+request.hello	{"client_version":"0.3.0","protocol":6,"type":"hello"}
 request.begin_task	{"task":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","type":"begin_task"}
 request.commit_task	{"run":"task-run","type":"commit_task"}
 request.find_blob	{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"type":"find_blob"}
@@ -18,7 +18,9 @@ request.find_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UN
 request.store_executable_identity	{"environment":{"RUSTFLAGS":"-Cdebuginfo=1","UNSET":null},"executable":"bin/rustc","stdout":[114,117,115,116,99],"type":"store_executable_identity"}
 request.find_file_digests	{"files":[{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":2100,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}],"scope":"content","type":"find_file_digests"}
 request.record_file_digests	{"entries":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"file":{"changed":[1700000000,21],"len":7,"modified":{"nanos_since_epoch":2100,"secs_since_epoch":1700000000},"path":"target/debug/deps/libserde.rlib"}}],"scope":"cc_input","type":"record_file_digests"}
-response.hello	{"agent_version":"0.3.0","protocol":5,"type":"hello"}
+request.join_action_promise	{"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"type":"join_action_promise"}
+request.complete_action_promise	{"claim":"claim-1","prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"type":"complete_action_promise"}
+response.hello	{"agent_version":"0.3.0","protocol":6,"type":"hello"}
 response.task_begun	{"run":"task-run","type":"task_begun"}
 response.task_committed	{"type":"task_committed"}
 response.blob	{"path":"cache/blob","type":"blob"}
@@ -42,6 +44,10 @@ response.executable_identity_missing	{"stdout":null,"type":"executable_identity"
 response.error	{"message":"incompatible protocol","type":"error"}
 response.file_digests	{"digests":[{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},null],"type":"file_digests"}
 response.file_digests_recorded	{"type":"file_digests_recorded"}
+response.action_promise_claimed	{"claim":"claim-1","prediction":null,"type":"action_promise"}
+response.action_promise_complete	{"claim":null,"prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"type":"action_promise"}
+response.action_promise_unavailable	{"claim":null,"prediction":null,"type":"action_promise"}
+response.action_promise_completed	{"type":"action_promise_completed"}
 record.action_result	{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"metadata":null,"output_root":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"version":1}
 record.directory	{"directories":[],"files":[{"digest":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"executable":false,"mode":420,"name":"lib.rlib"}],"symlinks":[],"version":1}
 record.rustc_metadata	{"kind":"rustc","stderr":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"stdout":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"version":1}

--- a/crates/mbx-cache-protocol/src/lib.rs
+++ b/crates/mbx-cache-protocol/src/lib.rs
@@ -40,6 +40,8 @@ pub const DIGEST_LIST_MEDIA_TYPE: &str = "application/vnd.mbx.cache-digests.v1+j
 /// carries only the results a service actually holds.
 pub const ACTION_RESULT_BATCH_MEDIA_TYPE: &str =
     "application/vnd.mbx.cache-action-result-batch.v1+json";
+/// Media type for ephemeral, invocation-keyed compilation promises.
+pub const ACTION_PROMISE_MEDIA_TYPE: &str = "application/vnd.mbx.cache-action-promise.v1+json";
 /// Media type for the receipt describing an accepted blob-pack upload.
 pub const BLOB_PACK_RECEIPT_MEDIA_TYPE: &str =
     "application/vnd.mbx.cache-blob-pack-receipt.v1+json";
@@ -57,6 +59,8 @@ pub const MAX_BATCH_ITEMS: usize = 10_000;
 pub const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
 /// Maximum serialized adapter payload in one action prediction.
 pub const MAX_ACTION_PREDICTION_PAYLOAD: usize = 256 * 1024;
+/// Maximum opaque lease-token length accepted for an action promise.
+pub const MAX_ACTION_PROMISE_CLAIM_BYTES: usize = 256;
 
 /// Serialize a protocol record using the JSON Canonicalization Scheme.
 pub fn canonical_json(value: &impl Serialize) -> serde_json::Result<Vec<u8>> {
@@ -354,6 +358,85 @@ pub struct ActionPrediction {
     pub payload: String,
 }
 
+/// Request to join or claim one invocation-wide compilation promise.
+///
+/// The invocation digest lives in the endpoint URL. The adapter remains in
+/// the body so a server can reject a client trying to join a promise created
+/// by a different action adapter under the same digest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionPromiseJoin {
+    /// Action adapter that will interpret the completed prediction.
+    pub adapter: String,
+}
+
+/// State returned when a client joins an invocation-wide promise.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+#[non_exhaustive]
+pub enum ActionPromiseState {
+    /// This client owns the lease and should perform the compilation.
+    Claimed {
+        /// Opaque bearer token required to complete this claim.
+        claim: String,
+    },
+    /// Another client owns the lease; retry after the stated delay.
+    Pending {
+        /// Minimum delay before asking again.
+        retry_after_ms: u64,
+    },
+    /// The owner published a prediction through which this client can restore.
+    Complete {
+        /// Prediction for reconstructing and looking up the final action key.
+        prediction: ActionPrediction,
+    },
+}
+
+/// Immutable completion of an invocation-wide compilation promise.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionPromiseCompletion {
+    /// Opaque token returned to the client that claimed the promise.
+    pub claim: String,
+    /// Prediction naming the action result that was published first.
+    pub prediction: ActionPrediction,
+}
+
+impl ActionPromiseJoin {
+    /// Whether the join names a valid action adapter.
+    pub fn validate(&self) -> eyre::Result<()> {
+        if !valid_adapter_name(&self.adapter) {
+            eyre::bail!("invalid action promise adapter name");
+        }
+        Ok(())
+    }
+}
+
+impl ActionPromiseState {
+    /// Check the bounds and prediction invariants of a server response.
+    pub fn validate(&self) -> eyre::Result<()> {
+        match self {
+            Self::Claimed { claim }
+                if claim.is_empty() || claim.len() > MAX_ACTION_PROMISE_CLAIM_BYTES =>
+            {
+                eyre::bail!("invalid action promise claim token")
+            }
+            Self::Complete { prediction } => prediction.validate(),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl ActionPromiseCompletion {
+    /// Check the claim-token bound and completed prediction.
+    pub fn validate(&self) -> eyre::Result<()> {
+        if self.claim.is_empty() || self.claim.len() > MAX_ACTION_PROMISE_CLAIM_BYTES {
+            eyre::bail!("invalid action promise claim token");
+        }
+        self.prediction.validate()
+    }
+}
+
 /// Predictions associated with one stable task identity.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -435,11 +518,7 @@ impl ActionPrediction {
         if self.adapter.is_empty() {
             return Some("adapter name is empty".into());
         }
-        if !self
-            .adapter
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
-        {
+        if !valid_adapter_name(&self.adapter) {
             return Some(format!(
                 "adapter name {:?} is not alphanumeric, '-', or '_'",
                 self.adapter
@@ -456,6 +535,13 @@ impl ActionPrediction {
         }
         None
     }
+}
+
+fn valid_adapter_name(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
 fn valid_task_identity(value: &str) -> bool {
@@ -536,6 +622,9 @@ pub struct CapabilityFeatures {
     /// Delegated transfers are available.
     #[serde(default)]
     pub delegated_transfers: bool,
+    /// Invocation-wide claim and promise endpoints are available.
+    #[serde(default)]
+    pub action_promises: bool,
 }
 
 /// Server-advertised request and object limits.

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -190,6 +190,12 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
                         Some(&prediction.action),
                     ) {
                         Ok(Some((action, cached))) => {
+                            // Mirror the successful fleet handoff locally:
+                            // the remote promise is ephemeral, while this
+                            // record survives for the next local flight.
+                            if let Some(flight) = &flight {
+                                flight.leave(&prediction.payload);
+                            }
                             replay_bytes(&cached.stdout, &cached.stderr)?;
                             record_action_hit(
                                 &action,

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -148,6 +148,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
             &task,
             &invocation_digest,
             &mut looked_up,
+            None,
         ) {
             Ok(Some((action, cached))) => {
                 replay_bytes(&cached.stdout, &cached.stderr)?;
@@ -160,6 +161,58 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
                     "a flight prediction was not restored: {error:#}"
                 ));
             }
+        }
+    }
+    let mut remote_claim = None;
+    if flight.is_some() {
+        match session::request_agent(&[AgentRequest::JoinActionPromise {
+            adapter: ADAPTER.into(),
+            invocation: invocation_digest.clone(),
+        }]) {
+            Ok(responses) => match responses.into_iter().next() {
+                Some(AgentResponse::ActionPromise {
+                    claim: Some(claim),
+                    prediction: None,
+                }) => remote_claim = Some(claim),
+                Some(AgentResponse::ActionPromise {
+                    claim: None,
+                    prediction: Some(prediction),
+                }) if prediction.adapter == ADAPTER
+                    && prediction.invocation == invocation_digest =>
+                {
+                    match restore_flight_prediction(
+                        &prediction.payload,
+                        &invocation,
+                        &context,
+                        &task,
+                        &invocation_digest,
+                        &mut looked_up,
+                        Some(&prediction.action),
+                    ) {
+                        Ok(Some((action, cached))) => {
+                            replay_bytes(&cached.stdout, &cached.stderr)?;
+                            record_action_hit(
+                                &action,
+                                cached.restore,
+                                &compilation_name(&invocation),
+                            );
+                            return Ok(ExitCode::SUCCESS);
+                        }
+                        Ok(None) => {}
+                        Err(error) => session::report_shim_warning(&format!(
+                            "a remote flight prediction was not restored: {error:#}"
+                        )),
+                    }
+                }
+                Some(AgentResponse::ActionPromise { .. }) => {}
+                Some(AgentResponse::Error { message }) => session::report_shim_warning(&format!(
+                    "remote flight coordination failed: {message}"
+                )),
+                _ => {}
+            },
+            Err(error) => session::report_shim_warning(&format!(
+                "remote flight coordination failed: {error:#}"
+            )),
         }
     }
     // Recorded here rather than where the prediction came up empty, because
@@ -231,6 +284,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         &searchable,
         before,
         flight.as_ref(),
+        remote_claim.as_deref(),
         &portable,
     ) {
         #[cfg(debug_assertions)]
@@ -256,6 +310,7 @@ fn publish(
     searchable: &BTreeSet<PathBuf>,
     before: Option<BTreeMap<PathBuf, CacheDigest>>,
     flight: Option<&crate::scheduler::Flight>,
+    remote_claim: Option<&str>,
     portable: &Portable,
 ) -> Result<()> {
     let discovered = discover(invocation, context, depfile)?;
@@ -273,7 +328,14 @@ fn publish(
     let action = invocation.action(context.clone())?;
     publish_result(&action, invocation, output, &context.path_mappings)?;
     let prediction = invocation.prediction(context, duration_ns)?;
-    record_prediction(task, invocation_digest, &action.digest, &prediction, flight);
+    record_prediction(
+        task,
+        invocation_digest,
+        &action.digest,
+        &prediction,
+        flight,
+        remote_claim,
+    );
     Ok(())
 }
 
@@ -291,6 +353,7 @@ fn restore_flight_prediction(
     task: &str,
     invocation_digest: &CacheDigest,
     looked_up: &mut bool,
+    recorded_action: Option<&CacheDigest>,
 ) -> Result<Option<(CacheDigest, CachedCompilation)>> {
     let prediction: CcInputPrediction = serde_json::from_str(payload)?;
     let discovered = prediction.discover(
@@ -301,6 +364,9 @@ fn restore_flight_prediction(
     let mut candidate = context.clone();
     discovered.clone().apply_to(&mut candidate)?;
     let action = invocation.action(candidate)?;
+    if recorded_action.is_some_and(|recorded| recorded != &action.digest) {
+        bail!("the action promise no longer matches its predicted inputs");
+    }
     *looked_up = true;
     let restored = restore_result(
         &action,
@@ -312,7 +378,14 @@ fn restore_flight_prediction(
     let Some(cached) = restored else {
         return Ok(None);
     };
-    record_prediction(task, invocation_digest, &action.digest, &prediction, None);
+    record_prediction(
+        task,
+        invocation_digest,
+        &action.digest,
+        &prediction,
+        None,
+        None,
+    );
     Ok(Some((action.digest, cached)))
 }
 
@@ -704,6 +777,7 @@ fn record_prediction(
     action: &CacheDigest,
     prediction: &CcInputPrediction,
     flight: Option<&crate::scheduler::Flight>,
+    remote_claim: Option<&str>,
 ) {
     let Ok(payload) = serde_json::to_string(prediction) else {
         return;
@@ -713,15 +787,22 @@ fn record_prediction(
     if let Some(flight) = flight {
         flight.leave(&payload);
     }
+    let wire_prediction = ActionPrediction {
+        invocation: invocation.clone(),
+        action: action.clone(),
+        adapter: ADAPTER.into(),
+        payload,
+    };
     let _ = session::request_agent(&[AgentRequest::RecordActionPrediction {
         task: task.to_string(),
-        prediction: ActionPrediction {
-            invocation: invocation.clone(),
-            action: action.clone(),
-            adapter: ADAPTER.into(),
-            payload,
-        },
+        prediction: wire_prediction.clone(),
     }]);
+    if let Some(claim) = remote_claim {
+        let _ = session::request_agent(&[AgentRequest::CompleteActionPromise {
+            claim: claim.to_string(),
+            prediction: wire_prediction,
+        }]);
+    }
 }
 
 /// Task identity for a compilation's predictions.

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -109,7 +109,14 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         };
         if let Some(cached) = restored {
             if !verify {
-                record_prediction(&task, &invocation_digest, &action.digest, &prediction, None);
+                record_prediction(
+                    &task,
+                    &invocation_digest,
+                    &action.digest,
+                    &prediction,
+                    None,
+                    None,
+                );
                 replay_bytes(&cached.stdout, &cached.stderr)?;
                 record_action_hit(
                     &action.digest,

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -305,6 +305,10 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
                     });
                     match restored {
                         Ok(Some(cached)) => {
+                            // Mirror the successful fleet handoff locally:
+                            // the remote promise is ephemeral, while this
+                            // record survives for the next local flight.
+                            flight.flight.leave(&prediction.payload);
                             let _ = replay_bytes(&cached.stdout, &cached.stderr);
                             return Ok(ExitCode::SUCCESS);
                         }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -260,6 +260,71 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             }
         }
     }
+    let mut remote_claim = None;
+    if let Some(flight) = &flight
+        // Incremental artifacts are deliberately never published, so they
+        // must not acquire a fleet lease whose promise they cannot fulfill.
+        && !learned.engaged()
+    {
+        match session::request_agent(&[AgentRequest::JoinActionPromise {
+            adapter: "rustc".into(),
+            invocation: flight.invocation.clone(),
+        }]) {
+            Ok(responses) => match responses.into_iter().next() {
+                Some(AgentResponse::ActionPromise {
+                    claim: Some(claim),
+                    prediction: None,
+                }) => remote_claim = Some(claim),
+                Some(AgentResponse::ActionPromise {
+                    claim: None,
+                    prediction: Some(prediction),
+                }) if prediction.adapter == "rustc"
+                    && prediction.invocation == flight.invocation =>
+                {
+                    let context = base_action_context(
+                        compilation.rustc,
+                        compilation.working_dir,
+                        compilation.portable,
+                    );
+                    let restored = context.and_then(|context| {
+                        restore_prediction_payload(
+                            &compilation,
+                            &outputs,
+                            context,
+                            &flight.invocation,
+                            &prediction.payload,
+                            // A promise is not part of this task's manifest.
+                            // Record a successful restore so the next build
+                            // does not need the ephemeral promise again.
+                            None,
+                            true,
+                            &mut action_lookup_attempted,
+                            learned_enabled,
+                            &mut learned,
+                        )
+                    });
+                    match restored {
+                        Ok(Some(cached)) => {
+                            let _ = replay_bytes(&cached.stdout, &cached.stderr);
+                            return Ok(ExitCode::SUCCESS);
+                        }
+                        Ok(None) => {}
+                        Err(error) => eprintln!(
+                            "mbx[warning]: a remote flight prediction was not restored: {error:#}"
+                        ),
+                    }
+                }
+                Some(AgentResponse::ActionPromise { .. }) => {}
+                Some(AgentResponse::Error { message }) => {
+                    eprintln!("mbx[warning]: remote flight coordination failed: {message}")
+                }
+                _ => {}
+            },
+            Err(error) => {
+                eprintln!("mbx[warning]: remote flight coordination failed: {error:#}")
+            }
+        }
+    }
     // No usable action key, and now no flight prediction either: this
     // compilation runs without an action-result lookup ever being made, which
     // is not a miss and has to be counted as its own thing or the summary
@@ -358,6 +423,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
                     .as_ref()
                     .filter(|_| !learned.engaged())
                     .map(|flight| &flight.flight),
+                remote_claim.as_deref().filter(|_| !learned.engaged()),
             );
             Ok(())
         })();
@@ -868,6 +934,7 @@ fn record_prediction(
     discovered: &DiscoveredInputs,
     timing: &CompileTiming,
     flight: Option<&crate::scheduler::Flight>,
+    remote_claim: Option<&str>,
 ) {
     let result = (|| {
         let invocation = compilation.invocation;
@@ -887,11 +954,23 @@ fn record_prediction(
             flight.leave(&payload);
         }
         record_prediction_value(
-            invocation_digest,
+            invocation_digest.clone(),
             action.clone(),
-            payload,
+            payload.clone(),
             invocation.crate_name(),
         );
+        if let Some(claim) = remote_claim {
+            let prediction = ActionPrediction {
+                invocation: invocation_digest,
+                action: action.clone(),
+                adapter: "rustc".into(),
+                payload,
+            };
+            let _ = session::request_agent(&[AgentRequest::CompleteActionPromise {
+                claim: claim.to_string(),
+                prediction,
+            }]);
+        }
         Result::<()>::Ok(())
     })();
     if let Err(error) = result {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -293,10 +293,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
                             context,
                             &flight.invocation,
                             &prediction.payload,
-                            // A promise is not part of this task's manifest.
-                            // Record a successful restore so the next build
-                            // does not need the ephemeral promise again.
-                            None,
+                            Some(&prediction.action),
                             true,
                             &mut action_lookup_attempted,
                             learned_enabled,
@@ -649,6 +646,7 @@ fn restore_predicted_result(
         context,
         &invocation_digest,
         &prediction.payload,
+        Some(&prediction.action),
         restore_outputs,
         action_lookup_attempted,
         learned_enabled,
@@ -669,6 +667,7 @@ fn restore_prediction_payload(
     mut context: ActionContext,
     invocation_digest: &CacheDigest,
     payload: &str,
+    expected_action: Option<&CacheDigest>,
     restore_outputs: bool,
     action_lookup_attempted: &mut bool,
     learned_enabled: bool,
@@ -703,6 +702,9 @@ fn restore_prediction_payload(
     )?;
     match restored {
         Some((action, mut cached)) => {
+            if expected_action.is_some_and(|expected| expected != &action) {
+                bail!("the action prediction no longer matches its predicted inputs");
+            }
             cached.restore.avoided_compiler_duration_ns = input_prediction.compiler_duration_ns;
             if restore_outputs {
                 record_action_hit(&action, cached.restore, invocation.crate_name());
@@ -1032,6 +1034,7 @@ fn restore_flight_prediction(
         context,
         invocation_digest,
         payload,
+        None,
         true,
         action_lookup_attempted,
         learned_enabled,

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -646,7 +646,11 @@ fn restore_predicted_result(
         context,
         &invocation_digest,
         &prediction.payload,
-        Some(&prediction.action),
+        // A manifest prediction intentionally survives source changes: its
+        // payload is rehashed to derive the action for the current inputs.
+        // Only a completed remote promise must still name the exact action it
+        // promised before any of that action's outputs may be materialized.
+        None,
         restore_outputs,
         action_lookup_attempted,
         learned_enabled,

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -690,6 +690,9 @@ fn restore_prediction_payload(
     )?;
     discovered.clone().apply_to(&mut context)?;
     let candidates = ActionCandidates::build(invocation, context, compilation.linker.clone())?;
+    if expected_action.is_some_and(|expected| !candidates.contains(expected)) {
+        bail!("the action prediction no longer matches its predicted inputs");
+    }
     // From this point onward, every return follows at least one action-result
     // request, including error responses from a corrupt local record.
     *action_lookup_attempted = true;
@@ -702,9 +705,6 @@ fn restore_prediction_payload(
     )?;
     match restored {
         Some((action, mut cached)) => {
-            if expected_action.is_some_and(|expected| expected != &action) {
-                bail!("the action prediction no longer matches its predicted inputs");
-            }
             cached.restore.avoided_compiler_duration_ns = input_prediction.compiler_duration_ns;
             if restore_outputs {
                 record_action_hit(&action, cached.restore, invocation.crate_name());
@@ -766,6 +766,13 @@ impl ActionCandidates {
                 .transpose()?,
             literal: invocation.action_linked_by(literal_context, linker)?,
         })
+    }
+
+    fn contains(&self, digest: &CacheDigest) -> bool {
+        self.portable
+            .as_ref()
+            .is_some_and(|action| &action.digest == digest)
+            || &self.literal.digest == digest
     }
 
     /// The key this compilation is published under.

--- a/docs/cache-server.md
+++ b/docs/cache-server.md
@@ -139,6 +139,13 @@ as labels. The server has no deletion endpoint; retention and disaster
 recovery are administrative concerns (back up PostgreSQL, use bucket
 versioning or replication as required).
 
+A server advertising action promises can coordinate identical cold
+compilations across replicas. Claims are short-lived database leases scoped by
+namespace and invocation digest; completion is accepted only after the named
+action result is durable. This state is coordination rather than cache content:
+abandoned claims expire, completed promises are immutable for their retention
+window, and no promise endpoint bypasses the namespace's write authorization.
+
 ## Protocol
 
 The wire protocol — endpoints, media types, canonical hashing, and the

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -14,7 +14,7 @@ the handshake and do not exchange cache requests. Adding, removing, or changing
 a request or response therefore requires incrementing `AGENT_PROTOCOL_VERSION`.
 
 `crates/mbx-cache-core/tests/agent_protocol.rs` exercises every request and
-response variant against `tests/fixtures/agent-protocol-v5.jsonl`. Its exhaustive
+response variant against `tests/fixtures/agent-protocol-v6.jsonl`. Its exhaustive
 matches make a newly added variant fail to compile until the fixture and the
 protocol-version decision are reviewed together.
 
@@ -27,6 +27,9 @@ stderr its caller reads as an answer, so it cannot write there itself, and the
 agent prints each distinct message once from the process that owns the build.
 v5 adds `find_file_digests` and `record_file_digests`, which let a shim reuse
 the digest of a file the session already read in full instead of rehashing it.
+v6 adds `join_action_promise` and `complete_action_promise`, carrying the local
+shim's invocation identity and the server lease or completed prediction needed
+for fleet-wide in-flight deduplication.
 The client and agent still require exact protocol and application-version
 equality, including when different applications ship them.
 
@@ -48,6 +51,7 @@ uses these resources:
 | action result | `GET`/`PUT /v1/action-results/{algorithm}/{hash}/{size}` | `application/vnd.mbx.cache-action-result.v1+json` |
 | action manifest | `GET`/`PUT /v1/action-manifests/{algorithm}/{hash}/{size}` | `application/vnd.mbx.cache-task-action-manifest.v1+json` |
 | action result batch | `POST /v1/action-results:batch` | `application/vnd.mbx.cache-action-result-batch.v1+json` |
+| action promise | `POST`/`PUT /v1/action-promises/{algorithm}/{hash}/{size}` | `application/vnd.mbx.cache-action-promise.v1+json` |
 | blob | `GET`/`PUT /v1/blobs/{algorithm}/{hash}/{size}` | media type requested by the caller |
 | blob pack | `POST /v1/blobs:pack` | `application/vnd.mbx.cache-blob-pack.v1` |
 | blob pack upload | `POST /v1/blobs:pack-upload` | `application/vnd.mbx.cache-blob-pack-receipt.v1+json` |
@@ -58,6 +62,15 @@ Both batched resources are extensions, gated on their own capability
 single-object resources when a feature is not advertised, and also when an
 advertised endpoint answers `404`, `405`, or `501` — after which it stops asking
 for the rest of the session. Neither is required to serve the baseline.
+
+Action promises are gated by `features.action_promises`. `POST` atomically
+returns a claim token, a bounded retry delay while another lease is live, or a
+completed `ActionPrediction`. `PUT` presents the claim token and prediction to
+complete the promise. A server must authorize both operations as writes, expire
+abandoned claims, refuse a completion whose action result is not already
+durable, and make the first valid completion immutable. Claim tokens are opaque
+bearer values and clients cap them at 256 bytes. As with other extensions,
+`404`, `405`, or `501` disables promises for the rest of the client session.
 
 A batched action-result response carries only the records the service holds, in
 no order, so each one is bound to its request by the action digest inside it

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -85,8 +85,9 @@ can be published under a key naming different content, and because writes are
 create-only nothing later overwrites it: every machine that downloads it fails
 verification and recompiles. `mbx cache verify` finds such an object locally.
 
-A bucket also does not answer batched lookups, stream blob packs,
-or negotiate compression. mbx asks for none of them against S3 and falls back
+A bucket also does not coordinate in-flight compilations, answer batched
+lookups, stream blob packs, or negotiate compression. mbx asks for none of
+them against S3 and falls back
 to per-object requests, which is what every version of the protocol has done
 against a server without the extensions. Expect more requests for the same
 build, and no compression on the wire.
@@ -138,6 +139,22 @@ Configured mode is constrained by the environment:
 This policy prevents untrusted code from publishing objects that later builds
 would trust. The server should still authenticate and authorize requests; the
 client-side policy is defense in depth, not an access-control boundary.
+
+### In-flight deduplication
+
+When a cache server advertises action promises, read-write runners atomically
+claim a cold compiler invocation before starting it. One runner compiles and
+publishes the result; other runners wait for its promise, rebuild the final
+action key from the promised input prediction, verify every input, and restore
+the published result. The prediction is only fulfilled after the action result
+and all referenced blobs are remotely durable.
+
+Claims are keyed by the pre-discovery invocation digest because a cold runner
+does not yet know the compiler-discovered inputs in the final action key. They
+are leases: a runner that dies or cannot publish leaves no durable cache record,
+and the server expires its claim so another runner can compile. Any endpoint
+error, unsupported server, read-only policy, or expired client wait degrades to
+an ordinary compilation. Read-only runners never acquire claims.
 
 ## GitLab CI
 


### PR DESCRIPTION
## Summary

- add an advertised action-promise endpoint contract for invocation-wide claim, wait, and immutable completion
- extend the cache agent and rustc/cc flights to coordinate cold compilations through compatible cache servers
- wait for all blobs and the action result to become remotely durable before fulfilling a promise
- preserve deny-by-default behavior: only read-write protocol remotes participate; S3, read-only, unsupported, and failed coordination fall back to normal compilation
- bump the exact shim/agent protocol to v6 and document the server contract

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Compatibility

Adding exact-protocol request and response variants is intentionally breaking for the unstable `mbx-cache-core` 0.x API. That crate can move from 0.9 to 0.10 in the release PR; this does not require an `mbx` 2.0 release. As documented in `RELEASING.md`, the public API compatibility check remains red for deliberate breaks until release-plz opens the version-bump release PR. This matches the protocol-v5 change in #164.

The reference server implementation lives in `jdx/mr-boxington-cache`; this PR defines and consumes the shared protocol extension.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler coordination and cache restore paths for rustc/cc with new remote lease semantics; failures degrade to normal compile, but bugs could cause duplicate work or incorrect restores if action matching is wrong.
> 
> **Overview**
> Extends **fleet-wide in-flight deduplication** beyond a single machine: when a read-write remote advertises `features.action_promises`, cold rustc/cc compilations can **claim an invocation-wide lease** on the cache server, wait on another runner’s completed prediction, or **fulfill a claim** only after the action result and blobs are remotely durable.
> 
> The **remote v1 protocol** gains `POST`/`PUT` on `/v1/action-promises/...` with new types (`ActionPromiseJoin`, `ActionPromiseState`, `ActionPromiseCompletion`) and capability gating; the **HTTP client** negotiates the feature and disables it on `404`/`405`/`501`. **S3 backends** return no-op for promises.
> 
> The **cache agent** bumps to **protocol v6** with `join_action_promise` / `complete_action_promise` (60-minute client wait with pending retries). **rustc** and **cc** shims call these during an active local flight (skipping incremental-only rustc paths); completed remote predictions must match the promised action digest before restore.
> 
> README and docs describe cross-runner coordination, write authorization, and lease semantics. Tests cover agent, HTTP client, and golden fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67c0b0b041274692562e0a5a9fab10937ebb54c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->