### PR TITLE
fix(cache): import exported sparse files

### DIFF
--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -347,8 +347,10 @@ pub fn import_archive(store: &Path, archive: &Path) -> Result<TransferOutcome> {
         }
         let destination = staging.path().join(&path);
         std::fs::create_dir_all(destination.parent().expect("entry has a parent"))?;
-        let mut output = std::fs::File::create(&destination)?;
-        std::io::copy(&mut entry, &mut output)?;
+        // `unpack` understands GNU sparse maps. A plain stream copy expands
+        // holes into physical zeroes, which is both slower and much larger for
+        // Rust artifacts containing sparse sections.
+        entry.unpack(&destination)?;
     }
     let manifest: ExportManifest =
         serde_json::from_slice(&std::fs::read(staging.path().join(EXPORT_MANIFEST))?)?;

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -336,7 +336,8 @@ pub fn import_archive(store: &Path, archive: &Path) -> Result<TransferOutcome> {
     let mut seen = BTreeSet::new();
     for entry in bundle.entries()? {
         let mut entry = entry?;
-        if !entry.header().entry_type().is_file() {
+        let entry_type = entry.header().entry_type();
+        if !entry_type.is_file() && !entry_type.is_gnu_sparse() {
             eyre::bail!("cache export contains a non-file entry");
         }
         let path = entry.path()?.into_owned();

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -348,6 +348,54 @@ fn exports_and_imports_the_last_builds_complete_closure() {
     );
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn imports_sparse_files_emitted_by_the_exporter() {
+    use std::io::{Seek, Write};
+
+    let source = tempfile::tempdir().unwrap();
+    let destination = tempfile::tempdir().unwrap();
+    let workspace = source.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let mut contents = vec![0; 8 * 1024 * 1024];
+    *contents.last_mut().unwrap() = 1;
+    let output = CacheDigest::blake3(&contents);
+    let output_path = LocalCas::new(source.path()).path_for(&output).unwrap();
+    std::fs::create_dir_all(output_path.parent().unwrap()).unwrap();
+    let mut sparse = std::fs::File::create(&output_path).unwrap();
+    sparse.set_len(contents.len() as u64).unwrap();
+    sparse.seek(std::io::SeekFrom::End(-1)).unwrap();
+    sparse.write_all(&[1]).unwrap();
+    drop(sparse);
+    let action = store_result(
+        source.path(),
+        "sparse output",
+        std::slice::from_ref(&output),
+    );
+    record_build(
+        source.path(),
+        &"9".repeat(64),
+        &workspace,
+        std::slice::from_ref(&action),
+    );
+    let archive = source.path().join("sparse.tar");
+
+    export_checkout(source.path(), &workspace, &archive).unwrap();
+    let mut tar = tar::Archive::new(std::fs::File::open(&archive).unwrap());
+    assert!(
+        tar.entries()
+            .unwrap()
+            .any(|entry| entry.unwrap().header().entry_type().is_gnu_sparse()),
+        "test fixture must exercise a GNU sparse tar entry"
+    );
+    import_archive(destination.path(), &archive).unwrap();
+
+    assert_eq!(
+        std::fs::read(LocalCas::new(destination.path()).path_for(&output).unwrap()).unwrap(),
+        contents
+    );
+}
+
 #[test]
 fn export_refuses_an_incomplete_build_closure() {
     let source = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- accept GNU sparse entries as regular file payloads during cache bundle import
- preserve sparse layout while unpacking, avoiding physical zero expansion
- retain rejection of directories, links, and other non-file archive entries
- add a Linux regression test that creates a sparse CAS object, exports it with mbx, and imports the emitted archive

Discovered while benchmarking jdx/mr-boxington-action#20 against `jdx/hk`: real Rust build artifacts are sparse, so the `tar` crate emits GNU sparse entries for them. On the 1.31 GiB hk closure used in that benchmark, sparse-aware unpacking reduced fresh-store import wall time from 27.9s to 8.9s.

## Verification

- `cargo test -p mbx-cache-store imports_sparse_files_emitted_by_the_exporter -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p mbx-cache-store --all-targets --no-default-features -- -D warnings`
- full repository CI on Linux, macOS, Windows, ARM, and musl
