### PR TITLE
perf(cache): reduce speculative action prefetch

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -72,9 +72,11 @@ const MAX_PREFETCH_TRANSFERS: usize = 48;
 ///
 /// Manifests deliberately retain predictions across compatible builds, so a
 /// large workspace can describe far more actions than the next invocation
-/// will request. Keep the most expensive recorded rustc actions warm and let
-/// foreground lookups fetch the long tail on demand.
-const MAX_PREFETCH_ACTIONS: usize = 512;
+/// will request. Keep the most expensive recorded actions warm and let
+/// foreground lookups fetch the long tail on demand. A 256-action ceiling also
+/// bounds speculative output transfer: real Cargo manifests commonly contain
+/// predictions for build-script work made unnecessary by an earlier cache hit.
+const MAX_PREFETCH_ACTIONS: usize = 256;
 const MAX_PREFETCH_ACTION_BATCH: usize = 256;
 /// Batched action lookups issued at once.
 ///


### PR DESCRIPTION
## Summary

- halve speculative action prefetch from 512 to 256 actions
- keep duration-ranked selection and on-demand restoration for the remaining predictions
- bound work made unnecessary by earlier build-script or compiler cache hits

## Evidence

The hk v1.2.0 warm-cache run prefetched 495 Linux actions and 501 macOS actions, but only 253 and 254 compilations became hits. Those speculative downloads transferred 1.3 GiB and 1.1 GiB and kept prefetch active for 178s and 169s. A 256-action cap matches the observed useful working set while leaving non-prefetched predictions available to foreground lookup.

Benchmark: https://github.com/jdx/hk/actions/runs/33395159164

## Validation

- `cargo fmt --check`
- `cargo test -p mbx-cache-core --lib`
- `cargo clippy -p mbx-cache-core --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change with on-demand fallback unchanged; main effect is less background download work, not correctness paths.
> 
> **Overview**
> **Lowers the per-task ceiling for speculative action prefetch** from 512 to **256** in `MAX_PREFETCH_ACTIONS`, so the cache agent downloads fewer predicted rustc action output closures up front.
> 
> Selection still ranks predictions by cost and restores anything outside the cap via foreground lookup. The updated comment calls out that Cargo manifests often retain predictions for build-script work that never runs after an earlier cache hit, so a tighter cap limits wasted speculative transfer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3823b7136c0025926c09e63b693700dff51d2136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->