### PR TITLE
feat: cache rustdoc actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ sooner this way.
 
 ## How it works
 
-An `mbx` Cargo command starts an in-process cache agent, points Cargo at a rustc shim with
-`RUSTC_WRAPPER`, and exits the agent with the build — there is no daemon. The shim
-derives an action key, restores cached outputs when possible, or runs the real
-compiler and publishes a successful result.
+An `mbx` Cargo command starts an in-process cache agent, points Cargo at rustc and
+rustdoc shims, and exits the agent with the build — there is no daemon. The shims
+derive action keys, restore cached outputs when possible, or run the real tool and
+publish a successful result. That includes `cargo doc`: rendered crate pages are
+cached independently, then rustdoc cheaply rebuilds their shared search indexes.
 
 Anything mbx cannot model exactly bypasses the cache. A native link is cached
 only when the linker itself can enter the key: host binaries and tests on Linux

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -50,4 +50,5 @@ mod cc;
 mod linker;
 mod materialize;
 mod rustc;
+mod rustdoc;
 mod scheduler;

--- a/crates/mbx/src/main.rs
+++ b/crates/mbx/src/main.rs
@@ -6,6 +6,9 @@ fn main() -> ExitCode {
     if mbx::session::is_rustc_shim() {
         return mbx::session::run_rustc_shim();
     }
+    if mbx::session::is_rustdoc_shim() {
+        return mbx::session::run_rustdoc_shim();
+    }
     if let Some(language) = mbx::session::is_cc_shim() {
         return mbx::session::run_cc_shim(language);
     }

--- a/crates/mbx/src/rustdoc.rs
+++ b/crates/mbx/src/rustdoc.rs
@@ -37,7 +37,43 @@ const REMOVED_ENVIRONMENT: &[&str] = &[
     "MBX_STAGING_DIR",
     "MBX_VERIFY",
     "RUSTC_WRAPPER",
+    "RUSTC_BOOTSTRAP",
     "RUSTDOC",
+];
+const HOST_ENVIRONMENT: &[&str] = &[
+    "_",
+    "CI",
+    "CARGO_HOME",
+    "CODEBUILD_BUILD_ID",
+    "COMSPEC",
+    "GITHUB_ACTIONS",
+    "HOME",
+    "HOSTNAME",
+    "NUMBER_OF_PROCESSORS",
+    "OLDPWD",
+    "PATH",
+    "PATHEXT",
+    "PWD",
+    "RUSTUP_HOME",
+    "SHLVL",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "USERDOMAIN",
+    "USERNAME",
+    "USERPROFILE",
+];
+const HOST_ENVIRONMENT_PREFIXES: &[&str] = &[
+    "ACTIONS_",
+    "BUILDKITE_",
+    "CIRCLE_",
+    "GITHUB_",
+    "JENKINS_",
+    "RUNNER_",
+    "TEAMCITY_",
+    "TF_BUILD",
 ];
 
 #[derive(Serialize)]
@@ -106,12 +142,14 @@ pub(crate) fn document(rustdoc: &OsStr, arguments: &[OsString]) -> Result<ExitCo
     prepare_command(&mut command);
     let output = command.output().wrap_err("failed to run rustdoc")?;
     let duration = duration_ns(started.elapsed());
-    if !output.status.success() {
-        bail!("mergeable rustdoc invocation failed");
-    }
-    session::record_compiler_invocation("miss", Some(&invocation.crate_name), duration);
     std::io::stdout().write_all(&output.stdout)?;
     std::io::stderr().write_all(&output.stderr)?;
+    if !output.status.success() {
+        return Ok(ExitCode::from(
+            u8::try_from(output.status.code().unwrap_or(1)).unwrap_or(1),
+        ));
+    }
+    session::record_compiler_invocation("miss", Some(&invocation.crate_name), duration);
 
     let archive = generated.path().join("rustdoc.archive");
     write_archive(&archive, &[(&doc, "doc"), (&parts, "parts")])?;
@@ -230,17 +268,20 @@ fn action_descriptor(rustdoc: &OsStr, invocation: &Invocation) -> Result<Vec<u8>
         .iter()
         .map(|arg| normalize(&arg.to_string_lossy(), &mappings))
         .collect();
-    let mut environment = BTreeMap::new();
-    for (name, value) in std::env::vars() {
-        if !name.starts_with("MBX_") && !REMOVED_ENVIRONMENT.contains(&name.as_str()) {
-            environment.insert(name, normalize(&value, &mappings));
-        }
-    }
+    let environment = action_environment(std::env::vars(), &mappings);
     let mut inputs = BTreeMap::new();
     let target = std::env::var_os(session::TARGET_DIR_ENV).map(PathBuf::from);
+    let workspace = std::env::var_os(session::WORKSPACE_ROOT_ENV).map(PathBuf::from);
+    let (input_root, portable_root) = workspace
+        .as_deref()
+        .filter(|workspace| invocation.manifest.starts_with(workspace))
+        .map_or((invocation.manifest.as_path(), "${package}"), |workspace| {
+            (workspace, "${workspace}")
+        });
     collect_tree(
-        &invocation.manifest,
-        &invocation.manifest,
+        input_root,
+        input_root,
+        portable_root,
         target.as_deref(),
         &mut inputs,
     )?;
@@ -253,6 +294,24 @@ fn action_descriptor(rustdoc: &OsStr, invocation: &Invocation) -> Result<Vec<u8>
         environment,
         inputs,
     })
+}
+
+fn action_environment(
+    environment: impl IntoIterator<Item = (String, String)>,
+    mappings: &[(String, String)],
+) -> BTreeMap<String, String> {
+    environment
+        .into_iter()
+        .filter(|(name, _)| {
+            !name.starts_with("MBX_")
+                && !REMOVED_ENVIRONMENT.contains(&name.as_str())
+                && !HOST_ENVIRONMENT.contains(&name.as_str())
+                && !HOST_ENVIRONMENT_PREFIXES
+                    .iter()
+                    .any(|prefix| name.starts_with(prefix))
+        })
+        .map(|(name, value)| (name, normalize(&value, mappings)))
+        .collect()
 }
 
 fn path_mappings(invocation: &Invocation) -> Vec<(String, String)> {
@@ -287,6 +346,7 @@ fn normalize(value: &str, mappings: &[(String, String)]) -> String {
 fn collect_tree(
     root: &Path,
     directory: &Path,
+    portable_root: &str,
     excluded: Option<&Path>,
     inputs: &mut BTreeMap<String, CacheDigest>,
 ) -> Result<()> {
@@ -294,23 +354,29 @@ fn collect_tree(
         let entry = entry?;
         let path = entry.path();
         let name = entry.file_name();
-        if entry.file_type()?.is_symlink() {
+        let file_type = entry.file_type()?;
+        // Managed target views are symlinks, so exclude generated output by
+        // name and configured location before applying the conservative source
+        // symlink check.
+        if (name == "target" && (file_type.is_dir() || file_type.is_symlink()))
+            || excluded.is_some_and(|excluded| path == excluded || path.starts_with(excluded))
+        {
+            continue;
+        }
+        if file_type.is_symlink() {
             bail!(
-                "package input tree contains a symbolic link: {}",
+                "rustdoc input tree contains a symbolic link: {}",
                 path.display()
             );
         }
-        if excluded.is_some_and(|excluded| path == excluded || path.starts_with(excluded)) {
-            continue;
-        }
         if path.is_dir() {
-            if name != ".git" && name != "target" {
-                collect_tree(root, &path, excluded, inputs)?;
+            if name != ".git" {
+                collect_tree(root, &path, portable_root, excluded, inputs)?;
             }
         } else if path.is_file() {
             let relative = path.strip_prefix(root)?;
             inputs.insert(
-                format!("${{package}}/{}", relative.to_string_lossy()),
+                format!("{portable_root}/{}", relative.to_string_lossy()),
                 CacheDigest::blake3_file(&path)?,
             );
         }
@@ -724,6 +790,46 @@ fn finalize_arguments(arguments: &[OsString]) -> Vec<OsString> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn action_environment_omits_host_identity_but_keeps_compile_inputs() {
+        let environment = action_environment(
+            [
+                ("GITHUB_RUN_ID".into(), "123".into()),
+                ("HOME".into(), "/home/one".into()),
+                ("CARGO_PKG_VERSION".into(), "1.2.3".into()),
+                ("DOCS_RS".into(), "1".into()),
+            ],
+            &[],
+        );
+
+        assert!(!environment.contains_key("GITHUB_RUN_ID"));
+        assert!(!environment.contains_key("HOME"));
+        assert_eq!(environment.get("CARGO_PKG_VERSION").unwrap(), "1.2.3");
+        assert_eq!(environment.get("DOCS_RS").unwrap(), "1");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_target_symlinks_are_excluded_before_source_symlinks_are_rejected() {
+        let package = tempfile::tempdir().unwrap();
+        let managed = tempfile::tempdir().unwrap();
+        std::fs::write(package.path().join("lib.rs"), "pub fn value() {}\n").unwrap();
+        std::os::unix::fs::symlink(managed.path(), package.path().join("target")).unwrap();
+        let mut inputs = BTreeMap::new();
+
+        collect_tree(
+            package.path(),
+            package.path(),
+            "${package}",
+            Some(managed.path()),
+            &mut inputs,
+        )
+        .unwrap();
+
+        assert_eq!(inputs.len(), 1);
+        assert!(inputs.contains_key("${package}/lib.rs"));
+    }
 
     #[test]
     fn archive_round_trip_installs_crate_pages_and_parts() {

--- a/crates/mbx/src/rustdoc.rs
+++ b/crates/mbx/src/rustdoc.rs
@@ -1,0 +1,778 @@
+//! Cache adapter for Cargo's rustdoc invocations.
+
+use crate::materialize::{
+    find_blobs, read_canonical_blob, read_verified_blob, record_action_hit, resolve_executable,
+};
+use crate::session;
+use crate::util::duration_ns;
+use eyre::{Context as _, Result, bail};
+use mbx_cache_core::{
+    AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode, RemoteActionResult,
+    RustcMetadata, canonical_json,
+};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io::{Read as _, Write as _};
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::time::Instant;
+
+const ARCHIVE_MAGIC: &[u8] = b"mbx-rustdoc-v1\0";
+const REMOVED_ENVIRONMENT: &[&str] = &[
+    "CARGO_MAKEFLAGS",
+    "MBX_BUILD",
+    "MBX_CC_SHIM_COMPILERS",
+    "MBX_LEARNED_INCREMENTAL",
+    "MBX_REAL_CC",
+    "MBX_REAL_CXX",
+    "MBX_REAL_RUSTDOC",
+    "MBX_SCHED_DIR",
+    "MBX_SCHED_PRIORITY",
+    "MBX_SCHED_SLOT_BYTES",
+    "MBX_SCHED_SLOTS",
+    "MBX_SHARE_OUT_DIR",
+    "MBX_SOCKET",
+    "MBX_STAGING_DIR",
+    "MBX_VERIFY",
+    "RUSTC_WRAPPER",
+    "RUSTDOC",
+];
+
+#[derive(Serialize)]
+struct ActionDescriptor {
+    adapter: &'static str,
+    version: u8,
+    rustdoc: String,
+    arguments: Vec<String>,
+    environment: BTreeMap<String, String>,
+    inputs: BTreeMap<String, CacheDigest>,
+}
+
+struct Invocation {
+    crate_name: String,
+    output: PathBuf,
+    manifest: PathBuf,
+    arguments: Vec<OsString>,
+}
+
+struct CachedDocs {
+    archive: PathBuf,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+#[derive(Default)]
+struct InstalledDocs {
+    files: u64,
+    bytes: u64,
+}
+
+pub(crate) fn document(rustdoc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
+    let invocation = Invocation::parse(arguments)?;
+    let action_bytes = action_descriptor(rustdoc, &invocation)?;
+    let action = CacheDigest::blake3(&action_bytes);
+    if let Some(cached) = restore(&action, &action_bytes)? {
+        let started = Instant::now();
+        let installed = install_archive(&cached.archive, &invocation)?;
+        finalize(rustdoc, &invocation)?;
+        record_action_hit(
+            &action,
+            mbx_cache_core::RestoreStats {
+                duration_ns: duration_ns(started.elapsed()),
+                output_files: installed.files,
+                output_bytes: installed.bytes,
+                copied_output_files: installed.files,
+                copied_output_bytes: installed.bytes,
+                ..Default::default()
+            },
+            &invocation.crate_name,
+        );
+        std::io::stdout().write_all(&cached.stdout)?;
+        std::io::stderr().write_all(&cached.stderr)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let generated = tempfile::tempdir()?;
+    let doc = generated.path().join("doc");
+    let parts = generated.path().join("parts");
+    std::fs::create_dir_all(&doc)?;
+    std::fs::create_dir_all(&parts)?;
+    let rewritten = invocation.rewritten(&doc, &parts);
+    let started = Instant::now();
+    let mut command = Command::new(rustdoc);
+    command.args(&rewritten);
+    prepare_command(&mut command);
+    let output = command.output().wrap_err("failed to run rustdoc")?;
+    let duration = duration_ns(started.elapsed());
+    if !output.status.success() {
+        bail!("mergeable rustdoc invocation failed");
+    }
+    session::record_compiler_invocation("miss", Some(&invocation.crate_name), duration);
+    std::io::stdout().write_all(&output.stdout)?;
+    std::io::stderr().write_all(&output.stderr)?;
+
+    let archive = generated.path().join("rustdoc.archive");
+    write_archive(&archive, &[(&doc, "doc"), (&parts, "parts")])?;
+    install_archive(&archive, &invocation)?;
+    finalize(rustdoc, &invocation)?;
+    publish(
+        &action,
+        &action_bytes,
+        &archive,
+        &output.stdout,
+        &output.stderr,
+    )?;
+    Ok(ExitCode::SUCCESS)
+}
+
+impl Invocation {
+    fn parse(arguments: &[OsString]) -> Result<Self> {
+        let arguments_utf8 = arguments
+            .iter()
+            .map(|arg| {
+                arg.to_str()
+                    .map(str::to_owned)
+                    .ok_or_else(|| eyre::eyre!("rustdoc argument is not UTF-8"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if arguments_utf8.iter().any(|arg| {
+            arg == "--test"
+                || arg == "--check"
+                || arg.starts_with("--merge")
+                || arg.starts_with("--parts-out-dir")
+                || arg.starts_with("--include-parts-dir")
+                || arg.starts_with("--emit")
+                || arg.starts_with("--output-format")
+                || arg == "-Zunstable-options"
+        }) {
+            bail!("rustdoc invocation owns its execution or merge mode");
+        }
+        let mut output = None;
+        let mut index = 0;
+        while index < arguments_utf8.len() {
+            let arg = &arguments_utf8[index];
+            if matches!(arg.as_str(), "-o" | "--out-dir" | "--output") {
+                index += 1;
+                output = arguments_utf8.get(index).map(PathBuf::from);
+            } else if let Some(value) = arg
+                .strip_prefix("--out-dir=")
+                .or_else(|| arg.strip_prefix("--output="))
+            {
+                output = Some(PathBuf::from(value));
+            }
+            index += 1;
+        }
+        let output = output.ok_or_else(|| eyre::eyre!("rustdoc has no output directory"))?;
+        let output = std::path::absolute(output)?;
+        let crate_name = std::env::var("CARGO_CRATE_NAME")
+            .or_else(|_| std::env::var("CARGO_PKG_NAME"))
+            .wrap_err("rustdoc invocation has no Cargo crate name")?;
+        let manifest = std::env::var_os("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .ok_or_else(|| eyre::eyre!("rustdoc invocation has no Cargo manifest directory"))?;
+        Ok(Self {
+            crate_name,
+            output,
+            manifest: std::path::absolute(manifest)?,
+            arguments: arguments.to_vec(),
+        })
+    }
+
+    fn rewritten(&self, output: &Path, parts: &Path) -> Vec<OsString> {
+        let mut rewritten = Vec::new();
+        let mut skip_output = false;
+        for argument in &self.arguments {
+            if skip_output {
+                skip_output = false;
+                continue;
+            }
+            let text = argument.to_string_lossy();
+            if matches!(text.as_ref(), "-o" | "--out-dir" | "--output") {
+                skip_output = true;
+                continue;
+            }
+            if text.starts_with("--out-dir=") || text.starts_with("--output=") {
+                continue;
+            }
+            rewritten.push(argument.clone());
+        }
+        rewritten.extend([
+            "-o".into(),
+            output.as_os_str().into(),
+            "-Zunstable-options".into(),
+            "--merge=none".into(),
+            "--parts-out-dir".into(),
+            parts.as_os_str().into(),
+        ]);
+        rewritten
+    }
+
+    fn parts_root(&self) -> Result<PathBuf> {
+        Ok(self
+            .output
+            .parent()
+            .ok_or_else(|| eyre::eyre!("rustdoc output has no parent"))?
+            .join(".mbx-rustdoc-parts"))
+    }
+}
+
+fn action_descriptor(rustdoc: &OsStr, invocation: &Invocation) -> Result<Vec<u8>> {
+    let rustdoc = resolve_executable(rustdoc)?;
+    let identity = Command::new(&rustdoc).arg("-Vv").output()?;
+    if !identity.status.success() {
+        bail!("rustdoc identity query failed");
+    }
+    let mappings = path_mappings(invocation);
+    let arguments = invocation
+        .arguments
+        .iter()
+        .map(|arg| normalize(&arg.to_string_lossy(), &mappings))
+        .collect();
+    let mut environment = BTreeMap::new();
+    for (name, value) in std::env::vars() {
+        if !name.starts_with("MBX_") && !REMOVED_ENVIRONMENT.contains(&name.as_str()) {
+            environment.insert(name, normalize(&value, &mappings));
+        }
+    }
+    let mut inputs = BTreeMap::new();
+    let target = std::env::var_os(session::TARGET_DIR_ENV).map(PathBuf::from);
+    collect_tree(
+        &invocation.manifest,
+        &invocation.manifest,
+        target.as_deref(),
+        &mut inputs,
+    )?;
+    collect_argument_inputs(&invocation.arguments, &mappings, &mut inputs)?;
+    canonical_json(&ActionDescriptor {
+        adapter: "rustdoc",
+        version: 1,
+        rustdoc: String::from_utf8(identity.stdout)?,
+        arguments,
+        environment,
+        inputs,
+    })
+}
+
+fn path_mappings(invocation: &Invocation) -> Vec<(String, String)> {
+    let mut roots = Vec::new();
+    for (name, value) in [
+        ("target", std::env::var_os(session::TARGET_DIR_ENV)),
+        ("workspace", std::env::var_os(session::WORKSPACE_ROOT_ENV)),
+    ] {
+        if let Some(value) = value {
+            roots.push((
+                PathBuf::from(value).to_string_lossy().into_owned(),
+                format!("${{{name}}}"),
+            ));
+        }
+    }
+    roots.push((
+        invocation.manifest.to_string_lossy().into_owned(),
+        "${package}".into(),
+    ));
+    roots.sort_by_key(|root| std::cmp::Reverse(root.0.len()));
+    roots
+}
+
+fn normalize(value: &str, mappings: &[(String, String)]) -> String {
+    mappings
+        .iter()
+        .fold(value.to_owned(), |value, (root, key)| {
+            value.replace(root, key)
+        })
+}
+
+fn collect_tree(
+    root: &Path,
+    directory: &Path,
+    excluded: Option<&Path>,
+    inputs: &mut BTreeMap<String, CacheDigest>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = entry.file_name();
+        if entry.file_type()?.is_symlink() {
+            bail!(
+                "package input tree contains a symbolic link: {}",
+                path.display()
+            );
+        }
+        if excluded.is_some_and(|excluded| path == excluded || path.starts_with(excluded)) {
+            continue;
+        }
+        if path.is_dir() {
+            if name != ".git" && name != "target" {
+                collect_tree(root, &path, excluded, inputs)?;
+            }
+        } else if path.is_file() {
+            let relative = path.strip_prefix(root)?;
+            inputs.insert(
+                format!("${{package}}/{}", relative.to_string_lossy()),
+                CacheDigest::blake3_file(&path)?,
+            );
+        }
+    }
+    // `root` is used to establish the portable spelling above; keeping this
+    // assertion here also refuses a symlink walk that escaped the package.
+    if !directory.starts_with(root) {
+        bail!("package input escaped its manifest directory");
+    }
+    Ok(())
+}
+
+fn collect_argument_inputs(
+    arguments: &[OsString],
+    mappings: &[(String, String)],
+    inputs: &mut BTreeMap<String, CacheDigest>,
+) -> Result<()> {
+    const PATH_FLAGS: &[&str] = &[
+        "--extend-css",
+        "--index-page",
+        "--markdown-css",
+        "--html-in-header",
+        "--html-before-content",
+        "--html-after-content",
+        "--theme",
+        "--with-examples",
+    ];
+    let mut index = 0;
+    while index < arguments.len() {
+        let text = arguments[index].to_string_lossy();
+        let path = if text == "--extern" {
+            index += 1;
+            let value = arguments
+                .get(index)
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| eyre::eyre!("rustdoc --extern has no UTF-8 value"))?;
+            Some(
+                value
+                    .split_once('=')
+                    .map(|(_, path)| path)
+                    .ok_or_else(|| eyre::eyre!("rustdoc --extern has no artifact"))?,
+            )
+        } else if let Some(value) = text.strip_prefix("--extern=") {
+            Some(
+                value
+                    .split_once('=')
+                    .map(|(_, path)| path)
+                    .ok_or_else(|| eyre::eyre!("rustdoc --extern has no artifact"))?,
+            )
+        } else if PATH_FLAGS.contains(&text.as_ref()) {
+            index += 1;
+            Some(
+                arguments
+                    .get(index)
+                    .and_then(|value| value.to_str())
+                    .ok_or_else(|| eyre::eyre!("rustdoc path flag has no UTF-8 value"))?,
+            )
+        } else {
+            PATH_FLAGS
+                .iter()
+                .find_map(|flag| text.strip_prefix(&format!("{flag}=")))
+        };
+        if let Some(path) = path {
+            let path = Path::new(path);
+            if !path.is_file() {
+                bail!("rustdoc input is not a file: {}", path.display());
+            }
+            inputs.insert(
+                normalize(&std::path::absolute(path)?.to_string_lossy(), mappings),
+                CacheDigest::blake3_file(path)?,
+            );
+        }
+        index += 1;
+    }
+    Ok(())
+}
+
+fn restore(action: &CacheDigest, action_bytes: &[u8]) -> Result<Option<CachedDocs>> {
+    let response = session::request_agent(&[AgentRequest::FindActionResult {
+        action: action.clone(),
+    }])?
+    .into_iter()
+    .next();
+    let Some(AgentResponse::ActionResult {
+        result: Some(result),
+    }) = response
+    else {
+        return Ok(None);
+    };
+    if result.version != 1 || result.action != *action {
+        bail!("cached rustdoc result has an invalid identity");
+    }
+    let metadata = result
+        .metadata
+        .ok_or_else(|| eyre::eyre!("rustdoc metadata is missing"))?;
+    let directory = result
+        .output_root
+        .ok_or_else(|| eyre::eyre!("rustdoc output is missing"))?;
+    let roots = find_blobs(&[action.clone(), metadata.clone(), directory.clone()])?;
+    if read_verified_blob(&roots[0], action, "rustdoc action")? != action_bytes {
+        bail!("cached rustdoc action descriptor does not match");
+    }
+    let metadata: RustcMetadata = read_canonical_blob(&roots[1], &metadata, "rustdoc metadata")?;
+    if metadata.version != 1 || metadata.kind != "rustc" {
+        bail!("cached rustdoc metadata is unsupported");
+    }
+    let directory: CacheDirectory = read_canonical_blob(&roots[2], &directory, "rustdoc output")?;
+    if directory.version != 1
+        || !directory.directories.is_empty()
+        || !directory.symlinks.is_empty()
+        || directory.files.len() != 1
+        || directory.files[0].name != "rustdoc.archive"
+    {
+        bail!("cached rustdoc output directory is invalid");
+    }
+    let node = &directory.files[0];
+    let blobs = find_blobs(&[
+        node.digest.clone(),
+        metadata.stdout.clone(),
+        metadata.stderr.clone(),
+    ])?;
+    let stdout = read_verified_blob(&blobs[1], &metadata.stdout, "rustdoc stdout")?;
+    let stderr = read_verified_blob(&blobs[2], &metadata.stderr, "rustdoc stderr")?;
+    Ok(Some(CachedDocs {
+        archive: blobs[0].clone(),
+        stdout,
+        stderr,
+    }))
+}
+
+fn publish(
+    action: &CacheDigest,
+    action_bytes: &[u8],
+    archive: &Path,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<()> {
+    let staging = tempfile::tempdir()?;
+    let stage = |name: &str, bytes: &[u8]| -> Result<(CacheDigest, PathBuf)> {
+        let path = staging.path().join(name);
+        std::fs::write(&path, bytes)?;
+        Ok((CacheDigest::blake3(bytes), path))
+    };
+    let action_blob = stage("action", action_bytes)?;
+    let stdout = stage("stdout", stdout)?;
+    let stderr = stage("stderr", stderr)?;
+    let archive_digest = CacheDigest::blake3_file(archive)?;
+    let metadata_bytes = canonical_json(&RustcMetadata {
+        version: 1,
+        // This is the common compiler-output metadata envelope. Keeping its
+        // protocol kind lets existing agents and collectors follow the two
+        // diagnostic blobs without teaching the wire format a second
+        // structurally identical record.
+        kind: "rustc".into(),
+        stdout: stdout.0.clone(),
+        stderr: stderr.0.clone(),
+    })?;
+    let metadata = stage("metadata", &metadata_bytes)?;
+    let directory_bytes = canonical_json(&CacheDirectory {
+        directories: Vec::new(),
+        files: vec![CacheFileNode {
+            digest: archive_digest.clone(),
+            executable: false,
+            mode: 0o644,
+            name: "rustdoc.archive".into(),
+        }],
+        symlinks: Vec::new(),
+        version: 1,
+    })?;
+    let directory = stage("directory", &directory_bytes)?;
+    let mut requests = vec![
+        AgentRequest::StoreBlob {
+            digest: action_blob.0,
+            source: action_blob.1,
+        },
+        AgentRequest::StoreBlob {
+            digest: stdout.0,
+            source: stdout.1,
+        },
+        AgentRequest::StoreBlob {
+            digest: stderr.0,
+            source: stderr.1,
+        },
+        AgentRequest::StoreBlob {
+            digest: archive_digest,
+            source: archive.to_path_buf(),
+        },
+        AgentRequest::StoreBlob {
+            digest: metadata.0.clone(),
+            source: metadata.1,
+        },
+        AgentRequest::StoreBlob {
+            digest: directory.0.clone(),
+            source: directory.1,
+        },
+        AgentRequest::StoreActionResult {
+            result: RemoteActionResult {
+                action: action.clone(),
+                metadata: Some(metadata.0),
+                output_root: Some(directory.0),
+                version: 1,
+            },
+        },
+    ];
+    for response in session::request_agent(&requests)? {
+        if let AgentResponse::Error { message } = response {
+            bail!(message);
+        }
+    }
+    requests.clear();
+    Ok(())
+}
+
+fn write_archive(path: &Path, roots: &[(&Path, &str)]) -> Result<()> {
+    let mut files = Vec::new();
+    for (root, prefix) in roots {
+        collect_archive_files(root, root, prefix, &mut files)?;
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut output = File::create(path)?;
+    output.write_all(ARCHIVE_MAGIC)?;
+    output.write_all(&(files.len() as u64).to_le_bytes())?;
+    for (name, source) in files {
+        let bytes = name.as_bytes();
+        let size = std::fs::metadata(&source)?.len();
+        output.write_all(&(bytes.len() as u32).to_le_bytes())?;
+        output.write_all(bytes)?;
+        output.write_all(&size.to_le_bytes())?;
+        std::io::copy(&mut File::open(source)?, &mut output)?;
+    }
+    Ok(())
+}
+
+fn collect_archive_files(
+    root: &Path,
+    dir: &Path,
+    prefix: &str,
+    files: &mut Vec<(String, PathBuf)>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_archive_files(root, &path, prefix, files)?;
+        } else if path.is_file() {
+            let relative = path
+                .strip_prefix(root)?
+                .to_string_lossy()
+                .replace('\\', "/");
+            files.push((format!("{prefix}/{relative}"), path));
+        }
+    }
+    Ok(())
+}
+
+fn install_archive(archive: &Path, invocation: &Invocation) -> Result<InstalledDocs> {
+    let mut input = File::open(archive)?;
+    let mut magic = vec![0; ARCHIVE_MAGIC.len()];
+    input.read_exact(&mut magic)?;
+    if magic != ARCHIVE_MAGIC {
+        bail!("cached rustdoc archive has an invalid header");
+    }
+    let count = read_u64(&mut input)?;
+    if count > 1_000_000 {
+        bail!("cached rustdoc archive has too many files");
+    }
+    let parts = invocation.parts_root()?.join(&invocation.crate_name);
+    let mut installed = InstalledDocs::default();
+    for _ in 0..count {
+        let name_len = read_u32(&mut input)? as usize;
+        if name_len > 1024 * 1024 {
+            bail!("cached rustdoc path is too long");
+        }
+        let mut name = vec![0; name_len];
+        input.read_exact(&mut name)?;
+        let name = String::from_utf8(name)?;
+        let relative = Path::new(&name);
+        if relative
+            .components()
+            .any(|part| !matches!(part, Component::Normal(_)))
+        {
+            bail!("cached rustdoc path is unsafe");
+        }
+        let destination = if let Ok(path) = relative.strip_prefix("doc") {
+            invocation.output.join(path)
+        } else if let Ok(path) = relative.strip_prefix("parts") {
+            parts.join(path)
+        } else {
+            bail!("cached rustdoc path has an unknown root");
+        };
+        let size = read_u64(&mut input)?;
+        if let Some(parent) = destination.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let temporary = destination.with_extension(format!("mbx-{}", std::process::id()));
+        let mut output = File::create(&temporary)?;
+        let copied = std::io::copy(&mut (&mut input).take(size), &mut output)?;
+        if copied != size {
+            bail!("cached rustdoc archive is truncated");
+        }
+        match std::fs::rename(&temporary, &destination) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                std::fs::remove_file(&destination)?;
+                std::fs::rename(temporary, destination)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+        installed.files = installed.files.saturating_add(1);
+        installed.bytes = installed.bytes.saturating_add(size);
+    }
+    Ok(installed)
+}
+
+fn read_u64(input: &mut File) -> Result<u64> {
+    let mut bytes = [0; 8];
+    input.read_exact(&mut bytes)?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+fn read_u32(input: &mut File) -> Result<u32> {
+    let mut bytes = [0; 4];
+    input.read_exact(&mut bytes)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn finalize(rustdoc: &OsStr, invocation: &Invocation) -> Result<()> {
+    std::fs::create_dir_all(&invocation.output)?;
+    let parts_root = invocation.parts_root()?;
+    std::fs::create_dir_all(&parts_root)?;
+    let lock_path = parts_root.join("merge.lock");
+    let mut lock = fslock::LockFile::open(&lock_path)?;
+    lock.lock()?;
+    let mut parts = std::fs::read_dir(&parts_root)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    parts.sort();
+    let mut command = Command::new(rustdoc);
+    command
+        .args(["-Zunstable-options", "--merge=finalize", "-o"])
+        .arg(&invocation.output);
+    prepare_command(&mut command);
+    command.args(finalize_arguments(&invocation.arguments));
+    for part in parts {
+        command.arg("--include-parts-dir").arg(part);
+    }
+    let status = command.status()?;
+    lock.unlock()?;
+    if !status.success() {
+        bail!("rustdoc shared-output finalization failed");
+    }
+    Ok(())
+}
+
+fn prepare_command(command: &mut Command) {
+    // These variables connect shims to their parent session or carry Cargo's
+    // jobserver file descriptors. They are not user compile-time inputs and
+    // would otherwise make every session's documentation key unique.
+    for name in REMOVED_ENVIRONMENT {
+        command.env_remove(name);
+    }
+    for name in std::env::vars_os()
+        .filter_map(|(name, _)| name.into_string().ok())
+        .filter(|name| name.starts_with("MBX_"))
+    {
+        command.env_remove(name);
+    }
+    // Mergeable rustdoc output is still guarded by unstable-options on stable
+    // toolchains. Scope the bootstrap escape hatch to this child; Cargo and
+    // every compilation it launches remain untouched.
+    command.env("RUSTC_BOOTSTRAP", "1");
+}
+
+fn finalize_arguments(arguments: &[OsString]) -> Vec<OsString> {
+    const WITH_VALUE: &[&str] = &[
+        "--resource-suffix",
+        "--static-root-path",
+        "--extend-css",
+        "--index-page",
+        "--markdown-css",
+        "--html-in-header",
+        "--html-before-content",
+        "--html-after-content",
+        "--default-theme",
+        "--theme",
+    ];
+    const FLAGS: &[&str] = &["--enable-index-page", "--disable-minification"];
+    let mut selected = Vec::new();
+    let mut index = 0;
+    while index < arguments.len() {
+        let text = arguments[index].to_string_lossy();
+        if WITH_VALUE.contains(&text.as_ref()) {
+            if let Some(value) = arguments.get(index + 1) {
+                selected.extend([arguments[index].clone(), value.clone()]);
+                index += 1;
+            }
+        } else if WITH_VALUE
+            .iter()
+            .any(|name| text.starts_with(&format!("{name}=")))
+            || FLAGS.contains(&text.as_ref())
+        {
+            selected.push(arguments[index].clone());
+        }
+        index += 1;
+    }
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_round_trip_installs_crate_pages_and_parts() {
+        let generated = tempfile::tempdir().unwrap();
+        let doc = generated.path().join("doc");
+        let parts = generated.path().join("parts");
+        std::fs::create_dir_all(doc.join("widget")).unwrap();
+        std::fs::create_dir_all(&parts).unwrap();
+        std::fs::write(doc.join("widget/index.html"), b"docs").unwrap();
+        std::fs::write(parts.join("lib.json"), b"parts").unwrap();
+        let archive = generated.path().join("archive");
+        write_archive(&archive, &[(&doc, "doc"), (&parts, "parts")]).unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        let invocation = Invocation {
+            crate_name: "widget".into(),
+            output: destination.path().join("doc"),
+            manifest: destination.path().into(),
+            arguments: Vec::new(),
+        };
+        install_archive(&archive, &invocation).unwrap();
+
+        assert_eq!(
+            std::fs::read(invocation.output.join("widget/index.html")).unwrap(),
+            b"docs"
+        );
+        assert_eq!(
+            std::fs::read(invocation.parts_root().unwrap().join("widget/lib.json")).unwrap(),
+            b"parts"
+        );
+    }
+
+    #[test]
+    fn finalize_keeps_only_shared_output_arguments() {
+        let arguments = vec![
+            "--crate-name".into(),
+            "widget".into(),
+            "--resource-suffix=abc".into(),
+            "--extend-css".into(),
+            "theme.css".into(),
+            "src/lib.rs".into(),
+        ];
+        assert_eq!(
+            finalize_arguments(&arguments),
+            vec![
+                OsString::from("--resource-suffix=abc"),
+                OsString::from("--extend-css"),
+                OsString::from("theme.css"),
+            ]
+        );
+    }
+}

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -37,7 +37,7 @@ use client::validate_handshake_response;
 use client::{request_agent_at, request_standalone_agent};
 pub(crate) use diagnostics::{note, report_shim_warning, reserve_stderr_for_compiler};
 use server::spawn_server;
-use shims::{CC_CRATE_ENV, CcShims, install_cc_shims, install_session_shim};
+use shims::{CC_CRATE_ENV, CcShims, install_cc_shims, install_session_shims};
 pub use shims::{
     PathShims, ShimLink, install_path_shims, install_shim, install_shim_named, shim_file_name,
 };
@@ -53,6 +53,7 @@ pub(crate) use stats::session_was_active;
 use stats::{cache_misses, should_display_stats, stale_manifest_note, write_stats_report};
 
 pub const RUSTC_SHIM_STEM: &str = "mbx-rustc";
+pub const RUSTDOC_SHIM_STEM: &str = "mbx-rustdoc";
 pub const CC_SHIM_STEM: &str = "mbx-cc";
 pub const CXX_SHIM_STEM: &str = "mbx-cxx";
 pub(crate) const PATH_SHIMS_ENV: &str = "MBX_CC_SHIM_COMPILERS";
@@ -68,6 +69,7 @@ pub const CACHE_LINKS_ENV: &str = "MBX_CACHE_LINKS";
 pub(crate) const WORKSPACE_ROOT_ENV: &str = "MBX_WORKSPACE_ROOT";
 pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
+const REAL_RUSTDOC_ENV: &str = "MBX_REAL_RUSTDOC";
 pub(crate) const BYPASS_LOG_ENV: &str = "MBX_BYPASS_LOG";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[cfg(unix)]
@@ -77,6 +79,7 @@ static SHIM_STAGING_NONCE: AtomicU64 = AtomicU64::new(0);
 pub struct CacheSession {
     socket: String,
     rustc_shim: PathBuf,
+    rustdoc_shim: PathBuf,
     cc_shims: Option<CcShims>,
     staging: PathBuf,
     verify: bool,
@@ -99,7 +102,7 @@ impl CacheSession {
     /// `session_dir` holds the shim, socket, and staging directory, and is
     /// expected to be a temporary directory owned by the caller.
     pub async fn start(session_dir: &Path, config: &Config) -> Result<Self> {
-        let shim = install_session_shim(session_dir)?;
+        let (shim, rustdoc_shim) = install_session_shims(session_dir)?;
         let cc_shims = if config.cc {
             // Build systems such as CMake persist HOST_CC as an absolute
             // compiler path. Keep the C/C++ shims outside the temporary
@@ -134,6 +137,7 @@ impl CacheSession {
         Ok(Self {
             socket,
             rustc_shim: shim,
+            rustdoc_shim,
             cc_shims,
             staging,
             verify: config.verify,
@@ -231,6 +235,16 @@ impl CacheSession {
             );
             environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
         }
+        let rustdoc = environment
+            .get("RUSTDOC")
+            .cloned()
+            .or_else(|| std::env::var("RUSTDOC").ok())
+            .unwrap_or_else(|| "rustdoc".into());
+        environment.insert(REAL_RUSTDOC_ENV.into(), rustdoc);
+        environment.insert(
+            "RUSTDOC".into(),
+            self.rustdoc_shim.to_string_lossy().into_owned(),
+        );
         self.begin_cc(environment);
         if self.incremental {
             // Hand the decision back to cargo, which compiles local packages
@@ -635,6 +649,44 @@ pub fn is_rustc_shim() -> bool {
         .map(Path::new)
         .and_then(Path::file_stem)
         .is_some_and(|stem| stem == OsStr::new(RUSTC_SHIM_STEM))
+}
+
+/// Whether this process was invoked as the rustdoc shim.
+pub fn is_rustdoc_shim() -> bool {
+    std::env::args_os()
+        .next()
+        .as_deref()
+        .map(Path::new)
+        .and_then(Path::file_stem)
+        .is_some_and(|stem| stem == OsStr::new(RUSTDOC_SHIM_STEM))
+}
+
+/// Ultra-early argv0 path used by Cargo's `RUSTDOC` integration.
+pub fn run_rustdoc_shim() -> ExitCode {
+    let rustdoc = std::env::var_os(REAL_RUSTDOC_ENV).unwrap_or_else(|| "rustdoc".into());
+    let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
+    match crate::rustdoc::document(&rustdoc, &arguments) {
+        Ok(code) => code,
+        Err(error) => {
+            let _ = request_agent(&[AgentRequest::RecordBypass {
+                kind: "rustdoc".into(),
+            }]);
+            #[cfg(debug_assertions)]
+            eprintln!("mbx[warning]: rustdoc cache bypassed: {error:#}");
+            run_transparent_rustdoc(rustdoc, arguments)
+        }
+    }
+}
+
+fn run_transparent_rustdoc(rustdoc: OsString, arguments: Vec<OsString>) -> ExitCode {
+    let status = Command::new(&rustdoc).args(arguments).status();
+    match status {
+        Ok(status) => ExitCode::from(u8::try_from(status.code().unwrap_or(1)).unwrap_or(1)),
+        Err(error) => {
+            eprintln!("mbx[error]: the rustdoc shim failed to execute rustdoc: {error}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
 /// Compiler names the standalone shim directory stands in for, and the

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -235,11 +235,7 @@ impl CacheSession {
             );
             environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
         }
-        let rustdoc = environment
-            .get("RUSTDOC")
-            .cloned()
-            .or_else(|| std::env::var("RUSTDOC").ok())
-            .unwrap_or_else(|| "rustdoc".into());
+        let rustdoc = configured_rustdoc(environment);
         environment.insert(REAL_RUSTDOC_ENV.into(), rustdoc);
         environment.insert(
             "RUSTDOC".into(),
@@ -423,6 +419,29 @@ impl CacheSession {
             events.0.finished(totals);
         }
         Ok(stats)
+    }
+}
+
+/// Select the rustdoc behind any session shim already present in the caller.
+///
+/// Integration tests (and nested `mbx` commands in general) can begin a cache
+/// session from inside another one. Chaining the outer rustdoc shim would make
+/// it name itself as the real rustdoc and recurse; unwrap it just as the rustc
+/// path preserves and explicitly models an existing wrapper.
+fn configured_rustdoc(environment: &BTreeMap<String, String>) -> String {
+    let configured = environment
+        .get("RUSTDOC")
+        .cloned()
+        .or_else(|| std::env::var("RUSTDOC").ok())
+        .unwrap_or_else(|| "rustdoc".into());
+    if Path::new(&configured).file_stem() == Some(OsStr::new(RUSTDOC_SHIM_STEM)) {
+        environment
+            .get(REAL_RUSTDOC_ENV)
+            .cloned()
+            .or_else(|| std::env::var(REAL_RUSTDOC_ENV).ok())
+            .unwrap_or_else(|| "rustdoc".into())
+    } else {
+        configured
     }
 }
 

--- a/crates/mbx/src/session/shims.rs
+++ b/crates/mbx/src/session/shims.rs
@@ -1,6 +1,8 @@
 #[cfg(unix)]
 use super::SHIM_STAGING_NONCE;
-use super::{PATH_SHIM_NAMES, REAL_CC_ENV, REAL_CXX_ENV, RUSTC_SHIM_STEM, is_same_binary};
+use super::{
+    PATH_SHIM_NAMES, REAL_CC_ENV, REAL_CXX_ENV, RUSTC_SHIM_STEM, RUSTDOC_SHIM_STEM, is_same_binary,
+};
 use eyre::{Context, Result};
 use log::debug;
 use mbx_cache_cc::CcLanguage;
@@ -366,9 +368,16 @@ fn canonical(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-pub(super) fn install_session_shim(session_dir: &Path) -> Result<PathBuf> {
+pub(super) fn install_session_shims(session_dir: &Path) -> Result<(PathBuf, PathBuf)> {
     let executable = std::env::current_exe().wrap_err("failed to locate the running mbx binary")?;
-    install_shim(&executable, session_dir, ShimLink::Tracking)
+    let rustc = install_shim(&executable, session_dir, ShimLink::Tracking)?;
+    let rustdoc = install_shim_named(
+        &executable,
+        session_dir,
+        RUSTDOC_SHIM_STEM,
+        ShimLink::Tracking,
+    )?;
+    Ok((rustc, rustdoc))
 }
 
 /// How an installed shim refers to the mbx binary behind it.

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -63,6 +63,22 @@ async fn session_environment_directs_cargo_at_the_shim() {
     session.finish().await.unwrap();
 }
 
+#[test]
+fn nested_sessions_unwrap_the_outer_rustdoc_shim() {
+    let values = BTreeMap::from([
+        (
+            "RUSTDOC".into(),
+            Path::new("outer-session")
+                .join(shim_file_name(RUSTDOC_SHIM_STEM))
+                .to_string_lossy()
+                .into_owned(),
+        ),
+        (REAL_RUSTDOC_ENV.into(), "custom-rustdoc".into()),
+    ]);
+
+    assert_eq!(configured_rustdoc(&values), "custom-rustdoc");
+}
+
 /// Build scripts may hand HOST_CC to CMake, which records its absolute path in
 /// CMakeCache.txt and reuses it on later cargo invocations. That path must
 /// therefore outlive the temporary mbx session that first configured CMake.

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -29,7 +29,10 @@ async fn session_environment_directs_cargo_at_the_shim() {
         .unwrap();
 
     let workspace = tempfile::tempdir().unwrap();
-    let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
+    let mut values = BTreeMap::from([
+        ("RUSTC_WRAPPER".into(), "existing".into()),
+        ("RUSTDOC".into(), "custom-rustdoc".into()),
+    ]);
     let run = session
         .begin(
             workspace.path(),
@@ -47,6 +50,13 @@ async fn session_environment_directs_cargo_at_the_shim() {
     let wrapper = Path::new(values.get("RUSTC_WRAPPER").unwrap());
     assert_eq!(wrapper.file_stem().unwrap(), RUSTC_SHIM_STEM);
     assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
+    assert_eq!(values.get(REAL_RUSTDOC_ENV).unwrap(), "custom-rustdoc");
+    assert_eq!(
+        Path::new(values.get("RUSTDOC").unwrap())
+            .file_stem()
+            .unwrap(),
+        RUSTDOC_SHIM_STEM
+    );
     assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");
     assert_eq!(values.get(VERIFY_ENV).unwrap(), "0");
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -48,13 +48,18 @@ fn write_dependent_project(directory: &Path) {
     )
     .unwrap();
     std::fs::write(
+        directory.join("README.md"),
+        "shared workspace documentation\n",
+    )
+    .unwrap();
+    std::fs::write(
         directory.join("base/Cargo.toml"),
         "[package]\nname = \"base\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
     )
     .unwrap();
     std::fs::write(
         directory.join("base/src/lib.rs"),
-        "pub fn value() -> u32 { 0 }\n",
+        "#![doc = include_str!(\"../../README.md\")]\npub fn value() -> u32 { 0 }\n",
     )
     .unwrap();
     std::fs::write(
@@ -169,7 +174,6 @@ fn document(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
         .args(["doc", "--offline", "--no-deps"])
         .env("MBX_CACHE_DIR", store)
         .env("MBX_STATS_REPORT", report)
-        .env("MBX_TARGET_VIEWS", "0")
         .env_remove("CARGO_TARGET_DIR")
         .output()
         .expect("mbx should run");
@@ -300,9 +304,11 @@ fn rustdoc_pages_restore_and_rebuild_the_shared_index() {
     let store = tempfile::tempdir().unwrap();
     let first = tempfile::tempdir().unwrap();
     let second = tempfile::tempdir().unwrap();
+    let changed = tempfile::tempdir().unwrap();
     let reports = tempfile::tempdir().unwrap();
     write_dependent_project(first.path());
     write_dependent_project(second.path());
+    write_dependent_project(changed.path());
 
     let cold = document(
         first.path(),
@@ -327,6 +333,58 @@ fn rustdoc_pages_restore_and_rebuild_the_shared_index() {
         index.contains("base") && index.contains("above"),
         "the finalized index should name both crates"
     );
+
+    std::fs::write(
+        changed.path().join("README.md"),
+        "changed workspace documentation\n",
+    )
+    .unwrap();
+    let changed_stats = document(
+        changed.path(),
+        store.path(),
+        &reports.path().join("changed-doc.json"),
+    );
+    assert!(
+        count(&changed_stats, "misses") >= 2,
+        "a workspace-level doc input should invalidate the cached pages: {changed_stats}"
+    );
+    let changed_page =
+        std::fs::read_to_string(changed.path().join("target/doc/base/index.html")).unwrap();
+    assert!(changed_page.contains("changed workspace documentation"));
+}
+
+#[cfg(unix)]
+#[test]
+fn a_failed_mergeable_render_is_not_run_again_transparently() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let project = tempfile::tempdir().unwrap();
+    let store = tempfile::tempdir().unwrap();
+    write_project(project.path());
+    let wrapper = project.path().join("count-rustdoc");
+    let count = project.path().join("rustdoc-count");
+    std::fs::write(
+        &wrapper,
+        "#!/bin/sh\nif [ \"$1\" = \"-Vv\" ]; then exec \"$TEST_REAL_RUSTDOC\" \"$@\"; fi\nprintf x >> \"$TEST_RUSTDOC_COUNT\"\nprintf 'one rustdoc failure\\n' >&2\nexit 7\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&wrapper, permissions).unwrap();
+    let rustdoc = which::which("rustdoc").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .args(["doc", "--offline", "--no-deps"])
+        .env("MBX_CACHE_DIR", store.path())
+        .env("RUSTDOC", &wrapper)
+        .env("TEST_REAL_RUSTDOC", rustdoc)
+        .env("TEST_RUSTDOC_COUNT", &count)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(std::fs::read(&count).unwrap(), b"x");
 }
 
 /// Remove the outputs behind a target link so the next build must restore.

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -163,6 +163,25 @@ fn build(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
     build_with(project, store, report, &[]).0
 }
 
+fn document(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project)
+        .args(["doc", "--offline", "--no-deps"])
+        .env("MBX_CACHE_DIR", store)
+        .env("MBX_STATS_REPORT", report)
+        .env("MBX_TARGET_VIEWS", "0")
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("mbx should run");
+    assert!(
+        output.status.success(),
+        "documentation failed ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&std::fs::read(report).unwrap()).unwrap()
+}
+
 /// Build as `build` does, with `settings` added to the environment.
 ///
 /// Returns what the build said on stderr alongside its statistics, because some
@@ -274,6 +293,40 @@ fn count(stats: &serde_json::Value, field: &str) -> u64 {
     stats[field]
         .as_u64()
         .unwrap_or_else(|| panic!("{field} should be a number"))
+}
+
+#[test]
+fn rustdoc_pages_restore_and_rebuild_the_shared_index() {
+    let store = tempfile::tempdir().unwrap();
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_dependent_project(first.path());
+    write_dependent_project(second.path());
+
+    let cold = document(
+        first.path(),
+        store.path(),
+        &reports.path().join("cold-doc.json"),
+    );
+    assert!(
+        count(&cold, "misses") >= 2,
+        "both crates should render: {cold}"
+    );
+    let warm = document(
+        second.path(),
+        store.path(),
+        &reports.path().join("warm-doc.json"),
+    );
+
+    assert!(count(&warm, "hits") >= 2, "rustdoc should restore: {warm}");
+    assert!(second.path().join("target/doc/base/index.html").is_file());
+    assert!(second.path().join("target/doc/above/index.html").is_file());
+    let index = std::fs::read_to_string(second.path().join("target/doc/crates.js")).unwrap();
+    assert!(
+        index.contains("base") && index.contains("above"),
+        "the finalized index should name both crates"
+    );
 }
 
 /// Remove the outputs behind a target link so the next build must restore.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -66,6 +66,17 @@ prediction for later invocations. A genuinely cold compilation may therefore
 have no key to look up yet. It still gets stored after compiling and can warm
 the next build.
 
+## Rustdoc actions
+
+Cargo invokes rustdoc through a separate shim. Each documentation action keys
+the rustdoc version and arguments, the package source tree, explicit compiler
+artifacts, and Cargo's compile-time environment. Rustdoc's mergeable-output
+mode separates deterministic per-crate pages from files such as the search
+index that combine every documented crate. mbx caches the former with the
+crate's merge metadata and runs rustdoc's inexpensive finalization step after
+restoring them, so cached dependency documentation remains composable and the
+shared indexes do not depend on restore order.
+
 ## Copy-on-write output restoration
 
 The cache agent verifies each local CAS blob against its digest before returning


### PR DESCRIPTION
## Summary

- install a rustdoc shim for cache sessions and cache deterministic per-crate documentation output
- store mergeable rustdoc parts, then cheaply rebuild shared search and index files after hits
- key rustdoc version, normalized arguments, environment, package inputs, extern artifacts, and custom doc inputs; fall back transparently for unsupported invocations
- document rustdoc caching and cover restoration across independent cold checkouts

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- focused cross-checkout rustdoc cache integration test

## Compatibility with #211

#211 routes transparent `cargo` commands through the same `CacheSession::begin` setup, so plain `cargo doc` automatically receives this rustdoc shim. I also merged the current #211 head with this branch locally: it merged without conflicts, and the focused rustdoc integration test and clippy both passed on the combined tree.

## AI assistance

AI-assisted — Tool: Codex; model: GPT-5; version: unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cache correctness surface (input hashing, merge/finalize ordering, env stripping) affects `cargo doc` output; mitigated by bypass paths and integration tests but still touches build artifacts users rely on.
> 
> **Overview**
> Adds **rustdoc caching** alongside the existing rustc wrapper: cache sessions now install an `mbx-rustdoc` shim, set `RUSTDOC` to it, and record the real tool in `MBX_REAL_RUSTDOC` (with nested-session unwrapping like `RUSTC_WRAPPER`).
> 
> The new **`rustdoc` adapter** keys actions on rustdoc identity, normalized args/env, workspace/package inputs, and path-referenced doc assets; unsupported modes (`--test`, `--check`, caller-owned merge flags, etc.) bypass. On a miss it rewrites invocations to rustdoc’s **mergeable output** (`--merge=none` + `--parts-out-dir`), archives per-crate HTML and merge **parts**, publishes to the cache agent, then runs **`--merge=finalize`** so shared artifacts like `crates.js` are rebuilt after hits. Cache hits restore the archive and run the same finalize step. Errors record a bypass and fall through to transparent rustdoc.
> 
> **Docs** (`README`, `how-it-works`) describe the dual-shim model. **Tests** cover session env wiring, unit behavior in `rustdoc.rs`, cross-checkout `cargo doc` hits/misses and index composition, and that a failed cached render is not retried transparently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bba19cb61b4c2c0281802f52f4dc94fb030f86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->