### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "blake3",
  "eyre",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.8...mbx-cache-cargo-v0.1.9) - 2026-08-31
+
+### Fixed
+
+- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
+
+### Other
+
+- bound remote cache prefetch work ([#239](https://github.com/jdx/mr-boxington/pull/239))
+
 ## [0.1.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.7...mbx-cache-cargo-v0.1.8) - 2026-08-30
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.8"
+version = "0.1.9"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.0...mbx-cache-cc-v0.10.1) - 2026-08-31
+
+### Fixed
+
+- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
+
 ## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.9.4...mbx-cache-cc-v0.10.0) - 2026-08-30
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.10.0"
+version = "0.10.1"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.0...mbx-cache-core-v0.10.1) - 2026-08-31
+
+### Fixed
+
+- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
+
+### Other
+
+- bound remote cache prefetch work ([#239](https://github.com/jdx/mr-boxington/pull/239))
+
 ## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.9.4...mbx-cache-core-v0.10.0) - 2026-08-30
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.10.0"
+version = "0.10.1"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.8" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.9" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.8...mbx-cache-protocol-v0.5.9) - 2026-08-31
+
+### Fixed
+
+- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
+
 ## [0.5.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.7...mbx-cache-protocol-v0.5.8) - 2026-08-30
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.8"
+version = "0.5.9"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.0...mbx-cache-rustc-v0.10.1) - 2026-08-31
+
+### Fixed
+
+- *(cache)* model rustc frontend parallelism flags ([#238](https://github.com/jdx/mr-boxington/pull/238))
+- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
+
 ## [0.10.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.9.4...mbx-cache-rustc-v0.10.0) - 2026-08-30
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.10.0"
+version = "0.10.1"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.8...mbx-cache-store-v0.1.9) - 2026-08-31
+
+### Fixed
+
+- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
+
 ## [0.1.8](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.7...mbx-cache-store-v0.1.8) - 2026-08-30
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.8"
+version = "0.1.9"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/jdx/mr-boxington/compare/v1.1.0...v1.2.0) - 2026-08-31
+
+### Added
+
+- support Mercurial and Sapling checkouts ([#232](https://github.com/jdx/mr-boxington/pull/232))
+
+### Fixed
+
+- *(setup)* prevent Cargo shim recursion after HOME changes ([#234](https://github.com/jdx/mr-boxington/pull/234))
+- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
+- support Delta worktrees ([#231](https://github.com/jdx/mr-boxington/pull/231))
+
+### Other
+
+- bound remote cache prefetch work ([#239](https://github.com/jdx/mr-boxington/pull/239))
+
 ## [1.1.0](https://github.com/jdx/mr-boxington/compare/v1.0.1...v1.1.0) - 2026-08-30
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.1.0"
+version = "1.2.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.8", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.8", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.9", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.1", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.1", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.9", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.1.0
+**Version:** 1.2.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.8 -> 0.5.9 (✓ API compatible changes)
* `mbx-cache-core`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `mbx-cache-cc`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `mbx`: 1.1.0 -> 1.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.8...mbx-cache-protocol-v0.5.9) - 2026-08-31

### Fixed

- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.0...mbx-cache-core-v0.10.1) - 2026-08-31

### Fixed

- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))

### Other

- bound remote cache prefetch work ([#239](https://github.com/jdx/mr-boxington/pull/239))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.8...mbx-cache-cargo-v0.1.9) - 2026-08-31

### Fixed

- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))

### Other

- bound remote cache prefetch work ([#239](https://github.com/jdx/mr-boxington/pull/239))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.0...mbx-cache-cc-v0.10.1) - 2026-08-31

### Fixed

- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.0...mbx-cache-rustc-v0.10.1) - 2026-08-31

### Fixed

- *(cache)* model rustc frontend parallelism flags ([#238](https://github.com/jdx/mr-boxington/pull/238))
- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.8...mbx-cache-store-v0.1.9) - 2026-08-31

### Fixed

- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
</blockquote>

## `mbx`

<blockquote>

## [1.2.0](https://github.com/jdx/mr-boxington/compare/v1.1.0...v1.2.0) - 2026-08-31

### Added

- support Mercurial and Sapling checkouts ([#232](https://github.com/jdx/mr-boxington/pull/232))

### Fixed

- *(setup)* prevent Cargo shim recursion after HOME changes ([#234](https://github.com/jdx/mr-boxington/pull/234))
- document Cargo shim activation for agents ([#233](https://github.com/jdx/mr-boxington/pull/233))
- support Delta worktrees ([#231](https://github.com/jdx/mr-boxington/pull/231))

### Other

- bound remote cache prefetch work ([#239](https://github.com/jdx/mr-boxington/pull/239))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical release metadata only; behavioral risk is whatever already landed on main and is summarized in the new changelog entries, not new code in this PR.
> 
> **Overview**
> Release-plz cut for **2026-08-31**: this PR only bumps workspace versions, syncs `Cargo.lock`, adds dated changelog sections, tightens path dependency version pins, and updates the generated CLI doc version string to **1.2.0**. No application source changes appear in the diff.
> 
> **`mbx` 1.2.0** documents checkout/worktree support (Mercurial, Sapling, Delta), a setup fix for Cargo shim recursion when `HOME` changes, agent docs for Cargo shim activation, and bounded remote cache prefetch work.
> 
> Cache crates get compatible patch releases (`mbx-cache-core` / `-cc` / `-rustc` **0.10.1**, `-protocol` **0.5.9**, `-cargo` / `-store` **0.1.9**), with **mbx-cache-rustc** also noting improved modeling of rustc frontend parallelism flags in cache keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7912459966752c47987484f2b23eac26915a93df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->