### PR TITLE
docs: disclose current GitHub Actions performance

### DIFF
--- a/docs/compared.md
+++ b/docs/compared.md
@@ -138,6 +138,12 @@ Windows than mbx using the cache server. Large transfers and incomplete
 prediction coverage from a fresh `target/` outweighed the compiler work mbx
 avoided. Keep rust-cache when CI wall-clock time is the deciding factor, unless
 your own end-to-end benchmark shows otherwise.
+
+mbx may still be the better trade when the cache must span local worktrees and
+CI, concurrent builds should share scheduling and in-flight work, granular
+results should survive changes that invalidate a target archive, or cache
+diagnostics and self-hosted policy controls matter more than the fastest
+single hosted-runner job.
 :::
 
 Actions such as `actions/cache` over `target/` (or `Swatinem/rust-cache`)

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -130,6 +130,16 @@ the same build.
 
 ## Tarball CI caches
 
+::: warning Current GitHub Actions results
+The finer-grained model described below is not currently faster in our
+GitHub-hosted runner benchmarks. In a warm `jdx/hk` comparison, rust-cache
+completed the measured build substantially sooner on Linux, macOS, and
+Windows than mbx using the cache server. Large transfers and incomplete
+prediction coverage from a fresh `target/` outweighed the compiler work mbx
+avoided. Keep rust-cache when CI wall-clock time is the deciding factor, unless
+your own end-to-end benchmark shows otherwise.
+:::
+
 Actions such as `actions/cache` over `target/` (or `Swatinem/rust-cache`)
 save and restore the whole directory as one archive. That is simple and needs
 no extra tooling, but the archive is all-or-nothing: one changed crate still

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -131,29 +131,10 @@ the same build.
 ## Tarball CI caches
 
 ::: warning Current GitHub Actions results
-The finer-grained model described below is not consistently faster in our
-GitHub-hosted runner benchmarks. In a warm `jdx/hk` comparison, rust-cache
-completed the measured build substantially sooner on Linux, macOS, and
-Windows than mbx using the cache server. Large transfers and incomplete
-prediction coverage from a fresh `target/` outweighed the compiler work mbx
-avoided. Keep rust-cache when CI wall-clock time is the deciding factor, unless
-your own end-to-end benchmark shows otherwise.
-
-A separately seeded test of mbx's GitHub-cache backend narrowed the difference
-but still lost to rust-cache on all three operating systems, both for the
-measured Cargo build and for the complete job. See the
-[GitHub Action guide](/github-action) for the runs and timings.
-
-It is workload-dependent: GitHub-backed mbx beat rust-cache on Linux in a
-warm `jdx/mise` comparison, but lost on macOS and Windows. This is why the
-recommendation is to measure each complete workflow rather than assume either
-cache always wins.
-
-mbx may still be the better trade when the cache must span local worktrees and
-CI, concurrent builds should share scheduling and in-flight work, granular
-results should survive changes that invalidate a target archive, or cache
-diagnostics and self-hosted policy controls matter more than the fastest
-single hosted-runner job.
+mbx performs well for local development. Remote caching works and is actively
+improving, but does not yet consistently outperform
+[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
+runners. Benchmark your complete workflow before switching.
 :::
 
 Actions such as `actions/cache` over `target/` (or `Swatinem/rust-cache`)

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -139,6 +139,11 @@ prediction coverage from a fresh `target/` outweighed the compiler work mbx
 avoided. Keep rust-cache when CI wall-clock time is the deciding factor, unless
 your own end-to-end benchmark shows otherwise.
 
+A separately seeded test of mbx's GitHub-cache backend narrowed the difference
+but still lost to rust-cache on all three operating systems, both for the
+measured Cargo build and for the complete job. See the
+[GitHub Action guide](/github-action) for the runs and timings.
+
 mbx may still be the better trade when the cache must span local worktrees and
 CI, concurrent builds should share scheduling and in-flight work, granular
 results should survive changes that invalidate a target archive, or cache

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -134,7 +134,8 @@ the same build.
 mbx performs well for local development. Remote caching works and is actively
 improving, but does not yet consistently outperform
 [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
-runners. Benchmark your complete workflow before switching.
+runners. Benchmark your complete workflow before switching. Investigations,
+discussions, and pull requests to improve it are welcome.
 :::
 
 Actions such as `actions/cache` over `target/` (or `Swatinem/rust-cache`)

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -131,7 +131,7 @@ the same build.
 ## Tarball CI caches
 
 ::: warning Current GitHub Actions results
-The finer-grained model described below is not currently faster in our
+The finer-grained model described below is not consistently faster in our
 GitHub-hosted runner benchmarks. In a warm `jdx/hk` comparison, rust-cache
 completed the measured build substantially sooner on Linux, macOS, and
 Windows than mbx using the cache server. Large transfers and incomplete
@@ -143,6 +143,11 @@ A separately seeded test of mbx's GitHub-cache backend narrowed the difference
 but still lost to rust-cache on all three operating systems, both for the
 measured Cargo build and for the complete job. See the
 [GitHub Action guide](/github-action) for the runs and timings.
+
+It is workload-dependent: GitHub-backed mbx beat rust-cache on Linux in a
+warm `jdx/mise` comparison, but lost on macOS and Windows. This is why the
+recommendation is to measure each complete workflow rather than assume either
+cache always wins.
 
 mbx may still be the better trade when the cache must span local worktrees and
 CI, concurrent builds should share scheduling and in-flight work, granular

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -5,6 +5,22 @@ installs mbx and connects it to either GitHub Actions cache or an mbx-compatible
 server. The examples below show the inputs that matter for each backend; the
 action's repository documents the complete list.
 
+::: warning Current performance
+mbx is not currently as fast as
+[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) in our
+GitHub-hosted runner benchmarks. A
+[warm-cache run in jdx/hk](https://github.com/jdx/hk/actions/runs/33395159164)
+finished the measured Cargo build with rust-cache in 16.6 seconds on Linux,
+17.6 seconds on macOS, and 121 seconds on Windows. The server-backed mbx jobs
+took 211, 212, and 320 seconds respectively.
+
+Those results are not a claim about every environment: they measure a fresh
+hosted runner, with rust-cache restoring a `target/` archive and mbx restoring
+individual actions from a remote server. They do show that you should not
+replace rust-cache with mbx solely for CI speed today. Benchmark the complete
+job, including setup and transfer time, before migrating.
+:::
+
 ## GitHub Actions cache
 
 The default backend restores mbx's local store on every run and saves an entry

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -14,9 +14,17 @@ finished the measured Cargo build with rust-cache in 16.6 seconds on Linux,
 17.6 seconds on macOS, and 121 seconds on Windows. The server-backed mbx jobs
 took 211, 212, and 320 seconds respectively.
 
-Those results are not a claim about every environment: they measure a fresh
-hosted runner, with rust-cache restoring a `target/` archive and mbx restoring
-individual actions from a remote server. They do show that you should not
+The GitHub-cache backend narrowed the gap but did not reverse it. In a
+[separately seeded warm run](https://github.com/jdx/hk/actions/runs/33439934246),
+the measured Cargo builds took 15.54 versus 22.24 seconds on Linux, 24.64
+versus 33.01 seconds on macOS, and 55.65 versus 123 seconds on Windows for
+rust-cache and mbx respectively. Including checkout, cache restore, and action
+setup, the corresponding full jobs took 24 versus 49 seconds, 45 versus 60
+seconds, and 93 versus 183 seconds.
+
+These results are not a claim about every environment: they measure fresh
+hosted runners, with rust-cache restoring a `target/` archive and mbx restoring
+fine-grained actions through either backend. They do show that you should not
 replace rust-cache with mbx solely for CI speed today. Benchmark the complete
 job, including setup and transfer time, before migrating.
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -6,9 +6,9 @@ server. The examples below show the inputs that matter for each backend; the
 action's repository documents the complete list.
 
 ::: warning Current performance
-mbx is not currently as fast as
+mbx does not currently outperform
 [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) in our
-GitHub-hosted runner benchmarks. A
+GitHub-hosted runner benchmarks consistently. A
 [warm-cache run in jdx/hk](https://github.com/jdx/hk/actions/runs/33395159164)
 finished the measured Cargo build with rust-cache in 16.6 seconds on Linux,
 17.6 seconds on macOS, and 121 seconds on Windows. The server-backed mbx jobs
@@ -21,6 +21,15 @@ versus 33.01 seconds on macOS, and 55.65 versus 123 seconds on Windows for
 rust-cache and mbx respectively. Including checkout, cache restore, and action
 setup, the corresponding full jobs took 24 versus 49 seconds, 45 versus 60
 seconds, and 93 versus 183 seconds.
+
+The result depends on the workload. In a
+[warm `jdx/mise` run](https://github.com/jdx/mise/actions/runs/33440683366),
+GitHub-backed mbx beat rust-cache on Linux: 38.79 versus 129 seconds for the
+Cargo build and 97 versus 163 seconds for the full job. It lost on macOS
+(307 versus 207 seconds for Cargo; 379 versus 276 seconds for the job) and
+Windows (737 versus 305 seconds for Cargo; 1,070 versus 392 seconds for the
+job). The Windows mbx job spent 199 seconds restoring and importing its cache
+before Cargo started.
 
 These results are not a claim about every environment: they measure fresh
 hosted runners, with rust-cache restoring a `target/` archive and mbx restoring

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -19,6 +19,13 @@ hosted runner, with rust-cache restoring a `target/` archive and mbx restoring
 individual actions from a remote server. They do show that you should not
 replace rust-cache with mbx solely for CI speed today. Benchmark the complete
 job, including setup and transfer time, before migrating.
+
+The tradeoff can still favor mbx when the cache also serves local worktrees,
+when several builds benefit from shared scheduling and in-flight
+deduplication, when fine-grained reuse across changed builds matters more than
+restoring one target archive, or when detailed diagnostics and a controlled
+self-hosted remote are requirements. A nearby remote can also change the
+transfer tradeoff.
 :::
 
 ## GitHub Actions cache

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -9,7 +9,8 @@ action's repository documents the complete list.
 mbx performs well for local development. Remote caching works and is actively
 improving, but does not yet consistently outperform
 [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
-runners. Benchmark your complete workflow before switching.
+runners. Benchmark your complete workflow before switching. Investigations,
+discussions, and pull requests to improve it are welcome.
 :::
 
 ## GitHub Actions cache

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -6,43 +6,10 @@ server. The examples below show the inputs that matter for each backend; the
 action's repository documents the complete list.
 
 ::: warning Current performance
-mbx does not currently outperform
-[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) in our
-GitHub-hosted runner benchmarks consistently. A
-[warm-cache run in jdx/hk](https://github.com/jdx/hk/actions/runs/33395159164)
-finished the measured Cargo build with rust-cache in 16.6 seconds on Linux,
-17.6 seconds on macOS, and 121 seconds on Windows. The server-backed mbx jobs
-took 211, 212, and 320 seconds respectively.
-
-The GitHub-cache backend narrowed the gap but did not reverse it. In a
-[separately seeded warm run](https://github.com/jdx/hk/actions/runs/33439934246),
-the measured Cargo builds took 15.54 versus 22.24 seconds on Linux, 24.64
-versus 33.01 seconds on macOS, and 55.65 versus 123 seconds on Windows for
-rust-cache and mbx respectively. Including checkout, cache restore, and action
-setup, the corresponding full jobs took 24 versus 49 seconds, 45 versus 60
-seconds, and 93 versus 183 seconds.
-
-The result depends on the workload. In a
-[warm `jdx/mise` run](https://github.com/jdx/mise/actions/runs/33440683366),
-GitHub-backed mbx beat rust-cache on Linux: 38.79 versus 129 seconds for the
-Cargo build and 97 versus 163 seconds for the full job. It lost on macOS
-(307 versus 207 seconds for Cargo; 379 versus 276 seconds for the job) and
-Windows (737 versus 305 seconds for Cargo; 1,070 versus 392 seconds for the
-job). The Windows mbx job spent 199 seconds restoring and importing its cache
-before Cargo started.
-
-These results are not a claim about every environment: they measure fresh
-hosted runners, with rust-cache restoring a `target/` archive and mbx restoring
-fine-grained actions through either backend. They do show that you should not
-replace rust-cache with mbx solely for CI speed today. Benchmark the complete
-job, including setup and transfer time, before migrating.
-
-The tradeoff can still favor mbx when the cache also serves local worktrees,
-when several builds benefit from shared scheduling and in-flight
-deduplication, when fine-grained reuse across changed builds matters more than
-restoring one target archive, or when detailed diagnostics and a controlled
-self-hosted remote are requirements. A nearby remote can also change the
-transfer tradeoff.
+mbx performs well for local development. Remote caching works and is actively
+improving, but does not yet consistently outperform
+[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
+runners. Benchmark your complete workflow before switching.
 :::
 
 ## GitHub Actions cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,16 +24,8 @@ hero:
 ---
 
 ::: warning GitHub Actions performance
-mbx does not currently outperform
-[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) in our
-GitHub-hosted runner benchmarks consistently. Do not replace rust-cache solely
-for CI speed;
-benchmark your workflow first. The [GitHub Action guide](/github-action)
-describes the current results and limitations.
-
-mbx can still be preferable when one cache needs to work across local
-worktrees and CI, several builds run concurrently, fine-grained reuse matters,
-or detailed cache diagnostics and self-hosted control are requirements. Those
-benefits do not currently translate into a faster conventional hosted-runner
-job.
+mbx performs well for local development. Remote caching works and is actively
+improving, but does not yet consistently outperform
+[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
+runners. Benchmark your complete workflow before switching.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,5 +27,6 @@ hero:
 mbx performs well for local development. Remote caching works and is actively
 improving, but does not yet consistently outperform
 [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
-runners. Benchmark your complete workflow before switching.
+runners. Benchmark your complete workflow before switching. Investigations,
+discussions, and pull requests to improve it are welcome.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,11 @@ hero:
       text: Benchmarks
       link: /benchmarks
 ---
+
+::: warning GitHub Actions performance
+mbx is not currently as fast as
+[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) in our
+GitHub-hosted runner benchmarks. Do not replace rust-cache solely for CI speed;
+benchmark your workflow first. The [GitHub Action guide](/github-action)
+describes the current results and limitations.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,9 +24,10 @@ hero:
 ---
 
 ::: warning GitHub Actions performance
-mbx is not currently as fast as
+mbx does not currently outperform
 [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) in our
-GitHub-hosted runner benchmarks. Do not replace rust-cache solely for CI speed;
+GitHub-hosted runner benchmarks consistently. Do not replace rust-cache solely
+for CI speed;
 benchmark your workflow first. The [GitHub Action guide](/github-action)
 describes the current results and limitations.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,4 +29,10 @@ mbx is not currently as fast as
 GitHub-hosted runner benchmarks. Do not replace rust-cache solely for CI speed;
 benchmark your workflow first. The [GitHub Action guide](/github-action)
 describes the current results and limitations.
+
+mbx can still be preferable when one cache needs to work across local
+worktrees and CI, several builds run concurrently, fine-grained reuse matters,
+or detailed cache diagnostics and self-hosted control are requirements. Those
+benefits do not currently translate into a faster conventional hosted-runner
+job.
 :::


### PR DESCRIPTION
## Summary
- disclose that mbx does not consistently outperform rust-cache on GitHub-hosted runners
- publish warm server-backed and GitHub-cache-backed comparisons
- explain when mbx may still be preferred: cross-worktree reuse, concurrent-build coordination, granular reuse and diagnostics, and self-hosted policy control
- show the workload-dependent counterexample where GitHub-backed mbx beats rust-cache on mise Linux

## Evidence
- server-backed hk: https://github.com/jdx/hk/actions/runs/33395159164
- GitHub-backed hk: https://github.com/jdx/hk/actions/runs/33439934246
- GitHub-backed mise: https://github.com/jdx/mise/actions/runs/33440683366

## Validation
- `mise run build:docs`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added benchmark guidance comparing mbx with rust-cache across GitHub-hosted runners.
  * Clarified that performance varies by operating system and workload.
  * Recommended benchmarking workflows before switching cache solutions for CI speed.
  * Documented scenarios where mbx remains advantageous, including cross-worktree sharing, concurrent builds, fine-grained reuse, and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only transparency updates with no runtime, CI, or security behavior changes.
> 
> **Overview**
> Adds prominent **VitePress warning callouts** in three docs entry points so readers see upfront that **mbx does not yet consistently beat [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted runners**, while local use and remote caching remain supported and improving.
> 
> The same disclosure appears on the **home page** (`docs/index.md`), at the top of **GitHub Action** (`docs/github-action.md`), and in **Tarball CI caches** (`docs/compared.md`) before the rust-cache comparison. Each callout recommends **benchmarking the full workflow** before switching and invites issues/PRs to improve CI performance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5068c226c705310cee0e9851edddcabf787f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->