### PR TITLE
fix(setup): prevent Cargo shim recursion after HOME changes

### DIFF
--- a/crates/mbx/src/cli/setup.rs
+++ b/crates/mbx/src/cli/setup.rs
@@ -18,7 +18,8 @@ if [ -z "$mbx_executable" ] || [ ! -x "$mbx_executable" ]; then
   exit 127
 fi
 MBX_CARGO_SHIM_MODE=1
-export MBX_CARGO_SHIM_MODE
+MBX_CARGO_SHIM_PATH="$shim_dir/cargo"
+export MBX_CARGO_SHIM_MODE MBX_CARGO_SHIM_PATH
 exec "$mbx_executable" "$@"
 "#;
 const RUST_ANALYZER_CONFIG_FILE: &str = "rust-analyzer.toml";

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -35,14 +35,20 @@ fn is_cargo_shim_path(path: &OsStr) -> bool {
 
 /// Run an invocation received through the persistent Cargo shim.
 pub fn run_cargo_shim() -> Result<ExitCode> {
-    let reported_shim = std::env::var_os(CARGO_SHIM_PATH_ENV);
+    let reported_shim = std::env::var_os(CARGO_SHIM_PATH_ENV)
+        .map(PathBuf::from)
+        .or_else(|| {
+            invoked_as_cargo()
+                .then(|| std::env::current_exe().ok())
+                .flatten()
+        });
     // The Windows launcher uses this only to select dispatch in the target mbx.
     // Do not leak it into Cargo, build scripts, or nested mbx commands.
     unsafe { std::env::remove_var(CARGO_SHIM_MODE_ENV) };
     unsafe { std::env::remove_var(CARGO_SHIM_PATH_ENV) };
     #[cfg(windows)]
     if invoked_as_cargo()
-        && let Some(code) = forward_to_current_mbx()?
+        && let Some(code) = forward_to_current_mbx(reported_shim.as_deref())?
     {
         return Ok(code);
     }
@@ -51,7 +57,7 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
     let configured_shim = shim_dir.join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
     let shim = resolve_active_cargo_shim(
         &configured_shim,
-        reported_shim.as_deref(),
+        reported_shim.as_deref().map(Path::as_os_str),
         std::env::var_os("PATH").as_deref(),
     );
     exclude_shim_from_path(&shim)?;
@@ -103,16 +109,21 @@ fn resolve_active_cargo_shim(
 }
 
 #[cfg(windows)]
-fn forward_to_current_mbx() -> Result<Option<ExitCode>> {
+fn forward_to_current_mbx(reported_shim: Option<&Path>) -> Result<Option<ExitCode>> {
     let Some(install_dir) = super::setup_install_dir() else {
         return Ok(None);
     };
     let Some(target) = super::setup::cargo_shim_target(&install_dir) else {
         return Ok(None);
     };
-    let status = Command::new(&target)
+    let mut command = Command::new(&target);
+    command
         .args(std::env::args_os().skip(1))
-        .env(CARGO_SHIM_MODE_ENV, "1")
+        .env(CARGO_SHIM_MODE_ENV, "1");
+    if let Some(reported_shim) = reported_shim {
+        command.env(CARGO_SHIM_PATH_ENV, reported_shim);
+    }
+    let status = command
         .status()
         .wrap_err_with(|| format!("failed to run the current mbx at {}", target.display()))?;
     Ok(Some(exit_code(status)))
@@ -438,6 +449,30 @@ mod tests {
         let path = std::env::join_paths([&shim_dir, &real_dir]).unwrap();
 
         let active = resolve_active_cargo_shim(&configured, None, Some(&path));
+        assert_eq!(active, shim);
+        let path = path_without_shim(&active, &path).unwrap();
+        assert_eq!(
+            resolve_real_cargo_from(&active, None, &path).unwrap(),
+            real.into_os_string()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn reported_windows_shim_wins_when_real_cargo_precedes_it_on_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let configured = directory.path().join("new-home/bin/cargo.exe");
+        let shim_dir = directory.path().join("shim");
+        let real_dir = directory.path().join("real");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::create_dir_all(&real_dir).unwrap();
+        let shim = shim_dir.join("cargo.exe");
+        let real = real_dir.join("cargo.exe");
+        std::fs::write(&shim, b"shim").unwrap();
+        std::fs::write(&real, b"real").unwrap();
+        let path = std::env::join_paths([&real_dir, &shim_dir]).unwrap();
+
+        let active = resolve_active_cargo_shim(&configured, Some(shim.as_os_str()), Some(&path));
         assert_eq!(active, shim);
         let path = path_without_shim(&active, &path).unwrap();
         assert_eq!(

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -2,12 +2,13 @@ use super::cargo::{CARGO_TARGET_DIR_ENV, cargo_roots, exit_code};
 use crate::config::Config;
 use eyre::{Context, Result};
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 use std::sync::OnceLock;
 
 const CARGO_SHIM_STEM: &str = "cargo";
 const CARGO_SHIM_MODE_ENV: &str = "MBX_CARGO_SHIM_MODE";
+const CARGO_SHIM_PATH_ENV: &str = "MBX_CARGO_SHIM_PATH";
 static PATH_BEFORE_SHIM_EXCLUSION: OnceLock<OsString> = OnceLock::new();
 
 /// Whether this process was installed under Cargo's name by `mbx setup`.
@@ -34,9 +35,11 @@ fn is_cargo_shim_path(path: &OsStr) -> bool {
 
 /// Run an invocation received through the persistent Cargo shim.
 pub fn run_cargo_shim() -> Result<ExitCode> {
+    let reported_shim = std::env::var_os(CARGO_SHIM_PATH_ENV);
     // The Windows launcher uses this only to select dispatch in the target mbx.
     // Do not leak it into Cargo, build scripts, or nested mbx commands.
     unsafe { std::env::remove_var(CARGO_SHIM_MODE_ENV) };
+    unsafe { std::env::remove_var(CARGO_SHIM_PATH_ENV) };
     #[cfg(windows)]
     if invoked_as_cargo()
         && let Some(code) = forward_to_current_mbx()?
@@ -45,7 +48,12 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
     }
     let shim_dir = super::setup_install_dir()
         .ok_or_else(|| eyre::eyre!("the platform data directory could not be located"))?;
-    let shim = shim_dir.join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+    let configured_shim = shim_dir.join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+    let shim = resolve_active_cargo_shim(
+        &configured_shim,
+        reported_shim.as_deref(),
+        std::env::var_os("PATH").as_deref(),
+    );
     exclude_shim_from_path(&shim)?;
     let real_cargo = resolve_real_cargo(&shim)?;
     let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
@@ -74,6 +82,24 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
     unsafe { std::env::set_var("CARGO", &real_cargo) };
     let (config, settings) = Config::load_for_cli()?;
     super::cargo::run(&config, &settings, &string_arguments)
+}
+
+fn resolve_active_cargo_shim(
+    configured: &Path,
+    reported: Option<&OsStr>,
+    path: Option<&OsStr>,
+) -> PathBuf {
+    reported
+        .map(Path::new)
+        .filter(|shim| is_cargo_shim_path(shim.as_os_str()) && shim.is_file())
+        .map(Path::to_path_buf)
+        .or_else(|| {
+            let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+            std::env::split_paths(path?)
+                .map(|dir| dir.join(name))
+                .find(|candidate| candidate.is_file())
+        })
+        .unwrap_or_else(|| configured.to_path_buf())
 }
 
 #[cfg(windows)]
@@ -392,6 +418,30 @@ mod tests {
 
         assert_eq!(
             resolve_real_cargo_from(&shim, Some(shim.as_os_str()), &path).unwrap(),
+            real.into_os_string()
+        );
+    }
+
+    #[test]
+    fn cargo_resolution_uses_the_active_shim_when_the_configured_home_changed() {
+        let directory = tempfile::tempdir().unwrap();
+        let configured = directory.path().join("new-home/bin/cargo");
+        let shim_dir = directory.path().join("original-home/bin");
+        let real_dir = directory.path().join("real");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::create_dir_all(&real_dir).unwrap();
+        let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+        let shim = shim_dir.join(name);
+        let real = real_dir.join(name);
+        std::fs::write(&shim, b"shim").unwrap();
+        std::fs::write(&real, b"real").unwrap();
+        let path = std::env::join_paths([&shim_dir, &real_dir]).unwrap();
+
+        let active = resolve_active_cargo_shim(&configured, None, Some(&path));
+        assert_eq!(active, shim);
+        let path = path_without_shim(&active, &path).unwrap();
+        assert_eq!(
+            resolve_real_cargo_from(&active, None, &path).unwrap(),
             real.into_os_string()
         );
     }


### PR DESCRIPTION
## Summary

- have the installed Cargo launcher report its actual path to mbx
- fall back to the active `cargo` found on `PATH` when that path is unavailable
- keep the configured install path as the final fallback
- add a regression test for commands that change `HOME` before invoking Cargo

This prevents the global Cargo shim from recursively rediscovering itself in test harnesses and other isolated environments that replace `HOME`.

## Validation

- `cargo test -p mbx cli::shim::tests`
- `cargo clippy -p mbx --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every Cargo shim invocation resolves itself and real Cargo; mistakes could break builds or reintroduce shim recursion, but scope is limited to shim dispatch and is covered by new tests.
> 
> **Overview**
> Fixes the global **Cargo shim** treating the wrong executable as “the shim” when `HOME` (or install layout) no longer matches the configured mbx data directory—common in tests and isolated shells.
> 
> The Unix shim launcher now exports **`MBX_CARGO_SHIM_PATH`** with its real `cargo` path. **`run_cargo_shim`** uses that path (or `current_exe` on direct invocation), strips both shim env vars before delegating, and picks the active shim via **`resolve_active_cargo_shim`**: reported path, then first `cargo` on `PATH`, then the configured install binary. Windows re-forwarding passes the reported path through the same env var.
> 
> Regression tests cover a stale configured home vs the shim on `PATH`, and Windows when real `cargo` appears before the shim on `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac49f29f16d53622835b1659a0f2fb9c6ab5b13f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cargo shim detection across Unix and Windows environments.
  * Ensured the active shim is correctly identified even when the configured installation location changes.
  * Prevented internal shim settings from being passed unintentionally to commands launched through Cargo.
  * Improved fallback behavior by checking available Cargo executables before using the configured shim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->