### PR TITLE
bound remote cache prefetch work

### DIFF
--- a/crates/mbx-cache-cargo/src/lib.rs
+++ b/crates/mbx-cache-cargo/src/lib.rs
@@ -71,15 +71,19 @@ struct ActionIdentity<'a> {
     version: u8,
     workspace: &'a str,
     command: &'a [String],
+    os: &'static str,
+    arch: &'static str,
 }
 
 /// Derive the prediction-manifest identity used by mbx for a Cargo command.
 pub fn build_identity(workspace_root: &Path, command: &[String]) -> String {
     let workspace = workspace_marker(workspace_root);
     let bytes = canonical_json(&ActionIdentity {
-        version: 1,
+        version: 2,
         workspace: &workspace,
         command,
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
     })
     .expect("Cargo build identity must serialize");
     CacheDigest::blake3(&bytes).hash

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -27,6 +27,9 @@ mod prefetch;
 mod stats;
 mod wire;
 
+#[cfg(test)]
+pub(crate) use prefetch::select_prefetch_actions;
+
 pub use file_digest::{
     FileDigestCache, FileDigestScope, FileIdentity, NoFileDigestCache, RecordedFileDigest,
 };
@@ -64,10 +67,21 @@ const MAX_FILE_DIGEST_BATCH: usize = 16 * 1024;
 const MAX_FILE_DIGEST_ENTRIES: usize = 1024 * 1024;
 const MAX_REMOTE_TRANSFERS: usize = 64;
 const MAX_PREFETCH_TRANSFERS: usize = 48;
+/// Most predicted actions whose complete output closures are downloaded
+/// speculatively for one task.
+///
+/// Manifests deliberately retain predictions across compatible builds, so a
+/// large workspace can describe far more actions than the next invocation
+/// will request. Keep the most expensive recorded rustc actions warm and let
+/// foreground lookups fetch the long tail on demand.
+const MAX_PREFETCH_ACTIONS: usize = 512;
 const MAX_PREFETCH_ACTION_BATCH: usize = 256;
-/// Batched action lookups issued at once, well inside the transfer budget: each
-/// asks about hundreds of actions, so a handful covers a large workspace.
-const MAX_PREFETCH_BATCH_LOOKUPS: usize = 4;
+/// Batched action lookups issued at once.
+///
+/// One request already asks about hundreds of actions. Serial batches keep a
+/// fleet of concurrent CI jobs from multiplying metadata pressure while blob
+/// transfers from earlier answers are also underway.
+const MAX_PREFETCH_BATCH_LOOKUPS: usize = 1;
 const PREFETCH_ACTION_BATCH_DELAY: Duration = Duration::from_millis(5);
 const MAX_PREFETCH_DIRECTORY_OBJECTS: usize = 100_000;
 const MAX_PREFETCH_OBJECTS_PER_WAVE: usize = 100_000;

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -1,5 +1,79 @@
 use super::*;
 
+#[derive(Clone)]
+pub(crate) struct PrefetchCandidate {
+    adapter: String,
+    priority: u64,
+}
+
+fn prediction_priority(prediction: &ActionPrediction) -> u64 {
+    let recorded_duration = serde_json::from_str::<serde_json::Value>(&prediction.payload)
+        .ok()
+        .and_then(|payload| payload.get("compiler_duration_ns")?.as_u64());
+    match (prediction.adapter.as_str(), recorded_duration) {
+        ("rustc" | "cc", Some(duration)) => duration,
+        ("rustc" | "cc", None) => 0,
+        // Build-script and task predictions do not record compiler time. They
+        // are few and often unlock many downstream compiler actions, so retain
+        // them ahead of the capped compiler tail.
+        _ => u64::MAX,
+    }
+}
+
+pub(crate) fn select_prefetch_actions<'a>(
+    predictions: impl Iterator<Item = &'a ActionPrediction>,
+) -> BTreeMap<CacheDigest, PrefetchCandidate> {
+    let mut actions = BTreeMap::<CacheDigest, PrefetchCandidate>::new();
+    for prediction in predictions {
+        let priority = prediction_priority(prediction);
+        let candidate =
+            actions
+                .entry(prediction.action.clone())
+                .or_insert_with(|| PrefetchCandidate {
+                    adapter: prediction.adapter.clone(),
+                    priority,
+                });
+        if priority > candidate.priority {
+            candidate.adapter.clone_from(&prediction.adapter);
+            candidate.priority = priority;
+        }
+    }
+    if actions.len() <= MAX_PREFETCH_ACTIONS {
+        return actions;
+    }
+    let mut ranked = actions.into_iter().collect::<Vec<_>>();
+    ranked.sort_unstable_by(|(left_action, left), (right_action, right)| {
+        right
+            .priority
+            .cmp(&left.priority)
+            .then_with(|| left_action.cmp(right_action))
+    });
+    ranked.truncate(MAX_PREFETCH_ACTIONS);
+    ranked.into_iter().collect()
+}
+
+fn ranked_prefetch_actions(
+    actions: &BTreeMap<CacheDigest, PrefetchCandidate>,
+) -> Vec<(CacheDigest, String)> {
+    let mut ranked = actions
+        .iter()
+        .map(|(action, candidate)| {
+            (
+                action.clone(),
+                candidate.adapter.clone(),
+                candidate.priority,
+            )
+        })
+        .collect::<Vec<_>>();
+    ranked.sort_unstable_by(|(left_action, _, left), (right_action, _, right)| {
+        right.cmp(left).then_with(|| left_action.cmp(right_action))
+    });
+    ranked
+        .into_iter()
+        .map(|(action, adapter, _)| (action, adapter))
+        .collect()
+}
+
 impl CacheAgent {
     pub(super) fn spawn_prefetch_predictions(&self, predictions: Vec<ActionPrediction>) {
         if predictions.is_empty() || !self.remote_mode.reads() || self.remote.is_none() {
@@ -21,12 +95,7 @@ impl CacheAgent {
         }
         self.stats.prefetch_runs.fetch_add(1, Ordering::Relaxed);
         let _timer = AtomicDurationTimer::start(&self.stats.prefetch_duration_ns);
-        let mut actions = BTreeMap::new();
-        for prediction in predictions {
-            actions
-                .entry(prediction.action.clone())
-                .or_insert_with(|| prediction.adapter.clone());
-        }
+        let actions = select_prefetch_actions(predictions);
         // One request per predicted action is the bulk of a prefetch's latency on
         // a large workspace, so ask for them together where the server allows it.
         match self.prefetch_action_batches(&actions).await {
@@ -37,7 +106,7 @@ impl CacheAgent {
                 warn!("remote action batch lookup failed: {error}");
             }
         }
-        let mut actions = actions.into_iter();
+        let mut actions = ranked_prefetch_actions(&actions).into_iter();
         let mut tasks = tokio::task::JoinSet::new();
         for _ in 0..MAX_PREFETCH_TRANSFERS {
             let Some((action, adapter)) = actions.next() else {
@@ -97,12 +166,12 @@ impl CacheAgent {
     /// so nothing is looked up twice.
     pub(super) async fn prefetch_action_batches(
         &self,
-        actions: &BTreeMap<CacheDigest, String>,
+        actions: &BTreeMap<CacheDigest, PrefetchCandidate>,
     ) -> Result<bool> {
-        let wanted: Vec<CacheDigest> = actions
-            .keys()
+        let wanted: Vec<CacheDigest> = ranked_prefetch_actions(actions)
+            .into_iter()
+            .map(|(action, _)| action)
             .filter(|action| !self.action_is_staged(action))
-            .cloned()
             .collect();
         if wanted.is_empty() {
             return Ok(true);
@@ -134,6 +203,7 @@ impl CacheAgent {
             })
             .buffer_unordered(MAX_PREFETCH_BATCH_LOOKUPS);
         let mut answered = true;
+        let mut resolved = Vec::new();
         while let Some(lookup) = lookups.next().await {
             let results = match lookup {
                 Ok(Some(results)) => results,
@@ -149,9 +219,11 @@ impl CacheAgent {
                     continue;
                 }
             };
-            let mut resolved = Vec::with_capacity(results.len());
             for result in results {
-                let Some(adapter) = actions.get(&result.action).cloned() else {
+                let Some(adapter) = actions
+                    .get(&result.action)
+                    .map(|candidate| candidate.adapter.clone())
+                else {
                     continue;
                 };
                 let lock = self.action_lock(&result.action);
@@ -165,12 +237,16 @@ impl CacheAgent {
                     .insert(result.action.clone(), result.clone());
                 resolved.push(PrefetchedAction { adapter, result });
             }
-            while !resolved.is_empty() {
-                let wave = resolved
-                    .drain(..resolved.len().min(MAX_PREFETCH_ACTION_BATCH))
-                    .collect();
-                self.prefetch_resolved_actions(wave).await;
-            }
+        }
+        // Finish the small metadata phase before starting any blob packs. This
+        // keeps pack bookkeeping from competing with later action batches for
+        // the server's database pool, and means serial batch requests do not
+        // sit behind minutes of artifact transfer.
+        while !resolved.is_empty() {
+            let wave = resolved
+                .drain(..resolved.len().min(MAX_PREFETCH_ACTION_BATCH))
+                .collect();
+            self.prefetch_resolved_actions(wave).await;
         }
         Ok(answered)
     }
@@ -810,5 +886,55 @@ impl CacheAgent {
             .downloaded_bytes
             .fetch_add(digest.size, Ordering::Relaxed);
         Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod selection_tests {
+    use super::*;
+
+    fn prediction(index: usize, duration: u64) -> ActionPrediction {
+        ActionPrediction {
+            invocation: CacheDigest::blake3(format!("invocation-{index}").as_bytes()),
+            action: CacheDigest::blake3(format!("action-{index}").as_bytes()),
+            adapter: "rustc".into(),
+            payload: serde_json::json!({ "compiler_duration_ns": duration }).to_string(),
+        }
+    }
+
+    #[test]
+    fn prefetch_selection_keeps_the_most_expensive_predictions() {
+        let predictions = (0..MAX_PREFETCH_ACTIONS + 8)
+            .map(|index| prediction(index, index as u64))
+            .collect::<Vec<_>>();
+
+        let selected = select_prefetch_actions(predictions.iter());
+
+        assert_eq!(selected.len(), MAX_PREFETCH_ACTIONS);
+        for prediction in predictions.iter().take(8) {
+            assert!(!selected.contains_key(&prediction.action));
+        }
+        for prediction in predictions.iter().skip(8) {
+            assert!(selected.contains_key(&prediction.action));
+        }
+    }
+
+    #[test]
+    fn non_rustc_predictions_are_not_starved_by_the_rustc_cap() {
+        let mut predictions = (0..MAX_PREFETCH_ACTIONS)
+            .map(|index| prediction(index, u64::MAX - 1))
+            .collect::<Vec<_>>();
+        let task = ActionPrediction {
+            invocation: CacheDigest::blake3(b"task invocation"),
+            action: CacheDigest::blake3(b"task action"),
+            adapter: "task".into(),
+            payload: "{}".into(),
+        };
+        predictions.push(task.clone());
+
+        let selected = select_prefetch_actions(predictions.iter());
+
+        assert_eq!(selected.len(), MAX_PREFETCH_ACTIONS);
+        assert!(selected.contains_key(&task.action));
     }
 }

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -2591,7 +2591,13 @@ async fn prefetch_skips_remote_negotiation_when_every_action_is_local() {
     fs::write(&action_source, b"already local action").unwrap();
     agent.cas.store_file(&action, &action_source).unwrap();
     agent.actions.store(&result).unwrap();
-    let actions = BTreeMap::from([(action, "rustc".into())]);
+    let prediction = ActionPrediction {
+        invocation: CacheDigest::blake3(b"already local invocation"),
+        action,
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let actions = select_prefetch_actions(std::iter::once(&prediction));
 
     assert!(agent.prefetch_action_batches(&actions).await.unwrap());
     assert_eq!(agent.stats().remote_action_lookups, 0);

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -589,6 +589,8 @@ struct ExecIdentity<'a> {
     version: u8,
     project: &'a str,
     command: &'a [String],
+    os: &'static str,
+    arch: &'static str,
 }
 
 /// Identity of a standalone build: the project and the command it runs.
@@ -600,9 +602,11 @@ struct ExecIdentity<'a> {
 pub fn exec_identity(project_root: &Path, command: &[String]) -> String {
     let project = exec_marker(project_root);
     let material = ExecIdentity {
-        version: 1,
+        version: 2,
         project: &project,
         command,
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
     };
     let bytes = canonical_json(&material).expect("exec identity must serialize");
     CacheDigest::blake3(&bytes).hash


### PR DESCRIPTION
## Summary

- partition task prediction manifests by OS and architecture so CI platforms do not prefetch each other’s actions
- cap speculative prefetch at 512 actions, retaining build/task actions and prioritizing compiler actions by recorded duration
- serialize the 256-key action batch lookups and finish metadata resolution before starting blob-pack downloads

Foreground cache lookups remain unchanged, so predictions outside the speculative cap are still fetched normally if the build requests them.

## Expected impact

The 512-action cap alone bounds the measured prediction volume by about 44% for hk and 66% for mise. Platform partitioning should reduce it further because the current warm jobs share prediction manifests across Linux, macOS, and Windows. A perfect prediction oracle would have removed about 72% of hk speculative actions and 41–46% on mise Linux/macOS in the last runs.

## Validation

- `cargo test -p mbx-cache-core --lib` (171 passed, 1 ignored)
- `cargo test -p mbx-cache-cargo`
- `cargo test -p mbx --lib` (307 passed, 1 ignored)
- `cargo clippy -p mbx-cache-core -p mbx-cache-cargo -p mbx --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Identity v2 changes manifest keys (existing v1 manifests stop matching until rebuilt), and prefetch caps alter warm-cache behavior under load—correctness paths still fetch on demand, but CI cache hit patterns may shift.
> 
> **Overview**
> Limits **speculative** remote cache prefetch and stops cross-platform manifest bleed; **on-demand** cache lookups are unchanged.
> 
> **Platform-scoped prediction manifests:** Cargo `build_identity` and standalone `exec_identity` bump to **version 2** and include `std::env::consts::OS` and `ARCH`, so Linux/macOS/Windows CI jobs no longer share the same prediction manifest key.
> 
> **Prefetch selection and caps:** New `select_prefetch_actions` keeps at most **512** predicted actions for speculative download. `rustc`/`cc` entries rank by `compiler_duration_ns` in the prediction payload; **task** and other non-compiler adapters stay at top priority so they are not dropped when the cap trims the rustc tail. Batch lookups use priority order end-to-end.
> 
> **Remote load shaping:** Concurrent batched action metadata lookups drop from **4 → 1** to reduce metadata pressure when many CI jobs run together. `prefetch_action_batches` now completes **all** batch metadata resolution before starting blob-pack downloads, so later batch requests are not blocked behind artifact transfer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50bfc39089093fbd1d3fcbdc72193f4ede55f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->