### PR TITLE
ci(perf): move benchmarks to dedicated runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - jdx-perf-v1
     - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-arm64
     - namespace-profile-endev-macos-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,74 +228,6 @@ jobs:
           cargo +nightly-2026-08-02 fuzz run dep_info -- -runs=1000
           cargo +nightly-2026-08-02 fuzz run rustc_paths -- -runs=1000
 
-  performance:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    env:
-      CARGO_INCREMENTAL: 0
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
-        with:
-          cache: false
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Install Valgrind
-        if: github.event_name == 'pull_request'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends valgrind
-      - name: Build benchmark driver
-        run: mise run perf:prepare
-      - name: Measure instruction counts
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir -p "$RUNNER_TEMP/mbx-measurements/tak"
-          tak run --record
-          tak history | tee "$RUNNER_TEMP/mbx-measurements/tak/history.md" >> "$GITHUB_STEP_SUMMARY"
-      - name: Compare instruction counts with the PR base
-        id: tak_compare
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        shell: bash
-        run: |
-          if git ls-remote --exit-code origin refs/notes/tak >/dev/null 2>&1; then
-            tak compare "origin/${GITHUB_BASE_REF}" \
-              | tee "$RUNNER_TEMP/mbx-measurements/tak/comparison.md" \
-              >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No shared tak history yet; this PR will seed it after merge." >> "$GITHUB_STEP_SUMMARY"
-          fi
-      - name: Stage benchmark driver
-        run: cp target/release/mbx "$RUNNER_TEMP/mbx-benchmark-driver"
-      - name: Measure cold and warm workspace builds
-        run: |
-          python3 benchmarks/measure_builds.py \
-            --mbx "$RUNNER_TEMP/mbx-benchmark-driver" \
-            --workspace "$GITHUB_WORKSPACE" \
-            --output "$RUNNER_TEMP/mbx-measurements/build"
-      - name: Publish job summary
-        if: always()
-        run: |
-          find "$RUNNER_TEMP/mbx-measurements" -name '*.md' -type f -print0 \
-            | sort -z \
-            | xargs -0 -r cat >> "$GITHUB_STEP_SUMMARY"
-      - name: Upload measurements
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: mbx-measurements-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/mbx-measurements
-          if-no-files-found: error
-          retention-days: 90
-      - name: Enforce instruction-count regression gate
-        if: steps.tak_compare.outcome == 'failure'
-        run: exit 1
-
   final:
     permissions: {}
     needs:
@@ -305,7 +237,6 @@ jobs:
       - lint
       - supply-chain
       - public-api
-      - performance
       - test
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 1
@@ -321,7 +252,6 @@ jobs:
           needs.compatibility.result != 'success' ||
           needs.supply-chain.result != 'success' ||
           needs.public-api.result != 'success' ||
-          needs.performance.result != 'success' ||
           needs.test.result != 'success'
         run: exit 1
       - run: echo "All CI jobs completed successfully"

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -87,9 +87,28 @@ jobs:
           sha=$(cat /tmp/tak-out/sha)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin refs/notes/tak:refs/notes/tak || true
-          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak
+          git fetch origin +refs/notes/tak:refs/notes/tak-remote || true
+          if git rev-parse --verify --quiet refs/notes/tak-remote >/dev/null; then
+            git update-ref refs/notes/tak refs/notes/tak-remote
+          fi
+          {
+            git notes --ref=tak show "$sha" 2>/dev/null || true
+            cat /tmp/tak-out/note
+          } | LC_ALL=C sort -u > /tmp/tak-out/merged-note
+          git notes --ref=tak add -f -F /tmp/tak-out/merged-note "$sha"
+
+          remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          for attempt in 1 2 3 4 5; do
+            if git push --quiet "$remote" refs/notes/tak:refs/notes/tak; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::could not publish refs/notes/tak after five attempts"
+              exit 1
+            fi
+            git fetch --quiet "$remote" +refs/notes/tak:refs/notes/tak-remote
+            git notes --ref=tak merge -s cat_sort_uniq refs/notes/tak-remote
+          done
 
   verify:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -37,7 +37,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -17,7 +17,7 @@ jobs:
   measure:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -38,7 +38,7 @@ jobs:
             echo '### Runner metadata'
             echo '```text'
             echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -17,7 +17,7 @@ jobs:
   measure:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -37,8 +37,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@78e4231'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -1,30 +1,27 @@
-name: performance history and correctness
+name: performance history
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
-  schedule:
-    # One bounded weekly canary, away from the top of the hour.
-    - cron: "17 6 * * 1"
 
+permissions: {}
 concurrency:
   group: performance-history
   cancel-in-progress: false
-
-permissions: {}
-
 env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
+  CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1
 
 jobs:
-  record:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
+  measure:
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
+    timeout-minutes: 30
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -33,22 +30,66 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
-      - name: Install Valgrind
+        env:
+          MISE_LOCKED: "1"
+      - name: Runner metadata
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends valgrind
-      - name: Measure and record
-        run: mise run perf:record
-      - name: Push measurements
-        if: github.ref == 'refs/heads/main'
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Build and measure
+        run: |
+          mise run perf:prepare
+          taskset -c 0-3 mise run perf:record
+      - name: Package measurement
+        run: |
+          mkdir -p /tmp/tak-out
+          git notes --ref=tak show HEAD > /tmp/tak-out/note
+          git rev-parse HEAD > /tmp/tak-out/sha
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+      - run: tak history >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    needs: measure
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Publish refs/notes/tak
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-          tak push
-      - name: Publish history
-        run: tak history >> "$GITHUB_STEP_SUMMARY"
+          sha=$(cat /tmp/tak-out/sha)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin refs/notes/tak:refs/notes/tak || true
+          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak
 
   verify:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/perf-pr-preflight.yml
+++ b/.github/workflows/perf-pr-preflight.yml
@@ -1,0 +1,14 @@
+name: perf-pr-preflight
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  complete:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The default-branch controller will independently validate this pull request."

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -59,7 +59,7 @@ jobs:
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -84,7 +84,7 @@ jobs:
             echo '### Runner metadata'
             echo '```text'
             echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -131,6 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      checks: write # attach the regression gate to the measured PR head SHA
       pull-requests: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -157,6 +158,29 @@ jobs:
           else
             gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" --field body="$(cat /tmp/tak-comment.md)"
           fi
+      - name: Publish the pull request check
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          status=$(cat /tmp/tak-out/status 2>/dev/null || echo 2)
+          if [ "$status" -eq 0 ]; then
+            conclusion=success
+            title='Instruction counts passed'
+          else
+            conclusion=failure
+            title='Instruction-count regression or measurement failure'
+          fi
+          test -f /tmp/tak-out/report.md || echo 'The comparison did not produce a report.' > /tmp/tak-out/report.md
+          jq -n --arg head_sha "$HEAD_SHA" --arg conclusion "$conclusion" \
+            --arg title "$title" --arg details_url "$RUN_URL" \
+            --rawfile summary /tmp/tak-out/report.md \
+            '{name:"perf / instruction-count",head_sha:$head_sha,status:"completed",conclusion:$conclusion,details_url:$details_url,output:{title:$title,summary:$summary}}' \
+            | gh api --method POST "repos/$GH_REPO/check-runs" --input -
+
       - name: Enforce gate
         if: always()
         run: |

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
   pull-requests: read
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: true
 env:
   CARGO_INCREMENTAL: "0"
@@ -64,6 +64,9 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,21 +1,62 @@
 name: perf-pr
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: # zizmor: ignore[dangerous-triggers] validates live PR metadata before any self-hosted job
+  workflow_run:
+    workflows: [perf-pr-preflight]
+    types: [completed]
 
 permissions:
   contents: read
+  pull-requests: read
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 env:
   CARGO_INCREMENTAL: "0"
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.pr.outputs.authorized }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - id: pr
+        name: Validate the pull request from the trusted default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          TRIGGER_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          exec 3>>"$GITHUB_OUTPUT"
+          echo 'authorized=false' >&3
+          [ "$TRIGGER_EVENT" = pull_request ] || exit 0
+          [ "$TRIGGER_CONCLUSION" = success ] || exit 0
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || exit 0
+          pr="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")"
+          [ "$(jq -r .state <<<"$pr")" = open ] || exit 0
+          [ "$(jq -r .user.login <<<"$pr")" = jdx ] || exit 0
+          [ "$(jq -r .head.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          [ "$(jq -r .base.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          head_sha="$(jq -r .head.sha <<<"$pr")"
+          [ "$head_sha" = "$TRIGGER_SHA" ] || exit 0
+          echo 'authorized=true' >&3
+          echo "base_ref=$(jq -r .base.ref <<<"$pr")" >&3
+          echo "head_sha=$head_sha" >&3
+          echo "pr_number=$PR_NUMBER" >&3
+
   measure:
-    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
@@ -26,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
           fetch-depth: 0
           persist-credentials: false
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
@@ -39,7 +80,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu
@@ -56,7 +97,7 @@ jobs:
       - name: Compare with the merge base
         id: compare
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
         run: |
           git fetch --quiet origin "$BASE_REF"
           base=$(git merge-base "origin/$BASE_REF" HEAD)
@@ -69,7 +110,7 @@ jobs:
       - name: Package report
         if: always()
         env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           mkdir -p /tmp/tak-out
           cp /tmp/tak-report.md /tmp/tak-out/report.md 2>/dev/null || echo "Comparison did not run." > /tmp/tak-out/report.md
@@ -85,8 +126,8 @@ jobs:
           if-no-files-found: error
 
   report:
-    needs: measure
-    if: always() && github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: [authorize, measure]
+    if: always() && needs.authorize.outputs.authorized == 'true' && needs.measure.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -100,7 +141,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
         run: |
           marker='<!-- tak-perf-pr -->'
           read -r head_sha base_sha < /tmp/tak-out/shas

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,123 @@
+name: perf-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+env:
+  CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1
+
+jobs:
+  measure:
+    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+      - name: Runner metadata
+        run: |
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Build and measure
+        run: |
+          mise run perf:prepare
+          taskset -c 0-3 mise run perf:record
+      - name: Compare with the merge base
+        id: compare
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --quiet origin "$BASE_REF"
+          base=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "$base" > /tmp/tak-base
+          set +e
+          tak compare "$base" > /tmp/tak-report.md
+          echo $? > /tmp/tak-status
+          set -e
+          cat /tmp/tak-report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Package report
+        if: always()
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p /tmp/tak-out
+          cp /tmp/tak-report.md /tmp/tak-out/report.md 2>/dev/null || echo "Comparison did not run." > /tmp/tak-out/report.md
+          cp /tmp/tak-status /tmp/tak-out/status 2>/dev/null || echo 2 > /tmp/tak-out/status
+          base=$(cat /tmp/tak-base 2>/dev/null || echo unknown)
+          printf '%s %s\n' "${HEAD_SHA:0:12}" "${base:0:12}" > /tmp/tak-out/shas
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+  report:
+    needs: measure
+    if: always() && github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+      - name: Comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          marker='<!-- tak-perf-pr -->'
+          read -r head_sha base_sha < /tmp/tak-out/shas
+          {
+            printf '%s\n### Instruction counts\n\n' "$marker"
+            cat /tmp/tak-out/report.md
+            # shellcheck disable=SC2016
+            printf '\n<sub>`%s` vs `%s` · measured on jdx-perf-v1.</sub>\n' "$head_sha" "$base_sha"
+          } > /tmp/tak-comment.md
+          existing="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n1)"
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$GH_REPO/issues/comments/$existing" --field body="$(cat /tmp/tak-comment.md)"
+          else
+            gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" --field body="$(cat /tmp/tak-comment.md)"
+          fi
+      - name: Enforce gate
+        if: always()
+        run: |
+          status=$(cat /tmp/tak-out/status)
+          test "$status" -eq 0 || { echo "::error::instruction-count comparison failed"; exit "$status"; }

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -59,7 +59,7 @@ jobs:
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -83,8 +83,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@78e4231'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
             uname -a
             lscpu
             mise --version

--- a/mise.lock
+++ b/mise.lock
@@ -86,46 +86,45 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools."github:jdx/tak"]]
-version = "0.0.8"
+version = "0.0.9"
 backend = "github:jdx/tak"
-specifiers = ["0.0.8"]
+specifiers = ["0.0.9"]
 
 [tools."github:jdx/tak"."platforms.linux-arm64"]
-checksum = "sha256:d3b5ee39a9be283586fcc1f40fffbe4003d0fce79905462f9e798ec488e148dd"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283627"
+checksum = "sha256:9069450a581d5918c7f40fe4120f054a71835da322604becb42b7acb5bd1e0a1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992902"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-arm64-musl"]
-checksum = "sha256:a3261a9ffe9fcb2c997687d1d044107ff311429e0d7385ec98e92c6ea1935e2c"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283626"
+checksum = "sha256:0caa3b6b66fe98298714a90e6de0690402a417f5b3c34d9aa9c912edf69a18f1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992901"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64"]
-checksum = "sha256:8def2146c565a331e2de9abebda238c22bb868335dc139db9a76aff1de1339c4"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283644"
+checksum = "sha256:dfb0020b976d679af5a7504190ffbcb201c0e11b2f7788901fd6f60740cd87d4"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992912"
 provenance = "github-attestations"
-provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.linux-x64-musl"]
-checksum = "sha256:442c866a7572936f639c39edb32042a2f60d78a9dd86116a429f6e31cc9840fe"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283646"
+checksum = "sha256:c761a4dbf695dc493744c79de0f3ab67a1698ee5af9afd35f6d019af36145420"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992915"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.macos-arm64"]
-checksum = "sha256:fbd5e2c3366f085cb8ce71362bcdc05fbf549e7787bd401ae085a1dee09bdb22"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283628"
+checksum = "sha256:be4690bad41265946803d11f145c22e01368164e7f1fe49befef8789259c9471"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992905"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.windows-x64"]
-checksum = "sha256:fd3157419889dc558c87e5779f89d123dc909bfc4f7557c970dcb95d71a97d1b"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283641"
+checksum = "sha256:a15f62ea6fa0051f8ae01fca58da26c550ae95fd9d7eccaa167ca53d6f2262b3"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992910"
 provenance = "github-attestations"
 
 [[tools.lychee]]

--- a/mise.toml
+++ b/mise.toml
@@ -160,7 +160,7 @@ depends = ["perf:prepare"]
 run = "tak run --record"
 
 [tools]
-"github:jdx/tak" = "0.0.8"
+"github:jdx/tak" = "0.0.9"
 aube = "latest"
 communique = "latest"
 lychee = "0.24.2"


### PR DESCRIPTION
## Summary

- route main and authorized pull-request benchmarks through `[self-hosted, jdx-perf-v1]`
- serialize benchmark work on the host and keep write credentials off measurement jobs
- pin Tak 0.0.9 through its checksum-verified GitHub release artifacts; no Cargo compilation is used
- retain GitHub-hosted jobs for publishing notes and enforcing the regression gate

## Security

- only same-repository pull requests authored by `jdx` can dispatch measurements
- controlling workflows remain on the default branch and check out the exact authorized head SHA
- actions and the benchmark container are digest-pinned; credentials and caches are disabled on the self-hosted job

## Validation

- `actionlint` on each changed workflow
- `mise lock github:jdx/tak --dry-run --json`
- installed the prebuilt release asset and confirmed `tak 0.0.9`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated performance validation for pull requests, including comparison results and status reporting.
  - Added performance history recording and publishing for ongoing trend tracking.
  - Added a preliminary pull request performance check before measurements run.

- **Improvements**
  - Updated performance measurement execution for more consistent results.
  - Expanded support for the required performance runner environment.
  - Improved workflow coordination and reporting when performance checks complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how performance gates run (new workflows, self-hosted execution, and note publishing) rather than application runtime code; misconfiguration could skip checks or publish bad `refs/notes/tak` data.
> 
> **Overview**
> **Moves instruction-count benchmarking off GitHub-hosted `ubuntu-24.04` CI** into dedicated `jdx-perf-v1` self-hosted jobs running a digest-pinned `perf-runner` container, with `taskset`/`cpuset` pinning and `TAK_RUNNER` labeling for reproducibility.
> 
> The **`performance` job is removed from `ci.yml`** (including Valgrind installs, cold/warm build measurements, artifact upload, and the `final` gate dependency). **PR regressions** are handled by new **`perf-pr-preflight`** (PR trigger on default branch) and **`perf-pr`** (`workflow_run` + strict authorization: open same-repo PR by `jdx`, head SHA matches trigger). Measurement stays on the self-hosted runner with **read-only** permissions; **`report`** on `ubuntu-latest` posts/updates a marked PR comment, publishes a **`perf / instruction-count`** check on the head SHA, and enforces the comparison gate.
> 
> **Main-branch history** in **`measure.yml`** is split: **`measure`** records on the perf runner and uploads a `tak` note artifact; **`publish`** merges and pushes `refs/notes/tak` with retries (write token only there). The weekly schedule trigger is dropped; **`tak` is bumped to 0.0.9** in `mise.toml` / `mise.lock`. **`actionlint`** adds the `jdx-perf-v1` runner label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909ae7ce3774fccecdd6d7e63943861f98c524be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->