### PR TITLE
fix: document Cargo shim activation for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ mise use --global --postinstall "mbx setup --yes" mr-boxington
 > [!NOTE]
 > The `--postinstall` setup hook requires mise 2026.8.15 or newer.
 
+Open a new shell and verify that plain Cargo resolves to the stable mbx shim:
+
+```sh
+command -v cargo
+# ~/.local/share/mbx/bin/cargo on Linux
+```
+
+mise activation handles interactive shells. SSH commands, coding agents, and
+other non-interactive tools may not load that activation; prepend
+`~/.local/share/mbx/bin` to `PATH` in a startup file they read (for example,
+`~/.zshenv` for zsh). Afterward, agents and people can use the ordinary `cargo`
+commands they already know; explicitly prefixing a command with `mbx` remains
+supported.
+
 With Cargo:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -63,11 +63,19 @@ mise use --global --postinstall "mbx setup --yes" mr-boxington
 > [!NOTE]
 > The `--postinstall` setup hook requires mise 2026.8.15 or newer.
 
-Open a new shell and verify that plain Cargo resolves to the stable mbx shim:
+Open a new shell and verify that plain Cargo resolves to the stable mbx shim.
+On Unix:
 
 ```sh
 command -v cargo
 # ~/.local/share/mbx/bin/cargo on Linux
+```
+
+On Windows, use PowerShell or `where.exe`:
+
+```powershell
+(Get-Command cargo).Path
+where.exe cargo
 ```
 
 mise activation handles interactive shells. SSH commands, coding agents, and

--- a/crates/mbx/src/cli/setup.rs
+++ b/crates/mbx/src/cli/setup.rs
@@ -199,6 +199,7 @@ pub(crate) fn setup_at_action(
     };
     if activated {
         println!("plain cargo commands now run through mbx in this mise scope");
+        print_activation_verification(&shim);
     } else if was_installed {
         println!("refreshed the Cargo shim at {}", shim.display());
     } else {
@@ -208,6 +209,18 @@ pub(crate) fn setup_at_action(
         }
     }
     Ok(ExitCode::SUCCESS)
+}
+
+fn print_activation_verification(shim: &Path) {
+    let directory = shim.parent().unwrap_or(shim);
+    println!(
+        "verify new shells with `command -v cargo`; expected {}",
+        shim.display()
+    );
+    println!(
+        "tools and non-interactive shells that do not activate mise need {} prepended to PATH",
+        directory.display()
+    );
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/cli/setup.rs
+++ b/crates/mbx/src/cli/setup.rs
@@ -211,8 +211,15 @@ pub(crate) fn setup_at_action(
     Ok(ExitCode::SUCCESS)
 }
 
+/// Explain how to verify activation, including shells that do not load mise.
 fn print_activation_verification(shim: &Path) {
     let directory = shim.parent().unwrap_or(shim);
+    #[cfg(windows)]
+    println!(
+        "verify new shells with `Get-Command cargo` in PowerShell or `where.exe cargo`; expected {}",
+        shim.display()
+    );
+    #[cfg(not(windows))]
     println!(
         "verify new shells with `command -v cargo`; expected {}",
         shim.display()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,6 +108,43 @@ mise is activated in the current shell. It recommends the config that defines
 Without an active mise shell, setup prints the exact shell-specific `PATH`
 change and never edits a shell startup file.
 
+### Verify plain Cargo
+
+Open a new shell after setup and verify which Cargo it finds:
+
+```sh
+command -v cargo
+# ~/.local/share/mbx/bin/cargo on Linux
+```
+
+mise activation supplies that path to shells where mise is active. SSH
+commands, coding agents, editors, and other non-interactive tools may use a
+startup path that does not activate mise. In that case, prepend the directory
+printed by `mbx setup` in a startup file those processes read. For zsh,
+`~/.zshenv` applies to interactive and non-interactive shells:
+
+```sh
+export PATH="$HOME/.local/share/mbx/bin:$PATH"
+```
+
+Start a new process and run `command -v cargo` again. Once it resolves to the
+shim, ordinary `cargo build`, `cargo test`, and `cargo check` commands use mbx
+automatically. Explicit `mbx cargo …` commands remain supported, but users and
+tools do not need to remember a special prefix.
+
+Coding agents generally need no mbx-specific skill or project instruction: the
+Cargo commands they already issue take the cached path. A project that wants to
+make the transparent behavior explicit can add this small note:
+
+```md
+Mr Boxington transparently caches ordinary `cargo` commands. No special command
+is required to use the shared cache.
+```
+
+Add that instruction to `AGENTS.md` only when the project wants to enforce the
+convention for every contributor. `mbx setup` does not edit repository-owned
+instruction files.
+
 On Unix, the stable `cargo` launcher uses the setup-time mbx while it exists,
 then resolves the active `mbx` from `PATH` after an upgrade removes that path.
 Windows `cargo.exe` resolves the active mbx from `PATH`, with the setup-time

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,11 +110,18 @@ change and never edits a shell startup file.
 
 ### Verify plain Cargo
 
-Open a new shell after setup and verify which Cargo it finds:
+Open a new shell after setup and verify which Cargo it finds. On Unix:
 
 ```sh
 command -v cargo
 # ~/.local/share/mbx/bin/cargo on Linux
+```
+
+On Windows, use PowerShell or `where.exe`:
+
+```powershell
+(Get-Command cargo).Path
+where.exe cargo
 ```
 
 mise activation supplies that path to shells where mise is active. SSH

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,19 +132,6 @@ shim, ordinary `cargo build`, `cargo test`, and `cargo check` commands use mbx
 automatically. Explicit `mbx cargo …` commands remain supported, but users and
 tools do not need to remember a special prefix.
 
-Coding agents generally need no mbx-specific skill or project instruction: the
-Cargo commands they already issue take the cached path. A project that wants to
-make the transparent behavior explicit can add this small note:
-
-```md
-Mr Boxington transparently caches ordinary `cargo` commands. No special command
-is required to use the shared cache.
-```
-
-Add that instruction to `AGENTS.md` only when the project wants to enforce the
-convention for every contributor. `mbx setup` does not edit repository-owned
-instruction files.
-
 On Unix, the stable `cargo` launcher uses the setup-time mbx while it exists,
 then resolves the active `mbx` from `PATH` after an upgrade removes that path.
 Windows `cargo.exe` resolves the active mbx from `PATH`, with the setup-time

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -133,6 +133,9 @@ EOF
     MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" MISE_CONFIG_FILE="$project_config" \
     "$MBX_BIN" setup --yes
   assert_success
+  assert_output --partial 'verify new shells with `command -v cargo`'
+  assert_output --partial "expected $MBX_SHIM_DIR/cargo"
+  assert_output --partial "non-interactive shells that do not activate mise need $MBX_SHIM_DIR prepended to PATH"
   assert_file_contains "$mise_log" "config set --append --file $project_config env._.path"
   assert_file_contains "$(dirname "$project_config")/rust-analyzer.toml" "$MBX_SHIM_DIR/cargo"
 

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -8,16 +8,21 @@ _common_setup() {
   # Setup tests begin with transparent Cargo inactive. Developers may already
   # have mbx enabled globally, so keep that host configuration out of the
   # isolated test PATH.
-  local inherited_cargo
-  inherited_cargo="$(command -v cargo)"
-  if [[ "$inherited_cargo" == */mbx/bin/cargo ]]; then
-    local inherited_shim_dir="${inherited_cargo%/cargo}"
-    PATH=":$PATH:"
-    PATH="${PATH//:$inherited_shim_dir:/:}"
-    PATH="${PATH#:}"
-    PATH="${PATH%:}"
-    export PATH
-  fi
+  local path_entry remaining_path="$PATH:" filtered_path="" first_path_entry=1
+  while [[ "$remaining_path" == *:* ]]; do
+    path_entry="${remaining_path%%:*}"
+    remaining_path="${remaining_path#*:}"
+    if [[ "$path_entry" == */mbx/bin ]]; then
+      continue
+    fi
+    if ((first_path_entry)); then
+      filtered_path="$path_entry"
+      first_path_entry=0
+    else
+      filtered_path+=":$path_entry"
+    fi
+  done
+  export PATH="$filtered_path"
 
   export PROJECT_ROOT
   PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -5,6 +5,20 @@ _common_setup() {
   load "test_helper/bats-assert/load"
   load "test_helper/bats-file/load"
 
+  # Setup tests begin with transparent Cargo inactive. Developers may already
+  # have mbx enabled globally, so keep that host configuration out of the
+  # isolated test PATH.
+  local inherited_cargo
+  inherited_cargo="$(command -v cargo)"
+  if [[ "$inherited_cargo" == */mbx/bin/cargo ]]; then
+    local inherited_shim_dir="${inherited_cargo%/cargo}"
+    PATH=":$PATH:"
+    PATH="${PATH//:$inherited_shim_dir:/:}"
+    PATH="${PATH#:}"
+    PATH="${PATH%:}"
+    export PATH
+  fi
+
   export PROJECT_ROOT
   PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   local target_dir="${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}"


### PR DESCRIPTION
## Summary

- print the expected Cargo shim path after mise activation
- document PATH setup for SSH, agents, editors, and non-interactive shells
- keep setup tests isolated when contributors already use mbx globally
- clarify that raw Cargo is the golden path while explicit mbx commands remain supported

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p mbx cli::setup_tests`
- `cargo clippy -p mbx --all-features --all-targets -- -D warnings`
- `test/bats/bin/bats test/setup.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and post-setup CLI messaging only; test harness PATH filtering has no production impact.
> 
> **Overview**
> After successful mise activation, **`mbx setup` now prints verification hints**: how to confirm `cargo` resolves to the installed shim (Unix `command -v` vs Windows `Get-Command` / `where.exe`), and that SSH, agents, and other non-interactive environments may need the shim directory prepended to `PATH`.
> 
> **README** and **getting-started** add matching **“Verify plain Cargo”** guidance, including a `~/.zshenv` example for zsh and a note that plain `cargo` is the expected workflow while `mbx` prefixes stay optional.
> 
> **Bats** asserts the new setup output and **strips `*/mbx/bin` from `PATH` in common test setup** so contributors with global mbx do not skew setup tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47eb012780ac769f1735dd4280dd12c70a7fba18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for verifying that Cargo uses mbx after setup.
  * Documented PATH configuration for non-interactive shells and tools that do not activate mise.
  * Clarified that explicit `mbx cargo` commands remain supported.

* **User Experience**
  * Setup now displays verification steps, including the expected Cargo path and required PATH configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->