### PR TITLE
fix: avoid reentering mise Cargo wrappers

### DIFF
--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -242,7 +242,12 @@ pub(super) fn prepare_explicit_cargo() -> Result<()> {
     let Some(proxy) = proxy else {
         return Ok(());
     };
-    let cargo = resolve_real_cargo_from(&proxy, std::env::var_os("CARGO").as_deref(), &path)?;
+    let cargo = resolve_explicit_cargo(
+        &proxy,
+        standalone_shim.as_deref(),
+        std::env::var_os("CARGO").as_deref(),
+        &path,
+    )?;
     PATH_BEFORE_SHIM_EXCLUSION.get_or_init(|| std::env::var_os("PATH").unwrap_or_default());
     // SAFETY: CLI dispatch is single-threaded here, before the cache session
     // or any child process has started.
@@ -270,6 +275,19 @@ fn path_without_cargo_proxies(
         !is_proxy
     });
     Ok((std::env::join_paths(directories)?, first_proxy))
+}
+
+/// Resolve Cargo for an explicit command without accepting its standalone shim.
+fn resolve_explicit_cargo(
+    proxy: &Path,
+    standalone_shim: Option<&Path>,
+    configured: Option<&OsStr>,
+    path: &OsStr,
+) -> Result<OsString> {
+    let configured = configured.filter(|candidate| {
+        standalone_shim.is_none_or(|shim| !same_path(Path::new(candidate), shim))
+    });
+    resolve_real_cargo_from(proxy, configured, path)
 }
 
 fn exclude_shim_from_path(shim: &Path) -> Result<()> {
@@ -615,19 +633,23 @@ mod tests {
     fn explicit_cargo_excludes_mise_wrapper_from_child_path() {
         let directory = tempfile::tempdir().unwrap();
         let wrapper_dir = directory.path().join("command-wrappers/bin");
+        let shim_dir = directory.path().join("mbx/bin");
         let tool_dir = directory.path().join("tool/bin");
         let real_dir = directory.path().join("real");
         std::fs::create_dir_all(&wrapper_dir).unwrap();
+        std::fs::create_dir_all(&shim_dir).unwrap();
         std::fs::create_dir_all(&tool_dir).unwrap();
         std::fs::create_dir_all(&real_dir).unwrap();
         let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
         let wrapper = wrapper_dir.join(name);
+        let shim = shim_dir.join(name);
         let real = real_dir.join(name);
         std::fs::write(&wrapper, b"mise wrapper").unwrap();
+        std::fs::write(&shim, b"mbx shim").unwrap();
         std::fs::write(&real, b"real").unwrap();
-        let path = std::env::join_paths([&wrapper_dir, &tool_dir, &real_dir]).unwrap();
+        let path = std::env::join_paths([&wrapper_dir, &shim_dir, &tool_dir, &real_dir]).unwrap();
 
-        let (path, proxy) = path_without_cargo_proxies(&path, None).unwrap();
+        let (path, proxy) = path_without_cargo_proxies(&path, Some(&shim)).unwrap();
 
         assert_eq!(proxy, Some(wrapper.clone()));
         assert_eq!(
@@ -635,7 +657,7 @@ mod tests {
             vec![tool_dir, real_dir.clone()]
         );
         assert_eq!(
-            resolve_real_cargo_from(&wrapper, None, &path).unwrap(),
+            resolve_explicit_cargo(&wrapper, Some(&shim), Some(shim.as_os_str()), &path).unwrap(),
             real.into_os_string()
         );
     }

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -229,22 +229,47 @@ fn same_path(left: &Path, right: &Path) -> bool {
     }
 }
 
-/// Keep explicit `mbx build`-style commands from rediscovering the persistent
-/// Cargo shim after setup has placed it first on PATH.
+/// Keep explicit `mbx build`-style commands from rediscovering a persistent
+/// Cargo shim or mise command wrapper on PATH.
 pub(super) fn prepare_explicit_cargo() -> Result<()> {
-    let Some(shim_dir) = super::setup_install_dir() else {
+    let standalone_shim = super::setup_install_dir()
+        .map(|directory| directory.join(if cfg!(windows) { "cargo.exe" } else { "cargo" }))
+        .filter(|shim| shim.is_file());
+    let Some(path) = std::env::var_os("PATH") else {
         return Ok(());
     };
-    let shim = shim_dir.join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
-    if !shim.is_file() {
+    let (path, proxy) = path_without_cargo_proxies(&path, standalone_shim.as_deref())?;
+    let Some(proxy) = proxy else {
         return Ok(());
-    }
-    exclude_shim_from_path(&shim)?;
-    let cargo = resolve_real_cargo(&shim)?;
+    };
+    let cargo = resolve_real_cargo_from(&proxy, std::env::var_os("CARGO").as_deref(), &path)?;
+    PATH_BEFORE_SHIM_EXCLUSION.get_or_init(|| std::env::var_os("PATH").unwrap_or_default());
     // SAFETY: CLI dispatch is single-threaded here, before the cache session
     // or any child process has started.
-    unsafe { std::env::set_var("CARGO", cargo) };
+    unsafe {
+        std::env::set_var("PATH", path);
+        std::env::set_var("CARGO", cargo);
+    }
     Ok(())
+}
+
+fn path_without_cargo_proxies(
+    path: &OsStr,
+    standalone_shim: Option<&Path>,
+) -> Result<(OsString, Option<PathBuf>)> {
+    let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+    let mut first_proxy = None;
+    let directories = std::env::split_paths(path).filter(|directory| {
+        let candidate = directory.join(name);
+        let is_standalone = standalone_shim.is_some_and(|shim| same_path(&candidate, shim));
+        let is_proxy =
+            candidate.is_file() && (is_standalone || is_mise_cargo_proxy_path(&candidate));
+        if is_proxy {
+            first_proxy.get_or_insert(candidate);
+        }
+        !is_proxy
+    });
+    Ok((std::env::join_paths(directories)?, first_proxy))
 }
 
 fn exclude_shim_from_path(shim: &Path) -> Result<()> {
@@ -583,6 +608,35 @@ mod tests {
         assert_eq!(
             std::env::split_paths(&path_without_shim(&shim, &path).unwrap()).collect::<Vec<_>>(),
             vec![real_dir]
+        );
+    }
+
+    #[test]
+    fn explicit_cargo_excludes_mise_wrapper_from_child_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let wrapper_dir = directory.path().join("command-wrappers/bin");
+        let tool_dir = directory.path().join("tool/bin");
+        let real_dir = directory.path().join("real");
+        std::fs::create_dir_all(&wrapper_dir).unwrap();
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::create_dir_all(&real_dir).unwrap();
+        let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+        let wrapper = wrapper_dir.join(name);
+        let real = real_dir.join(name);
+        std::fs::write(&wrapper, b"mise wrapper").unwrap();
+        std::fs::write(&real, b"real").unwrap();
+        let path = std::env::join_paths([&wrapper_dir, &tool_dir, &real_dir]).unwrap();
+
+        let (path, proxy) = path_without_cargo_proxies(&path, None).unwrap();
+
+        assert_eq!(proxy, Some(wrapper.clone()));
+        assert_eq!(
+            std::env::split_paths(&path).collect::<Vec<_>>(),
+            vec![tool_dir, real_dir.clone()]
+        );
+        assert_eq!(
+            resolve_real_cargo_from(&wrapper, None, &path).unwrap(),
+            real.into_os_string()
         );
     }
 

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -268,7 +268,7 @@ fn path_without_cargo_proxies(
         let candidate = directory.join(name);
         let is_standalone = standalone_shim.is_some_and(|shim| same_path(&candidate, shim));
         let is_proxy =
-            candidate.is_file() && (is_standalone || is_mise_cargo_proxy_path(&candidate));
+            candidate.is_file() && (is_standalone || is_mise_command_wrapper_path(&candidate));
         if is_proxy {
             first_proxy.get_or_insert(candidate);
         }
@@ -284,10 +284,25 @@ fn resolve_explicit_cargo(
     configured: Option<&OsStr>,
     path: &OsStr,
 ) -> Result<OsString> {
-    let configured = configured.filter(|candidate| {
-        standalone_shim.is_none_or(|shim| !same_path(Path::new(candidate), shim))
-    });
-    resolve_real_cargo_from(proxy, configured, path)
+    if let Some(configured) = configured.map(Path::new).filter(|candidate| {
+        candidate.is_absolute()
+            && candidate.is_file()
+            && !is_mise_command_wrapper_path(candidate)
+            && standalone_shim.is_none_or(|shim| !same_path(candidate, shim))
+    }) {
+        return Ok(configured.as_os_str().to_owned());
+    }
+    let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+    for directory in std::env::split_paths(path) {
+        let candidate = directory.join(name);
+        if candidate.is_file() {
+            return Ok(candidate.into_os_string());
+        }
+    }
+    eyre::bail!(
+        "could not find the real Cargo after excluding {}",
+        proxy.display()
+    )
 }
 
 fn exclude_shim_from_path(shim: &Path) -> Result<()> {
@@ -634,31 +649,42 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let wrapper_dir = directory.path().join("command-wrappers/bin");
         let shim_dir = directory.path().join("mbx/bin");
+        let mise_shims_dir = directory.path().join("mise/shims");
         let tool_dir = directory.path().join("tool/bin");
         let real_dir = directory.path().join("real");
         std::fs::create_dir_all(&wrapper_dir).unwrap();
         std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::create_dir_all(&mise_shims_dir).unwrap();
         std::fs::create_dir_all(&tool_dir).unwrap();
         std::fs::create_dir_all(&real_dir).unwrap();
         let name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
         let wrapper = wrapper_dir.join(name);
         let shim = shim_dir.join(name);
+        let mise_shim = mise_shims_dir.join(name);
         let real = real_dir.join(name);
         std::fs::write(&wrapper, b"mise wrapper").unwrap();
         std::fs::write(&shim, b"mbx shim").unwrap();
+        std::fs::write(&mise_shim, b"mise shim").unwrap();
         std::fs::write(&real, b"real").unwrap();
-        let path = std::env::join_paths([&wrapper_dir, &shim_dir, &tool_dir, &real_dir]).unwrap();
+        let path = std::env::join_paths([
+            &wrapper_dir,
+            &shim_dir,
+            &mise_shims_dir,
+            &tool_dir,
+            &real_dir,
+        ])
+        .unwrap();
 
         let (path, proxy) = path_without_cargo_proxies(&path, Some(&shim)).unwrap();
 
         assert_eq!(proxy, Some(wrapper.clone()));
         assert_eq!(
             std::env::split_paths(&path).collect::<Vec<_>>(),
-            vec![tool_dir, real_dir.clone()]
+            vec![mise_shims_dir, tool_dir, real_dir]
         );
         assert_eq!(
             resolve_explicit_cargo(&wrapper, Some(&shim), Some(shim.as_os_str()), &path).unwrap(),
-            real.into_os_string()
+            mise_shim.into_os_string()
         );
     }
 

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -368,6 +368,32 @@ EOF
   refute_output --partial "RUSTC_WRAPPER is already set"
 }
 
+@test "explicit mbx Cargo commands do not reenter mise's command wrapper" {
+  local project="$BATS_TEST_TMPDIR/explicit-mise-wrapper-project"
+  local wrapper_dir="$BATS_TEST_TMPDIR/mise-data/command-wrappers/bin"
+  local wrapper_log="$BATS_TEST_TMPDIR/mise-wrapper.log"
+  local real_cargo_dir
+  real_cargo_dir="$(dirname "$(command -v cargo)")"
+  write_project "$project"
+  mkdir -p "$wrapper_dir"
+  cat >"$wrapper_dir/cargo" <<'EOF'
+#!/bin/sh
+printf 'reentered\n' >>"$MBX_TEST_MISE_WRAPPER_LOG"
+exit 97
+EOF
+  chmod +x "$wrapper_dir/cargo"
+
+  run env -u CARGO \
+    PATH="$wrapper_dir:$real_cargo_dir:/usr/bin:/bin" \
+    MBX_TEST_MISE_WRAPPER_LOG="$wrapper_log" \
+    CARGO_TARGET_DIR="$BATS_TEST_TMPDIR/explicit-mise-wrapper-target" \
+    "$MBX_BIN" check --offline --manifest-path "$project/Cargo.toml"
+
+  assert_success
+  refute_output --partial "RUSTC_WRAPPER is already set"
+  [ ! -e "$wrapper_log" ]
+}
+
 @test "plain Cargo restores a second checkout through a full mbx session" {
   local first="$BATS_TEST_TMPDIR/first-checkout"
   local second="$BATS_TEST_TMPDIR/second-checkout"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -373,7 +373,7 @@ EOF
   local wrapper_dir="$BATS_TEST_TMPDIR/mise-data/command-wrappers/bin"
   local wrapper_log="$BATS_TEST_TMPDIR/mise-wrapper.log"
   local real_cargo_dir
-  real_cargo_dir="$(dirname "$(command -v cargo)")"
+  real_cargo_dir="$(dirname "$(rustup which cargo)")"
   write_project "$project"
   mkdir -p "$wrapper_dir"
   cat >"$wrapper_dir/cargo" <<'EOF'


### PR DESCRIPTION
## Summary

- remove mise command-wrapper Cargo proxies from PATH before explicit `mbx` Cargo commands
- resolve and export the underlying Cargo binary for the child process
- cover the behavior with unit and BATS regression tests

## Testing

- `cargo fmt --check`
- `cargo clippy -p mbx --all-targets -- -D warnings`
- `/home/coder/.cargo/bin/cargo test -p mbx`
- `MBX_BIN="$PWD/target/mbx-bootstrap/mbx" bats --filter "explicit mbx Cargo commands" test/setup.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how explicit mbx commands resolve Cargo and mutate PATH/CARGO at CLI startup; wrong proxy detection could break builds for mise or shim-heavy setups.
> 
> **Overview**
> Explicit `mbx` Cargo invocations (e.g. `mbx check`) no longer recurse through **mise** `command-wrappers/bin/cargo` or the installed **mbx** cargo shim when those appear first on `PATH`.
> 
> `prepare_explicit_cargo` now strips all such proxies via `path_without_cargo_proxies`, resolves the next usable `cargo` with `resolve_explicit_cargo` (honoring a valid `CARGO` when it is not a wrapper or mbx shim), and updates both **`PATH`** and **`CARGO`** for the child process. Unit and BATS tests cover wrapper removal and that the mise wrapper script is never executed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34be5dacab97bc00dc4613c69fb48b33ab61b138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit Cargo commands now bypass Cargo and mise command wrappers, allowing the real Cargo executable to run correctly.
  * Prevented explicit `mbx check` commands from reentering mise’s command wrapper.
  * Improved command behavior when wrapper scripts are present in `PATH`.

* **Tests**
  * Added coverage confirming wrapper bypass and successful real-Cargo resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->