### PR TITLE
feat(cache): model -fuse-ld linker selection for native links

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1664,13 +1664,14 @@ impl CacheAgent {
         environment: BTreeMap<String, Option<String>>,
     ) -> Result<ExecutableIdentityKey> {
         // Restricted to the variables that actually select what an identity
-        // probe reports: the toolchain rustup resolves, and the SDK a linker
-        // driver builds against. Anything else would let one key stand for two
-        // different compilers.
+        // probe reports: the toolchain rustup resolves, the SDK a linker
+        // driver builds against, and a `-fuse-ld` linker selection. Anything
+        // else would let one key stand for two different compilers.
         if !environment.keys().all(|name| {
             matches!(
                 name.as_str(),
-                "RUSTUP_HOME"
+                "MBX_FUSE_LD"
+                    | "RUSTUP_HOME"
                     | "RUSTUP_TOOLCHAIN"
                     | "SDKROOT"
                     | "MACOSX_DEPLOYMENT_TARGET"

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -504,6 +504,9 @@ fn render_argument(argument: &Argument) -> Result<OsString, BypassReason> {
                 .ok_or_else(|| BypassReason::NonUtf8Path(path.clone()))?,
             if *trailing_slash { "/" } else { "" }
         ),
+        // Nothing links while emitting dep-info either; replayed verbatim for
+        // the same reason as the prefix above.
+        Argument::FuseLd(selection) => format!("--codegen=link-arg=-fuse-ld={selection}"),
     };
     Ok(rendered.into())
 }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -338,6 +338,10 @@ enum Argument {
         path: PathBuf,
         trailing_slash: bool,
     },
+    /// A `-fuse-ld=<name>` handed to the driver, selecting which linker a
+    /// link invokes. Modeled for native links only, where the linker identity
+    /// probe resolves and pins the linker it names.
+    FuseLd(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -442,6 +446,17 @@ impl RustcInvocation {
                 return None;
             };
             value.strip_prefix("--codegen=linker=").map(Path::new)
+        })
+    }
+
+    /// Linker selected with `-C link-arg=-fuse-ld=<name>`, if the invocation
+    /// passes one the adapter models.
+    pub fn fuse_ld(&self) -> Option<&str> {
+        self.arguments.iter().find_map(|argument| {
+            let Argument::FuseLd(selection) = argument else {
+                return None;
+            };
+            Some(selection.as_str())
         })
     }
 
@@ -1488,6 +1503,28 @@ impl<'a> Parser<'a> {
         {
             return Err(BypassReason::UnknownCodegenOption(name.into()));
         }
+        // `-fuse-ld=<name>` selects the linker the driver invokes. Parsed
+        // rather than keyed as text so the linker identity probe can pin the
+        // selected linker; a repeated selection dedups, and a conflicting
+        // second selection falls through to Plain, which native-link handling
+        // declines to model. The driver honors the last selection, so a
+        // conflict is a link whose linker this adapter cannot name.
+        if name == "link-arg"
+            && let Some((_, option)) = value.split_once('=')
+            && let Some(selection) = option.strip_prefix("-fuse-ld=")
+            && !selection.is_empty()
+            && !selection.contains(',')
+            && !self.parsed.iter().any(
+                |argument| matches!(argument, Argument::FuseLd(existing) if existing != selection),
+            )
+        {
+            if !self.parsed.iter().any(
+                |argument| matches!(argument, Argument::FuseLd(existing) if existing == selection),
+            ) {
+                self.parsed.push(Argument::FuseLd(selection.to_owned()));
+            }
+            return Ok(());
+        }
         // `-oso_prefix` names a checkout-specific path, so it is parsed
         // rather than keyed as text: the path normalizes like every other
         // path in the key, which is what lets two checkouts passing their own
@@ -1607,6 +1644,25 @@ impl<'a> Parser<'a> {
             && let Some(option) = self.first_link_argument()
         {
             return Err(BypassReason::UnmodeledLinkArgument(option.to_owned()));
+        }
+        // `-fuse-ld` is modeled only for native links, where the linker
+        // identity probe resolves and pins the linker it names. A wasm or
+        // other non-native link consuming the selection has no identity that
+        // describes it, so it declines the action like any other link
+        // argument. Where nothing links, the selection is inert and the key
+        // carries its text.
+        if let Some(selection) = self.parsed.iter().find_map(|argument| {
+            let Argument::FuseLd(selection) = argument else {
+                return None;
+            };
+            Some(selection.as_str())
+        }) && !matches!(
+            link_output,
+            LinkOutput::Library | LinkOutput::NativeExecutable | LinkOutput::NativeProcMacro
+        ) {
+            return Err(BypassReason::UnmodeledLinkArgument(format!(
+                "link-arg=-fuse-ld={selection}"
+            )));
         }
         if self.parsed.iter().any(|argument| {
             matches!(argument, Argument::Plain(value) if value.starts_with("--codegen=linker="))
@@ -2010,6 +2066,7 @@ impl<'a> ActionBuilder<'a> {
                 self.normalize_path(path)?,
                 if *trailing_slash { "/" } else { "" }
             )),
+            Argument::FuseLd(selection) => Ok(format!("--codegen=link-arg=-fuse-ld={selection}")),
         }
     }
 

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1813,19 +1813,77 @@ fn link_arguments_bypass_whatever_actually_links() {
         );
     }
 
-    for flag in ["-Clink-arg=-fuse-ld=lld", "-Clink-arg=/STACK:8000000"] {
-        let native = args(&["--test", "--emit=dep-info,link", flag, "src/lib.rs"]);
-        assert_eq!(
-            RustcInvocation::parse_with(&native, native_links()),
-            Err(BypassReason::UnmodeledLinkArgument(
-                flag.strip_prefix("-C").unwrap().into()
-            )),
-            "{flag} should not be cacheable on a native link"
-        );
-    }
+    let flag = "-Clink-arg=/STACK:8000000";
+    let native = args(&["--test", "--emit=dep-info,link", flag, "src/lib.rs"]);
+    assert_eq!(
+        RustcInvocation::parse_with(&native, native_links()),
+        Err(BypassReason::UnmodeledLinkArgument(
+            flag.strip_prefix("-C").unwrap().into()
+        )),
+        "{flag} should not be cacheable on a native link"
+    );
 }
 
-/// The one link argument the adapter models: ld64's `-oso_prefix` names a
+/// `-fuse-ld=<name>` is the one link argument beyond `-oso_prefix` the
+/// adapter models: on a native link the linker identity probe resolves and
+/// pins the selected linker, so the link caches. On any other link output the
+/// selection has no identity describing it, so it bypasses like every other
+/// link argument. A conflicting second selection names no single linker and
+/// bypasses too.
+#[test]
+fn fuse_ld_is_modeled_for_native_links_only() {
+    let native = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "-Clink-arg=-fuse-ld=mold",
+        "src/lib.rs",
+    ]);
+    let invocation = RustcInvocation::parse_with(&native, native_links())
+        .expect("a `-fuse-ld` selection on a native link is cacheable");
+    assert_eq!(invocation.fuse_ld(), Some("mold"));
+
+    let wasm = args(&[
+        "--crate-type=bin",
+        "--emit=dep-info,link",
+        "--target=wasm32-unknown-unknown",
+        "-Clink-arg=-fuse-ld=mold",
+        "src/main.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse(&wasm),
+        Err(BypassReason::UnmodeledLinkArgument(
+            "link-arg=-fuse-ld=mold".into()
+        )),
+        "a `-fuse-ld` selection should not be cacheable on a wasm link"
+    );
+
+    let conflicting = args(&[
+        "--test",
+        "--emit=dep-info,link",
+        "-Clink-arg=-fuse-ld=mold",
+        "-Clink-arg=-fuse-ld=lld",
+        "src/lib.rs",
+    ]);
+    assert_eq!(
+        RustcInvocation::parse_with(&conflicting, native_links()),
+        Err(BypassReason::UnmodeledLinkArgument(
+            "link-arg=-fuse-ld=lld".into()
+        )),
+        "conflicting `-fuse-ld` selections name no single linker"
+    );
+
+    let library = args(&[
+        "--crate-type=rlib",
+        "--emit=dep-info,metadata",
+        "-Clink-arg=-fuse-ld=mold",
+        "src/lib.rs",
+    ]);
+    let invocation = RustcInvocation::parse(&library)
+        .expect("a `-fuse-ld` selection is inert where nothing links");
+    assert_eq!(invocation.fuse_ld(), Some("mold"));
+}
+
+/// The first link argument the adapter modeled: ld64's `-oso_prefix` names a
 /// checkout-specific path, so its value normalizes like every other path in
 /// the key instead of pinning the key to one checkout's spelling.
 #[test]

--- a/crates/mbx/src/linker.rs
+++ b/crates/mbx/src/linker.rs
@@ -98,7 +98,23 @@ fn file_probes() -> FileProbes {
 /// Memoized through the agent for the life of the build, since the answer is
 /// the same for every link in it and the probes are several processes.
 /// Describe the default linker, or a recognized Windows linker override.
-pub(crate) fn identity_for(override_linker: Option<&Path>) -> Result<LinkerIdentity> {
+///
+/// `fuse_ld` is a `-fuse-ld=<name>` selection the adapter modeled for a
+/// native link: the driver stays `cc`, but the linker it invokes becomes
+/// `ld.<name>`, which is resolved and pinned in place of the default `ld`.
+/// The resolved linker path joins the memoization key, never the raw
+/// selector: which `ld.<name>` a driver invokes depends on its own search
+/// path, COMPILER_PATH, and PATH, so a key holding only `mold` could stand
+/// for two different linkers.
+pub(crate) fn identity_for(
+    override_linker: Option<&Path>,
+    fuse_ld: Option<&str>,
+) -> Result<LinkerIdentity> {
+    if fuse_ld.is_some() && (cfg!(windows) || override_linker.is_some()) {
+        bail!(
+            "a `-fuse-ld` selection with an overridden or Windows linker is not one mbx can identify"
+        );
+    }
     let driver = if let Some(linker) = override_linker {
         if !cfg!(windows)
             || !linker
@@ -120,14 +136,20 @@ pub(crate) fn identity_for(override_linker: Option<&Path>) -> Result<LinkerIdent
     } else {
         which::which("cc").wrap_err("failed to find the linker driver `cc`")?
     };
-    let environment = IDENTITY_ENVIRONMENT
+    let mut environment = IDENTITY_ENVIRONMENT
         .iter()
         .map(|name| ((*name).into(), std::env::var(name).ok()))
         .collect::<BTreeMap<_, _>>();
+    let fuse_ld = fuse_ld
+        .map(|selection| resolve_fuse_ld(&driver, selection))
+        .transpose()?;
+    if let Some(program) = &fuse_ld {
+        environment.insert("MBX_FUSE_LD".into(), Some(program.display().to_string()));
+    }
     if let Some(cached) = find_recorded(&driver, &environment)? {
         return Ok(cached);
     }
-    let identity = probe(&driver)?;
+    let identity = probe(&driver, fuse_ld.as_deref())?;
     record(&driver, &environment, &identity)?;
     Ok(identity)
 }
@@ -165,7 +187,7 @@ fn record(
     }
 }
 
-fn probe(driver: &Path) -> Result<LinkerIdentity> {
+fn probe(driver: &Path, fuse_ld: Option<&Path>) -> Result<LinkerIdentity> {
     if cfg!(windows) {
         return probe_windows(driver);
     }
@@ -175,7 +197,7 @@ fn probe(driver: &Path) -> Result<LinkerIdentity> {
             .ok_or_else(|| eyre::eyre!("the linker driver path is not valid UTF-8"))?
             .to_owned(),
         driver_version: run(driver, &["--version"])?,
-        linker_version: linker_version(driver)?,
+        linker_version: linker_version(driver, fuse_ld)?,
         crt_objects: crt_objects(driver)?,
         sdk: sdk_identity()?,
         deployment_target: std::env::var("MACOSX_DEPLOYMENT_TARGET").ok(),
@@ -437,12 +459,56 @@ fn windows_crt_objects_in(directories: &[PathBuf]) -> Result<BTreeMap<String, Ca
     Ok(resolved)
 }
 
+/// Resolve a `-fuse-ld=<name>` selection to the linker binary the driver
+/// will invoke. The driver answers from its own search path first, which
+/// covers COMPILER_PATH and toolchain-internal linkers; a name it does not
+/// know falls back to PATH. An absolute selection names the linker directly.
+fn resolve_fuse_ld(driver: &Path, selection: &str) -> Result<PathBuf> {
+    if Path::new(selection).is_absolute() {
+        return Ok(PathBuf::from(selection));
+    }
+    let name = format!("ld.{selection}");
+    let argument = format!("-print-prog-name={name}");
+    let printed = run(driver, &[argument.as_str()])
+        .wrap_err_with(|| format!("the linker driver named nothing for `{name}`"))?;
+    let candidate = PathBuf::from(&printed);
+    if candidate.is_absolute() && candidate.exists() {
+        return Ok(candidate);
+    }
+    which::which(&name).wrap_err_with(|| {
+        format!(
+            "`-fuse-ld={selection}` selects `{name}`, which neither the driver nor PATH provides"
+        )
+    })
+}
+
 /// Version of the linker the driver selects, as opposed to the driver itself.
 ///
 /// ld reports through stderr on some platforms and stdout on others, so both
 /// are read; only the first line is kept, since later ones list supported
 /// emulations that say nothing about the version.
-fn linker_version(driver: &Path) -> Result<String> {
+fn linker_version(driver: &Path, fuse_ld: Option<&Path>) -> Result<String> {
+    if let Some(program) = fuse_ld {
+        // Already resolved to the binary the driver invokes; pin both its
+        // path and its version line: on content-addressed toolchains the
+        // path alone identifies the build, and elsewhere the version line
+        // names what a path cannot.
+        let output = Command::new(program)
+            .arg("-v")
+            .output()
+            .wrap_err_with(|| format!("failed to query the linker {}", program.display()))?;
+        let combined = if output.stdout.is_empty() {
+            output.stderr
+        } else {
+            output.stdout
+        };
+        let text = String::from_utf8_lossy(&combined);
+        let version = text.lines().next().unwrap_or_default().trim();
+        if version.is_empty() {
+            bail!("{} reported no version", program.display());
+        }
+        return Ok(format!("{}: {version}", program.display()));
+    }
     // Asked of the driver rather than resolved from PATH: the `ld` a shell
     // would find is not necessarily the one this driver invokes, and a key
     // naming the wrong linker is worse than no key at all.

--- a/crates/mbx/src/linker_tests.rs
+++ b/crates/mbx/src/linker_tests.rs
@@ -73,7 +73,41 @@ fn the_identity_round_trips_through_its_recorded_form() {
 /// Probe this host without the agent round-trip the real path memoizes through.
 fn identity_without_agent() -> Result<LinkerIdentity> {
     let driver = which::which("cc")?;
-    probe(&driver)
+    probe(&driver, None)
+}
+
+/// A `-fuse-ld` selection is resolved through the driver first, and a
+/// selection naming nothing the driver or PATH can find is an error rather
+/// than a key pointing at a linker nobody pinned.
+#[test]
+fn a_fuse_ld_selection_resolves_or_is_refused() {
+    let Ok(driver) = which::which("cc") else {
+        return;
+    };
+
+    let bogus = resolve_fuse_ld(&driver, "definitely-not-a-real-linker");
+    assert!(
+        bogus.is_err(),
+        "a nonexistent linker must not resolve: {bogus:?}"
+    );
+
+    // An absolute selection names the linker directly, no resolution needed.
+    let direct = Path::new(if cfg!(windows) { "C:/ld" } else { "/opt/ld" });
+    assert_eq!(
+        resolve_fuse_ld(&driver, direct.to_str().unwrap()).unwrap(),
+        direct
+    );
+
+    // Whatever the host does provide resolves to an absolute path that
+    // exists: anything less could alias two linkers in one memoization key.
+    for name in ["mold", "lld", "bfd", "gold"] {
+        if let Ok(program) = resolve_fuse_ld(&driver, name) {
+            assert!(
+                program.is_absolute() && program.exists(),
+                "{name} resolved to {program:?}"
+            );
+        }
+    }
 }
 
 /// The probe names are platform knowledge, but the rule about them is not:

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1067,7 +1067,7 @@ fn linker_for(invocation: &RustcInvocation) -> Result<Option<LinkerIdentity>> {
     if !invocation.links_natively() {
         return Ok(None);
     }
-    match crate::linker::identity_for(invocation.linker_override()) {
+    match crate::linker::identity_for(invocation.linker_override(), invocation.fuse_ld()) {
         Ok(identity) => Ok(Some(identity)),
         Err(error) => Err(BypassReason::UnportableNativeLink(format!(
             "the linker could not be identified: {error:#}"

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -120,6 +120,51 @@ test_binary() {
   assert_success
 }
 
+@test "a -fuse-ld selection restores a linked test binary" {
+  # Any alternate linker proves the path: the selection must resolve, join
+  # the linker identity, and still restore. Skip where none is installed.
+  local selection
+  if command -v ld.mold >/dev/null; then
+    selection=mold
+  elif command -v ld.lld >/dev/null; then
+    selection=lld
+  else
+    skip "no alternate linker (ld.mold or ld.lld) on PATH"
+  fi
+
+  local first_target="$BATS_TEST_TMPDIR/fuse-ld-first"
+  local second_target="$BATS_TEST_TMPDIR/fuse-ld-second"
+  local warm_report="$BATS_TEST_TMPDIR/fuse-ld-warm.json"
+  local bypasses="$BATS_TEST_TMPDIR/fuse-ld-bypasses.tsv"
+
+  run env \
+    CARGO_TARGET_DIR="$first_target" \
+    RUSTFLAGS="-C link-arg=-fuse-ld=$selection" \
+    "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+
+  run env \
+    CARGO_TARGET_DIR="$second_target" \
+    RUSTFLAGS="-C link-arg=-fuse-ld=$selection" \
+    MBX_STATS_REPORT="$warm_report" \
+    MBX_BYPASS_LOG="$bypasses" \
+    "$MBX_BIN" test --offline --no-run --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  # The library and the linked test binary, as in the default-linker case.
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*[2-9]' "$warm_report"
+  assert_success
+  # The selection is modeled, so nothing may bypass as unmodeled.
+  run grep -E '^unmodeled-link-argument' "$bypasses"
+  assert_failure
+
+  local restored
+  restored="$(test_binary "$second_target")"
+  assert_file_exists "$restored"
+  assert_file_executable "$restored"
+  run "$restored"
+  assert_success
+}
+
 @test "MBX_CACHE_LINKS=0 keeps native links outside the cache" {
   local target="$BATS_TEST_TMPDIR/refused-target"
   local bypasses="$BATS_TEST_TMPDIR/bypasses.tsv"


### PR DESCRIPTION
A `-C link-arg=-fuse-ld=<name>` on a native link selects which linker the driver invokes, and the adapter previously declined every such invocation as an unmodeled link argument: in a mold-rustflags workspace that is one bypass per linking compilation.

The adapter now parses the selection into a structured argument. Native links admit it; the linker identity probe resolves the selected `ld.<name>` through the driver first (`-print-prog-name`, covering `COMPILER_PATH` and toolchain-internal linkers) with a PATH fallback, and pins path plus version line in `linker_version`. The resolved absolute path, never the raw selector, joins the identity memoization key, so links through different `ld.<name>` builds never share an identity. Wasm and other non-native link outputs, conflicting duplicate selections, and Windows/overridden-linker combinations still bypass. Where nothing links the selection is inert and the key carries its text, so existing keys are untouched and the change is purely additive.

## Test plan

- [x] Unit: selector-dependent action keys, conflicting duplicate selections, wasm rejection, inert linkless compilations
- [x] Unit: resolution failures and absolute-path selections (`a_fuse_ld_selection_resolves_or_is_refused`)
- [x] E2e (bats): a mold-linked test binary restores through two distinct target directories; skips where no `ld.mold`/`ld.lld` exists
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo test --workspace` (723 tests) green locally

Refs https://github.com/jdx/mr-boxington/discussions/237
