### PR TITLE
fix(cache): model rustc frontend parallelism flags

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -1394,6 +1394,12 @@ impl<'a> Parser<'a> {
                 let value = self.take_value(&rendered_flag, inline)?;
                 self.parse_codegen(&value)
             }
+            "jobs-frontend" => {
+                let value = self.take_value(&rendered_flag, inline)?;
+                self.parsed
+                    .push(Argument::Plain(format!("{rendered_flag}={value}")));
+                Ok(())
+            }
             _ => Err(BypassReason::UnknownFlag(rendered_flag)),
         }
     }
@@ -1401,8 +1407,18 @@ impl<'a> Parser<'a> {
     fn parse_short(&mut self, value: &str) -> Result<(), BypassReason> {
         if let Some(attached) = value.strip_prefix("-Z") {
             let option = self.take_value("-Z", (!attached.is_empty()).then_some(attached))?;
-            if option == "shell-argfiles" {
-                self.parsed.push(Argument::Plain("-Zshell-argfiles".into()));
+            match option.as_str() {
+                "shell-argfiles" | "unstable-options" => {
+                    self.parsed.push(Argument::Plain(format!("-Z{option}")));
+                    return Ok(());
+                }
+                "threads" | "threads=" => {
+                    return Err(BypassReason::MissingValue("-Zthreads".into()));
+                }
+                _ => {}
+            }
+            if option.starts_with("threads=") {
+                self.parsed.push(Argument::Plain(format!("-Z{option}")));
                 return Ok(());
             }
             return Err(BypassReason::UnknownFlag(format!("-Z{option}")));

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1018,6 +1018,52 @@ fn unknown_and_incremental_options_bypass() {
 }
 
 #[test]
+fn models_parallel_frontend_options_in_the_action_key() {
+    let invocation = |parallelism: &[&str]| {
+        let mut arguments = vec![
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+        ];
+        arguments.extend_from_slice(parallelism);
+        arguments.push("src/lib.rs");
+        RustcInvocation::parse(&args(&arguments)).unwrap()
+    };
+    let key = |invocation: RustcInvocation| {
+        invocation
+            .action(context(&[("src/lib.rs", "source")]))
+            .unwrap()
+            .digest
+    };
+
+    let attached = invocation(&["-Zthreads=16"]);
+    let separate = invocation(&["-Z", "threads=16"]);
+    assert_eq!(attached, separate);
+    assert_ne!(key(attached), key(invocation(&["-Zthreads=8"])));
+
+    let jobs_frontend = invocation(&["-Zunstable-options", "--jobs-frontend=16"]);
+    assert_ne!(key(separate), key(jobs_frontend));
+    assert_eq!(
+        invocation(&["-Zunstable-options", "--jobs-frontend", "16"]),
+        invocation(&["-Zunstable-options", "--jobs-frontend=16"])
+    );
+}
+
+#[test]
+fn parallel_frontend_options_require_values() {
+    for arguments in [
+        vec!["-Zthreads", "src/lib.rs"],
+        vec!["-Zthreads=", "src/lib.rs"],
+        vec!["--jobs-frontend=", "src/lib.rs"],
+    ] {
+        assert!(matches!(
+            RustcInvocation::parse(&args(&arguments)),
+            Err(BypassReason::MissingValue(_))
+        ));
+    }
+}
+
+#[test]
 fn linked_and_unmodeled_outputs_bypass() {
     for (arguments, expected) in [
         (


### PR DESCRIPTION
## Summary

- model `-Zthreads=N` in the rustc cache adapter instead of conservatively bypassing
- canonicalize attached and separate `-Z` spellings while keeping the thread count in the action key
- support the replacement `--jobs-frontend=N` spelling and its required `-Zunstable-options` gate
- keep unknown unstable flags conservative

Addresses https://github.com/jdx/mr-boxington/discussions/237

## Testing

- `cargo test -p mbx-cache-rustc`
- `mise run lint`
- `mise run test` (Rust suite passed; initial Bats run could not load uninitialized submodules)
- `git submodule update --init --recursive`
- `mise run test:e2e`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to rustc argument parsing and action-key material in the cache adapter, with new unit tests guarding equivalence and key separation; no auth, I/O, or runtime behavior outside cache eligibility.
> 
> **Overview**
> **Enables action caching** for rustc invocations that set frontend parallelism, instead of treating those flags as unknown and bypassing the cache.
> 
> The rustc cache adapter now **records `-Zthreads=N` and `--jobs-frontend=N`** in the action key (with the thread count preserved), and treats **`-Zunstable-options`** as a known gate for the `--jobs-frontend` spelling. **Attached and split `-Z` forms** normalize to the same parsed invocation; **different thread counts** produce different cache keys. **Bare or empty values** (`-Zthreads`, `-Zthreads=`, `--jobs-frontend=`) still bypass with a missing-value reason; other unrecognized `-Z` flags stay conservative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d8cb17a0d44a082929d189de32dda1b8448f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of compiler options that configure parallel frontend processing.
  * Invalid or incomplete parallel-processing options are now identified correctly instead of being misinterpreted.
  * Equivalent option formats now produce consistent cache behavior, while different values are tracked separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->