### PR TITLE
perf(cache): prefetch outputs in progressive waves

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -77,7 +77,11 @@ const MAX_PREFETCH_TRANSFERS: usize = 48;
 /// bounds speculative output transfer: real Cargo manifests commonly contain
 /// predictions for build-script work made unnecessary by an earlier cache hit.
 const MAX_PREFETCH_ACTIONS: usize = 256;
-const MAX_PREFETCH_ACTION_BATCH: usize = 256;
+// Resolve speculative actions progressively so the most valuable predictions
+// become usable first and cancellation at the end of a build abandons a small
+// tail instead of one workspace-sized transfer wave. Action-result lookup is
+// still batched independently; this only bounds each output-closure download.
+const MAX_PREFETCH_ACTION_WAVE: usize = 32;
 /// Batched action lookups issued at once.
 ///
 /// One request already asks about hundreds of actions. Serial batches keep a

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -74,6 +74,25 @@ fn ranked_prefetch_actions(
         .collect()
 }
 
+fn rank_resolved_prefetch_actions(
+    actions: &BTreeMap<CacheDigest, PrefetchCandidate>,
+    resolved: &mut [PrefetchedAction],
+) {
+    resolved.sort_unstable_by(|left, right| {
+        let left_priority = actions
+            .get(&left.result.action)
+            .map(|candidate| candidate.priority)
+            .unwrap_or_default();
+        let right_priority = actions
+            .get(&right.result.action)
+            .map(|candidate| candidate.priority)
+            .unwrap_or_default();
+        right_priority
+            .cmp(&left_priority)
+            .then_with(|| left.result.action.cmp(&right.result.action))
+    });
+}
+
 impl CacheAgent {
     pub(super) fn spawn_prefetch_predictions(&self, predictions: Vec<ActionPrediction>) {
         if predictions.is_empty() || !self.remote_mode.reads() || self.remote.is_none() {
@@ -242,6 +261,9 @@ impl CacheAgent {
         // keeps pack bookkeeping from competing with later action batches for
         // the server's database pool, and means serial batch requests do not
         // sit behind minutes of artifact transfer.
+        // Batch results are unordered, so restore prediction priority before
+        // dividing the output downloads into progressive waves.
+        rank_resolved_prefetch_actions(actions, &mut resolved);
         while !resolved.is_empty() {
             let wave = resolved
                 .drain(..resolved.len().min(MAX_PREFETCH_ACTION_WAVE))
@@ -936,5 +958,40 @@ mod selection_tests {
 
         assert_eq!(selected.len(), MAX_PREFETCH_ACTIONS);
         assert!(selected.contains_key(&task.action));
+    }
+
+    #[test]
+    fn unordered_batch_results_are_restored_to_prediction_priority() {
+        let predictions = (0..MAX_PREFETCH_ACTION_WAVE + 2)
+            .map(|index| prediction(index, index as u64))
+            .collect::<Vec<_>>();
+        let actions = select_prefetch_actions(predictions.iter());
+        let mut resolved = predictions
+            .iter()
+            .map(|prediction| PrefetchedAction {
+                adapter: prediction.adapter.clone(),
+                result: RemoteActionResult {
+                    action: prediction.action.clone(),
+                    metadata: None,
+                    output_root: None,
+                    version: 1,
+                },
+            })
+            .collect::<Vec<_>>();
+
+        rank_resolved_prefetch_actions(&actions, &mut resolved);
+
+        let expected = predictions
+            .iter()
+            .rev()
+            .map(|prediction| &prediction.action)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            resolved
+                .iter()
+                .map(|action| &action.result.action)
+                .collect::<Vec<_>>(),
+            expected
+        );
     }
 }

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -148,7 +148,7 @@ impl CacheAgent {
                 let agent = self.clone();
                 tasks.spawn(async move { agent.resolve_prefetch_action(action, adapter).await });
             }
-            if resolved.len() == MAX_PREFETCH_ACTION_BATCH {
+            if resolved.len() == MAX_PREFETCH_ACTION_WAVE {
                 self.prefetch_resolved_actions(std::mem::take(&mut resolved))
                     .await;
             }
@@ -244,7 +244,7 @@ impl CacheAgent {
         // sit behind minutes of artifact transfer.
         while !resolved.is_empty() {
             let wave = resolved
-                .drain(..resolved.len().min(MAX_PREFETCH_ACTION_BATCH))
+                .drain(..resolved.len().min(MAX_PREFETCH_ACTION_WAVE))
                 .collect();
             self.prefetch_resolved_actions(wave).await;
         }


### PR DESCRIPTION
## Summary

- keep action-result discovery fully batched
- download speculative action output closures in ranked waves of 32
- let end-of-build cancellation abandon a small tail instead of a workspace-sized 256-action transfer wave

The hk warm benchmark downloaded 1.3 GiB for 495 prefetched actions on Linux while 538 compiler predictions went unconsulted. At that run's average payload (~2.6 MiB/action), a 32-action active wave is roughly 84 MiB of speculative work at a time, though individual action sizes vary.

This complements #242: the 256 cap bounds the total candidate set; progressive waves bound how much of that set is actively being expanded and downloaded before cancellation can stop the tail.

## Validation

- `cargo fmt --check`
- `cargo test -p mbx-cache-core --lib`
- `cargo clippy -p mbx-cache-core --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote prefetch timing and download batching in the cache agent; behavior is covered by a new unit test but affects production I/O under load.
> 
> **Overview**
> Remote speculative prefetch still caps candidates at **256** actions and keeps **batched** action-result lookups unchanged, but **output-closure downloads** are now chunked in **waves of 32** instead of flushing up to 256 at once.
> 
> After batched metadata lookups return (unordered), resolved actions are **re-sorted by prediction priority** via new `rank_resolved_prefetch_actions` so the highest-value predictions download first within each wave. The same wave size applies on the per-action resolve path when results accumulate before `prefetch_resolved_actions`.
> 
> **Intent:** high-priority blobs become usable sooner, and when a build ends or prefetch is cancelled, less speculative transfer work is in flight (~tens of MiB per wave vs. a full 256-action wave).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b04d50453277b6023214406e84a70dd9a09eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->