### PR TITLE
ci(perf): run bench refresh on dedicated runner

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -30,8 +30,9 @@ env:
 
 jobs:
   # Only benchmark when the mbx that produced the published numbers is older
-  # than the one on main. A docs or chore push does not invalidate a timing,
-  # and rerunning anyway would republish noise as though it were a change.
+  # than the latest release. A docs or chore push does not invalidate a timing,
+  # and benchmarking an unreleased checkout would publish numbers users cannot
+  # reproduce with the version they can install.
   check:
     name: Check version drift
     runs-on: ubuntu-24.04
@@ -40,29 +41,28 @@ jobs:
       contents: read
     outputs:
       drift: ${{ steps.drift.outputs.drift }}
-      workspace: ${{ steps.drift.outputs.workspace }}
+      release: ${{ steps.drift.outputs.release }}
       bench: ${{ steps.drift.outputs.bench }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Compare workspace against published benchmark
+      - name: Compare latest release against published benchmark
         id: drift
         env:
           FORCE_REFRESH: ${{ github.event_name == 'workflow_dispatch' && inputs.force }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # `mbx` states its own version literally; release-plz writes it. That
-          # is cheaper and more reliable here than resolving a dependency graph.
-          WORKSPACE=$(sed -n '/^\[package\]/,/^\[/ s/^version = "\(.*\)"/\1/p' crates/mbx/Cargo.toml)
+          RELEASE=$(gh release view --json tagName --jq '.tagName | ltrimstr("v")')
           # Absent until the first refresh lands, which is itself drift.
           BENCH=$(jq -r '.versions.mbx // empty' benchmarks/results.json 2>/dev/null || true)
-          if [ -z "$WORKSPACE" ]; then
-            echo "::error::Could not read the mbx version from crates/mbx/Cargo.toml"
+          if [ -z "$RELEASE" ]; then
+            echo "::error::Could not resolve the latest mbx release"
             exit 1
           fi
-          echo "workspace=$WORKSPACE" >> "$GITHUB_OUTPUT"
+          echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
           echo "bench=$BENCH" >> "$GITHUB_OUTPUT"
-          if [ "$FORCE_REFRESH" = "true" ] || [ "$BENCH" != "$WORKSPACE" ]; then
+          if [ "$FORCE_REFRESH" = "true" ] || [ "$BENCH" != "$RELEASE" ]; then
             echo "drift=true" >> "$GITHUB_OUTPUT"
           else
             echo "drift=false" >> "$GITHUB_OUTPUT"
@@ -113,12 +113,33 @@ jobs:
       # the published numbers name.
       - name: Install kache
         run: cargo install kache --locked --version 0.16.0
+      - name: Install released mbx
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE: v${{ needs.check.outputs.release }}
+        run: |
+          archive=mbx-x86_64-unknown-linux-gnu.tar.gz
+          install_dir="$RUNNER_TEMP/mbx-release"
+          mkdir -p "$install_dir"
+          gh release download "$RELEASE" \
+            --pattern "$archive" \
+            --pattern SHA256SUMS \
+            --dir "$install_dir"
+          grep "  $archive$" "$install_dir/SHA256SUMS" \
+            | (cd "$install_dir" && sha256sum --check --strict -)
+          tar -xzf "$install_dir/$archive" -C "$install_dir"
+          echo "MBX_BENCH_BINARY=$install_dir/mbx" >> "$GITHUB_ENV"
       # Clippy for 1.97.1 and the alternate 1.96.0 toolchain are part of the
       # pinned image, so this job never needs static.rust-lang.org at runtime.
       - name: Refresh benchmarks
         env:
           MBX_BENCH_ALTERNATE_TOOLCHAIN: 1.96.0
-        run: mise run bench:refresh
+        run: |
+          python3 benchmarks/real_world.py \
+            --mbx "$MBX_BENCH_BINARY" \
+            --scenarios cold,warm,commit,worktree,toolchain,contention \
+            --output target/benchmarks \
+            --write-results benchmarks/results.json
       - name: Publish job summary
         if: always()
         # A run that failed before writing its summary has already reported
@@ -203,14 +224,14 @@ jobs:
           # The default token cannot: this repository does not let Actions
           # create them, and one it opened would not start CI anyway.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          WORKSPACE: ${{ needs.check.outputs.workspace }}
+          RELEASE: ${{ needs.check.outputs.release }}
           BENCH: ${{ needs.check.outputs.bench }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           cat > "$RUNNER_TEMP/body.md" <<EOF
           ## Refreshed real-world benchmarks
 
-          \`benchmarks/results.json\` was measured with \`${BENCH:-no previous run}\`; the workspace is now \`mbx ${WORKSPACE}\`. Re-ran \`mise run bench:refresh\` on the fixed Namespace Linux xlarge profile: a pinned checkout of jdx/hk built under raw cargo, mbx, and kache across the cold, warm, next-commit, cross-worktree, toolchain-change, and six-job contention scenarios.
+          \`benchmarks/results.json\` was measured with \`${BENCH:-no previous run}\`; the latest release is now \`mbx ${RELEASE}\`. Re-ran the benchmark with that release on the dedicated performance runner: a pinned checkout of jdx/hk built under raw cargo, mbx, and kache across the cold, warm, next-commit, cross-worktree, toolchain-change, and six-job contention scenarios.
 
           The [run summary](${RUN_URL}) has the table these numbers came from, and the run's artifacts have the per-build logs.
 
@@ -220,7 +241,7 @@ jobs:
           Generated by the \`bench-refresh\` workflow.
           EOF
           EXISTING=$(gh pr list --state open --head bench-refresh --json number --jq '.[0].number // empty')
-          TITLE="chore: refresh real-world benchmarks for mbx v${WORKSPACE}"
+          TITLE="chore: refresh real-world benchmarks for mbx v${RELEASE}"
           if [ -n "$EXISTING" ]; then
             gh pr edit "$EXISTING" --title "$TITLE" --body-file "$RUNNER_TEMP/body.md"
           else

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -71,8 +71,12 @@ jobs:
     if: needs.check.outputs.drift == 'true'
     # Keep the runner class fixed: the six-job contention scenario needs enough
     # CPU to reproduce the large parallel CI job it models, and timings cannot
-    # be compared across machine classes.
-    runs-on: namespace-profile-endev-linux-amd64-xlarge
+    # be compared across machine classes. The host-wide lease serializes this
+    # with every other jdx performance job.
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      options: --cpuset-cpus 0-7
     # The full refresh also runs every cache scenario and the toolchain guard.
     timeout-minutes: 180
     permissions:
@@ -85,6 +89,23 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
+        env:
+          MISE_LOCKED: "1"
+      - name: Runner metadata
+        run: |
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Install Clippy for the benchmark toolchain
         run: rustup component add clippy
       # Pinned: the comparison is only fair while both caches are the versions

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -24,6 +24,9 @@ concurrency:
 env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
+  # Rust 1.97.1 is part of the digest-pinned benchmark image.
+  MISE_DISABLE_TOOLS: rust
+  RUSTUP_TOOLCHAIN: 1.97.1
 
 jobs:
   # Only benchmark when the mbx that produced the published numbers is older
@@ -75,7 +78,7 @@ jobs:
     # with every other jdx performance job.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7
     # The full refresh also runs every cache scenario and the toolchain guard.
     timeout-minutes: 180
@@ -96,8 +99,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@34a523e'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
             uname -a
             lscpu
             mise --version
@@ -106,20 +109,15 @@ jobs:
             valgrind --version
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-      - name: Install Clippy for the benchmark toolchain
-        run: rustup component add clippy
       # Pinned: the comparison is only fair while both caches are the versions
       # the published numbers name.
       - name: Install kache
         run: cargo install kache --locked --version 0.16.0
-      # The compiler-change guard needs a second Rust to switch to. `stable`
-      # is whatever the runner image ships; the benchmark skips the guard,
-      # loudly, if that ever resolves to the subject's own pin.
-      - name: Install the alternate toolchain
-        run: rustup toolchain install --profile minimal stable
+      # Clippy for 1.97.1 and the alternate 1.96.0 toolchain are part of the
+      # pinned image, so this job never needs static.rust-lang.org at runtime.
       - name: Refresh benchmarks
         env:
-          MBX_BENCH_ALTERNATE_TOOLCHAIN: stable
+          MBX_BENCH_ALTERNATE_TOOLCHAIN: 1.96.0
         run: mise run bench:refresh
       - name: Publish job summary
         if: always()

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -11,13 +11,16 @@ concurrency:
   cancel-in-progress: false
 env:
   CARGO_INCREMENTAL: "0"
+  # Rust 1.97.1 is part of the digest-pinned benchmark image.
+  MISE_DISABLE_TOOLS: rust
+  RUSTUP_TOOLCHAIN: 1.97.1
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1
 
 jobs:
   measure:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -37,8 +40,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@34a523e'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -13,6 +13,9 @@ concurrency:
   cancel-in-progress: true
 env:
   CARGO_INCREMENTAL: "0"
+  # Rust 1.97.1 is part of the digest-pinned benchmark image.
+  MISE_DISABLE_TOOLS: rust
+  RUSTUP_TOOLCHAIN: 1.97.1
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1
 
 jobs:
@@ -59,7 +62,7 @@ jobs:
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -83,8 +86,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@34a523e'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
             uname -a
             lscpu
             mise --version

--- a/benchmarks/real_world.py
+++ b/benchmarks/real_world.py
@@ -743,7 +743,12 @@ def contention_permits() -> int:
     The scenario is about the default anyone would actually run under, so this
     is the CPU count rather than a number chosen to make the bound look tight.
     """
-    return os.cpu_count() or 1
+    try:
+        # Python 3.12's os.cpu_count() reports the host total inside a cpuset.
+        # Affinity is the set this benchmark process can actually schedule on.
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return os.cpu_count() or 1
 
 
 def validate(scenarios: list[dict[str, object]]) -> list[str]:


### PR DESCRIPTION
## Summary

- run the weekly real-world benchmark refresh on `[self-hosted, jdx-perf-v1]`
- use the digest-pinned Ubuntu 24.04 benchmark image and eight benchmark cores
- retain the existing read-only measurement / GitHub-hosted publication boundary
- record the runner image, environment revision, CPU topology, kernel, and toolchain in the job summary

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how public benchmark numbers are produced (runner, released binary, release-based drift) and contention sizing; mistakes could publish misleading or unreproducible timings on the site.
> 
> **Overview**
> Moves real-world **bench-refresh** onto the same dedicated **`jdx-perf-v1`** host and digest-pinned **`perf-runner`** image as other perf workflows (eight CPUs via **`--cpuset-cpus 0-7`**), with Rust **1.97.1** from the image instead of mise-installed rust.
> 
> **Drift detection** now compares **`benchmarks/results.json`** to the **latest GitHub release tag**, not the workspace **`Cargo.toml`** version, so published numbers match what users can install. The refresh job **downloads the release tarball**, verifies **SHA256SUMS**, and runs **`real_world.py`** with **`MBX_BENCH_BINARY`** instead of **`mise run bench:refresh`**; runtime **rustup** installs for clippy/alternate toolchains are dropped in favor of image-pinned **1.96.0** for the toolchain scenario.
> 
> **`measure.yml`** and **`perf-pr.yml`** bump the **`perf-runner`** digest and record the new environment revision in job summaries. **`contention_permits()`** in **`real_world.py`** uses **`os.sched_getaffinity(0)`** so the contention scenario sizes parallelism to the cpuset, not the host CPU count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d612a1508ea5f2a338785378b43e5c2df210ba11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved benchmark refresh consistency by using the latest released version and a dedicated, pinned performance environment.
  * Updated benchmark runner environments and toolchain versions for more reproducible results.
  * Added runner metadata, including environment, kernel, CPU, and toolchain details, to benchmark summaries.

* **Bug Fixes**
  * Improved benchmark resource detection so concurrency reflects the CPUs available to the benchmark process, including constrained environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->