### PR TITLE
docs: show project-scoped mise wrapper

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,8 +29,11 @@ command = "mbx"
 env = { MBX_CARGO_SHIM_MODE = "1" }
 ```
 
-Then run `mise install`. This avoids changing the global mise configuration,
-and every contributor who activates the project gets the same Cargo wrapper.
+Then run `mise install`. This installs mbx but does not activate the wrapper in
+the parent shell. Run project tasks with `mise run`, or activate mise in the
+shell before invoking plain `cargo` commands. This avoids changing the global
+mise configuration, and every contributor who activates the project gets the
+same Cargo wrapper.
 
 ### Release archive
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,6 +17,21 @@ shim but only prints an upgrade warning instead of editing mise configuration.
 With `--global`, mise activates mbx in its global configuration. Drop
 `--global` to activate it only in the current project's configuration.
 
+To keep the wrapper project-scoped and reviewable, commit it directly in the
+project's `mise.toml` instead:
+
+```toml
+[tools]
+mr-boxington = "1.3.0"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
+```
+
+Then run `mise install`. This avoids changing the global mise configuration,
+and every contributor who activates the project gets the same Cargo wrapper.
+
 ### Release archive
 
 :::tabs


### PR DESCRIPTION
## Summary
- document the committed, project-scoped mise configuration for mr-boxington
- use inline `env = { MBX_CARGO_SHIM_MODE = "1" }` wrapper syntax
- keep the existing global installation path while showing the reviewable project alternative

## Validation
- `mise run build:docs`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or build behavior impact.
> 
> **Overview**
> The **mise** install section in `getting-started.md` now documents a **committed, project-scoped** alternative to `mise use --global`: pin `mr-boxington` and define `[wrappers.cargo]` with `command = "mbx"` and inline `env = { MBX_CARGO_SHIM_MODE = "1" }` in the repo’s `mise.toml`.
> 
> It explains running **`mise install`** (no global wrapper activation), using **`mise run`** or an activated shell for plain `cargo`, and why that keeps config reviewable and consistent for contributors. The existing global `mise use` path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bfcc9a67e1d983027de3c34b60924c720f559a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added setup instructions for configuring the `mr-boxington` tool and Cargo wrapper with project-scoped mise settings.
  - Documented version pinning and Cargo shim mode.
  - Updated installation guidance to use `mise install` without changing global configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->