### PR TITLE
perf: cache build scripts with Cargo's default inputs

### DIFF
--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -57,6 +57,7 @@ enum InputState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Prediction {
+    #[serde(default)]
     default_package: bool,
     environment: Vec<String>,
     inputs: Vec<String>,
@@ -205,21 +206,38 @@ fn find_prediction(invocation: &CacheDigest) -> Result<Option<Prediction>> {
         Some(AgentResponse::ActionPrediction {
             prediction: Some(found),
         }) if found.adapter == ADAPTER && found.invocation == *invocation => {
-            let prediction: Prediction = serde_json::from_str(&found.payload)?;
-            if prediction.version != 2
-                || (prediction.default_package
-                    && (prediction.inputs != ["${build_script_manifest_dir}"]
-                        || !prediction.environment.is_empty()))
-                || canonical_json(&prediction)? != found.payload.as_bytes()
-            {
-                bail!("cached build-script prediction is unsupported");
-            }
-            Ok(Some(prediction))
+            Ok(Some(decode_prediction(&found.payload)?))
         }
         Some(AgentResponse::ActionPrediction { prediction: None }) => Ok(None),
         Some(AgentResponse::Error { message }) => bail!(message),
         _ => bail!("cache agent returned an unexpected build-script prediction response"),
     }
+}
+
+fn decode_prediction(payload: &str) -> Result<Prediction> {
+    let value: serde_json::Value = serde_json::from_str(payload)?;
+    if canonical_json(&value)? != payload.as_bytes() {
+        bail!("cached build-script prediction is unsupported");
+    }
+    let has_default_package = value
+        .as_object()
+        .is_some_and(|value| value.contains_key("default_package"));
+    let prediction: Prediction = serde_json::from_value(value)?;
+    let supported_version = match prediction.version {
+        // Version 1 predates Cargo-default package inputs. Every prediction it
+        // stored came from explicit rerun directives, so false is exact.
+        1 => !has_default_package && !prediction.default_package,
+        2 => has_default_package,
+        _ => false,
+    };
+    if !supported_version
+        || (prediction.default_package
+            && (prediction.inputs != ["${build_script_manifest_dir}"]
+                || !prediction.environment.is_empty()))
+    {
+        bail!("cached build-script prediction is unsupported");
+    }
+    Ok(prediction)
 }
 
 fn record_prediction(
@@ -807,6 +825,8 @@ mod tests {
         assert!(!parsed.default_package);
         assert_eq!(parsed.inputs, ["src/a.h"]);
         assert_eq!(parsed.environment, ["MODE"]);
+        let encoded = String::from_utf8(canonical_json(&parsed).unwrap()).unwrap();
+        assert_eq!(decode_prediction(&encoded).unwrap(), parsed);
     }
 
     #[test]
@@ -816,6 +836,24 @@ mod tests {
             .unwrap();
         assert!(parsed.default_package);
         assert_eq!(parsed.inputs, ["${build_script_manifest_dir}"]);
+    }
+
+    #[test]
+    fn version_one_predictions_remain_usable() {
+        let parsed = decode_prediction(
+            r#"{"environment":["MODE"],"inputs":["input.h"],"portable_out_dir":true,"version":1}"#,
+        )
+        .unwrap();
+        assert!(!parsed.default_package);
+        assert_eq!(parsed.inputs, ["input.h"]);
+        assert_eq!(parsed.environment, ["MODE"]);
+        assert!(
+            decode_prediction(
+                r#"{"environment":[],"inputs":["input.h"],"portable_out_dir":true,"version":2}"#
+            )
+            .is_err(),
+            "version 2 must carry its default-package mode"
+        );
     }
 
     #[test]

--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -57,6 +57,7 @@ enum InputState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Prediction {
+    default_package: bool,
     environment: Vec<String>,
     inputs: Vec<String>,
     portable_out_dir: bool,
@@ -162,7 +163,7 @@ pub(crate) fn run() -> Result<ExitCode> {
 
     let caching = (|| -> Result<()> {
         let Some(prediction) = parse_prediction(&output.stdout)? else {
-            record_bypass("build-script-no-declared-inputs");
+            record_bypass("build-script-always-rerun");
             return Ok(());
         };
         let (action_bytes, action) = build_action(&binary_action, &prediction)?;
@@ -205,7 +206,12 @@ fn find_prediction(invocation: &CacheDigest) -> Result<Option<Prediction>> {
             prediction: Some(found),
         }) if found.adapter == ADAPTER && found.invocation == *invocation => {
             let prediction: Prediction = serde_json::from_str(&found.payload)?;
-            if prediction.version != 1 || canonical_json(&prediction)? != found.payload.as_bytes() {
+            if prediction.version != 2
+                || (prediction.default_package
+                    && (prediction.inputs != ["${build_script_manifest_dir}"]
+                        || !prediction.environment.is_empty()))
+                || canonical_json(&prediction)? != found.payload.as_bytes()
+            {
                 bail!("cached build-script prediction is unsupported");
             }
             Ok(Some(prediction))
@@ -262,14 +268,19 @@ fn parse_prediction(stdout: &[u8]) -> Result<Option<Prediction>> {
             environment.insert(name.to_string());
         }
     }
-    if inputs.is_empty() && environment.is_empty() {
-        return Ok(None);
+    let default_package = inputs.is_empty() && environment.is_empty();
+    if default_package {
+        // With no rerun directives Cargo treats the complete package source as
+        // the build script's input. Keep that implicit declaration explicit in
+        // the prediction so equivalent package trees can share the execution.
+        inputs.insert("${build_script_manifest_dir}".into());
     }
     Ok(Some(Prediction {
+        default_package,
         inputs: inputs.into_iter().collect(),
         environment: environment.into_iter().collect(),
         portable_out_dir: out_dir_is_portable()?,
-        version: 1,
+        version: 2,
     }))
 }
 
@@ -290,7 +301,12 @@ fn build_action(
         } else {
             working_dir.join(path)
         };
-        inputs.insert(declared.clone(), input_state(&resolved, &mappings)?);
+        let state = if prediction.default_package {
+            package_input_state(&resolved, &mappings)?
+        } else {
+            input_state(&resolved, &mappings)?
+        };
+        inputs.insert(declared.clone(), state);
     }
     let environment = prediction
         .environment
@@ -325,12 +341,24 @@ fn build_action(
 }
 
 fn input_state(path: &Path, mappings: &[PathMapping]) -> Result<InputState> {
-    input_state_at(path, mappings, 0)
+    input_state_at(path, mappings, &[], 0)
+}
+
+fn package_input_state(path: &Path, mappings: &[PathMapping]) -> Result<InputState> {
+    let mut excluded = vec![path.join(".git"), path.join("target")];
+    if let Some(target) = std::env::var_os(session::TARGET_DIR_ENV) {
+        let target = std::path::absolute(target)?;
+        if target.starts_with(path) {
+            excluded.push(target);
+        }
+    }
+    input_state_at(path, mappings, &excluded, 0)
 }
 
 fn input_state_at(
     path: &Path,
     mappings: &[PathMapping],
+    excluded: &[PathBuf],
     symlink_depth: usize,
 ) -> Result<InputState> {
     let metadata = match std::fs::symlink_metadata(path) {
@@ -352,7 +380,12 @@ fn input_state_at(
         };
         return Ok(InputState::Symlink {
             target: normalize_environment_value(&target.to_string_lossy(), mappings),
-            referent: Box::new(input_state_at(&resolved, mappings, symlink_depth + 1)?),
+            referent: Box::new(input_state_at(
+                &resolved,
+                mappings,
+                excluded,
+                symlink_depth + 1,
+            )?),
         });
     }
     if metadata.is_file() {
@@ -365,10 +398,11 @@ fn input_state_at(
         entries.sort_by_key(std::fs::DirEntry::file_name);
         let children = entries
             .into_iter()
+            .filter(|entry| !excluded.iter().any(|excluded| entry.path() == *excluded))
             .map(|entry| {
                 Ok((
                     entry.file_name().to_string_lossy().into_owned(),
-                    input_state_at(&entry.path(), mappings, symlink_depth)?,
+                    input_state_at(&entry.path(), mappings, excluded, symlink_depth)?,
                 ))
             })
             .collect::<Result<BTreeMap<_, _>>>()?;
@@ -770,17 +804,36 @@ mod tests {
     #[test]
     fn directives_are_deduplicated_and_both_cargo_spellings_are_accepted() {
         let parsed = parse_prediction(b"cargo:rerun-if-changed=src/a.h\ncargo::rerun-if-changed=src/a.h\ncargo:rerun-if-env-changed=MODE\n").unwrap().unwrap();
+        assert!(!parsed.default_package);
         assert_eq!(parsed.inputs, ["src/a.h"]);
         assert_eq!(parsed.environment, ["MODE"]);
     }
 
     #[test]
-    fn no_declared_inputs_bypasses_execution_caching() {
-        assert!(
-            parse_prediction(b"cargo:rustc-cfg=hello\n")
-                .unwrap()
-                .is_none()
-        );
+    fn no_declared_inputs_use_cargos_package_default() {
+        let parsed = parse_prediction(b"cargo:rustc-cfg=hello\n")
+            .unwrap()
+            .unwrap();
+        assert!(parsed.default_package);
+        assert_eq!(parsed.inputs, ["${build_script_manifest_dir}"]);
+    }
+
+    #[test]
+    fn cargos_package_default_excludes_generated_and_vcs_trees() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("input"), "same").unwrap();
+        std::fs::create_dir(directory.path().join("target")).unwrap();
+        std::fs::create_dir(directory.path().join(".git")).unwrap();
+        std::fs::write(directory.path().join("target/output"), "first").unwrap();
+        std::fs::write(directory.path().join(".git/HEAD"), "first").unwrap();
+        let first = package_input_state(directory.path(), &[]).unwrap();
+        std::fs::write(directory.path().join("target/output"), "second").unwrap();
+        std::fs::write(directory.path().join(".git/HEAD"), "second").unwrap();
+        let second = package_input_state(directory.path(), &[]).unwrap();
+        assert_eq!(first, second);
+        std::fs::write(directory.path().join("input"), "changed").unwrap();
+        let changed = package_input_state(directory.path(), &[]).unwrap();
+        assert_ne!(second, changed);
     }
 
     #[test]

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -119,7 +119,7 @@ pub(crate) struct RawConfig {
     /// Share eligible compilations that read `OUT_DIR`.
     #[usage(env = "MBX_SHARE_OUT_DIR", default = true)]
     share_out_dir: bool,
-    /// Cache executions of build scripts that declare their inputs. This may
+    /// Cache executions of build scripts using Cargo's freshness inputs. This may
     /// also be set in workspace `.mbx.toml`; the environment variable wins.
     #[usage(env = "MBX_BUILD_SCRIPT_EXECUTION", default = true)]
     build_script_execution: bool,

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1067,6 +1067,46 @@ fn write_execution_cached_project(directory: &Path, declares_inputs: bool) {
     assert!(status.success());
 }
 
+/// Write a fixture that relies on Cargo's implicit package-wide build-script
+/// input. Its execution log lives outside the package so observing a run does
+/// not itself invalidate that input.
+fn write_default_input_project(directory: &Path, execution_log: &Path) {
+    std::fs::create_dir_all(directory.join("src")).unwrap();
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        "[package]\nname = \"default-input-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(directory.join("input.txt"), "first\n").unwrap();
+    let build_script =
+        "use std::{env, fs, path::PathBuf};\n\
+         fn main() {\n\
+             let log = PathBuf::from($EXECUTION_LOG);\n\
+             let mut runs = fs::read_to_string(&log).unwrap_or_default();\n\
+             runs.push_str(\"run\\n\");\n\
+             fs::write(log, runs).unwrap();\n\
+             let input = fs::read_to_string(\"input.txt\").unwrap();\n\
+             let out = PathBuf::from(env::var_os(\"OUT_DIR\").unwrap());\n\
+             fs::write(out.join(\"generated.rs\"), format!(\"pub const VALUE: &str = {:?};\\n\", input)).unwrap();\n\
+         }\n"
+            .replace(
+                "$EXECUTION_LOG",
+                &format!("{:?}", execution_log.to_str().unwrap()),
+            );
+    std::fs::write(directory.join("build.rs"), build_script).unwrap();
+    std::fs::write(
+        directory.join("src/lib.rs"),
+        "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\n",
+    )
+    .unwrap();
+    let status = Command::new(cargo())
+        .current_dir(directory)
+        .args(["generate-lockfile", "--offline"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
 #[test]
 fn build_script_execution_and_out_dir_restore_across_checkouts() {
     let store = tempfile::tempdir().unwrap();
@@ -1180,25 +1220,48 @@ fn changed_declared_environment_executes_build_script_again() {
 }
 
 #[test]
-fn build_script_without_declared_inputs_bypasses_execution_cache() {
+fn build_script_without_declared_inputs_uses_the_package_tree() {
+    let store = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let log = tempfile::NamedTempFile::new().unwrap();
+    write_default_input_project(first.path(), log.path());
+    write_default_input_project(second.path(), log.path());
+    build(
+        first.path(),
+        store.path(),
+        &reports.path().join("first.json"),
+    );
+    let (warm, _) = build_with(
+        second.path(),
+        store.path(),
+        &reports.path().join("second.json"),
+        &[],
+    );
+    assert_eq!(std::fs::read_to_string(log.path()).unwrap(), "run\n");
+    assert!(count(&warm, "hits") >= 1, "build script should hit: {warm}");
+}
+
+#[test]
+fn a_changed_implicit_package_input_executes_the_build_script_again() {
     let store = tempfile::tempdir().unwrap();
     let reports = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();
-    write_execution_cached_project(project.path(), false);
+    let log = tempfile::NamedTempFile::new().unwrap();
+    write_default_input_project(project.path(), log.path());
     build(
         project.path(),
         store.path(),
         &reports.path().join("first.json"),
     );
+    std::fs::write(project.path().join("input.txt"), "second\n").unwrap();
     build(
         project.path(),
         store.path(),
         &reports.path().join("second.json"),
     );
-    assert_eq!(
-        std::fs::read_to_string(project.path().join("runs")).unwrap(),
-        "2"
-    );
+    assert_eq!(std::fs::read_to_string(log.path()).unwrap(), "run\nrun\n");
 }
 
 #[test]
@@ -1341,10 +1404,13 @@ fn two_checkouts_share(generated: Generated, settings: &[(&str, &str)]) -> bool 
     write_generated_project(first.path(), generated);
     write_generated_project(second.path(), generated);
 
-    let settings: Vec<(&str, &str)> = [("MBX_CACHE_LINKS", "0")]
-        .into_iter()
-        .chain(settings.iter().copied())
-        .collect();
+    let settings: Vec<(&str, &str)> = [
+        ("MBX_CACHE_LINKS", "0"),
+        ("MBX_BUILD_SCRIPT_EXECUTION", "0"),
+    ]
+    .into_iter()
+    .chain(settings.iter().copied())
+    .collect();
     build_with(
         first.path(),
         store.path(),
@@ -2092,9 +2158,8 @@ fn main() {
         .status()
         .expect("the C compiler should run");
     assert!(status.success(), "the fixture's C should compile");
-    // This fixture tests the C action itself. Declaring no build-script inputs
-    // deliberately keeps execution caching out of the way, so the second
-    // checkout reaches the compiler shim whose behavior is under test.
+    // The tests disable build-script execution caching so the second checkout
+    // reaches the compiler shim whose behavior is under test.
     println!("cargo:rustc-cfg=c_compiled");
 }
 "#,
@@ -2152,17 +2217,21 @@ fn warm_checkout_hits(settings: &[(&str, &str)]) -> u64 {
     write_c_project(first.path());
     write_c_project(second.path());
 
+    let settings: Vec<(&str, &str)> = [("MBX_BUILD_SCRIPT_EXECUTION", "0")]
+        .into_iter()
+        .chain(settings.iter().copied())
+        .collect();
     build_with(
         first.path(),
         store.path(),
         &reports.path().join("first.json"),
-        settings,
+        &settings,
     );
     let (warm, _) = build_with(
         second.path(),
         store.path(),
         &reports.path().join("second.json"),
-        settings,
+        &settings,
     );
     count(&warm, "hits")
 }
@@ -2263,13 +2332,13 @@ fn objects_landing_beside_a_generated_header_still_cross_checkouts() {
         first.path(),
         store.path(),
         &reports.path().join("cold.json"),
-        &[],
+        &[("MBX_BUILD_SCRIPT_EXECUTION", "0")],
     );
     let (warm, _) = build_with(
         second.path(),
         store.path(),
         &reports.path().join("warm.json"),
-        &[],
+        &[("MBX_BUILD_SCRIPT_EXECUTION", "0")],
     );
     assert_eq!(
         count(&warm, "hits"),

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -12,7 +12,7 @@ Read from, in ascending precedence — the last one that names a setting wins:
 - **Default:** `true`
 - **Set with:** `MBX_BUILD_SCRIPT_EXECUTION`
 
-Cache executions of build scripts that declare their inputs. This may also be set in workspace `.mbx.toml`; the environment variable wins.
+Cache executions of build scripts using Cargo's freshness inputs. This may also be set in workspace `.mbx.toml`; the environment variable wins.
 
 ### `bypass_log`
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -2,7 +2,7 @@
 
 mr boxington favors correct uncached work over risky cache reuse.
 
-## Build-script execution needs declared inputs
+## Build-script execution follows Cargo's freshness inputs
 
 mbx caches running `build.rs`, not only compiling it. After a successful first
 run, the script's `cargo:rerun-if-changed` and `cargo:rerun-if-env-changed`
@@ -17,10 +17,10 @@ model.
 Set `build_script_execution = false` or `MBX_BUILD_SCRIPT_EXECUTION=0` to turn
 off this layer while retaining ordinary Rust and C/C++ compilation caching.
 
-A script that emits neither kind of rerun directive always runs. Cargo's
-package-wide default for such scripts is intentionally not guessed into a cache
-key: an uncached execution is cheaper than claiming an input set the script did
-not declare.
+A script that emits neither kind of rerun directive uses Cargo's package-wide
+default. mbx hashes the package tree into the action key, excluding the target
+directory and version-control metadata. This content key is stricter than
+Cargo's timestamp check while remaining portable across equivalent checkouts.
 
 Cached directives remap `OUT_DIR`, manifest/workspace and target roots, and
 `CARGO_HOME` to the restoring environment. Output trees that do not contain the

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -12,6 +12,10 @@ setup() {
   unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI MBX_CC MBX_CACHE_LINKS
   unset CC CXX HOST_CC HOST_CXX TARGET_CC TARGET_CXX MBX_REAL_CC MBX_REAL_CXX
   export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store"
+  # Every test in this file measures the compiler shim a build script calls.
+  # Keep execution caching from restoring the script before it reaches that
+  # shim; build-script execution has its own Rust integration coverage.
+  export MBX_BUILD_SCRIPT_EXECUTION=0
 
   # A real compilation, not `cc -v`: that is what the adapter's identity probe
   # runs, and sharing the signal would let a regression there skip these tests


### PR DESCRIPTION
## Summary

- treat a build script with no `rerun-if` directives as depending on its package tree, matching Cargo's default freshness rule
- exclude target and version-control state from the portable package content key
- preserve explicit always-rerun behavior for an empty `rerun-if-changed=` directive
- update isolated C and `OUT_DIR` tests to disable execution caching when measuring another cache layer

Motivated by https://github.com/jdx/mr-boxington/discussions/240.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p mbx --all-features --all-targets -- -D warnings`
- `cargo test -p mbx --lib build_script::tests`
- focused build-script reuse, invalidation, C-cache, and `OUT_DIR` integration tests

The full `mbx` build integration target has two unrelated failures under the current toolchain (`verification_is_clean_across_target_directories` and `rustdoc_pages_restore_and_rebuild_the_shared_index`); both reproduce unchanged at base commit `922e9ed`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caching now keys on full package content hashing; incorrect exclusions or version migration could cause stale hits or unnecessary misses, though empty `rerun-if-changed=` still bypasses cache.
> 
> **Overview**
> **Build scripts with no `rerun-if` directives can now be execution-cached** instead of always bypassing. Those scripts are modeled like Cargo: the implicit input is the package tree under `${build_script_manifest_dir}`, with **prediction version 2** and a `default_package` flag.
> 
> The package content key is a recursive hash that **skips `target`, `.git`, and the workspace target directory** when it lives inside the package, so build artifacts and VCS noise do not break reuse across checkouts. Explicit `rerun-if-changed` / `rerun-if-env-changed` behavior is unchanged; **empty `rerun-if-changed=` still forces always-rerun** (bypass reason is now `build-script-always-rerun`). Cached **version 1** predictions without `default_package` still decode for explicit-input scripts.
> 
> Docs and config text now describe freshness as Cargo's inputs. Integration and Bats tests that measure the **C compiler shim** or other layers set **`MBX_BUILD_SCRIPT_EXECUTION=0`** so build-script restore does not mask what they assert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 863bae04ac50b12f9f54d7700a8f95820e7fea09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->