### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "blake3",
  "eyre",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.9...mbx-cache-cargo-v0.1.10) - 2026-08-31
+
+### Added
+
+- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
+
 ## [0.1.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.8...mbx-cache-cargo-v0.1.9) - 2026-08-31
 
 ### Fixed

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.9"
+version = "0.1.10"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.1...mbx-cache-cc-v0.10.2) - 2026-08-31
+
+### Added
+
+- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
+
 ## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.0...mbx-cache-cc-v0.10.1) - 2026-08-31
 
 ### Fixed

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.10.1"
+version = "0.10.2"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.1...mbx-cache-core-v0.10.2) - 2026-08-31
+
+### Added
+
+- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
+
+### Other
+
+- *(cache)* prefetch outputs in progressive waves ([#244](https://github.com/jdx/mr-boxington/pull/244))
+- *(cache)* reduce speculative action prefetch ([#242](https://github.com/jdx/mr-boxington/pull/242))
+
 ## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.0...mbx-cache-core-v0.10.1) - 2026-08-31
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.10.1"
+version = "0.10.2"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.9" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.10" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.9...mbx-cache-protocol-v0.5.10) - 2026-08-31
+
+### Added
+
+- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
+
 ## [0.5.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.8...mbx-cache-protocol-v0.5.9) - 2026-08-31
 
 ### Fixed

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.9"
+version = "0.5.10"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.1...mbx-cache-rustc-v0.10.2) - 2026-08-31
+
+### Added
+
+- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
+
 ## [0.10.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.0...mbx-cache-rustc-v0.10.1) - 2026-08-31
 
 ### Fixed

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.10.1"
+version = "0.10.2"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.9...mbx-cache-store-v0.1.10) - 2026-08-31
+
+### Added
+
+- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
+
 ## [0.1.9](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.8...mbx-cache-store-v0.1.9) - 2026-08-31
 
 ### Fixed

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.9"
+version = "0.1.10"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/jdx/mr-boxington/compare/v1.2.0...v1.3.0) - 2026-08-31
+
+### Added
+
+- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
+
+### Other
+
+- cache build scripts with Cargo's default inputs ([#245](https://github.com/jdx/mr-boxington/pull/245))
+
 ## [1.2.0](https://github.com/jdx/mr-boxington/compare/v1.1.0...v1.2.0) - 2026-08-31
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.2.0"
+version = "1.3.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.1", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.9", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.1", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.1", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.9", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.10", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.2", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.2", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.10", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.2.0
+**Version:** 1.3.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.9 -> 0.5.10 (✓ API compatible changes)
* `mbx-cache-core`: 0.10.1 -> 0.10.2 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `mbx-cache-cc`: 0.10.1 -> 0.10.2 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.10.1 -> 0.10.2 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `mbx`: 1.2.0 -> 1.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.9...mbx-cache-protocol-v0.5.10) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.1...mbx-cache-core-v0.10.2) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))

### Other

- *(cache)* prefetch outputs in progressive waves ([#244](https://github.com/jdx/mr-boxington/pull/244))
- *(cache)* reduce speculative action prefetch ([#242](https://github.com/jdx/mr-boxington/pull/242))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.9...mbx-cache-cargo-v0.1.10) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.1...mbx-cache-cc-v0.10.2) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.1...mbx-cache-rustc-v0.10.2) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.9...mbx-cache-store-v0.1.10) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
</blockquote>

## `mbx`

<blockquote>

## [1.3.0](https://github.com/jdx/mr-boxington/compare/v1.2.0...v1.3.0) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))

### Other

- cache build scripts with Cargo's default inputs ([#245](https://github.com/jdx/mr-boxington/pull/245))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only changes versions, changelogs, lockfile, and generated docs; behavioral changes shipped in earlier merges.
> 
> **Overview**
> **Release-only PR** (release-plz): bumps crate versions, refreshes `Cargo.lock`, finalizes per-crate `CHANGELOG.md` entries, and updates the generated CLI docs version string to **1.3.0**. No application logic changes appear in this diff.
> 
> **`mbx` 1.3.0** documents setup using **mise command wrappers** ([#249]) and caching **build scripts with Cargo’s default inputs** ([#245]).
> 
> **`mbx-cache-core` 0.10.2** adds the same setup note plus cache prefetch tweaks: **progressive-wave output prefetch** ([#244]) and **less speculative action prefetch** ([#242]). Dependent crates (`mbx-cache-protocol`, `mbx-cache-cargo`, `mbx-cache-cc`, `mbx-cache-rustc`, `mbx-cache-store`) get matching patch bumps and dependency version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f332caf5e655312b35d093ed9cf30a323221aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->