### PR TITLE
fix: support Delta worktrees

### DIFF
--- a/crates/mbx/src/cli/cargo_tests.rs
+++ b/crates/mbx/src/cli/cargo_tests.rs
@@ -14,6 +14,22 @@ fn prefers_the_outermost_lockfile_as_the_workspace_root() {
 }
 
 #[test]
+fn keeps_workspace_discovery_inside_a_delta_worktree() {
+    let directory = tempfile::tempdir().unwrap();
+    let repository = directory.path().join("project");
+    let worktree = repository.join(".delta/worktrees/thread");
+    let member = worktree.join("crates/member");
+    std::fs::create_dir_all(&member).unwrap();
+    std::fs::write(repository.join("Cargo.lock"), "outer").unwrap();
+    std::fs::write(repository.join("Cargo.toml"), "[workspace]\n").unwrap();
+    std::fs::write(worktree.join("Cargo.lock"), "inner").unwrap();
+    std::fs::write(worktree.join("Cargo.toml"), "[workspace]\n").unwrap();
+    std::fs::write(member.join("Cargo.toml"), "[package]\n").unwrap();
+
+    assert_eq!(workspace_root(&member), worktree);
+}
+
+#[test]
 fn falls_back_to_a_manifest_without_a_lockfile() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path();

--- a/crates/mbx/src/cli/exec.rs
+++ b/crates/mbx/src/cli/exec.rs
@@ -1,6 +1,7 @@
 use super::cargo::{absolute, account_session, inherited_environment, run_cargo};
 use crate::config::{CliSettings, Config};
 use crate::session::{self, CacheSession};
+use crate::util::is_delta_worktree_root;
 use eyre::Result;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -89,7 +90,12 @@ pub(super) fn discover_project_root(working_dir: &Path) -> PathBuf {
     loop {
         // `.git` may be a plain file in a linked worktree. Jujutsu's marker is
         // a directory today, but existence is the useful distinction for both.
-        if directory.join(".git").exists() || directory.join(".jj").exists() {
+        // Delta-managed worktrees have no marker of their own: their location
+        // below `.delta/worktrees` establishes the checkout boundary.
+        if directory.join(".git").exists()
+            || directory.join(".jj").exists()
+            || is_delta_worktree_root(directory)
+        {
             return directory.to_path_buf();
         }
         match directory.parent() {

--- a/crates/mbx/src/cli/exec_tests.rs
+++ b/crates/mbx/src/cli/exec_tests.rs
@@ -25,3 +25,16 @@ fn discovers_a_nested_git_project_root() {
 
     assert_eq!(discover_project_root(&nested), inner);
 }
+
+#[test]
+/// A Delta-managed checkout is a project boundary despite having no VCS marker.
+fn discovers_a_delta_worktree_project_root() {
+    let directory = tempfile::tempdir().unwrap();
+    let repository = directory.path().join("project");
+    let worktree = repository.join(".delta/worktrees/thread");
+    let nested = worktree.join("src/build");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::create_dir(repository.join(".git")).unwrap();
+
+    assert_eq!(discover_project_root(&nested), worktree);
+}

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -18,8 +18,29 @@ pub fn workspace_root(start: &Path) -> std::path::PathBuf {
         if directory.join("Cargo.toml").is_file() {
             manifest = Some(directory.to_path_buf());
         }
+        // Delta checkouts are independent source trees nested below the
+        // original repository's `.delta/worktrees` directory. Do not let a
+        // lockfile in that enclosing repository replace the checkout's own
+        // workspace root.
+        if is_delta_worktree_root(directory) {
+            break;
+        }
     }
     lockfile.or(manifest).unwrap_or_else(|| start.to_path_buf())
+}
+
+/// Whether `directory` is the root of a Delta-managed checkout.
+///
+/// Delta worktrees are not Git worktrees and do not carry a `.git` marker.
+/// Their checkout directory itself is the project boundary.
+pub fn is_delta_worktree_root(directory: &Path) -> bool {
+    directory
+        .parent()
+        .is_some_and(|parent| parent.file_name() == Some(std::ffi::OsStr::new("worktrees")))
+        && directory
+            .parent()
+            .and_then(Path::parent)
+            .is_some_and(|parent| parent.file_name() == Some(std::ffi::OsStr::new(".delta")))
 }
 
 /// Write `contents` to `path` so readers never observe a partial file.


### PR DESCRIPTION
## Summary

- recognize Delta-managed checkout roots under `.delta/worktrees`
- keep Cargo workspace fallback discovery inside the managed checkout
- make `mbx exec` use the Delta checkout rather than the enclosing repository

## Testing

- `cargo test -p mbx --lib`
- `cargo clippy -p mbx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized path-discovery changes with new unit tests; wrong boundaries could mis-key caches or Cargo roots in Delta layouts but do not touch auth, security, or data handling.
> 
> **Overview**
> **mbx** now treats Delta-managed checkouts under `*/.delta/worktrees/*` as their own project boundary, even though they lack a `.git` or `.jj` marker.
> 
> `discover_project_root` stops at that path so `mbx exec` keys cache and workspace policy to the Delta checkout instead of the enclosing repository. `workspace_root` stops walking upward once it hits a Delta root, so an outer repo `Cargo.lock` no longer overrides the worktree’s own workspace.
> 
> Detection lives in **`is_delta_worktree_root`**, which matches directories whose parent is `worktrees` and grandparent is `.delta`. Tests cover workspace discovery and project-root discovery inside a nested Delta worktree layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c649c6a47d45df32f5abea13f13e2863670f9482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->