### PR TITLE
feat(setup): use mise command wrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.16
       - name: Build documentation
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -88,6 +90,8 @@ jobs:
           persist-credentials: false
       - if: runner.os != 'Windows'
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.16
       - if: matrix.os != 'windows-latest'
         uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
-        with:
-          version: 2026.8.16
       - name: Build documentation
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -90,8 +88,6 @@ jobs:
           persist-credentials: false
       - if: runner.os != 'Windows'
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
-        with:
-          version: 2026.8.16
       - if: matrix.os != 'windows-latest'
         uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:

--- a/README.md
+++ b/README.md
@@ -61,14 +61,15 @@ mise use --global --postinstall "mbx setup --yes" mr-boxington
 ```
 
 > [!NOTE]
-> The `--postinstall` setup hook requires mise 2026.8.15 or newer.
+> Automatic Cargo wrapping requires mise 2026.8.16 or newer. Older versions
+> receive an upgrade warning and are not configured.
 
-Open a new shell and verify that plain Cargo resolves to the stable mbx shim.
-On Unix:
+Open a new shell and verify that plain Cargo resolves to mise's command
+wrapper. On Unix:
 
 ```sh
 command -v cargo
-# ~/.local/share/mbx/bin/cargo on Linux
+# ~/.local/share/mise/command-wrappers/bin/cargo on Linux
 ```
 
 On Windows, use PowerShell or `where.exe`:
@@ -78,8 +79,9 @@ On Windows, use PowerShell or `where.exe`:
 where.exe cargo
 ```
 
-mise activation handles interactive shells. SSH commands, coding agents, and
-other non-interactive tools may not load that activation; prepend
+`mbx setup` writes a `[wrappers.cargo]` entry and runs `mise reshim`. mise
+activation handles interactive shells. SSH commands, coding agents, and other
+non-interactive tools may not load that activation; prepend
 `~/.local/share/mbx/bin` to `PATH` in a startup file they read (for example,
 `~/.zshenv` for zsh). Afterward, agents and people can use the ordinary `cargo`
 commands they already know; explicitly prefixing a command with `mbx` remains

--- a/crates/mbx/src/cli/mod.rs
+++ b/crates/mbx/src/cli/mod.rs
@@ -33,6 +33,8 @@ pub(crate) fn cargo_activation_path() -> Option<std::ffi::OsString> {
     shim::activation_path()
 }
 
+pub(crate) use shim::is_mise_command_wrapper_path;
+
 #[cfg(test)]
 use prefetch::validate_prefetch_config;
 #[cfg(all(test, unix))]

--- a/crates/mbx/src/cli/setup.rs
+++ b/crates/mbx/src/cli/setup.rs
@@ -23,6 +23,9 @@ export MBX_CARGO_SHIM_MODE MBX_CARGO_SHIM_PATH
 exec "$mbx_executable" "$@"
 "#;
 const RUST_ANALYZER_CONFIG_FILE: &str = "rust-analyzer.toml";
+const MISE_WRAPPERS_MINIMUM_VERSION: (u64, u64, u64) = (2026, 8, 16);
+const MISE_WRAPPERS_MINIMUM_VERSION_DISPLAY: &str = "2026.8.16";
+const CARGO_WRAPPER_MODE_ENV: &str = "MBX_CARGO_SHIM_MODE";
 const RUST_ANALYZER_CHECK_ARGUMENTS: [&str; 4] = [
     "check",
     "--workspace",
@@ -35,10 +38,10 @@ pub(super) struct SetupArgs {
     /// Accept the recommended activation scope without prompting.
     #[usage(long)]
     pub(super) yes: bool,
-    /// Activate the Cargo shim in mise's global configuration.
+    /// Activate the Cargo wrapper in mise's global configuration.
     #[usage(long)]
     pub(super) global: bool,
-    /// Activate the Cargo shim in the current project's mise configuration.
+    /// Activate the Cargo wrapper in the current project's mise configuration.
     #[usage(long)]
     pub(super) local: bool,
     /// Report whether plain Cargo integration is installed and current.
@@ -145,7 +148,6 @@ pub(crate) fn setup_at_action(
 ) -> Result<ExitCode> {
     let shim = install_dir.join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
     let was_installed = shim.is_file();
-    let configured_path = portable_home_path(install_dir);
 
     match action {
         SetupAction::Status => {
@@ -157,7 +159,8 @@ pub(crate) fn setup_at_action(
                 println!("mbx setup is outdated; run `mbx setup`");
                 return Ok(ExitCode::FAILURE);
             }
-            if matches!(scope, MiseScope::None) || mise_path_is_configured(scope, &configured_path)?
+            if matches!(scope, MiseScope::None)
+                || (mise_wrappers_available() && mise_wrapper_is_configured(scope)?)
             {
                 println!("mbx setup is installed and current: {}", shim.display());
                 return Ok(ExitCode::SUCCESS);
@@ -166,8 +169,8 @@ pub(crate) fn setup_at_action(
             return Ok(ExitCode::FAILURE);
         }
         SetupAction::Uninstall => {
-            let activation_removed = !matches!(scope, MiseScope::None)
-                && update_mise_path(scope, "--remove", &configured_path)?;
+            let activation_removed =
+                !matches!(scope, MiseScope::None) && update_mise_wrapper(scope, action)?;
             if activation_removed {
                 println!(
                     "removed mbx Cargo activation; {} was left in place for other scopes",
@@ -194,7 +197,7 @@ pub(crate) fn setup_at_action(
     }
 
     let activated = if !matches!(scope, MiseScope::None) {
-        update_mise_path(scope, "--append", &configured_path)?
+        update_mise_wrapper(scope, action)?
     } else {
         false
     };
@@ -217,13 +220,11 @@ fn print_activation_verification(shim: &Path) {
     let directory = shim.parent().unwrap_or(shim);
     #[cfg(windows)]
     println!(
-        "verify new shells with `Get-Command cargo` in PowerShell or `where.exe cargo`; expected {}",
-        shim.display()
+        "verify new shells with `Get-Command cargo` in PowerShell or `where.exe cargo`; it should resolve through mise's command-wrappers directory"
     );
     #[cfg(not(windows))]
     println!(
-        "verify new shells with `command -v cargo`; expected {}",
-        shim.display()
+        "verify new shells with `command -v cargo`; it should resolve through mise's command-wrappers directory"
     );
     println!(
         "tools and non-interactive shells that do not activate mise need {} prepended to PATH",
@@ -519,91 +520,95 @@ fn command_exists(name: &str) -> bool {
     })
 }
 
-fn portable_home_path(path: &Path) -> String {
-    dirs::home_dir()
-        .and_then(|home| path.strip_prefix(home).ok())
-        .map(|relative| Path::new("~").join(relative).display().to_string())
-        .unwrap_or_else(|| path.display().to_string())
-}
-
-fn mise_scope_arguments(scope: &MiseScope, command: &mut Command) {
-    match scope {
-        MiseScope::File(path) => {
-            command.args(["--file".as_ref(), path.as_os_str()]);
-        }
-        MiseScope::Global => {
-            command.arg("--global");
-        }
-        MiseScope::Local | MiseScope::None => {}
-    }
-}
-
-fn update_mise_path(scope: &MiseScope, operation: &str, path: &str) -> Result<bool> {
-    if !mise_supports_collection_updates() {
-        let config = mise_scope_config_path(scope)?;
-        eprintln!(
-            "mbx[setup]: this mise cannot update env._.path without replacing existing entries"
-        );
-        let action = match operation {
-            "--append" => "add",
-            "--remove" => "remove",
-            _ => eyre::bail!("unsupported mise path update: {operation}"),
-        };
-        eprintln!(
-            "mbx[setup]: {action} {path:?} {} env._.path in {}",
-            if operation == "--append" {
-                "to"
-            } else {
-                "from"
-            },
-            config.display()
-        );
+fn update_mise_wrapper(scope: &MiseScope, action: SetupAction) -> Result<bool> {
+    if !mise_wrappers_available() {
         return Ok(false);
     }
-    // `mise use` runs postinstall before writing a new config. Seed the exact
-    // path it provided, and trust it only for the `mise config set` subprocess.
-    let created_config = if operation == "--append"
-        && let MiseScope::File(config) = scope
-        && !config.exists()
-    {
-        if let Some(parent) = config.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(config)
-        {
-            Ok(_) => Some(config),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
-            Err(error) => return Err(error.into()),
-        }
-    } else {
-        None
+    let config = mise_scope_config_path(scope)?;
+    let contents = match std::fs::read_to_string(&config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error.into()),
     };
-    let mut command = Command::new("mise");
-    command.args(["config", "set", operation]);
-    mise_scope_arguments(scope, &mut command);
-    if let Some(config) = created_config {
-        command.env("MISE_TRUSTED_CONFIG_PATHS", config);
+    let mut document = contents
+        .parse::<toml_edit::DocumentMut>()
+        .wrap_err_with(|| format!("failed to parse {}", config.display()))?;
+    let configured = mise_wrapper_is_configured_in(&document);
+
+    match action {
+        SetupAction::Status => return Ok(configured),
+        SetupAction::Install if configured => return Ok(true),
+        SetupAction::Install => {
+            if document
+                .get("wrappers")
+                .and_then(toml_edit::Item::as_table_like)
+                .and_then(|wrappers| wrappers.get("cargo"))
+                .is_some()
+            {
+                eprintln!(
+                    "mbx[setup]: left {} unchanged because wrappers.cargo is already configured",
+                    config.display()
+                );
+                return Ok(false);
+            }
+            document["wrappers"]["cargo"]["command"] = toml_edit::value("mbx");
+            document["wrappers"]["cargo"]["env"][CARGO_WRAPPER_MODE_ENV] = toml_edit::value("1");
+        }
+        SetupAction::Uninstall if !configured => return Ok(false),
+        SetupAction::Uninstall => {
+            let wrappers = document
+                .get_mut("wrappers")
+                .and_then(toml_edit::Item::as_table_like_mut)
+                .expect("the configured wrapper has a wrappers table");
+            wrappers.remove("cargo");
+            if wrappers.is_empty() {
+                document.remove("wrappers");
+            }
+        }
     }
-    command.args(["env._.path", path]);
-    let status = command
+
+    crate::util::write_atomic(&config, document.to_string().as_bytes())?;
+    let status = Command::new("mise")
+        .arg("reshim")
+        .env("MISE_CONFIG_FILE", &config)
+        .env("MISE_TRUSTED_CONFIG_PATHS", &config)
         .status()
-        .wrap_err("failed to run `mise config set`")?;
+        .wrap_err("failed to run `mise reshim`")?;
     if !status.success() {
-        eyre::bail!("mise could not update env._.path");
+        eyre::bail!("mise could not refresh command wrappers");
     }
     Ok(true)
 }
 
-fn mise_supports_collection_updates() -> bool {
+fn mise_supports_wrappers() -> bool {
     Command::new("mise")
-        .args(["config", "set", "--help"])
+        .arg("--version")
         .output()
-        .is_ok_and(|output| {
-            output.status.success() && String::from_utf8_lossy(&output.stdout).contains("--append")
-        })
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| mise_version_from_output(&output.stdout))
+        .is_some_and(|version| version >= MISE_WRAPPERS_MINIMUM_VERSION)
+}
+
+fn mise_wrappers_available() -> bool {
+    let available = mise_supports_wrappers();
+    if !available {
+        eprintln!(
+            "mbx[setup]: mise {MISE_WRAPPERS_MINIMUM_VERSION_DISPLAY} or newer is required for [wrappers]; upgrade mise to activate plain cargo commands"
+        );
+    }
+    available
+}
+
+pub(super) fn mise_version_from_output(output: &[u8]) -> Option<(u64, u64, u64)> {
+    let version = String::from_utf8_lossy(output);
+    let version = version.split_whitespace().next()?.trim_start_matches('v');
+    let mut parts = version.split('.').map(str::parse);
+    Some((
+        parts.next()?.ok()?,
+        parts.next()?.ok()?,
+        parts.next()?.ok()?,
+    ))
 }
 
 fn mise_scope_config_path(scope: &MiseScope) -> Result<PathBuf> {
@@ -652,22 +657,9 @@ fn nearest_project_config() -> Option<PathBuf> {
     None
 }
 
-fn mise_path_is_configured(scope: &MiseScope, path: &str) -> Result<bool> {
-    if !mise_supports_collection_updates() {
-        return mise_path_file_is_configured(&mise_scope_config_path(scope)?, path);
-    }
-    let mut command = Command::new("mise");
-    command.args(["config", "get"]);
-    mise_scope_arguments(scope, &mut command);
-    command.arg("env._.path");
-    let output = command
-        .output()
-        .wrap_err("failed to run `mise config get`")?;
-    Ok(output.status.success() && String::from_utf8_lossy(&output.stdout).contains(path))
-}
-
-fn mise_path_file_is_configured(config: &Path, path: &str) -> Result<bool> {
-    let contents = match std::fs::read_to_string(config) {
+fn mise_wrapper_is_configured(scope: &MiseScope) -> Result<bool> {
+    let config = mise_scope_config_path(scope)?;
+    let contents = match std::fs::read_to_string(&config) {
         Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => return Err(error.into()),
@@ -675,19 +667,26 @@ fn mise_path_file_is_configured(config: &Path, path: &str) -> Result<bool> {
     let document = contents
         .parse::<toml_edit::DocumentMut>()
         .wrap_err_with(|| format!("failed to parse {}", config.display()))?;
-    let Some(value) = document
+    Ok(mise_wrapper_is_configured_in(&document))
+}
+
+pub(super) fn mise_wrapper_is_configured_in(document: &toml_edit::DocumentMut) -> bool {
+    let Some(cargo) = document
+        .get("wrappers")
+        .and_then(toml_edit::Item::as_table_like)
+        .and_then(|wrappers| wrappers.get("cargo"))
+        .and_then(toml_edit::Item::as_table_like)
+    else {
+        return false;
+    };
+    let command_is_mbx = cargo.get("command").and_then(toml_edit::Item::as_str) == Some("mbx");
+    let shim_mode_is_set = cargo
         .get("env")
         .and_then(toml_edit::Item::as_table_like)
-        .and_then(|env| env.get("_"))
-        .and_then(toml_edit::Item::as_table_like)
-        .and_then(|paths| paths.get("path"))
-    else {
-        return Ok(false);
-    };
-    Ok(value.as_str() == Some(path)
-        || value
-            .as_array()
-            .is_some_and(|array| array.iter().any(|entry| entry.as_str() == Some(path))))
+        .and_then(|env| env.get(CARGO_WRAPPER_MODE_ENV))
+        .and_then(toml_edit::Item::as_str)
+        == Some("1");
+    command_is_mbx && shim_mode_is_set
 }
 
 fn print_manual_activation(path: &Path) {

--- a/crates/mbx/src/cli/setup_tests.rs
+++ b/crates/mbx/src/cli/setup_tests.rs
@@ -295,3 +295,37 @@ fn mise_config_selection_finds_the_first_config_that_defines_mbx() {
     );
     assert_eq!(mbx_mise_config_from_json(b"not json"), None);
 }
+
+#[test]
+fn mise_wrapper_version_parsing_uses_the_calendar_version() {
+    assert_eq!(
+        mise_version_from_output(b"2026.8.16 linux-x64 (2026-08-31)"),
+        Some((2026, 8, 16))
+    );
+    assert_eq!(
+        mise_version_from_output(b"v2027.1.2 windows-x64"),
+        Some((2027, 1, 2))
+    );
+    assert_eq!(mise_version_from_output(b"not-a-version"), None);
+}
+
+#[test]
+fn mise_wrapper_detection_requires_mbx_shim_mode() {
+    let configured = r#"
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
+"#
+    .parse::<toml_edit::DocumentMut>()
+    .unwrap();
+    assert!(mise_wrapper_is_configured_in(&configured));
+
+    for raw in [
+        "[wrappers]\ncargo = \"mbx\"\n",
+        "[wrappers.cargo]\ncommand = \"mbx\"\n",
+        "[wrappers.cargo]\ncommand = \"other\"\nenv = { MBX_CARGO_SHIM_MODE = \"1\" }\n",
+    ] {
+        let document = raw.parse::<toml_edit::DocumentMut>().unwrap();
+        assert!(!mise_wrapper_is_configured_in(&document));
+    }
+}

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -42,6 +42,10 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
                 .then(|| std::env::current_exe().ok())
                 .flatten()
         });
+    // mise removes its wrapper directory before launching mbx, so there is no
+    // shim path to exclude. Treating the first remaining Cargo as a shim would
+    // instead remove the real tool from PATH.
+    let invoked_via_mise_wrapper = !invoked_as_cargo() && reported_shim.is_none();
     // The Windows launcher uses this only to select dispatch in the target mbx.
     // Do not leak it into Cargo, build scripts, or nested mbx commands.
     unsafe { std::env::remove_var(CARGO_SHIM_MODE_ENV) };
@@ -55,13 +59,17 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
     let shim_dir = super::setup_install_dir()
         .ok_or_else(|| eyre::eyre!("the platform data directory could not be located"))?;
     let configured_shim = shim_dir.join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
-    let shim = resolve_active_cargo_shim(
-        &configured_shim,
-        reported_shim.as_deref().map(Path::as_os_str),
-        std::env::var_os("PATH").as_deref(),
-    );
-    exclude_shim_from_path(&shim)?;
-    let real_cargo = resolve_real_cargo(&shim)?;
+    let real_cargo = if invoked_via_mise_wrapper {
+        resolve_real_cargo(&configured_shim)?
+    } else {
+        let shim = resolve_active_cargo_shim(
+            &configured_shim,
+            reported_shim.as_deref().map(Path::as_os_str),
+            std::env::var_os("PATH").as_deref(),
+        );
+        exclude_shim_from_path(&shim)?;
+        resolve_real_cargo(&shim)?
+    };
     let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
     if mbx_disabled() || cargo_proxy_passthrough(&arguments) {
         return run_real_cargo(&real_cargo, &arguments);
@@ -311,7 +319,7 @@ fn resolve_real_cargo_from(
             continue;
         }
         let candidate = directory.join(name);
-        if candidate.is_file() {
+        if candidate.is_file() && !is_mise_command_wrapper_path(&candidate) {
             return Ok(candidate.into_os_string());
         }
     }
@@ -522,7 +530,7 @@ mod tests {
         std::fs::write(&shim, b"shim").unwrap();
         std::fs::write(&wrapper, b"wrapper").unwrap();
         std::fs::write(&real, b"real").unwrap();
-        let path = std::env::join_paths([&real_dir]).unwrap();
+        let path = std::env::join_paths([&wrapper_dir, &real_dir]).unwrap();
 
         assert_eq!(
             configured_real_cargo(&shim, Some(wrapper.as_os_str())),

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -282,12 +282,18 @@ fn configured_real_cargo(current: &Path, configured: Option<&OsStr>) -> Option<O
     let current_dir = current.parent();
     (configured.is_absolute()
         && configured.is_file()
+        && !is_mise_command_wrapper_path(configured)
         && current_dir.is_none_or(|current_dir| {
             configured
                 .parent()
                 .is_some_and(|parent| !same_path(parent, current_dir))
         }))
     .then(|| configured.as_os_str().to_owned())
+}
+
+pub(crate) fn is_mise_command_wrapper_path(path: &Path) -> bool {
+    let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+    path.ends_with(Path::new("command-wrappers").join("bin").join(name))
 }
 
 fn resolve_real_cargo_from(
@@ -497,6 +503,34 @@ mod tests {
         assert_eq!(
             configured_real_cargo(&shim, Some(real.as_os_str())),
             Some(real.into_os_string())
+        );
+    }
+
+    #[test]
+    fn cargo_resolution_rejects_mise_command_wrapper_as_the_real_cargo() {
+        let directory = tempfile::tempdir().unwrap();
+        let shim_dir = directory.path().join("shim");
+        let wrapper_dir = directory.path().join("command-wrappers/bin");
+        let real_dir = directory.path().join("real");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::create_dir_all(&wrapper_dir).unwrap();
+        std::fs::create_dir_all(&real_dir).unwrap();
+        let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+        let shim = shim_dir.join(name);
+        let wrapper = wrapper_dir.join(name);
+        let real = real_dir.join(name);
+        std::fs::write(&shim, b"shim").unwrap();
+        std::fs::write(&wrapper, b"wrapper").unwrap();
+        std::fs::write(&real, b"real").unwrap();
+        let path = std::env::join_paths([&real_dir]).unwrap();
+
+        assert_eq!(
+            configured_real_cargo(&shim, Some(wrapper.as_os_str())),
+            None
+        );
+        assert_eq!(
+            resolve_real_cargo_from(&shim, Some(wrapper.as_os_str()), &path).unwrap(),
+            real.into_os_string()
         );
     }
 

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -290,7 +290,7 @@ fn configured_real_cargo(current: &Path, configured: Option<&OsStr>) -> Option<O
     let current_dir = current.parent();
     (configured.is_absolute()
         && configured.is_file()
-        && !is_mise_command_wrapper_path(configured)
+        && !is_mise_cargo_proxy_path(configured)
         && current_dir.is_none_or(|current_dir| {
             configured
                 .parent()
@@ -302,6 +302,25 @@ fn configured_real_cargo(current: &Path, configured: Option<&OsStr>) -> Option<O
 pub(crate) fn is_mise_command_wrapper_path(path: &Path) -> bool {
     let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
     path.ends_with(Path::new("command-wrappers").join("bin").join(name))
+}
+
+fn is_mise_cargo_proxy_path(path: &Path) -> bool {
+    if is_mise_command_wrapper_path(path) {
+        return true;
+    }
+    let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+    let Some(shims) = path.parent().filter(|parent| {
+        parent.file_name() == Some(OsStr::new("shims"))
+            && path.file_name() == Some(OsStr::new(name))
+    }) else {
+        return false;
+    };
+    let Some(data_dir) = shims.parent() else {
+        return false;
+    };
+    data_dir.file_name() == Some(OsStr::new("mise"))
+        || std::env::var_os("MISE_DATA_DIR")
+            .is_some_and(|configured| same_path(data_dir, Path::new(&configured)))
 }
 
 fn resolve_real_cargo_from(
@@ -319,7 +338,7 @@ fn resolve_real_cargo_from(
             continue;
         }
         let candidate = directory.join(name);
-        if candidate.is_file() && !is_mise_command_wrapper_path(&candidate) {
+        if candidate.is_file() && !is_mise_cargo_proxy_path(&candidate) {
             return Ok(candidate.into_os_string());
         }
     }
@@ -515,29 +534,37 @@ mod tests {
     }
 
     #[test]
-    fn cargo_resolution_rejects_mise_command_wrapper_as_the_real_cargo() {
+    fn cargo_resolution_rejects_mise_proxies_as_the_real_cargo() {
         let directory = tempfile::tempdir().unwrap();
         let shim_dir = directory.path().join("shim");
         let wrapper_dir = directory.path().join("command-wrappers/bin");
+        let mise_shims_dir = directory.path().join("mise/shims");
         let real_dir = directory.path().join("real");
         std::fs::create_dir_all(&shim_dir).unwrap();
         std::fs::create_dir_all(&wrapper_dir).unwrap();
+        std::fs::create_dir_all(&mise_shims_dir).unwrap();
         std::fs::create_dir_all(&real_dir).unwrap();
         let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
         let shim = shim_dir.join(name);
         let wrapper = wrapper_dir.join(name);
+        let mise_shim = mise_shims_dir.join(name);
         let real = real_dir.join(name);
         std::fs::write(&shim, b"shim").unwrap();
         std::fs::write(&wrapper, b"wrapper").unwrap();
+        std::fs::write(&mise_shim, b"mise shim").unwrap();
         std::fs::write(&real, b"real").unwrap();
-        let path = std::env::join_paths([&wrapper_dir, &real_dir]).unwrap();
+        let path = std::env::join_paths([&wrapper_dir, &mise_shims_dir, &real_dir]).unwrap();
 
         assert_eq!(
             configured_real_cargo(&shim, Some(wrapper.as_os_str())),
             None
         );
         assert_eq!(
-            resolve_real_cargo_from(&shim, Some(wrapper.as_os_str()), &path).unwrap(),
+            configured_real_cargo(&shim, Some(mise_shim.as_os_str())),
+            None
+        );
+        assert_eq!(
+            resolve_real_cargo_from(&shim, Some(mise_shim.as_os_str()), &path).unwrap(),
             real.into_os_string()
         );
     }

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -253,10 +253,16 @@ fn setup_check() -> Check {
         &executable,
         &expected_shim,
         crate::cli::cargo_activation_path().as_deref(),
+        mise_cargo_wrapper_is_configured(),
     )
 }
 
-fn setup_check_at(executable: &Path, expected_shim: &Path, path: Option<&OsStr>) -> Check {
+fn setup_check_at(
+    executable: &Path,
+    expected_shim: &Path,
+    path: Option<&OsStr>,
+    mise_wrapper_configured: bool,
+) -> Check {
     if !expected_shim.is_file() {
         return Check::warn(
             "setup",
@@ -274,6 +280,19 @@ fn setup_check_at(executable: &Path, expected_shim: &Path, path: Option<&OsStr>)
     }
 
     let active_cargo = path.and_then(cargo_on_path);
+    if mise_wrapper_configured
+        && active_cargo
+            .as_deref()
+            .is_some_and(crate::cli::is_mise_command_wrapper_path)
+    {
+        return Check::pass(
+            "setup",
+            format!(
+                "mise Cargo wrapper is active and the fallback shim is current at {}",
+                expected_shim.display()
+            ),
+        );
+    }
     if active_cargo
         .as_deref()
         .is_none_or(|cargo| !same_path(cargo, expected_shim))
@@ -298,6 +317,19 @@ fn setup_check_at(executable: &Path, expected_shim: &Path, path: Option<&OsStr>)
             expected_shim.display()
         ),
     )
+}
+
+fn mise_cargo_wrapper_is_configured() -> bool {
+    let config_value = |key: &str| {
+        Command::new("mise")
+            .args(["config", "get", key])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    };
+    config_value("wrappers.cargo.command").as_deref() == Some("mbx")
+        && config_value("wrappers.cargo.env.MBX_CARGO_SHIM_MODE").as_deref() == Some("1")
 }
 
 fn cargo_on_path(path: &OsStr) -> Option<PathBuf> {
@@ -466,13 +498,13 @@ mod tests {
 
         let real_first = std::env::join_paths([&real_dir, &shim_dir]).unwrap();
         assert_eq!(
-            setup_check_at(&executable, &shim, Some(&real_first)).detail,
+            setup_check_at(&executable, &shim, Some(&real_first), false).detail,
             "Cargo shim is not installed; plain Cargo bypasses mbx, while explicit `mbx <cargo-command>` still works"
         );
 
         std::fs::write(&shim, b"old mbx").unwrap();
         assert_eq!(
-            setup_check_at(&executable, &shim, Some(&real_first)).detail,
+            setup_check_at(&executable, &shim, Some(&real_first), false).detail,
             "Cargo shim is outdated; run `mbx setup`"
         );
 
@@ -483,15 +515,25 @@ mod tests {
             crate::cli::DoctorSetupAction::Install,
         )
         .unwrap();
-        let inactive = setup_check_at(&executable, &shim, Some(&real_first));
+        let inactive = setup_check_at(&executable, &shim, Some(&real_first), false);
         assert_eq!(inactive.severity, Severity::Warn);
         assert!(inactive.detail.contains("current but not active"));
         assert!(inactive.detail.contains(&real_cargo.display().to_string()));
 
         let shim_first = std::env::join_paths([&shim_dir, &real_dir]).unwrap();
-        let active = setup_check_at(&executable, &shim, Some(&shim_first));
+        let active = setup_check_at(&executable, &shim, Some(&shim_first), false);
         assert_eq!(active.severity, Severity::Pass);
         assert!(active.detail.contains("active and current"));
+
+        let wrapper_dir = directory.path().join("command-wrappers/bin");
+        let wrapper = wrapper_dir.join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+        std::fs::create_dir_all(&wrapper_dir).unwrap();
+        std::fs::write(&wrapper, b"mise wrapper").unwrap();
+        make_executable(&wrapper);
+        let wrapper_first = std::env::join_paths([&wrapper_dir, &real_dir]).unwrap();
+        let active = setup_check_at(&executable, &shim, Some(&wrapper_first), true);
+        assert_eq!(active.severity, Severity::Pass);
+        assert!(active.detail.contains("mise Cargo wrapper is active"));
     }
 
     #[cfg(unix)]
@@ -505,7 +547,7 @@ mod tests {
         std::fs::write(&executable, b"current mbx").unwrap();
         std::fs::write(&shim, crate::cli::DOCTOR_CARGO_SHIM_LAUNCHER).unwrap();
 
-        let check = setup_check_at(&executable, &shim, Some(shim_dir.as_os_str()));
+        let check = setup_check_at(&executable, &shim, Some(shim_dir.as_os_str()), false);
         assert_eq!(check.severity, Severity::Warn);
         assert!(check.detail.contains("current but not active"));
         assert!(check.detail.contains("PATH resolves cargo to nothing"));

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -7,8 +7,8 @@ Make plain Cargo commands run through mbx.
 
 ## Flags
 - **`--yes`** — Accept the recommended activation scope without prompting.
-- **`--global`** — Activate the Cargo shim in mise's global configuration.
-- **`--local`** — Activate the Cargo shim in the current project's mise configuration.
+- **`--global`** — Activate the Cargo wrapper in mise's global configuration.
+- **`--local`** — Activate the Cargo wrapper in the current project's mise configuration.
 - **`--status`** — Report whether plain Cargo integration is installed and current.
 - **`--uninstall`** — Remove mbx activation from the selected scope.
 - **`-h --help`** — Print help

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,10 @@
 mise use --global --postinstall "mbx setup --yes" mr-boxington
 ```
 
-::: info Requires mise 2026.8.15 or newer
-The `--postinstall` setup hook requires mise 2026.8.15 or newer.
+::: info Requires mise 2026.8.16 or newer
+Automatic Cargo wrapping uses mise's `[wrappers]` configuration, available in
+mise 2026.8.16 and newer. With an older mise, setup installs the standalone
+shim but only prints an upgrade warning instead of editing mise configuration.
 :::
 
 With `--global`, mise activates mbx in its global configuration. Drop
@@ -100,21 +102,24 @@ cargo install mbx --locked
 mbx setup
 ```
 
-During `mise use --postinstall`, `mbx setup --yes` activates the configuration
+During `mise use --postinstall`, `mbx setup --yes` adds a `[wrappers.cargo]`
+entry to the configuration
 named by `MISE_CONFIG_FILE`. Otherwise, setup only integrates with mise when
 mise is activated in the current shell. It recommends the config that defines
 `mr-boxington`, then the nearest project config, and finally the global config.
 `mbx setup` prompts before using that recommendation; `--yes` accepts it.
 Without an active mise shell, setup prints the exact shell-specific `PATH`
-change and never edits a shell startup file.
+change and never edits a shell startup file. Setup runs `mise reshim` after
+adding or removing the wrapper.
 
 ### Verify plain Cargo
 
-Open a new shell after setup and verify which Cargo it finds. On Unix:
+Open a new shell after setup and verify that Cargo resolves to mise's command
+wrapper. On Unix:
 
 ```sh
 command -v cargo
-# ~/.local/share/mbx/bin/cargo on Linux
+# ~/.local/share/mise/command-wrappers/bin/cargo on Linux
 ```
 
 On Windows, use PowerShell or `where.exe`:
@@ -124,7 +129,10 @@ On Windows, use PowerShell or `where.exe`:
 where.exe cargo
 ```
 
-mise activation supplies that path to shells where mise is active. SSH
+mise activation supplies the command-wrapper path to shells where mise is active.
+The wrapper invokes `mbx` with Cargo shim mode enabled, then mise removes its
+dispatch directories before mbx delegates to the configured or system Cargo.
+SSH
 commands, coding agents, editors, and other non-interactive tools may use a
 startup path that does not activate mise. In that case, prepend the directory
 printed by `mbx setup` in a startup file those processes read. For zsh,
@@ -139,11 +147,11 @@ shim, ordinary `cargo build`, `cargo test`, and `cargo check` commands use mbx
 automatically. Explicit `mbx cargo …` commands remain supported, but users and
 tools do not need to remember a special prefix.
 
-On Unix, the stable `cargo` launcher uses the setup-time mbx while it exists,
-then resolves the active `mbx` from `PATH` after an upgrade removes that path.
-Windows `cargo.exe` resolves the active mbx from `PATH`, with the setup-time
-path as a fallback. Upgrading a mise-managed mbx does not require running setup
-again.
+Outside mise activation, the stable `cargo` launcher uses the setup-time mbx
+while it exists, then resolves the active `mbx` from `PATH` after an upgrade
+removes that path. Windows `cargo.exe` resolves the active mbx from `PATH`, with
+the setup-time path as a fallback. Upgrading a mise-managed mbx does not require
+running setup again.
 
 Setup also configures rust-analyzer's background check in the matching global
 or project scope. The editor invokes the stable Cargo shim by its absolute path,
@@ -276,17 +284,18 @@ mbx doctor
   ok  cache        /home/you/.cache/mbx is writable
   ok  config       50.0 GiB budget, automatic gc enabled, managed targets enabled at /home/you/.cache/mbx/targets
   ok  reflink      supported by the cache filesystem
-  ok  setup        Cargo shim is active and current at /home/you/.local/share/mbx/bin/cargo
+  ok  setup        mise Cargo wrapper is active and the fallback shim is current at /home/you/.local/share/mbx/bin/cargo
   ok  remote       not configured; using the local cache
 
 0 failures, 0 warnings
 ```
 
-Doctor checks that the installed Cargo shim matches the running mbx and is the
-first `cargo` on `PATH`, along with the Cargo and rustc executables, cache write
-access, filesystem reflink support, effective remote policy, and remote protocol
-connectivity. Warnings describe setup problems, optional features, or fallbacks;
-failures make the command exit unsuccessfully.
+Doctor checks that mise's Cargo wrapper is active, or that the installed fallback
+shim matches the running mbx and is the first `cargo` on `PATH`. It also checks
+the Cargo and rustc executables, cache write access, filesystem reflink support,
+effective remote policy, and remote protocol connectivity. Warnings describe
+setup problems, optional features, or fallbacks; failures make the command exit
+unsuccessfully.
 
 ## Read the result
 

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -117,14 +117,11 @@ EOF
 cat >"$fake_bin/mise" <<'EOF'
 #!/bin/sh
 printf '%s\n' "$*" >>"$MBX_TEST_MISE_LOG"
-if [ "$1 $2 $3" = "config set --help" ]; then
-  printf '%s\n' '--append --remove --global'
+if [ "$1" = "--version" ]; then
+  printf '%s\n' '2026.8.16 linux-x64 (2026-08-31)'
 fi
 if [ "$1 $2 $3" = "config ls --json" ]; then
   printf '%s\n' "${MBX_TEST_MISE_CONFIGS:-[]}"
-fi
-if [ "$1 $2" = "config get" ]; then
-  printf '%s\n' "$MBX_TEST_SHIM_DIR"
 fi
 EOF
   chmod +x "$fake_bin/mise"
@@ -134,9 +131,12 @@ EOF
     "$MBX_BIN" setup --yes
   assert_success
   assert_output --partial 'verify new shells with `command -v cargo`'
-  assert_output --partial "expected $MBX_SHIM_DIR/cargo"
+  assert_output --partial "mise's command-wrappers directory"
   assert_output --partial "non-interactive shells that do not activate mise need $MBX_SHIM_DIR prepended to PATH"
-  assert_file_contains "$mise_log" "config set --append --file $project_config env._.path"
+  assert_file_contains "$project_config" '[wrappers.cargo]'
+  assert_file_contains "$project_config" 'command = "mbx"'
+  assert_file_contains "$project_config" 'MBX_CARGO_SHIM_MODE = "1"'
+  assert_file_contains "$mise_log" "reshim"
   assert_file_contains "$(dirname "$project_config")/rust-analyzer.toml" "$MBX_SHIM_DIR/cargo"
 
   run env -u MISE_CONFIG_FILE PATH="$fake_bin:$PATH" MISE_SHELL=zsh \
@@ -145,7 +145,8 @@ EOF
     MBX_TEST_MISE_LOG="$mise_log" MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" \
     "$MBX_BIN" setup --yes
   assert_success
-  assert_file_contains "$mise_log" "config set --append --global env._.path"
+  assert_file_contains "$BATS_TEST_TMPDIR/global.toml" '[wrappers.cargo]'
+  assert_file_contains "$BATS_TEST_TMPDIR/global.toml" 'MBX_CARGO_SHIM_MODE = "1"'
   assert_file_contains "$MBX_RA_CONFIG" "$MBX_SHIM_DIR/cargo"
 
   run env -u MISE_CONFIG_FILE PATH="$fake_bin:$PATH" MISE_SHELL=zsh \
@@ -153,27 +154,27 @@ EOF
     MBX_TEST_MISE_LOG="$mise_log" MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" \
     "$MBX_BIN" setup --yes
   assert_success
-  assert_file_contains "$mise_log" "config set --append --file $project_config env._.path"
+  assert_file_contains "$project_config" '[wrappers.cargo]'
 
   cd "$(dirname "$project_config")"
   run env -u MISE_CONFIG_FILE PATH="$fake_bin:$PATH" MISE_SHELL=zsh \
     MBX_TEST_MISE_CONFIGS='[]' MBX_TEST_MISE_LOG="$mise_log" \
     MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" "$MBX_BIN" setup --yes
   assert_success
-  assert_file_contains "$mise_log" "config set --append --file $project_config env._.path"
+  assert_file_contains "$project_config" '[wrappers.cargo]'
 
   : >"$mise_log"
   run env -u MISE_CONFIG_FILE -u MISE_SHELL PATH="$fake_bin:$PATH" \
     MBX_TEST_MISE_LOG="$mise_log" MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" \
     "$MBX_BIN" setup --yes
   assert_success
-  run grep -F "config set --append" "$mise_log"
+  run grep -F "reshim" "$mise_log"
   assert_failure
 
   run env PATH="$fake_bin:$PATH" MBX_TEST_MISE_LOG="$mise_log" \
     MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" "$MBX_BIN" setup --local
   assert_success
-  assert_file_contains "$mise_log" "config set --append env._.path"
+  assert_file_contains "$project_config" '[wrappers.cargo]'
 
   run env PATH="$fake_bin:$PATH" MISE_SHELL=zsh \
     MISE_GLOBAL_CONFIG_FILE="$BATS_TEST_TMPDIR/global.toml" \
@@ -181,10 +182,11 @@ EOF
     MBX_TEST_MISE_LOG="$mise_log" MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" \
     "$MBX_BIN" setup --uninstall
   assert_success
-  assert_file_contains "$mise_log" "config set --remove --global env._.path"
+  run grep -F '[wrappers.cargo]' "$BATS_TEST_TMPDIR/global.toml"
+  assert_failure
 }
 
-@test "setup prints config instructions for older mise clients without editing" {
+@test "setup warns for older mise clients without editing their config" {
   local fake_bin="$BATS_TEST_TMPDIR/legacy-mise-bin"
   local global_config="$BATS_TEST_TMPDIR/legacy-global.toml"
   local project="$BATS_TEST_TMPDIR/legacy-project"
@@ -192,8 +194,8 @@ EOF
   project="$(cd "$project" && pwd -P)"
   cat >"$fake_bin/mise" <<'EOF'
 #!/bin/sh
-if [ "$1 $2 $3" = "config set --help" ]; then
-  printf '%s\n' 'Usage: mise config set --file FILE KEY VALUE'
+if [ "$1" = "--version" ]; then
+  printf '%s\n' '2026.8.15 linux-x64 (2026-08-30)'
 fi
 EOF
   chmod +x "$fake_bin/mise"
@@ -203,10 +205,10 @@ EOF
   run env PATH="$fake_bin:$PATH" MISE_GLOBAL_CONFIG_FILE="$global_config" \
     "$MBX_BIN" setup --global
   assert_success
-  assert_output --partial "cannot update env._.path"
-  assert_output --partial "add \"$MBX_SHIM_DIR\" to env._.path in $global_config"
+  assert_output --partial "mise 2026.8.16 or newer is required for [wrappers]"
+  assert_output --partial "upgrade mise"
   assert_file_contains "$global_config" "# global comment"
-  run grep -F "$MBX_SHIM_DIR" "$global_config"
+  run grep -F '[wrappers.cargo]' "$global_config"
   assert_failure
   run env PATH="$fake_bin:$PATH" MISE_GLOBAL_CONFIG_FILE="$global_config" \
     "$MBX_BIN" setup --global --status
@@ -216,22 +218,11 @@ EOF
   cd "$project"
   run env PATH="$fake_bin:$PATH" "$MBX_BIN" setup --local
   assert_success
-  assert_output --partial "add \"$MBX_SHIM_DIR\" to env._.path in $project/mise.toml"
+  assert_output --partial "mise 2026.8.16 or newer is required for [wrappers]"
   assert_file_contains "$project/mise.toml" "/existing/bin"
   assert_file_contains "$project/mise.toml" "# local comment"
-  run grep -F "$MBX_SHIM_DIR" "$project/mise.toml"
+  run grep -F '[wrappers.cargo]' "$project/mise.toml"
   assert_failure
-
-  printf '# local comment\n[env]\n_.path = ["/existing/bin", "%s"]\n' \
-    "$MBX_SHIM_DIR" >"$project/mise.toml"
-  run env PATH="$fake_bin:$PATH" "$MBX_BIN" setup --local --status
-  assert_success
-  assert_output --partial "installed and current"
-  run env PATH="$fake_bin:$PATH" "$MBX_BIN" setup --local --uninstall
-  assert_success
-  assert_output --partial "remove \"$MBX_SHIM_DIR\" from env._.path in $project/mise.toml"
-  assert_file_contains "$project/mise.toml" "$MBX_SHIM_DIR"
-  assert_file_contains "$project/mise.toml" "/existing/bin"
 }
 
 @test "mise postinstall activates transparent Cargo in local and global scopes" {
@@ -242,7 +233,14 @@ EOF
   local compiler="$BATS_TEST_TMPDIR/mise-counting-rustc"
   local rustc_log="$BATS_TEST_TMPDIR/mise-rustc.log"
   local real_rustc
-  real_rustc="$(command -v rustc)"
+  local real_cargo_dir
+  if command -v rustup >/dev/null 2>&1; then
+    real_rustc="$(rustup which rustc)"
+    real_cargo_dir="$(dirname "$(rustup which cargo)")"
+  else
+    real_rustc="$(command -v rustc)"
+    real_cargo_dir="$(dirname "$(command -v cargo)")"
+  fi
   export MISE_DATA_DIR="$BATS_TEST_TMPDIR/mise-data"
   export MISE_CACHE_DIR="$BATS_TEST_TMPDIR/mise-cache"
   export MISE_GLOBAL_CONFIG_FILE="$BATS_TEST_TMPDIR/mise-global.toml"
@@ -267,22 +265,27 @@ EOF
   cd "$project"
   run mise use --yes --postinstall "$MBX_BIN setup --yes" mr-boxington
   assert_success
+  cp "$MBX_BIN" "$(mise where mr-boxington)/mbx"
   assert_file_executable "$MBX_SHIM_DIR/cargo"
-  assert_file_contains "$project/mise.toml" "$MBX_SHIM_DIR"
+  assert_file_contains "$project/mise.toml" '[wrappers.cargo]'
+  assert_file_contains "$project/mise.toml" 'MBX_CARGO_SHIM_MODE = "1"'
 
   run mise exec -- sh -c 'command -v cargo'
   assert_success
-  assert_output "$MBX_SHIM_DIR/cargo"
-  run mise exec -- "$MBX_BIN" doctor
+  assert_output "$MISE_DATA_DIR/command-wrappers/bin/cargo"
+  run mise exec -- env PATH="$MISE_DATA_DIR/command-wrappers/bin:$PATH:$real_cargo_dir" \
+    "$MBX_BIN" doctor
   assert_success
-  assert_output --partial "Cargo shim is active and current"
+  assert_output --partial "mise Cargo wrapper is active"
 
-  run mise exec -- env CARGO_INCREMENTAL=0 \
+  run mise exec -- env PATH="$MISE_DATA_DIR/command-wrappers/bin:$PATH:$real_cargo_dir" \
+    CARGO_INCREMENTAL=0 \
     CARGO_TARGET_DIR="$BATS_TEST_TMPDIR/mise-first-target" \
     MBX_TEST_REAL_RUSTC="$real_rustc" MBX_TEST_RUSTC_LOG="$rustc_log" RUSTC="$compiler" \
     sh -c 'cd "$1" && cargo build --offline' sh "$first"
   assert_success
-  run mise exec -- env CARGO_INCREMENTAL=0 \
+  run mise exec -- env PATH="$MISE_DATA_DIR/command-wrappers/bin:$PATH:$real_cargo_dir" \
+    CARGO_INCREMENTAL=0 \
     CARGO_TARGET_DIR="$BATS_TEST_TMPDIR/mise-second-target" \
     MBX_TEST_REAL_RUSTC="$real_rustc" MBX_TEST_RUSTC_LOG="$rustc_log" RUSTC="$compiler" \
     sh -c 'cd "$1" && cargo build --offline' sh "$second"
@@ -293,20 +296,22 @@ EOF
 
   run env MISE_CONFIG_FILE="$project/mise.toml" "$MBX_BIN" setup --uninstall
   assert_success
-  run grep -F "$MBX_SHIM_DIR" "$project/mise.toml"
+  run grep -F '[wrappers.cargo]' "$project/mise.toml"
   assert_failure
 
   export MISE_DATA_DIR="$BATS_TEST_TMPDIR/mise-global-data"
   cd "$outside"
   run mise use --yes --global --postinstall "$MBX_BIN setup --yes" mr-boxington
   assert_success
-  assert_file_contains "$MISE_GLOBAL_CONFIG_FILE" "$MBX_SHIM_DIR"
+  cp "$MBX_BIN" "$(mise where mr-boxington)/mbx"
+  assert_file_contains "$MISE_GLOBAL_CONFIG_FILE" '[wrappers.cargo]'
   run mise exec -- sh -c 'command -v cargo'
   assert_success
-  assert_output "$MBX_SHIM_DIR/cargo"
-  run mise exec -- "$MBX_BIN" doctor
+  assert_output "$MISE_DATA_DIR/command-wrappers/bin/cargo"
+  run mise exec -- env PATH="$MISE_DATA_DIR/command-wrappers/bin:$PATH:$real_cargo_dir" \
+    "$MBX_BIN" doctor
   assert_success
-  assert_output --partial "Cargo shim is active and current"
+  assert_output --partial "mise Cargo wrapper is active"
 }
 
 @test "the Cargo shim preserves Cargo's namespace and disable escape hatch" {

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -270,6 +270,13 @@ EOF
   assert_file_contains "$project/mise.toml" 'command = "mbx"'
   assert_file_contains "$project/mise.toml" 'MBX_CARGO_SHIM_MODE = "1"'
 
+  local mbx_tool_dir
+  mbx_tool_dir="$(mise where mr-boxington)"
+  run env PATH="$MISE_DATA_DIR/command-wrappers/bin:$mbx_tool_dir:$real_cargo_dir:/usr/bin:/bin" \
+    cargo --version
+  assert_success
+  assert_output --regexp '^cargo [0-9]'
+
   run mise exec -- sh -c 'command -v cargo'
   assert_success
   assert_output "$MISE_DATA_DIR/command-wrappers/bin/cargo"
@@ -277,6 +284,9 @@ EOF
     "$MBX_BIN" doctor
   assert_success
   assert_output --partial "mise Cargo wrapper is active"
+  run mise exec -- env PATH="$MISE_DATA_DIR/command-wrappers/bin:$PATH:$real_cargo_dir" \
+    "$MBX_BIN" metadata --manifest-path "$first/Cargo.toml" --no-deps --format-version 1 --offline
+  assert_success
 
   run mise exec -- env PATH="$MISE_DATA_DIR/command-wrappers/bin:$PATH:$real_cargo_dir" \
     CARGO_INCREMENTAL=0 \

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -133,7 +133,7 @@ EOF
   assert_output --partial 'verify new shells with `command -v cargo`'
   assert_output --partial "mise's command-wrappers directory"
   assert_output --partial "non-interactive shells that do not activate mise need $MBX_SHIM_DIR prepended to PATH"
-  assert_file_contains "$project_config" '[wrappers.cargo]'
+  assert_file_contains "$project_config" 'command = "mbx"'
   assert_file_contains "$project_config" 'command = "mbx"'
   assert_file_contains "$project_config" 'MBX_CARGO_SHIM_MODE = "1"'
   assert_file_contains "$mise_log" "reshim"
@@ -145,7 +145,7 @@ EOF
     MBX_TEST_MISE_LOG="$mise_log" MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" \
     "$MBX_BIN" setup --yes
   assert_success
-  assert_file_contains "$BATS_TEST_TMPDIR/global.toml" '[wrappers.cargo]'
+  assert_file_contains "$BATS_TEST_TMPDIR/global.toml" 'command = "mbx"'
   assert_file_contains "$BATS_TEST_TMPDIR/global.toml" 'MBX_CARGO_SHIM_MODE = "1"'
   assert_file_contains "$MBX_RA_CONFIG" "$MBX_SHIM_DIR/cargo"
 
@@ -154,14 +154,14 @@ EOF
     MBX_TEST_MISE_LOG="$mise_log" MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" \
     "$MBX_BIN" setup --yes
   assert_success
-  assert_file_contains "$project_config" '[wrappers.cargo]'
+  assert_file_contains "$project_config" 'command = "mbx"'
 
   cd "$(dirname "$project_config")"
   run env -u MISE_CONFIG_FILE PATH="$fake_bin:$PATH" MISE_SHELL=zsh \
     MBX_TEST_MISE_CONFIGS='[]' MBX_TEST_MISE_LOG="$mise_log" \
     MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" "$MBX_BIN" setup --yes
   assert_success
-  assert_file_contains "$project_config" '[wrappers.cargo]'
+  assert_file_contains "$project_config" 'command = "mbx"'
 
   : >"$mise_log"
   run env -u MISE_CONFIG_FILE -u MISE_SHELL PATH="$fake_bin:$PATH" \
@@ -174,7 +174,7 @@ EOF
   run env PATH="$fake_bin:$PATH" MBX_TEST_MISE_LOG="$mise_log" \
     MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" "$MBX_BIN" setup --local
   assert_success
-  assert_file_contains "$project_config" '[wrappers.cargo]'
+  assert_file_contains "$project_config" 'command = "mbx"'
 
   run env PATH="$fake_bin:$PATH" MISE_SHELL=zsh \
     MISE_GLOBAL_CONFIG_FILE="$BATS_TEST_TMPDIR/global.toml" \
@@ -182,7 +182,7 @@ EOF
     MBX_TEST_MISE_LOG="$mise_log" MBX_TEST_SHIM_DIR="$MBX_SHIM_DIR" \
     "$MBX_BIN" setup --uninstall
   assert_success
-  run grep -F '[wrappers.cargo]' "$BATS_TEST_TMPDIR/global.toml"
+  run grep -F 'MBX_CARGO_SHIM_MODE' "$BATS_TEST_TMPDIR/global.toml"
   assert_failure
 }
 
@@ -208,7 +208,7 @@ EOF
   assert_output --partial "mise 2026.8.16 or newer is required for [wrappers]"
   assert_output --partial "upgrade mise"
   assert_file_contains "$global_config" "# global comment"
-  run grep -F '[wrappers.cargo]' "$global_config"
+  run grep -F 'MBX_CARGO_SHIM_MODE' "$global_config"
   assert_failure
   run env PATH="$fake_bin:$PATH" MISE_GLOBAL_CONFIG_FILE="$global_config" \
     "$MBX_BIN" setup --global --status
@@ -221,7 +221,7 @@ EOF
   assert_output --partial "mise 2026.8.16 or newer is required for [wrappers]"
   assert_file_contains "$project/mise.toml" "/existing/bin"
   assert_file_contains "$project/mise.toml" "# local comment"
-  run grep -F '[wrappers.cargo]' "$project/mise.toml"
+  run grep -F 'MBX_CARGO_SHIM_MODE' "$project/mise.toml"
   assert_failure
 }
 
@@ -267,7 +267,7 @@ EOF
   assert_success
   cp "$MBX_BIN" "$(mise where mr-boxington)/mbx"
   assert_file_executable "$MBX_SHIM_DIR/cargo"
-  assert_file_contains "$project/mise.toml" '[wrappers.cargo]'
+  assert_file_contains "$project/mise.toml" 'command = "mbx"'
   assert_file_contains "$project/mise.toml" 'MBX_CARGO_SHIM_MODE = "1"'
 
   run mise exec -- sh -c 'command -v cargo'
@@ -296,7 +296,7 @@ EOF
 
   run env MISE_CONFIG_FILE="$project/mise.toml" "$MBX_BIN" setup --uninstall
   assert_success
-  run grep -F '[wrappers.cargo]' "$project/mise.toml"
+  run grep -F 'MBX_CARGO_SHIM_MODE' "$project/mise.toml"
   assert_failure
 
   export MISE_DATA_DIR="$BATS_TEST_TMPDIR/mise-global-data"
@@ -304,7 +304,7 @@ EOF
   run mise use --yes --global --postinstall "$MBX_BIN setup --yes" mr-boxington
   assert_success
   cp "$MBX_BIN" "$(mise where mr-boxington)/mbx"
-  assert_file_contains "$MISE_GLOBAL_CONFIG_FILE" '[wrappers.cargo]'
+  assert_file_contains "$MISE_GLOBAL_CONFIG_FILE" 'command = "mbx"'
   run mise exec -- sh -c 'command -v cargo'
   assert_success
   assert_output "$MISE_DATA_DIR/command-wrappers/bin/cargo"


### PR DESCRIPTION
## Summary

- configure plain Cargo through mise 2026.8.16 command wrappers instead of `env._.path`
- warn without editing mise configuration when mise is too old
- recognize the mise wrapper in `mbx doctor` and prevent `CARGO` from recursing through it
- update setup documentation and behavioral coverage

## Testing

- `mise run ci`
- `MBX_BIN="$PWD/target/mbx-bootstrap/mbx" test/bats/bin/bats test/setup.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every mise-integrated shell resolves and delegates `cargo`; misconfiguration or version gating could leave users on plain Cargo or break resolution, but scope is localized to setup/shim/doctor with strong test coverage.
> 
> **Overview**
> **`mbx setup` now activates plain `cargo` through mise’s `[wrappers.cargo]` config** (command `mbx`, env `MBX_CARGO_SHIM_MODE=1`) and runs **`mise reshim`**, instead of appending the mbx shim directory to `env._.path` via `mise config set`.
> 
> **mise 2026.8.16+** is required for that path; older mise still gets the fallback shim install but only an **upgrade warning**—no mise config edits. Status, install, and uninstall all key off the wrapper TOML (and leave unrelated `wrappers.cargo` alone).
> 
> The **Cargo shim** treats **mise wrapper invocations** differently: it skips shim-directory PATH stripping and **ignores mise `command-wrappers` and `mise/shims` paths** when resolving the real `cargo`, avoiding wrapper recursion.
> 
> **`mbx doctor`** passes when the active `cargo` is mise’s command-wrapper, not only when the mbx shim wins on `PATH`. Docs, README, and Bats tests are updated for the new verify path and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8c0b15fa23b72652e5c2e8a2e276e7f97cd4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->