### PR TITLE
chore(ci): fail closed without notarization credentials

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -143,8 +143,6 @@ jobs:
     secrets:
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
-      # Optional: absent, the macOS binary ships signed but un-notarized and
-      # the build annotates a warning rather than failing the release.
       APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ on:
       CERTIFICATES_P12_PASS:
         required: true
       APPLE_API_KEY_P8:
-        required: false
+        required: true
       APPLE_API_KEY_ID:
-        required: false
+        required: true
       APPLE_API_ISSUER_ID:
-        required: false
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -228,8 +228,8 @@ jobs:
           set -euo pipefail
 
           if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
-            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships a signed but un-notarized macOS binary. Gatekeeper will block it for anyone who downloads the archive through a browser. See RELEASING.md."
-            exit 0
+            echo "::error title=Notarization credentials missing::App Store Connect credentials are required for macOS releases. See RELEASING.md."
+            exit 1
           fi
 
           # Outside the workspace, so no later step can sweep the key into an

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -118,10 +118,8 @@ successful releases:
   its key and issuer identifiers. It has to be a team key rather than an
   individual one: `notarytool` takes an issuer only for team keys and rejects it
   for individual keys. The macOS job submits the signed binary to Apple's
-  notary service with them. These three are the one optional entry in this list:
-  without them the release still ships, the binary is still signed, and the
-  build annotates a warning instead of failing. What it loses is Gatekeeper
-  approval for anyone who downloads the archive through a browser — see
+  notary service with them. All three are required: the release fails rather
+  than publishing a macOS binary without Gatekeeper approval. See
   [Notarization](#notarization).
 - **A crates.io Trusted Publisher for every published crate** — `mbx`,
   `mbx-cache-cargo`, `mbx-cache-cc`, `mbx-cache-core`, `mbx-cache-protocol`,


### PR DESCRIPTION
## Summary
- require all App Store Connect credentials in the reusable release workflow
- fail the macOS release job if any credential resolves to an empty value
- document notarization credentials as a release requirement

## Testing
- `actionlint .github/workflows/release.yml .github/workflows/release-plz.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*