### PR TITLE
feat: cache Windows links and MSVC compiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.10.0"
+version = "0.9.4"
 dependencies = [
  "mbx-cache-core",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "mbx-cache-core",
  "serde",

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.9.4"
+version = "0.10.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.10.0"
+version = "0.9.4"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -17,11 +17,11 @@ all-features = true
 [dependencies]
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 
 [dev-dependencies]
-serde_json = "1"
 tempfile = "3"
 
 [features]

--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -631,7 +631,7 @@ fn parses_a_typical_msvc_cc_crate_invocation() {
     assert_eq!(invocation.include_dirs(), [PathBuf::from("include")]);
     assert_eq!(invocation.language(), CcLanguage::C);
     assert_eq!(
-        invocation.dependency_arguments(Path::new("deps.json"), CcCompilerFamily::Msvc),
+        invocation.dependency_arguments_for(Path::new("deps.json"), CcCompilerFamily::Msvc),
         argv(&["/sourceDependencies", "deps.json"])
     );
 }

--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -639,10 +639,21 @@ fn parses_a_typical_msvc_cc_crate_invocation() {
 }
 
 #[test]
+fn msvc_processor_and_floating_point_flags_are_admitted() {
+    for flag in ["/favor:AMD64", "/fp:precise", "/fp:fast"] {
+        let arguments = argv(&[flag, "/Foout.obj", "/c", "a.c"]);
+        CcInvocation::parse_msvc(&arguments)
+            .unwrap_or_else(|reason| panic!("{flag} should be admitted: {reason}"));
+    }
+}
+
+#[test]
 fn msvc_unmodeled_outputs_and_dependency_flags_bypass() {
     for flag in [
         "/showIncludes",
         "/sourceDependencies",
+        "/Faassembly.asm",
+        "/Fpheader.pch",
         "/Zi",
         "/Fdcompile.pdb",
     ] {

--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -594,11 +594,11 @@ fn compiler_families_classify_from_probe_text() {
 }
 
 #[test]
-fn msvc_style_probe_output_bypasses_as_an_unsupported_driver() {
+fn msvc_style_probe_output_selects_the_msvc_adapter() {
     let probe = "Microsoft (R) C/C++ Optimizing Compiler Version 19.38\n";
     assert_eq!(
-        CcCompilerFamily::classify(probe).unwrap_err().kind(),
-        "unsupported-compiler-driver"
+        CcCompilerFamily::classify(probe).unwrap(),
+        CcCompilerFamily::Msvc
     );
 }
 
@@ -607,6 +607,49 @@ fn only_gcc_carries_an_external_assembler_in_its_identity() {
     assert!(CcCompilerFamily::Gcc.uses_external_assembler());
     assert!(!CcCompilerFamily::Clang.uses_external_assembler());
     assert!(!CcCompilerFamily::AppleClang.uses_external_assembler());
+    assert!(!CcCompilerFamily::Msvc.uses_external_assembler());
+}
+
+#[test]
+fn parses_a_typical_msvc_cc_crate_invocation() {
+    let arguments = argv(&[
+        "/nologo",
+        "/MD",
+        "/Z7",
+        "/Brepro",
+        "/Iinclude",
+        "/D",
+        "FEATURE=1",
+        "/Foout\\widget.obj",
+        "/c",
+        "src\\widget.c",
+    ]);
+    let invocation = CcInvocation::parse_for(&arguments, CcCompilerFamily::Msvc)
+        .expect("MSVC invocation should be admitted");
+    assert_eq!(invocation.source(), Path::new("src\\widget.c"));
+    assert_eq!(invocation.output(), Path::new("out\\widget.obj"));
+    assert_eq!(invocation.include_dirs(), [PathBuf::from("include")]);
+    assert_eq!(invocation.language(), CcLanguage::C);
+    assert_eq!(
+        invocation.dependency_arguments(Path::new("deps.json"), CcCompilerFamily::Msvc),
+        argv(&["/sourceDependencies", "deps.json"])
+    );
+}
+
+#[test]
+fn msvc_unmodeled_outputs_and_dependency_flags_bypass() {
+    for flag in [
+        "/showIncludes",
+        "/sourceDependencies",
+        "/Zi",
+        "/Fdcompile.pdb",
+    ] {
+        let arguments = argv(&[flag, "/Foout.obj", "/c", "a.c"]);
+        assert!(
+            CcInvocation::parse_for(&arguments, CcCompilerFamily::Msvc).is_err(),
+            "{flag} should bypass"
+        );
+    }
 }
 
 #[test]

--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -593,6 +593,7 @@ fn compiler_families_classify_from_probe_text() {
     );
 }
 
+#[cfg(windows)]
 #[test]
 fn msvc_style_probe_output_selects_the_msvc_adapter() {
     let probe = "Microsoft (R) C/C++ Optimizing Compiler Version 19.38\n";
@@ -607,6 +608,7 @@ fn only_gcc_carries_an_external_assembler_in_its_identity() {
     assert!(CcCompilerFamily::Gcc.uses_external_assembler());
     assert!(!CcCompilerFamily::Clang.uses_external_assembler());
     assert!(!CcCompilerFamily::AppleClang.uses_external_assembler());
+    #[cfg(windows)]
     assert!(!CcCompilerFamily::Msvc.uses_external_assembler());
 }
 
@@ -624,14 +626,14 @@ fn parses_a_typical_msvc_cc_crate_invocation() {
         "/c",
         "src\\widget.c",
     ]);
-    let invocation = CcInvocation::parse_for(&arguments, CcCompilerFamily::Msvc)
-        .expect("MSVC invocation should be admitted");
+    let invocation =
+        CcInvocation::parse_msvc(&arguments).expect("MSVC invocation should be admitted");
     assert_eq!(invocation.source(), Path::new("src\\widget.c"));
     assert_eq!(invocation.output(), Path::new("out\\widget.obj"));
     assert_eq!(invocation.include_dirs(), [PathBuf::from("include")]);
     assert_eq!(invocation.language(), CcLanguage::C);
     assert_eq!(
-        invocation.dependency_arguments_for(Path::new("deps.json"), CcCompilerFamily::Msvc),
+        invocation.msvc_dependency_arguments(Path::new("deps.json")),
         argv(&["/sourceDependencies", "deps.json"])
     );
 }
@@ -646,7 +648,7 @@ fn msvc_unmodeled_outputs_and_dependency_flags_bypass() {
     ] {
         let arguments = argv(&[flag, "/Foout.obj", "/c", "a.c"]);
         assert!(
-            CcInvocation::parse_for(&arguments, CcCompilerFamily::Msvc).is_err(),
+            CcInvocation::parse_msvc(&arguments).is_err(),
             "{flag} should bypass"
         );
     }

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -40,7 +40,7 @@ impl CcDepfile {
 
     /// Read the dependency output emitted by the selected compiler family.
     pub fn read_for(path: &Path, family: CcCompilerFamily) -> Result<Self, CcBypassReason> {
-        if family == CcCompilerFamily::Msvc {
+        if family.is_msvc() {
             Self::read_msvc(path)
         } else {
             Self::read(path)
@@ -48,7 +48,7 @@ impl CcDepfile {
     }
 
     /// Read MSVC's `/sourceDependencies` JSON output.
-    fn read_msvc(path: &Path) -> Result<Self, CcBypassReason> {
+    pub fn read_msvc(path: &Path) -> Result<Self, CcBypassReason> {
         let contents = std::fs::read(path).map_err(|error| CcBypassReason::DepfileRead {
             path: path.to_path_buf(),
             message: error.to_string(),

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -1,8 +1,8 @@
 //! Dependency-list parsing and input discovery for C and C++ compiles.
 
 use crate::{
-    CcActionContext, CcActionInput, CcBypassReason, MAX_INPUT_BYTES, MAX_MANIFEST_ENTRIES,
-    MAX_PREDICTED_INPUTS, normalize_components,
+    CcActionContext, CcActionInput, CcBypassReason, CcCompilerFamily, MAX_INPUT_BYTES,
+    MAX_MANIFEST_ENTRIES, MAX_PREDICTED_INPUTS, normalize_components,
 };
 use mbx_cache_core::{
     CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, RecordedFileDigest,
@@ -36,6 +36,54 @@ impl CcDepfile {
                 message: error.to_string(),
             })?;
         Self::parse(&contents)
+    }
+
+    /// Read the dependency output emitted by the selected compiler family.
+    pub fn read_for(path: &Path, family: CcCompilerFamily) -> Result<Self, CcBypassReason> {
+        if family == CcCompilerFamily::Msvc {
+            Self::read_msvc(path)
+        } else {
+            Self::read(path)
+        }
+    }
+
+    /// Read MSVC's `/sourceDependencies` JSON output.
+    fn read_msvc(path: &Path) -> Result<Self, CcBypassReason> {
+        let contents = std::fs::read(path).map_err(|error| CcBypassReason::DepfileRead {
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        })?;
+        let value: serde_json::Value = serde_json::from_slice(&contents)
+            .map_err(|error| CcBypassReason::MalformedDepfile(error.to_string()))?;
+        let data = value
+            .get("Data")
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| CcBypassReason::MalformedDepfile("missing Data object".into()))?;
+        if data
+            .get("ImportedModules")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|modules| !modules.is_empty())
+            || data.get("ProvidedModule").is_some_and(|module| {
+                !module.is_null() && module.as_str().is_none_or(|s| !s.is_empty())
+            })
+        {
+            return Err(CcBypassReason::MalformedDepfile(
+                "C++ module dependencies are not modeled".into(),
+            ));
+        }
+        let includes = data
+            .get("Includes")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| CcBypassReason::MalformedDepfile("missing Includes array".into()))?;
+        let files = includes
+            .iter()
+            .map(|entry| {
+                entry.as_str().map(PathBuf::from).ok_or_else(|| {
+                    CcBypassReason::MalformedDepfile("non-string include path".into())
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { files })
     }
 
     /// Parse a GNU-style dependency list.

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -457,7 +457,7 @@ fn parses_msvc_source_dependencies() {
     )
     .expect("write dependency JSON");
 
-    let dependencies = CcDepfile::read_for(&path, CcCompilerFamily::Msvc).expect("parse");
+    let dependencies = CcDepfile::read_msvc(&path).expect("parse");
     assert_eq!(
         dependencies.files,
         [

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -446,3 +446,23 @@ fn a_vouched_cc_input_skips_the_scan_it_already_passed() {
             .unwrap_err();
     assert_eq!(reason.kind(), "embedded-timestamp-macro");
 }
+
+#[test]
+fn parses_msvc_source_dependencies() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("deps.json");
+    std::fs::write(
+        &path,
+        r#"{"Version":"1.2","Data":{"Source":"src\\a.c","ProvidedModule":"","ImportedModules":[],"Includes":["include\\a.h","C:\\SDK\\stdio.h"]}}"#,
+    )
+    .expect("write dependency JSON");
+
+    let dependencies = CcDepfile::read_for(&path, CcCompilerFamily::Msvc).expect("parse");
+    assert_eq!(
+        dependencies.files,
+        [
+            PathBuf::from("include\\a.h"),
+            PathBuf::from("C:\\SDK\\stdio.h")
+        ]
+    );
+}

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -1561,10 +1561,16 @@ impl<'a> MsvcParser<'a> {
         if matches!(lower.as_str(), "e" | "ep" | "p") {
             return Err(CcBypassReason::NonObjectOutput(value.into()));
         }
-        if lower.starts_with("fa") || lower.starts_with("fd") || lower.starts_with("zi") {
+        if (lower.starts_with("fa") && !lower.starts_with("favor:"))
+            || lower.starts_with("fd")
+            || lower.starts_with("zi")
+        {
             return Err(CcBypassReason::SplitDebugOutput(value.into()));
         }
-        if lower.starts_with("yc") || lower.starts_with("yu") || lower.starts_with("fp") {
+        if lower.starts_with("yc")
+            || lower.starts_with("yu")
+            || (lower.starts_with("fp") && !lower.starts_with("fp:"))
+        {
             return Err(CcBypassReason::PrecompiledHeader(value.into()));
         }
         if lower == "link" || lower.starts_with("bt+") || lower.starts_with("analyze") {

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -676,11 +676,21 @@ impl CcInvocation {
     /// `-MD` rather than `-MMD`: system headers are exactly the inputs most
     /// likely to change without any other key component noticing, because the
     /// compiler identity does not cover the C library or the platform SDK.
-    pub fn dependency_arguments(&self, depfile: &Path, family: CcCompilerFamily) -> Vec<OsString> {
+    pub fn dependency_arguments(&self, depfile: &Path) -> Vec<OsString> {
+        vec!["-MD".into(), "-MF".into(), depfile.into()]
+    }
+
+    /// Arguments to append so a driver from `family` writes its dependency
+    /// list beside the object.
+    pub fn dependency_arguments_for(
+        &self,
+        depfile: &Path,
+        family: CcCompilerFamily,
+    ) -> Vec<OsString> {
         if family == CcCompilerFamily::Msvc {
             vec!["/sourceDependencies".into(), depfile.into()]
         } else {
-            vec!["-MD".into(), "-MF".into(), depfile.into()]
+            self.dependency_arguments(depfile)
         }
     }
 

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -416,6 +416,9 @@ impl CcLanguage {
 
     /// Default driver name to fall back to when no real compiler is pinned.
     pub fn default_driver(self) -> &'static str {
+        if cfg!(windows) {
+            return "cl.exe";
+        }
         match self {
             Self::C => "cc",
             Self::Cxx => "c++",
@@ -432,6 +435,8 @@ pub enum CcCompilerFamily {
     Clang,
     /// Apple's clang distribution.
     AppleClang,
+    /// Microsoft's `cl.exe` driver.
+    Msvc,
 }
 
 impl CcCompilerFamily {
@@ -441,6 +446,7 @@ impl CcCompilerFamily {
             Self::Gcc => "gcc",
             Self::Clang => "clang",
             Self::AppleClang => "apple-clang",
+            Self::Msvc => "msvc",
         }
     }
 
@@ -458,6 +464,8 @@ impl CcCompilerFamily {
             Ok(Self::Clang)
         } else if probe.contains("gcc version") {
             Ok(Self::Gcc)
+        } else if probe.contains("Microsoft (R) C/C++ Optimizing Compiler") {
+            Ok(Self::Msvc)
         } else {
             Err(CcBypassReason::UnsupportedCompilerDriver(
                 probe.lines().next().unwrap_or_default().into(),
@@ -612,6 +620,18 @@ impl CcInvocation {
         Parser::new(arguments).parse()
     }
 
+    /// Parse a command line using the syntax of `family`.
+    pub fn parse_for(
+        arguments: &[OsString],
+        family: CcCompilerFamily,
+    ) -> Result<Self, CcBypassReason> {
+        if family == CcCompilerFamily::Msvc {
+            MsvcParser::new(arguments).parse()
+        } else {
+            Self::parse(arguments)
+        }
+    }
+
     /// Source file this invocation compiles.
     pub fn source(&self) -> &Path {
         &self.source
@@ -656,8 +676,12 @@ impl CcInvocation {
     /// `-MD` rather than `-MMD`: system headers are exactly the inputs most
     /// likely to change without any other key component noticing, because the
     /// compiler identity does not cover the C library or the platform SDK.
-    pub fn dependency_arguments(&self, depfile: &Path) -> Vec<OsString> {
-        vec!["-MD".into(), "-MF".into(), depfile.into()]
+    pub fn dependency_arguments(&self, depfile: &Path, family: CcCompilerFamily) -> Vec<OsString> {
+        if family == CcCompilerFamily::Msvc {
+            vec!["/sourceDependencies".into(), depfile.into()]
+        } else {
+            vec!["-MD".into(), "-MF".into(), depfile.into()]
+        }
     }
 
     /// Digest of the pre-input fingerprint, used to look up a prediction.
@@ -804,6 +828,18 @@ pub fn environment_inputs<F>(
 where
     F: Fn(&str) -> Option<String>,
 {
+    environment_inputs_for(lookup, sysroot, CcCompilerFamily::Clang)
+}
+
+/// Read the modeled environment for a particular compiler family.
+pub fn environment_inputs_for<F>(
+    lookup: F,
+    sysroot: Option<&Path>,
+    family: CcCompilerFamily,
+) -> Result<BTreeMap<String, Option<String>>, CcBypassReason>
+where
+    F: Fn(&str) -> Option<String>,
+{
     for name in BYPASS_ENVIRONMENT {
         if lookup(name).is_some() {
             return Err(CcBypassReason::UnsupportedEnvironment((*name).into()));
@@ -817,6 +853,24 @@ where
             continue;
         }
         environment.insert((*name).to_string(), lookup(name));
+    }
+    if family == CcCompilerFamily::Msvc {
+        // INCLUDE changes header resolution without appearing in argv. The
+        // toolset and SDK versions make the otherwise machine-local paths
+        // meaningful when action records move between hosts.
+        for name in [
+            "INCLUDE",
+            "VCToolsVersion",
+            "WindowsSDKVersion",
+            "UCRTVersion",
+        ] {
+            environment.insert(name.into(), lookup(name));
+        }
+        for name in ["CL", "_CL_"] {
+            if lookup(name).is_some() {
+                return Err(CcBypassReason::UnsupportedEnvironment(name.into()));
+            }
+        }
     }
     Ok(environment)
 }
@@ -1344,6 +1398,246 @@ impl<'a> Parser<'a> {
         }
         self.parsed.push(Argument::Plain(value.into()));
         Ok(())
+    }
+}
+
+/// Conservative parser for the command lines emitted by the `cc` crate for
+/// Microsoft's compiler. It intentionally admits only flags whose effects are
+/// either present in argv or covered by dependency discovery.
+struct MsvcParser<'a> {
+    arguments: &'a [OsString],
+    index: usize,
+    parsed: Vec<Argument>,
+    source: Option<PathBuf>,
+    output: Option<PathBuf>,
+    include_dirs: Vec<PathBuf>,
+    required_inputs: Vec<PathBuf>,
+    explicit_language: Option<CcLanguage>,
+    compiling: bool,
+}
+
+impl<'a> MsvcParser<'a> {
+    fn new(arguments: &'a [OsString]) -> Self {
+        Self {
+            arguments,
+            index: 0,
+            parsed: Vec::new(),
+            source: None,
+            output: None,
+            include_dirs: Vec::new(),
+            required_inputs: Vec::new(),
+            explicit_language: None,
+            compiling: false,
+        }
+    }
+
+    fn parse(mut self) -> Result<CcInvocation, CcBypassReason> {
+        while self.index < self.arguments.len() {
+            let value = self.current()?.to_owned();
+            self.index += 1;
+            if let Some(file) = value.strip_prefix('@') {
+                return Err(CcBypassReason::ResponseFile(file.into()));
+            }
+            if value.starts_with('/') || value.starts_with('-') {
+                self.parse_flag(&value)?;
+            } else {
+                self.add_source(&value)?;
+            }
+        }
+        if !self.compiling {
+            return Err(CcBypassReason::NotACompile);
+        }
+        let source = self.source.clone().ok_or(CcBypassReason::MissingInput)?;
+        let output = self.output.clone().ok_or(CcBypassReason::MissingOutput)?;
+        let language = self.explicit_language.unwrap_or_else(|| {
+            if source
+                .extension()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.eq_ignore_ascii_case("c"))
+            {
+                CcLanguage::C
+            } else {
+                CcLanguage::Cxx
+            }
+        });
+        self.required_inputs.push(source.clone());
+        Ok(CcInvocation {
+            arguments: self.parsed,
+            source,
+            output,
+            include_dirs: self.include_dirs,
+            required_inputs: self.required_inputs,
+            language,
+            sysroot: None,
+        })
+    }
+
+    fn current(&self) -> Result<&str, CcBypassReason> {
+        self.arguments[self.index]
+            .to_str()
+            .ok_or(CcBypassReason::NonUtf8Argument { index: self.index })
+    }
+
+    fn value(&mut self, flag: &str, attached: &str) -> Result<String, CcBypassReason> {
+        if !attached.is_empty() {
+            return Ok(attached.into());
+        }
+        if self.index == self.arguments.len() {
+            return Err(CcBypassReason::MissingValue(flag.into()));
+        }
+        let value = self.current()?.to_owned();
+        self.index += 1;
+        Ok(value)
+    }
+
+    fn add_source(&mut self, value: &str) -> Result<(), CcBypassReason> {
+        if self.source.is_some() {
+            return Err(CcBypassReason::MultipleInputs);
+        }
+        let path = PathBuf::from(value);
+        if self.explicit_language.is_none()
+            && !path
+                .extension()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| {
+                    matches!(
+                        value.to_ascii_lowercase().as_str(),
+                        "c" | "cc" | "cpp" | "cxx"
+                    )
+                })
+        {
+            return Err(CcBypassReason::UnsupportedLanguage(value.into()));
+        }
+        self.source = Some(path.clone());
+        self.parsed.push(Argument::Source(path));
+        Ok(())
+    }
+
+    fn parse_flag(&mut self, value: &str) -> Result<(), CcBypassReason> {
+        let option = value.trim_start_matches(['/', '-']);
+        let lower = option.to_ascii_lowercase();
+        if matches!(lower.as_str(), "?" | "help") {
+            return Err(CcBypassReason::CompilerQuery);
+        }
+        if lower == "showincludes" || lower.starts_with("sourcedependencies") {
+            return Err(CcBypassReason::CallerDependencyFlags(value.into()));
+        }
+        if matches!(lower.as_str(), "e" | "ep" | "p") {
+            return Err(CcBypassReason::NonObjectOutput(value.into()));
+        }
+        if lower.starts_with("fa") || lower.starts_with("fd") || lower.starts_with("zi") {
+            return Err(CcBypassReason::SplitDebugOutput(value.into()));
+        }
+        if lower.starts_with("yc") || lower.starts_with("yu") || lower.starts_with("fp") {
+            return Err(CcBypassReason::PrecompiledHeader(value.into()));
+        }
+        if lower == "link" || lower.starts_with("bt+") || lower.starts_with("analyze") {
+            return Err(CcBypassReason::ToolPassthrough(value.into()));
+        }
+        if matches!(lower.as_str(), "ld" | "ldd") {
+            return Err(CcBypassReason::NotACompile);
+        }
+        if lower == "c" {
+            self.compiling = true;
+            self.parsed.push(Argument::Plain("/c".into()));
+            return Ok(());
+        }
+        for (prefix, canonical) in [("Fo", "/Fo"), ("I", "/I"), ("FI", "/FI")] {
+            if let Some(attached) = option.strip_prefix(prefix) {
+                let path = PathBuf::from(self.value(canonical, attached)?);
+                if prefix == "Fo" {
+                    self.output = Some(path.clone());
+                } else if prefix == "I" {
+                    self.include_dirs.push(path.clone());
+                }
+                self.parsed.push(Argument::Path {
+                    flag: canonical.into(),
+                    path,
+                });
+                return Ok(());
+            }
+        }
+        if lower.starts_with("external:i") {
+            let path = PathBuf::from(self.value("/external:I", &option[10..])?);
+            self.include_dirs.push(path.clone());
+            self.parsed.push(Argument::Path {
+                flag: "/external:I".into(),
+                path,
+            });
+            return Ok(());
+        }
+        if option.starts_with("Tc") || option.starts_with("Tp") {
+            let c = option.starts_with("Tc");
+            let path = self.value(if c { "/Tc" } else { "/Tp" }, &option[2..])?;
+            self.explicit_language = Some(if c { CcLanguage::C } else { CcLanguage::Cxx });
+            return self.add_source(&path);
+        }
+        if lower.starts_with("pathmap:") {
+            let rest = &option[8..];
+            let (from, to) = rest.split_once('=').unwrap_or((rest, ""));
+            self.parsed.push(Argument::PrefixMap {
+                flag: "/pathmap".into(),
+                from: PathBuf::from(from),
+                to: to.into(),
+            });
+            return Ok(());
+        }
+        if matches!(option, "D" | "U") {
+            let definition = self.value(value, "")?;
+            self.parsed
+                .push(Argument::Plain(format!("/{option}{definition}")));
+            return Ok(());
+        }
+        // Definitions and the ordinary code-generation/diagnostic switches
+        // produced by cc-rs are self-contained text and can be keyed verbatim.
+        let definition = option.starts_with('D') || option.starts_with('U');
+        let warning = matches!(lower.as_str(), "wall" | "wx" | "wx-")
+            || lower
+                .strip_prefix('w')
+                .is_some_and(|value| value.bytes().all(|byte| byte.is_ascii_digit()))
+            || ["wd", "we", "wo"].iter().any(|prefix| {
+                lower
+                    .strip_prefix(prefix)
+                    .is_some_and(|value| value.bytes().all(|byte| byte.is_ascii_digit()))
+            });
+        let admitted = definition
+            || warning
+            || lower.starts_with("std:")
+            || lower.starts_with("arch:")
+            || lower.starts_with("favor:")
+            || lower.starts_with("volatile:")
+            || lower.starts_with("fp:")
+            || lower.starts_with("eh")
+            || lower.starts_with('o')
+            || lower.starts_with("ob")
+            || lower.starts_with("oi")
+            || lower.starts_with("ot")
+            || lower.starts_with("oy")
+            || lower.starts_with("gs")
+            || lower.starts_with("gr")
+            || lower.starts_with("gy")
+            || lower.starts_with("gw")
+            || lower.starts_with("gl")
+            || lower.starts_with("zc:")
+            || lower.starts_with("diagnostics:")
+            || matches!(
+                lower.as_str(),
+                "nologo"
+                    | "brepro"
+                    | "bigobj"
+                    | "utf-8"
+                    | "permissive-"
+                    | "z7"
+                    | "md"
+                    | "mdd"
+                    | "mt"
+                    | "mtd"
+            );
+        if admitted {
+            self.parsed.push(Argument::Plain(value.into()));
+            return Ok(());
+        }
+        Err(CcBypassReason::UnknownFlag(value.into()))
     }
 }
 

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -436,6 +436,7 @@ pub enum CcCompilerFamily {
     /// Apple's clang distribution.
     AppleClang,
     /// Microsoft's `cl.exe` driver.
+    #[cfg(windows)]
     Msvc,
 }
 
@@ -446,6 +447,7 @@ impl CcCompilerFamily {
             Self::Gcc => "gcc",
             Self::Clang => "clang",
             Self::AppleClang => "apple-clang",
+            #[cfg(windows)]
             Self::Msvc => "msvc",
         }
     }
@@ -456,16 +458,30 @@ impl CcCompilerFamily {
         matches!(self, Self::Gcc)
     }
 
+    /// Whether this is Microsoft's `cl.exe` driver.
+    pub fn is_msvc(self) -> bool {
+        #[cfg(windows)]
+        {
+            matches!(self, Self::Msvc)
+        }
+        #[cfg(not(windows))]
+        {
+            false
+        }
+    }
+
     /// Classify a driver from its verbose probe output.
     pub fn classify(probe: &str) -> Result<Self, CcBypassReason> {
+        #[cfg(windows)]
+        if probe.contains("Microsoft (R) C/C++ Optimizing Compiler") {
+            return Ok(Self::Msvc);
+        }
         if probe.contains("Apple clang version") {
             Ok(Self::AppleClang)
         } else if probe.contains("clang version") {
             Ok(Self::Clang)
         } else if probe.contains("gcc version") {
             Ok(Self::Gcc)
-        } else if probe.contains("Microsoft (R) C/C++ Optimizing Compiler") {
-            Ok(Self::Msvc)
         } else {
             Err(CcBypassReason::UnsupportedCompilerDriver(
                 probe.lines().next().unwrap_or_default().into(),
@@ -625,11 +641,16 @@ impl CcInvocation {
         arguments: &[OsString],
         family: CcCompilerFamily,
     ) -> Result<Self, CcBypassReason> {
-        if family == CcCompilerFamily::Msvc {
+        if family.is_msvc() {
             MsvcParser::new(arguments).parse()
         } else {
             Self::parse(arguments)
         }
+    }
+
+    /// Parse a command line using Microsoft `cl.exe` syntax.
+    pub fn parse_msvc(arguments: &[OsString]) -> Result<Self, CcBypassReason> {
+        MsvcParser::new(arguments).parse()
     }
 
     /// Source file this invocation compiles.
@@ -687,11 +708,16 @@ impl CcInvocation {
         depfile: &Path,
         family: CcCompilerFamily,
     ) -> Vec<OsString> {
-        if family == CcCompilerFamily::Msvc {
+        if family.is_msvc() {
             vec!["/sourceDependencies".into(), depfile.into()]
         } else {
             self.dependency_arguments(depfile)
         }
+    }
+
+    /// Arguments to append so `cl.exe` writes `/sourceDependencies` JSON.
+    pub fn msvc_dependency_arguments(&self, depfile: &Path) -> Vec<OsString> {
+        vec!["/sourceDependencies".into(), depfile.into()]
     }
 
     /// Digest of the pre-input fingerprint, used to look up a prediction.
@@ -864,7 +890,7 @@ where
         }
         environment.insert((*name).to_string(), lookup(name));
     }
-    if family == CcCompilerFamily::Msvc {
+    if family.is_msvc() {
         // INCLUDE changes header resolution without appearing in argv. The
         // toolset and SDK versions make the otherwise machine-local paths
         // meaningful when action records move between hosts.

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1492,7 +1492,17 @@ impl CacheAgent {
         if !environment.keys().all(|name| {
             matches!(
                 name.as_str(),
-                "RUSTUP_HOME" | "RUSTUP_TOOLCHAIN" | "SDKROOT" | "MACOSX_DEPLOYMENT_TARGET"
+                "RUSTUP_HOME"
+                    | "RUSTUP_TOOLCHAIN"
+                    | "SDKROOT"
+                    | "MACOSX_DEPLOYMENT_TARGET"
+                    | "LIB"
+                    | "UCRTVersion"
+                    | "UniversalCRTSdkDir"
+                    | "VCToolsInstallDir"
+                    | "VCToolsVersion"
+                    | "WindowsSdkDir"
+                    | "WindowsSDKVersion"
             )
         }) {
             bail!("executable identity contains an unsupported environment variable");

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -3183,16 +3183,27 @@ async fn memoizes_client_observed_executable_identities() {
     ));
 }
 
-/// A linker driver's identity depends on the SDK it builds against, so those
-/// names key an identity too. Everything else stays refused: a name that does
-/// not select what the probe reports would let one key stand for two answers.
+/// A linker driver's identity depends on the SDK and toolchain environment it
+/// builds against, so those names key an identity too. Everything else stays
+/// refused: a name that does not select what the probe reports would let one
+/// key stand for two answers.
 #[tokio::test]
 async fn identity_keys_admit_only_names_that_select_the_answer() {
     let directory = tempfile::tempdir().unwrap();
     let agent = CacheAgent::new(directory.path(), "test-version");
     let executable = directory.path().join("cc");
 
-    for name in ["SDKROOT", "MACOSX_DEPLOYMENT_TARGET"] {
+    for name in [
+        "SDKROOT",
+        "MACOSX_DEPLOYMENT_TARGET",
+        "LIB",
+        "UCRTVersion",
+        "UniversalCRTSdkDir",
+        "VCToolsInstallDir",
+        "VCToolsVersion",
+        "WindowsSdkDir",
+        "WindowsSDKVersion",
+    ] {
         let response = agent
             .respond(AgentRequest::StoreExecutableIdentity {
                 executable: executable.clone(),

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -405,6 +405,35 @@ impl RustcInvocation {
         )
     }
 
+    /// Linker selected with `-C linker`, if the invocation overrides rustc's
+    /// platform default.
+    pub fn linker_override(&self) -> Option<&Path> {
+        self.arguments.iter().find_map(|argument| {
+            let Argument::Plain(value) = argument else {
+                return None;
+            };
+            value.strip_prefix("--codegen=linker=").map(Path::new)
+        })
+    }
+
+    fn emits_windows_pdb(&self) -> bool {
+        if !cfg!(windows) || !self.links_natively() {
+            return false;
+        }
+        let mut enabled = false;
+        for argument in &self.arguments {
+            let Argument::Plain(value) = argument else {
+                continue;
+            };
+            if value == "-g" {
+                enabled = true;
+            } else if let Some(value) = value.strip_prefix("--codegen=debuginfo=") {
+                enabled = !matches!(value, "0" | "none");
+            }
+        }
+        enabled
+    }
+
     /// Whether the contents of native search directories cannot reach this
     /// invocation's outputs.
     ///
@@ -536,7 +565,7 @@ impl RustcInvocation {
                 "link" => match self.link_output {
                     LinkOutput::Library => ("lib", "rlib"),
                     LinkOutput::WasmExecutable => ("", "wasm"),
-                    LinkOutput::NativeExecutable => ("", ""),
+                    LinkOutput::NativeExecutable => ("", std::env::consts::EXE_EXTENSION),
                     LinkOutput::NativeProcMacro => (
                         std::env::consts::DLL_PREFIX,
                         std::env::consts::DLL_SUFFIX.trim_start_matches('.'),
@@ -573,6 +602,9 @@ impl RustcInvocation {
                 )
             {
                 return Err(BypassReason::AmbiguousOutputName(path));
+            }
+            if emit.kind == "link" && self.emits_windows_pdb() {
+                files.insert(path.with_extension("pdb"));
             }
             files.insert(path);
         }
@@ -1390,7 +1422,9 @@ impl<'a> Parser<'a> {
         if name == "incremental" {
             return Err(BypassReason::Incremental);
         }
-        if SUPPORTED_CODEGEN_OPTIONS.binary_search(&name).is_err() {
+        if SUPPORTED_CODEGEN_OPTIONS.binary_search(&name).is_err()
+            && !(cfg!(windows) && name == "linker")
+        {
             return Err(BypassReason::UnknownCodegenOption(name.into()));
         }
         // `-oso_prefix` names a checkout-specific path, so it is parsed

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -594,12 +594,19 @@ impl RustcInvocation {
             // so a program that answers to a library's name would be restored
             // without the permission that makes it runnable. Nothing cargo
             // emits looks like this; a hand-built invocation could.
+            let has_library_extension = path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| matches!(extension, "rlib" | "rmeta"))
+                || (cfg!(windows)
+                    && path
+                        .file_stem()
+                        .and_then(|stem| Path::new(stem).extension())
+                        .and_then(|extension| extension.to_str())
+                        .is_some_and(|extension| matches!(extension, "rlib" | "rmeta")));
             if emit.kind == "link"
                 && !matches!(self.link_output, LinkOutput::Library)
-                && matches!(
-                    path.extension().and_then(|extension| extension.to_str()),
-                    Some("rlib" | "rmeta")
-                )
+                && has_library_extension
             {
                 return Err(BypassReason::AmbiguousOutputName(path));
             }
@@ -1546,6 +1553,14 @@ impl<'a> Parser<'a> {
             && let Some(option) = self.first_link_argument()
         {
             return Err(BypassReason::UnmodeledLinkArgument(option.to_owned()));
+        }
+        if self.parsed.iter().any(|argument| {
+            matches!(argument, Argument::Plain(value) if value.starts_with("--codegen=linker="))
+        }) && !matches!(
+            link_output,
+            LinkOutput::NativeExecutable | LinkOutput::NativeProcMacro
+        ) {
+            return Err(BypassReason::UnknownCodegenOption("linker".into()));
         }
         // `-oso_prefix` is modeled, but only where ld64 is the linker reading
         // it: a native macOS link. Any other linker sees an option this

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1449,12 +1449,14 @@ fn a_program_named_like_a_library_is_not_cacheable() {
         "src/lib.rs",
     ]);
     let invocation = RustcInvocation::parse_with(&arguments, native_links()).unwrap();
+    let mut ambiguous = workspace().join("target/debug/deps/widget.rlib");
+    if !std::env::consts::EXE_EXTENSION.is_empty() {
+        ambiguous.set_extension(format!("rlib.{}", std::env::consts::EXE_EXTENSION));
+    }
 
     assert_eq!(
         invocation.outputs(&workspace()),
-        Err(BypassReason::AmbiguousOutputName(
-            workspace().join("target/debug/deps/widget.rlib")
-        ))
+        Err(BypassReason::AmbiguousOutputName(ambiguous))
     );
 
     // A library by that name is exactly what it claims to be.

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1141,10 +1141,10 @@ fn native_links_are_admitted_only_when_the_caller_models_them() {
     assert!(RustcInvocation::parse_with(&binary, native_links()).is_ok());
 }
 
-/// A linked program has no extension, and its executable bit is part of what
-/// the cache promises to restore.
+/// A linked program has the host executable extension, and its executable bit
+/// is part of what the cache promises to restore.
 #[test]
-fn a_native_program_is_named_without_an_extension() {
+fn a_native_program_uses_the_host_executable_name() {
     let working_dir = workspace();
     let invocation = RustcInvocation::parse_with(
         &args(&[
@@ -1158,13 +1158,50 @@ fn a_native_program_is_named_without_an_extension() {
         native_links(),
     )
     .unwrap();
-    let linked = working_dir.join("target/debug/deps/widget-abc123");
+    let name = if std::env::consts::EXE_EXTENSION.is_empty() {
+        "widget-abc123".into()
+    } else {
+        format!("widget-abc123.{}", std::env::consts::EXE_EXTENSION)
+    };
+    let linked = working_dir.join("target/debug/deps").join(name);
 
     let outputs = invocation.outputs(&working_dir).unwrap();
 
     assert_eq!(outputs.files, vec![linked.clone()]);
     assert!(outputs.is_executable(&linked));
     assert!(invocation.links_natively());
+}
+
+#[cfg(windows)]
+#[test]
+fn a_debug_native_program_caches_its_pdb() {
+    let working_dir = workspace();
+    let invocation = RustcInvocation::parse_with(
+        &args(&[
+            "--crate-name=widget",
+            "--test",
+            "--emit=dep-info,link",
+            "--out-dir=target/debug/deps",
+            "-Cdebuginfo=2",
+            "src/lib.rs",
+        ]),
+        native_links(),
+    )
+    .unwrap();
+
+    let outputs = invocation.outputs(&working_dir).unwrap();
+    assert!(
+        outputs
+            .files
+            .iter()
+            .any(|path| path.extension().is_some_and(|ext| ext == "exe"))
+    );
+    assert!(
+        outputs
+            .files
+            .iter()
+            .any(|path| path.extension().is_some_and(|ext| ext == "pdb"))
+    );
 }
 
 /// rustc without `--target` links for the host by construction, which is the

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1258,17 +1258,27 @@ fn unportable_native_links_still_bypass() {
             "-Clink-self-contained",
             BypassReason::UnportableNativeLink("link-self-contained".into()),
         ),
-        // Not modeled at all, so it never reaches the portability question.
-        (
-            "-Clinker=/usr/bin/false",
-            BypassReason::UnknownCodegenOption("linker".into()),
-        ),
     ] {
         let arguments = args(&["--test", "--emit=dep-info,link", flag, "src/lib.rs"]);
         assert_eq!(
             RustcInvocation::parse_with(&arguments, native_links()),
             Err(expected),
             "{flag} should not be cacheable"
+        );
+    }
+
+    let linker = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "-Clinker=/usr/bin/false",
+        "src/lib.rs",
+    ]);
+    if cfg!(windows) {
+        assert!(RustcInvocation::parse_with(&linker, native_links()).is_ok());
+    } else {
+        assert_eq!(
+            RustcInvocation::parse_with(&linker, native_links()),
+            Err(BypassReason::UnknownCodegenOption("linker".into()))
         );
     }
 

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 memchr = "2"
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
 mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.7", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.0", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.4", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.4", default-features = false }
 mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.7", default-features = false }
 rand = "0.10"

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 memchr = "2"
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.9.4", default-features = false }
 mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.7", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.9.4", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.0", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.9.4", default-features = false }
 mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.7", default-features = false }
 rand = "0.10"

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -186,7 +186,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let compilation_started = SystemTime::now();
     let mut command = Command::new(compiler);
     command.args(arguments);
-    command.args(invocation.dependency_arguments(&depfile, context.compiler.family));
+    command.args(invocation.dependency_arguments_for(&depfile, context.compiler.family));
     let output = command
         .output()
         .wrap_err_with(|| format!("failed to run {}", Path::new(compiler).display()))?;

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -370,7 +370,7 @@ impl Portable {
             else {
                 continue;
             };
-            let mut flag = OsString::from(if family == CcCompilerFamily::Msvc {
+            let mut flag = OsString::from(if family.is_msvc() {
                 "/pathmap:"
             } else {
                 "-fdebug-prefix-map="
@@ -602,7 +602,7 @@ fn compiler_identity(compiler: &OsStr, language: CcLanguage) -> Result<CcCompile
         probe_executable(&executable, &["-v"], &executable)?
     };
     let family = CcCompilerFamily::classify(&probe)?;
-    let target = if family == CcCompilerFamily::Msvc {
+    let target = if family.is_msvc() {
         std::env::var("VSCMD_ARG_TGT_ARCH").unwrap_or_default()
     } else {
         probe

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -20,7 +20,7 @@ use crate::session;
 use eyre::{Context, Result, bail};
 use mbx_cache_cc::{
     CcAction, CcActionContext, CcBypassReason, CcCompilerFamily, CcCompilerIdentity, CcDepfile,
-    CcDiscoveredInputs, CcInputPrediction, CcInvocation, CcLanguage, environment_inputs,
+    CcDiscoveredInputs, CcInputPrediction, CcInvocation, CcLanguage, environment_inputs_for,
     is_system_path, manifest_snapshot,
 };
 use mbx_cache_core::{
@@ -45,14 +45,18 @@ const ADAPTER: &str = "cc";
 pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -> Result<ExitCode> {
     let working_dir = std::env::current_dir()?;
     let mappings = path_mappings(&working_dir);
+    let identity = compiler_identity(compiler, language)?;
     // Appended before anything parses, so the flag is part of the key the same
     // way the caller's own prefix maps are.
-    let portable = Portable::detect(&mappings);
+    let portable = Portable::detect(&mappings, identity.family);
     let arguments = portable.applied_to(arguments);
     let arguments = arguments.as_ref();
-    let invocation = CcInvocation::parse(arguments)?;
-    let environment = environment_inputs(|name| std::env::var(name).ok(), invocation.sysroot())?;
-    let identity = compiler_identity(compiler, language)?;
+    let invocation = CcInvocation::parse_for(arguments, identity.family)?;
+    let environment = environment_inputs_for(
+        |name| std::env::var(name).ok(),
+        invocation.sysroot(),
+        identity.family,
+    )?;
     let mut context = CcActionContext {
         compiler: identity,
         working_dir: working_dir.clone(),
@@ -182,7 +186,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let compilation_started = SystemTime::now();
     let mut command = Command::new(compiler);
     command.args(arguments);
-    command.args(invocation.dependency_arguments(&depfile));
+    command.args(invocation.dependency_arguments(&depfile, context.compiler.family));
     let output = command
         .output()
         .wrap_err_with(|| format!("failed to run {}", Path::new(compiler).display()))?;
@@ -344,7 +348,7 @@ struct Portable {
 }
 
 impl Portable {
-    fn detect(mappings: &[PathMapping]) -> Self {
+    fn detect(mappings: &[PathMapping], family: CcCompilerFamily) -> Self {
         let mut portable = Self {
             arguments: Vec::new(),
             values: Vec::new(),
@@ -366,7 +370,11 @@ impl Portable {
             else {
                 continue;
             };
-            let mut flag = OsString::from("-fdebug-prefix-map=");
+            let mut flag = OsString::from(if family == CcCompilerFamily::Msvc {
+                "/pathmap:"
+            } else {
+                "-fdebug-prefix-map="
+            });
             flag.push(&value);
             flag.push("=");
             flag.push(&placeholder);
@@ -416,7 +424,7 @@ fn discover(
     context: &CcActionContext,
     depfile: &Path,
 ) -> Result<CcDiscoveredInputs> {
-    let dependencies = CcDepfile::read(depfile)?;
+    let dependencies = CcDepfile::read_for(depfile, context.compiler.family)?;
     let mut files = BTreeSet::new();
     for path in dependencies
         .files
@@ -452,7 +460,7 @@ fn searchable_directories(invocation: &CcInvocation, working_dir: &Path) -> BTre
                 .parent()
                 .map(|parent| absolute(parent, working_dir)),
         )
-        .filter(|directory| !is_system_path(directory))
+        .filter(|directory| !is_system_include_path(directory))
         .collect()
 }
 
@@ -499,7 +507,7 @@ fn manifest_directories(
                 .iter()
                 .filter_map(|file| file.parent().map(Path::to_path_buf)),
         )
-        .filter(|directory| !is_system_path(directory))
+        .filter(|directory| !is_system_include_path(directory))
         .collect()
 }
 
@@ -542,8 +550,26 @@ fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
         "rustup_home",
     );
     add(dirs::home_dir(), "home");
+    add(std::env::var_os("VCINSTALLDIR").map(PathBuf::from), "msvc");
+    add(
+        std::env::var_os("WindowsSdkDir").map(PathBuf::from),
+        "windows_sdk",
+    );
+    add(
+        std::env::var_os("UniversalCRTSdkDir").map(PathBuf::from),
+        "ucrt_sdk",
+    );
     let _ = working_dir;
     mappings
+}
+
+fn is_system_include_path(path: &Path) -> bool {
+    is_system_path(path)
+        || ["VCINSTALLDIR", "WindowsSdkDir", "UniversalCRTSdkDir"]
+            .iter()
+            .filter_map(std::env::var_os)
+            .map(PathBuf::from)
+            .any(|root| path.starts_with(root))
 }
 
 fn rustc_path_mappings(mappings: &[PathMapping]) -> Vec<mbx_cache_rustc::PathMapping> {
@@ -566,13 +592,25 @@ fn session_path(name: &str) -> Option<PathBuf> {
 /// the compiler just to ask its version.
 fn compiler_identity(compiler: &OsStr, language: CcLanguage) -> Result<CcCompilerIdentity> {
     let executable = resolve_executable(compiler)?;
-    let probe = probe_executable(&executable, &["-v"], &executable)?;
+    let is_cl = executable
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("cl"));
+    let probe = if is_cl {
+        probe_msvc(&executable)?
+    } else {
+        probe_executable(&executable, &["-v"], &executable)?
+    };
     let family = CcCompilerFamily::classify(&probe)?;
-    let target = probe
-        .lines()
-        .find_map(|line| line.strip_prefix("Target: "))
-        .unwrap_or_default()
-        .to_string();
+    let target = if family == CcCompilerFamily::Msvc {
+        std::env::var("VSCMD_ARG_TGT_ARCH").unwrap_or_default()
+    } else {
+        probe
+            .lines()
+            .find_map(|line| line.strip_prefix("Target: "))
+            .unwrap_or_default()
+            .to_string()
+    };
     let assembler = if family.uses_external_assembler() {
         assembler_identity(&executable)
     } else {
@@ -585,6 +623,40 @@ fn compiler_identity(compiler: &OsStr, language: CcLanguage) -> Result<CcCompile
         target,
         assembler,
     })
+}
+
+/// MSVC prints its detailed `/Bv` identity before complaining that no source
+/// was supplied. That non-zero exit is a property of the query shape, not a
+/// failed identity probe, so accept it only when the expected banner is there.
+fn probe_msvc(executable: &Path) -> Result<String> {
+    let environment = BTreeMap::new();
+    if let Ok(responses) = session::request_agent(&[AgentRequest::FindExecutableIdentity {
+        executable: executable.to_path_buf(),
+        environment: environment.clone(),
+    }]) && let Some(AgentResponse::ExecutableIdentity { stdout: Some(text) }) =
+        responses.into_iter().next()
+    {
+        return Ok(String::from_utf8_lossy(&text).into_owned());
+    }
+    let output = Command::new(executable)
+        .arg("/Bv")
+        .output()
+        .map_err(|error| CcBypassReason::CompilerIdentityUnavailable(error.to_string()))?;
+    let mut text = String::from_utf8_lossy(&output.stderr).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    if !text.contains("Microsoft (R) C/C++ Optimizing Compiler") {
+        return Err(CcBypassReason::CompilerIdentityUnavailable(format!(
+            "{} did not report an MSVC compiler identity",
+            executable.display()
+        ))
+        .into());
+    }
+    let _ = session::request_agent(&[AgentRequest::StoreExecutableIdentity {
+        executable: executable.to_path_buf(),
+        environment,
+        stdout: text.clone().into_bytes(),
+    }]);
+    Ok(text)
 }
 
 /// The assembler path a driver named, if it named one at all.

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -134,8 +134,8 @@ pub(crate) struct RawConfig {
     savings: String,
     /// Cache natively linked test binaries, executables, and proc macros. On macOS this
     /// also passes ld64 `-oso_prefix` so a debug-info link's debug map stops
-    /// naming this checkout, which is what lets it cache. Linux and macOS
-    /// only, and a link mbx cannot describe exactly still links normally.
+    /// naming this checkout, which is what lets it cache. Supported on Linux,
+    /// macOS, and Windows; a link mbx cannot describe exactly still links normally.
     #[usage(
         key = "cache_links",
         env = "MBX_CACHE_LINKS",

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -20,7 +20,17 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Environment that selects what the probes below report.
-const IDENTITY_ENVIRONMENT: &[&str] = &["SDKROOT", "MACOSX_DEPLOYMENT_TARGET"];
+const IDENTITY_ENVIRONMENT: &[&str] = &[
+    "SDKROOT",
+    "MACOSX_DEPLOYMENT_TARGET",
+    "LIB",
+    "UCRTVersion",
+    "UniversalCRTSdkDir",
+    "VCToolsInstallDir",
+    "VCToolsVersion",
+    "WindowsSdkDir",
+    "WindowsSDKVersion",
+];
 
 /// What the driver is asked to place, and which of it a key cannot do without.
 ///
@@ -87,8 +97,29 @@ fn file_probes() -> FileProbes {
 ///
 /// Memoized through the agent for the life of the build, since the answer is
 /// the same for every link in it and the probes are several processes.
-pub(crate) fn identity() -> Result<LinkerIdentity> {
-    let driver = which::which("cc").wrap_err("failed to find the linker driver `cc`")?;
+/// Describe the default linker, or a recognized Windows linker override.
+pub(crate) fn identity_for(override_linker: Option<&Path>) -> Result<LinkerIdentity> {
+    let driver = if let Some(linker) = override_linker {
+        if !cfg!(windows)
+            || !linker
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    matches!(
+                        name.to_ascii_lowercase().as_str(),
+                        "link" | "link.exe" | "lld-link" | "lld-link.exe"
+                    )
+                })
+        {
+            bail!("the selected linker is not one mbx can identify");
+        }
+        which::which(linker)
+            .wrap_err_with(|| format!("failed to find linker `{}`", linker.display()))?
+    } else if cfg!(windows) {
+        which::which("link.exe").wrap_err("failed to find the linker `link.exe`")?
+    } else {
+        which::which("cc").wrap_err("failed to find the linker driver `cc`")?
+    };
     let environment = IDENTITY_ENVIRONMENT
         .iter()
         .map(|name| ((*name).into(), std::env::var(name).ok()))
@@ -135,6 +166,9 @@ fn record(
 }
 
 fn probe(driver: &Path) -> Result<LinkerIdentity> {
+    if cfg!(windows) {
+        return probe_windows(driver);
+    }
     Ok(LinkerIdentity {
         driver: driver
             .to_str()
@@ -146,6 +180,109 @@ fn probe(driver: &Path) -> Result<LinkerIdentity> {
         sdk: sdk_identity()?,
         deployment_target: std::env::var("MACOSX_DEPLOYMENT_TARGET").ok(),
     })
+}
+
+/// Bind a Windows link to the MSVC/LLVM linker, toolset, SDK, and CRT import
+/// libraries selected by the developer environment.
+fn probe_windows(linker: &Path) -> Result<LinkerIdentity> {
+    let is_lld = linker
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.to_ascii_lowercase().starts_with("lld-link"));
+    let linker_report = run_allowing_status(linker, if is_lld { &["--version"] } else { &["/?"] })?;
+    let linker_version = linker_report
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    let cl = which::which("cl.exe")
+        .wrap_err("failed to find `cl.exe` for the MSVC toolchain identity")?;
+    let compiler_version = run_allowing_status(&cl, &["/Bv"])?;
+    let crt_objects = windows_crt_objects()?;
+    let sdk = windows_sdk_identity()?;
+    Ok(LinkerIdentity {
+        driver: linker
+            .to_str()
+            .ok_or_else(|| eyre::eyre!("the linker path is not valid UTF-8"))?
+            .to_owned(),
+        driver_version: compiler_version,
+        linker_version,
+        crt_objects,
+        sdk: Some(sdk),
+        deployment_target: None,
+    })
+}
+
+fn run_allowing_status(program: &Path, arguments: &[&str]) -> Result<String> {
+    let output = Command::new(program)
+        .args(arguments)
+        .output()
+        .wrap_err_with(|| format!("failed to run {}", program.display()))?;
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    let reported = text.trim();
+    if reported.is_empty() {
+        bail!("{} {arguments:?} reported nothing", program.display());
+    }
+    Ok(reported.to_owned())
+}
+
+fn windows_sdk_identity() -> Result<String> {
+    windows_sdk_identity_for(|name| std::env::var(name).ok())
+}
+
+fn windows_sdk_identity_for(lookup: impl Fn(&str) -> Option<String>) -> Result<String> {
+    let values = ["VCToolsVersion", "WindowsSDKVersion", "UCRTVersion"]
+        .into_iter()
+        .filter_map(|name| {
+            lookup(name)
+                .filter(|value| !value.is_empty())
+                .map(|value| format!("{name}={value}"))
+        })
+        .collect::<Vec<_>>();
+    if values.len() < 2 {
+        bail!("the MSVC toolset and Windows SDK versions could not be identified");
+    }
+    Ok(values.join("; "))
+}
+
+fn windows_crt_objects() -> Result<BTreeMap<String, CacheDigest>> {
+    let directories = std::env::var_os("LIB")
+        .map(|value| std::env::split_paths(&value).collect::<Vec<_>>())
+        .unwrap_or_default();
+    windows_crt_objects_in(&directories)
+}
+
+fn windows_crt_objects_in(directories: &[PathBuf]) -> Result<BTreeMap<String, CacheDigest>> {
+    let names = [
+        "libcmt.lib",
+        "libcmtd.lib",
+        "msvcrt.lib",
+        "msvcrtd.lib",
+        "vcruntime.lib",
+        "vcruntimed.lib",
+        "ucrt.lib",
+        "ucrtd.lib",
+    ];
+    let mut resolved = BTreeMap::<String, CacheDigest>::new();
+    for name in names {
+        if let Some(path) = directories
+            .iter()
+            .map(|dir| dir.join(name))
+            .find(|path| path.is_file())
+        {
+            let digest = CacheDigest::blake3_file(&path)
+                .wrap_err_with(|| format!("failed to hash CRT library {}", path.display()))?;
+            resolved.insert(name.into(), digest);
+        }
+    }
+    if !resolved.keys().any(|name| name.starts_with("vcruntime"))
+        || !resolved.keys().any(|name| name.starts_with("ucrt"))
+    {
+        bail!("the MSVC and Universal CRT libraries could not both be identified");
+    }
+    Ok(resolved)
 }
 
 /// Version of the linker the driver selects, as opposed to the driver itself.

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -140,6 +140,26 @@ fn a_platform_that_places_nothing_is_still_identified() {
     assert!(probe_files(&probes, |_| None).unwrap().is_empty());
 }
 
+#[test]
+fn a_windows_identity_requires_toolset_sdk_and_both_crts() {
+    let version = windows_sdk_identity_for(|name| match name {
+        "VCToolsVersion" => Some("14.40".into()),
+        "WindowsSDKVersion" => Some("10.0.26100.0".into()),
+        _ => None,
+    })
+    .unwrap();
+    assert!(version.contains("VCToolsVersion=14.40"));
+    assert!(windows_sdk_identity_for(|_| None).is_err());
+
+    let directory = tempfile::tempdir().unwrap();
+    std::fs::write(directory.path().join("vcruntime.lib"), b"vc runtime").unwrap();
+    std::fs::write(directory.path().join("ucrt.lib"), b"universal crt").unwrap();
+    let identity = windows_crt_objects_in(&[directory.path().to_path_buf()]).unwrap();
+    assert_eq!(identity.len(), 2);
+    std::fs::remove_file(directory.path().join("ucrt.lib")).unwrap();
+    assert!(windows_crt_objects_in(&[directory.path().to_path_buf()]).is_err());
+}
+
 /// `SDKROOT` names the SDK a link is made against, so it has to be the SDK
 /// every part of the identity describes. Reporting the default SDK's version
 /// beside another SDK's path would put an SDK nothing was built against in the
@@ -169,7 +189,7 @@ fn the_sdk_identity_follows_sdkroot() {
 fn the_platform_gate_does_not_depend_on_who_set_the_variable() {
     assert_eq!(
         crate::session::cache_links_supported(),
-        cfg!(any(target_os = "linux", target_os = "macos"))
+        cfg!(any(target_os = "linux", target_os = "macos", windows))
     );
     // Whatever the environment says, an unsupported host never admits links.
     if !crate::session::cache_links_supported() {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -859,7 +859,7 @@ fn linker_for(invocation: &RustcInvocation) -> Result<Option<LinkerIdentity>> {
     if !invocation.links_natively() {
         return Ok(None);
     }
-    match crate::linker::identity() {
+    match crate::linker::identity_for(invocation.linker_override()) {
         Ok(identity) => Ok(Some(identity)),
         Err(error) => Err(BypassReason::UnportableNativeLink(format!(
             "the linker could not be identified: {error:#}"

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -638,6 +638,7 @@ const PATH_SHIM_NAMES: &[(&str, CcLanguage)] = &[
     ("c++", CcLanguage::Cxx),
     ("g++", CcLanguage::Cxx),
     ("clang++", CcLanguage::Cxx),
+    ("cl.exe", CcLanguage::Cxx),
 ];
 
 /// The language a standalone shim name selects, if the name is one.
@@ -660,6 +661,7 @@ pub fn is_cc_shim() -> Option<CcLanguage> {
     match stem.as_str() {
         CC_SHIM_STEM => Some(CcLanguage::C),
         CXX_SHIM_STEM => Some(CcLanguage::Cxx),
+        "cl" if cfg!(windows) => Some(CcLanguage::Cxx),
         // `mbx-cxx-...` is tested first: `mbx-cc-` is not a prefix of it, but
         // reading it the other way round invites the mistake.
         other if other.starts_with(&format!("{CXX_SHIM_STEM}-")) => Some(CcLanguage::Cxx),
@@ -1094,7 +1096,7 @@ pub(crate) fn record_file_digests(scope: FileDigestScope, entries: Vec<RecordedF
 /// cannot describe would otherwise key a link as though the linker did not
 /// matter.
 pub fn cache_links_supported() -> bool {
-    cfg!(any(target_os = "linux", target_os = "macos"))
+    cfg!(any(target_os = "linux", target_os = "macos", windows))
 }
 
 /// Whether the shim may cache a natively linked program.

--- a/crates/mbx/src/session/shims.rs
+++ b/crates/mbx/src/session/shims.rs
@@ -124,7 +124,7 @@ pub(super) const CC_CRATE_ENV: &[&str] = &["CC", "CXX", "HOST_CC", "HOST_CXX"];
 /// one compiler, and so a machine with no C compiler simply gets no shims
 /// instead of a build script that fails differently than it would have.
 pub(super) fn install_cc_shims(shims_dir: &Path) -> Result<Option<CcShims>> {
-    if !cfg!(unix) {
+    if !cfg!(any(unix, windows)) {
         return Ok(None);
     }
     let executable = std::env::current_exe().wrap_err("failed to locate the running mbx binary")?;
@@ -253,7 +253,7 @@ pub struct PathShims {
 /// running through the cache rather than around it. Nothing is added to any
 /// `PATH` but the one handed to a single `mbx exec` command.
 pub fn install_path_shims(directory: &Path) -> Result<Option<PathShims>> {
-    if !cfg!(unix) {
+    if !cfg!(any(unix, windows)) {
         return Ok(None);
     }
     let executable = std::env::current_exe().wrap_err("failed to locate the running mbx binary")?;
@@ -321,7 +321,26 @@ fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
+    // Windows cannot replace an executable while another process has it open,
+    // so a stable existing shim is preferable to a racy in-place upgrade. A
+    // missing shim is pinned to this binary by hard link, with copy fallback.
+    if destination.is_file() {
+        return Ok(());
+    }
+    if let Err(link_error) = std::fs::hard_link(executable, destination) {
+        std::fs::copy(executable, destination).wrap_err_with(|| {
+            format!(
+                "failed to install the shim {} by hard link ({link_error}) or copy",
+                destination.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
 fn link_path_shim(_executable: &Path, _destination: &Path) -> Result<()> {
     eyre::bail!("PATH shims are not supported on this platform")
 }

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -82,7 +82,7 @@ summary lines together, and compare wall-clock time when evaluating the cache.
 
 A link mbx cannot describe always runs, so its downstream crates may have work
 to do on an otherwise warm build. Native executables, tests, and proc macros on
-Linux and macOS, plus binaries, tests, and `cdylib`s for supported self-contained
+Linux, macOS, and Windows, plus binaries, tests, and `cdylib`s for supported self-contained
 WebAssembly targets, may be restored as hits; see
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 
@@ -105,9 +105,8 @@ The usual causes, roughly in the order they show up:
   changed artifacts make crates above them miss too. See
   [limits](/limits#incremental-compilations-are-not-cached).
 - **A link could not be described.** Native executables, tests, and proc macros
-  are cached on Linux and macOS, and self-contained WebAssembly targets
-  everywhere, but native links with custom or unmodeled inputs and links built
-  on Windows still run. A rebuilt dylib can also change the keys of its
+  are cached on Linux, macOS, and Windows, and self-contained WebAssembly targets
+  everywhere, but native links with custom or unmodeled inputs still run. A rebuilt dylib can also change the keys of its
   downstream crates. `mbx explain` reports why the link bypassed; see
   [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 - **The inputs actually differ.** A different toolchain, feature set, profile,

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -31,7 +31,7 @@ Cache root.
 - **Scope:** only from the environment or the command line
 - **Set with:** `MBX_CACHE_LINKS`
 
-Cache natively linked test binaries, executables, and proc macros. On macOS this also passes ld64 `-oso_prefix` so a debug-info link's debug map stops naming this checkout, which is what lets it cache. Linux and macOS only, and a link mbx cannot describe exactly still links normally.
+Cache natively linked test binaries, executables, and proc macros. On macOS this also passes ld64 `-oso_prefix` so a debug-info link's debug map stops naming this checkout, which is what lets it cache. Supported on Linux, macOS, and Windows; a link mbx cannot describe exactly still links normally.
 
 ### `cc`
 

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -48,7 +48,7 @@ it is safe to let CI write.
   publish cannot, and one that may publish still cannot rewrite or remove
   what an earlier build wrote.
 
-If you need CUDA, distributed compilation, or C and C++ on Windows and MSVC,
+If you need CUDA or distributed compilation,
 sccache is the right tool. Both wrap rustc through `RUSTC_WRAPPER`, so they
 cannot be combined for the same build.
 
@@ -65,7 +65,7 @@ requests. The differences below are mostly those three goals.
 
 Like mbx, kache is a content-addressed `RUSTC_WRAPPER` cache built for sharing
 compilations across worktrees, with C and C++ compiler shims, S3-compatible
-and filesystem remotes, and executable caching on Linux and macOS.
+and filesystem remotes, and executable caching on Linux, macOS, and Windows.
 
 - **Nothing to install or keep running.** `kache init` installs an OS service
   by default, with a `--no-service` opt-out. mbx starts an in-process agent
@@ -115,16 +115,16 @@ and filesystem remotes, and executable caching on Linux and macOS.
   kache installs them alongside its service, so once they are on `PATH` every
   build on the machine goes through the cache; mbx puts them on `PATH` for a
   single [`mbx exec`](/standalone-builds) command, so a build is cached when
-  it asks to be and untouched otherwise. kache covers Windows;
-  mbx shims only the plain Unix driver names.
-- **Linked binaries.** Both cache them on Linux and macOS. mbx keys on the
+  it asks to be and untouched otherwise. Both cover Windows; mbx intercepts
+  `cl.exe` there and the plain gcc/clang driver names on Unix.
+- **Linked binaries.** Both cache them on Linux, macOS, and Windows. mbx keys on the
   resolved linker, startup objects, libc, and SDK rather than dep-info alone,
   because a binary linked against a different libc or SDK is a different
   binary. On a host mbx cannot describe that precisely, it links normally
   rather than handing back one it cannot vouch for.
 
-If you build on Windows, or want the C and C++ shims installed once rather
-than wrapping the commands that should use them, kache is worth evaluating.
+If you want the C and C++ shims installed once rather than wrapping the
+commands that should use them, kache is worth evaluating.
 Both tools wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
 the same build.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ scenario in [benchmarks](/benchmarks#cold).
 ## Why does a fully warm build still take time?
 
 Links mbx cannot describe always run — a large binary re-links even when every
-compilation hit. Host binaries and tests are restored on Linux and macOS, and
+compilation hit. Host binaries and tests are restored on Linux, macOS, and Windows, and
 self-contained WebAssembly targets everywhere; the rest is
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,12 +120,11 @@ differences, which the pages they belong to also note in place:
 - The managed `target` link needs Developer Mode or a privileged process;
   where Windows refuses to create it, Cargo keeps its ordinary target
   directory. See [managed target directories](/managed-targets).
-- rustc compilations are cached as on every platform, but there is no
-  native-link tier: host programs and tests link as they always did, and only
-  the self-contained WebAssembly targets restore linked binaries. See
+- rustc compilations and native host links are cached; native-link keys bind
+  the selected MSVC/LLVM linker, Windows SDK, and CRT. See
   [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
-- No C or C++ shims are installed, and MSVC invocations are never modeled, so
-  build-script C and `mbx exec` caching are Unix-only. See
+- MSVC C and C++ compiles from build scripts and `mbx exec` are cached through
+  a conservative `cl.exe` adapter. See
   [limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
 
 ## Run a build

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -30,16 +30,17 @@ linker, so it is cached on every platform:
 mbx caches those links because all explicit artifacts are modeled inputs and
 the linker, CRT objects, and bundled libc are covered by the Rust toolchain
 identity. Custom target specifications, external WebAssembly toolchains,
-native libraries, custom linkers, disabled WASI CRT bundling, and
+native libraries, unrecognized custom linkers, disabled WASI CRT bundling, and
 non-affirmative `link-self-contained` modes remain uncached.
 
-Host test binaries and executables are cached on Linux and macOS, by putting
+Host test binaries and executables are cached on Linux, macOS, and Windows, by putting
 the rest of the link into the key: the resolved `cc` driver and its version,
 the linker it selects, the startup objects and libc it resolves (hashed), and
-on macOS the SDK. Two hosts that differ in any of those produce different keys
+on macOS the SDK. On Windows the key identifies `link.exe` or `lld-link`, the
+MSVC toolset and Windows SDK versions, and the selected VC and Universal CRT
+libraries. Two hosts that differ in any of those produce different keys
 and miss, rather than sharing a binary neither of them built. `cache_links`
-(`MBX_CACHE_LINKS=0`) turns it off; Windows has no such tier, and a build
-there links its programs as it always did.
+(`MBX_CACHE_LINKS=0`) turns it off.
 
 Some hosts cannot be described at all. mbx asks the driver to place a startup
 object and a libc, and a host where neither resolves gets no linker identity
@@ -97,11 +98,12 @@ mbx caches the C and C++ a cargo build script compiles for the host through
 the `cc` crate, and the C and C++ of a command run under
 [`mbx exec`](/standalone-builds), which puts shims for the plain driver names
 on `PATH` for that command alone. A compile mbx never stood in for — one
-outside both paths, or on Windows, where no shims are installed — is not
+outside both paths — is not
 reached. Neither are cross compilations: a cargo build installs the shims as
 `HOST_CC` and `HOST_CXX`, which the `cc` crate consults only when host and
 target agree, and `mbx exec` shims only `cc`, `c++`, `gcc`, `g++`, `clang`,
-and `clang++`, leaving a versioned toolchain to the build that chose it.
+and `clang++` on Unix, plus `cl.exe` on Windows, leaving a versioned toolchain
+to the build that chose it.
 
 A cross compile is cached when the build names its own compiler, through
 `CC_<target>`, `CXX_<target>`, `TARGET_CC`, or `TARGET_CXX`: mbx wraps what
@@ -111,11 +113,12 @@ tables — guessing wrong would not cost a cache hit, it would build the object
 with the wrong compiler. A value that is a command rather than a path, such as
 `ccache gcc`, is left alone for the same reason.
 
-Only a plain single-source `-c` compile through a gcc-style or clang-style
+Only a plain single-source object compile through a gcc-, clang-, or MSVC-style
 driver is admitted. Linking, preprocessing, assembly, Objective-C, precompiled
 headers, coverage instrumentation, compiler plugins, options forwarded to a
-sub-tool with `-Wp,`/`-Wa,`/`-Wl,`/`-Xclang`, response files, and MSVC all
-bypass, as does any flag the adapter does not model. A source or header that
+sub-tool with `-Wp,`/`-Wa,`/`-Wl,`/`-Xclang`, and response files all bypass,
+as does any flag the adapter does not model. MSVC compiler PDBs, modules, and
+other extra outputs also bypass. A source or header that
 expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__` bypasses too: its object is
 not a function of its inputs.
 

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -20,12 +20,14 @@ nothing is installed globally.
 
 ## What `mbx exec` does
 
-While the command runs, mbx puts wrappers for the common Unix compiler names
-at the front of `PATH`:
+While the command runs, mbx puts wrappers for the common compiler names at the
+front of `PATH`:
 
 ```text
 cc  c++  gcc  g++  clang  clang++
 ```
+
+On Windows it wraps `cl.exe` instead.
 
 When the build tool calls one of those names, mbx checks the cache first. On a
 hit, it restores the object file. On a miss, it runs the compiler that would
@@ -59,13 +61,13 @@ real compiler without using the cache.
 
 ## What gets cached
 
-mbx caches ordinary gcc- and clang-style compile commands that compile one C
-or C++ source file into an object with `-c`. It does not cache links,
+mbx caches ordinary gcc-, clang-, and MSVC-style compile commands that compile
+one C or C++ source file into an object. It does not cache links,
 multi-source compiler calls, or commands whose behavior it cannot model
 safely. Those commands still run normally; the session summary reports why
 they bypassed the cache.
 
-`mbx exec` only intercepts the six unversioned compiler names listed above. It
+`mbx exec` only intercepts the unversioned compiler names listed above. It
 leaves commands such as `gcc-13`, absolute compiler paths, and explicitly
 selected cross-compilers alone.
 

--- a/e2e-win/Cache.Tests.ps1
+++ b/e2e-win/Cache.Tests.ps1
@@ -57,4 +57,40 @@ fn main() {
         $LASTEXITCODE | Should -Be 0 -Because $warm
         $warm | Should -Match 'mbx\[cache\]: [1-9][0-9]* hits'
     }
+
+    It 'restores a natively linked executable' {
+        New-Item -ItemType Directory -Path src | Out-Null
+        @'
+[package]
+name = "native-link-fixture"
+version = "0.1.0"
+edition = "2024"
+'@ | Set-Content -Encoding utf8 Cargo.toml
+        'fn main() { println!("linked"); }' | Set-Content -Encoding utf8 src\main.rs
+
+        $lockfile = & cargo generate-lockfile 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $lockfile
+        $cold = & mbx build --release 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $cold
+
+        Remove-Item -Recurse -Force target
+        $warm = & mbx build --release 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $warm
+        $warm | Should -Match 'mbx\[cache\]: [1-9][0-9]* hits'
+        Test-Path target\release\native-link-fixture.exe | Should -BeTrue
+    }
+
+    It 'restores an MSVC object compiled through mbx exec' {
+        'int answer(void) { return 42; }' | Set-Content -Encoding ascii hello.c
+
+        $cold = & mbx exec cl.exe /nologo /Z7 /Brepro /Fohello.obj /c hello.c 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $cold
+        Test-Path hello.obj | Should -BeTrue
+
+        Remove-Item hello.obj
+        $warm = & mbx exec cl.exe /nologo /Z7 /Brepro /Fohello.obj /c hello.c 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0 -Because $warm
+        $warm | Should -Match 'mbx\[cache\]: 1 hit'
+        Test-Path hello.obj | Should -BeTrue
+    }
 }

--- a/e2e-win/Cache.Tests.ps1
+++ b/e2e-win/Cache.Tests.ps1
@@ -81,14 +81,15 @@ edition = "2024"
     }
 
     It 'restores an MSVC object compiled through mbx exec' {
-        'int answer(void) { return 42; }' | Set-Content -Encoding ascii hello.c
+        New-Item -ItemType Directory -Path src | Out-Null
+        'int answer(void) { return 42; }' | Set-Content -Encoding ascii src\hello.c
 
-        $cold = & mbx exec cl.exe /nologo /Z7 /Brepro /Fohello.obj /c hello.c 2>&1 | Out-String
+        $cold = & mbx exec cl.exe /nologo /Z7 /Brepro /Fohello.obj /c src\hello.c 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0 -Because $cold
         Test-Path hello.obj | Should -BeTrue
 
         Remove-Item hello.obj
-        $warm = & mbx exec cl.exe /nologo /Z7 /Brepro /Fohello.obj /c hello.c 2>&1 | Out-String
+        $warm = & mbx exec cl.exe /nologo /Z7 /Brepro /Fohello.obj /c src\hello.c 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0 -Because $warm
         $warm | Should -Match 'mbx\[cache\]: 1 hit'
         Test-Path hello.obj | Should -BeTrue

--- a/e2e-win/run.ps1
+++ b/e2e-win/run.ps1
@@ -2,6 +2,19 @@ param(
     [string]$TestName
 )
 
+if (-not (Get-Command cl.exe -ErrorAction Ignore)) {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path $vswhere)) {
+        throw 'Visual Studio Installer could not be found; the Windows cache tests require MSVC'
+    }
+    $installation = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
+    if (-not $installation) {
+        throw 'An installed Visual Studio C++ toolchain could not be found'
+    }
+    Import-Module (Join-Path $installation 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
+    Enter-VsDevShell -VsInstallPath $installation -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64'
+}
+
 $config = New-PesterConfiguration
 $config.Run.Path = $PSScriptRoot
 $config.Run.Exit = $true


### PR DESCRIPTION
## Summary

- add a Windows native-link tier for `link.exe` and `lld-link`, keyed by toolchain, Windows SDK, and hashed CRT identity
- add conservative `cl.exe` compile caching using `/sourceDependencies`, Windows shims, and MSVC-aware argument and path modeling
- restore Windows executable/PDB outputs and update the documented platform comparison
- add unit coverage plus Windows end-to-end tests for native links and MSVC objects

## Validation

- `cargo test -p mbx-cache-rustc -p mbx-cache-cc -p mbx --lib`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Windows-specific end-to-end cases are included for the Windows CI runner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cache keys and restored artifacts for native links and MSVC compiles on Windows—incorrect linker/CRT or depfile modeling could serve wrong binaries or objects across machines.
> 
> **Overview**
> **Windows becomes a first-class caching tier** for native host links and for C/C++ compiles driven through `cl.exe`, with docs and e2e tests updated to match.
> 
> **Native links on Windows** can be restored when `MBX_CACHE_LINKS` is on: linker identity now covers `link.exe` / `lld-link` (including `-Clinker=` on Windows), keys MSVC toolset/SDK versions and hashed CRT import libs from `LIB`, and extends executable-identity env allowlists. Rustc output modeling adds `.exe` names, treats ambiguous `*.rlib.exe`-style outputs correctly, and includes companion `.pdb` files when debug info is enabled.
> 
> **MSVC compile caching** adds `CcCompilerFamily::Msvc`, a conservative `MsvcParser`, `/sourceDependencies` JSON depfile parsing (`serde_json`), family-specific env keys (`INCLUDE`, toolset/SDK versions), `/pathmap:` for portable `OUT_DIR`, and integration in `mbx` (probe via `/Bv`, MSVC path roots, shims for `cl.exe` on Windows). Unmodeled MSVC flags (PDBs, modules, caller dependency flags) still bypass.
> 
> **Platform plumbing**: C/C++ shims install on Windows (hard-link fallback), `cache_links_supported` includes Windows, and Windows CI loads the VS dev shell plus new Pester cases for linked binaries and `mbx exec cl` object restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e339b3454a49bae6d126ff91c91ed60d2ea391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->