### PR TITLE
feat: support Mercurial and Sapling checkouts

### DIFF
--- a/crates/mbx/src/cli/cargo_tests.rs
+++ b/crates/mbx/src/cli/cargo_tests.rs
@@ -30,21 +30,18 @@ fn keeps_workspace_discovery_inside_a_delta_worktree() {
 }
 
 #[test]
-fn keeps_workspace_discovery_inside_mercurial_and_sapling_checkouts() {
-    for marker in [".hg", ".sl"] {
+fn vcs_markers_do_not_override_the_cargo_workspace() {
+    for marker in [".git", ".jj", ".hg", ".sl"] {
         let directory = tempfile::tempdir().unwrap();
         let outer = directory.path();
-        let checkout = outer.join(marker.trim_start_matches('.'));
-        let member = checkout.join("crates/member");
+        let member = outer.join("crates/member");
         std::fs::create_dir_all(&member).unwrap();
-        std::fs::create_dir(checkout.join(marker)).unwrap();
-        std::fs::write(outer.join("Cargo.lock"), "outer").unwrap();
+        std::fs::create_dir(member.join(marker)).unwrap();
+        std::fs::write(outer.join("Cargo.lock"), "version = 4\n").unwrap();
         std::fs::write(outer.join("Cargo.toml"), "[workspace]\n").unwrap();
-        std::fs::write(checkout.join("Cargo.lock"), "inner").unwrap();
-        std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").unwrap();
         std::fs::write(member.join("Cargo.toml"), "[package]\n").unwrap();
 
-        assert_eq!(workspace_root(&member), checkout, "marker: {marker}");
+        assert_eq!(workspace_root(&member), outer, "marker: {marker}");
     }
 }
 

--- a/crates/mbx/src/cli/cargo_tests.rs
+++ b/crates/mbx/src/cli/cargo_tests.rs
@@ -30,6 +30,25 @@ fn keeps_workspace_discovery_inside_a_delta_worktree() {
 }
 
 #[test]
+fn keeps_workspace_discovery_inside_mercurial_and_sapling_checkouts() {
+    for marker in [".hg", ".sl"] {
+        let directory = tempfile::tempdir().unwrap();
+        let outer = directory.path();
+        let checkout = outer.join(marker.trim_start_matches('.'));
+        let member = checkout.join("crates/member");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::create_dir(checkout.join(marker)).unwrap();
+        std::fs::write(outer.join("Cargo.lock"), "outer").unwrap();
+        std::fs::write(outer.join("Cargo.toml"), "[workspace]\n").unwrap();
+        std::fs::write(checkout.join("Cargo.lock"), "inner").unwrap();
+        std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").unwrap();
+        std::fs::write(member.join("Cargo.toml"), "[package]\n").unwrap();
+
+        assert_eq!(workspace_root(&member), checkout, "marker: {marker}");
+    }
+}
+
+#[test]
 fn falls_back_to_a_manifest_without_a_lockfile() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path();

--- a/crates/mbx/src/cli/exec.rs
+++ b/crates/mbx/src/cli/exec.rs
@@ -1,7 +1,7 @@
 use super::cargo::{absolute, account_session, inherited_environment, run_cargo};
 use crate::config::{CliSettings, Config};
 use crate::session::{self, CacheSession};
-use crate::util::is_delta_worktree_root;
+use crate::util::is_checkout_root;
 use eyre::Result;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -88,14 +88,7 @@ pub(super) fn run(config: &Config, settings: &CliSettings, args: &ExecArgs) -> R
 pub(super) fn discover_project_root(working_dir: &Path) -> PathBuf {
     let mut directory = working_dir;
     loop {
-        // `.git` may be a plain file in a linked worktree. Jujutsu's marker is
-        // a directory today, but existence is the useful distinction for both.
-        // Delta-managed worktrees have no marker of their own: their location
-        // below `.delta/worktrees` establishes the checkout boundary.
-        if directory.join(".git").exists()
-            || directory.join(".jj").exists()
-            || is_delta_worktree_root(directory)
-        {
+        if is_checkout_root(directory) {
             return directory.to_path_buf();
         }
         match directory.parent() {

--- a/crates/mbx/src/cli/exec_tests.rs
+++ b/crates/mbx/src/cli/exec_tests.rs
@@ -38,3 +38,19 @@ fn discovers_a_delta_worktree_project_root() {
 
     assert_eq!(discover_project_root(&nested), worktree);
 }
+
+#[test]
+/// Native Mercurial and Sapling markers establish project boundaries.
+fn discovers_mercurial_and_sapling_project_roots() {
+    for marker in [".hg", ".sl"] {
+        let directory = tempfile::tempdir().unwrap();
+        let outer = directory.path();
+        let checkout = outer.join(marker.trim_start_matches('.'));
+        let nested = checkout.join("src/build");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir(outer.join(".git")).unwrap();
+        std::fs::create_dir(checkout.join(marker)).unwrap();
+
+        assert_eq!(discover_project_root(&nested), checkout, "marker: {marker}");
+    }
+}

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -623,14 +623,24 @@ fn exec_marker(project_root: &Path) -> String {
 }
 
 /// The origin URL names a project the same way in every worktree and clone,
-/// which a checkout's directory name does not. Try Git first so colocated
-/// Jujutsu repositories keep exactly the identity they had before.
+/// which a checkout's directory name does not. Try Git first for colocated
+/// repositories so they keep exactly the identity they had before.
 fn project_origin_marker(project_root: &Path) -> Option<String> {
-    if project_root.join(".jj").exists() && !project_root.join(".git").exists() {
-        jj_origin_marker(project_root)
-    } else {
-        git_origin_marker(project_root).or_else(|| jj_origin_marker(project_root))
+    if !project_root.join(".git").exists() {
+        if project_root.join(".jj").exists() {
+            return jj_origin_marker(project_root);
+        }
+        if project_root.join(".sl").exists() {
+            return sapling_origin_marker(project_root);
+        }
+        if project_root.join(".hg").exists() {
+            return mercurial_origin_marker(project_root);
+        }
     }
+    git_origin_marker(project_root)
+        .or_else(|| jj_origin_marker(project_root))
+        .or_else(|| sapling_origin_marker(project_root))
+        .or_else(|| mercurial_origin_marker(project_root))
 }
 
 /// Read Git's origin without imposing a repository layout on explicit roots.
@@ -644,8 +654,7 @@ fn git_origin_marker(project_root: &Path) -> Option<String> {
     if !output.status.success() {
         return None;
     }
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!url.is_empty()).then(|| format!("origin\0{url}"))
+    origin_marker_from_output(&output.stdout)
 }
 
 /// Read Jujutsu's origin only from a root that is itself a Jujutsu checkout.
@@ -679,6 +688,44 @@ fn jj_origin_url(remotes: &str) -> Option<&str> {
             None
         }
     })
+}
+
+/// Read the default source from a native Sapling checkout.
+fn sapling_origin_marker(project_root: &Path) -> Option<String> {
+    default_path_origin_marker("sl", project_root, &["config", "paths.default"], ".sl")
+}
+
+/// Read the default source from a Mercurial checkout.
+fn mercurial_origin_marker(project_root: &Path) -> Option<String> {
+    default_path_origin_marker("hg", project_root, &["paths", "default"], ".hg")
+}
+
+fn default_path_origin_marker(
+    program: &str,
+    project_root: &Path,
+    arguments: &[&str],
+    marker: &str,
+) -> Option<String> {
+    // Without this gate the command may discover an unrelated enclosing
+    // checkout, just as Jujutsu would.
+    if !project_root.join(marker).exists() {
+        return None;
+    }
+    let output = Command::new(program)
+        .arg("-R")
+        .arg(project_root)
+        .args(arguments)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    origin_marker_from_output(&output.stdout)
+}
+
+fn origin_marker_from_output(output: &[u8]) -> Option<String> {
+    let url = String::from_utf8_lossy(output).trim().to_string();
+    (!url.is_empty()).then(|| format!("origin\0{url}"))
 }
 
 fn action_remote_cache(config: &Config, store: &Path) -> Result<Option<AgentRemoteCache>> {

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -342,6 +342,15 @@ fn reads_the_origin_from_jujutsu_remote_output() {
 }
 
 #[test]
+fn reads_mercurial_and_sapling_default_paths_as_origins() {
+    assert_eq!(
+        origin_marker_from_output(b"https://example.com/project\n"),
+        Some("origin\0https://example.com/project".to_string())
+    );
+    assert_eq!(origin_marker_from_output(b"\n"), None);
+}
+
+#[test]
 /// A nested Git checkout must not inherit an enclosing Jujutsu remote.
 fn a_nested_git_checkout_does_not_query_jujutsu() {
     let directory = tempfile::tempdir().unwrap();
@@ -352,6 +361,37 @@ fn a_nested_git_checkout_does_not_query_jujutsu() {
     std::fs::create_dir(inner.join(".git")).unwrap();
 
     assert_eq!(jj_origin_marker(&inner), None);
+}
+
+#[test]
+fn native_checkouts_do_not_inherit_an_enclosing_git_origin() {
+    for marker in [".hg", ".sl"] {
+        let directory = tempfile::tempdir().unwrap();
+        let outer = directory.path();
+        let inner = outer.join("vendor");
+        std::fs::create_dir(&inner).unwrap();
+        std::fs::create_dir(inner.join(marker)).unwrap();
+        assert!(
+            Command::new("git")
+                .arg("init")
+                .arg("--quiet")
+                .arg(outer)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(outer)
+                .args(["remote", "add", "origin", "https://example.com/outer.git"])
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        assert_eq!(project_origin_marker(&inner), None, "marker: {marker}");
+    }
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -18,22 +18,29 @@ pub fn workspace_root(start: &Path) -> std::path::PathBuf {
         if directory.join("Cargo.toml").is_file() {
             manifest = Some(directory.to_path_buf());
         }
-        // Delta checkouts are independent source trees nested below the
-        // original repository's `.delta/worktrees` directory. Do not let a
-        // lockfile in that enclosing repository replace the checkout's own
+        // A nested checkout is an independent source tree. Do not let a
+        // lockfile in its enclosing repository replace the checkout's own
         // workspace root.
-        if is_delta_worktree_root(directory) {
+        if is_checkout_root(directory) {
             break;
         }
     }
     lockfile.or(manifest).unwrap_or_else(|| start.to_path_buf())
 }
 
-/// Whether `directory` is the root of a Delta-managed checkout.
+/// Whether `directory` is the root of a supported VCS or managed checkout.
 ///
-/// Delta worktrees are not Git worktrees and do not carry a `.git` marker.
-/// Their checkout directory itself is the project boundary.
-pub fn is_delta_worktree_root(directory: &Path) -> bool {
+/// Marker existence, rather than file type, covers linked/shared checkouts
+/// whose metadata marker may be a file or symbolic link. Delta worktrees have
+/// no marker of their own, so their managed location establishes the boundary.
+pub fn is_checkout_root(directory: &Path) -> bool {
+    [".git", ".jj", ".hg", ".sl"]
+        .iter()
+        .any(|marker| directory.join(marker).exists())
+        || is_delta_worktree_root(directory)
+}
+
+fn is_delta_worktree_root(directory: &Path) -> bool {
     directory
         .parent()
         .is_some_and(|parent| parent.file_name() == Some(std::ffi::OsStr::new("worktrees")))

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -18,10 +18,12 @@ pub fn workspace_root(start: &Path) -> std::path::PathBuf {
         if directory.join("Cargo.toml").is_file() {
             manifest = Some(directory.to_path_buf());
         }
-        // A nested checkout is an independent source tree. Do not let a
-        // lockfile in its enclosing repository replace the checkout's own
-        // workspace root.
-        if is_checkout_root(directory) {
+        // Delta checkouts are independent source trees nested below the
+        // original repository's `.delta/worktrees` directory. Do not let a
+        // lockfile in that enclosing repository replace the checkout's own
+        // workspace root. Ordinary VCS markers are not boundaries here: a
+        // Cargo workspace may legitimately contain a nested repository.
+        if is_delta_worktree_root(directory) {
             break;
         }
     }


### PR DESCRIPTION
## Summary

- recognize native Mercurial (`.hg`) and Sapling (`.sl`) project boundaries
- use Mercurial and Sapling default remotes to share lockfile-less `mbx exec` predictions across clones
- prevent native checkouts from inheriting the origin of an enclosing Git repository
- preserve Cargo workspace discovery when workspace members contain VCS markers

## Testing

- `cargo test -p mbx --lib`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how project roots and origin markers are resolved for exec/session caching; incorrect boundaries could mis-key predictions, though behavior is covered by new tests and mostly extends existing VCS patterns.
> 
> **Overview**
> Extends **mbx** project detection and session identity beyond Git/Jujutsu/Delta to **Mercurial** (`.hg`) and **Sapling** (`.sl`).
> 
> **Checkout boundaries:** `discover_project_root` now uses shared `is_checkout_root`, which treats `.git`, `.jj`, `.hg`, `.sl`, and Delta worktree paths as project roots (marker existence, not file type).
> 
> **Cross-clone identity:** `project_origin_marker` reads Sapling `paths.default` and Mercurial `paths.default` when the root is a native checkout without `.git`, and avoids using an enclosing Git `origin` for those trees. Git-first behavior for colocated repos is preserved; shared `origin_marker_from_output` formats markers.
> 
> **Cargo workspaces:** Workspace root walking still stops only at Delta worktree roots—not at ordinary VCS markers—so nested repos inside a workspace do not steal the outer workspace lockfile/manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b039b9bc9cdfc312d451cca9f4d25edc2963710d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing Mercurial and Sapling checkouts alongside Git and Jujutsu.
  - Improved project and workspace root detection across supported version-control systems.
  - Added origin detection for Mercurial and Sapling repositories.

- **Bug Fixes**
  - Prevented nested checkouts from incorrectly inheriting the enclosing repository’s origin.
  - Ensured workspace discovery continues correctly through version-control markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->