### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.10...mbx-cache-cargo-v0.1.11) - 2026-09-01
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.9...mbx-cache-cargo-v0.1.10) - 2026-08-31
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.10"
+version = "0.1.11"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.10.2"
+version = "0.10.3"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.2...mbx-cache-core-v0.10.3) - 2026-09-01
+
+### Added
+
+- *(cache)* model -fuse-ld linker selection for native links ([#254](https://github.com/jdx/mr-boxington/pull/254))
+
 ## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.1...mbx-cache-core-v0.10.2) - 2026-08-31
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.10.2"
+version = "0.10.3"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.2...mbx-cache-rustc-v0.10.3) - 2026-09-01
+
+### Added
+
+- *(cache)* model -fuse-ld linker selection for native links ([#254](https://github.com/jdx/mr-boxington/pull/254))
+
 ## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.1...mbx-cache-rustc-v0.10.2) - 2026-08-31
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.10.2"
+version = "0.10.3"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.10...mbx-cache-store-v0.1.11) - 2026-09-01
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.9...mbx-cache-store-v0.1.10) - 2026-08-31
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.10"
+version = "0.1.11"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.2", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.10", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.2", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.2", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.10", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.11", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.3", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.3", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.11", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.10.2 -> 0.10.3 (✓ API compatible changes)
* `mbx-cache-cc`: 0.10.2 -> 0.10.3
* `mbx-cache-rustc`: 0.10.2 -> 0.10.3 (✓ API compatible changes)
* `mbx`: 1.3.0 -> 1.3.1
* `mbx-cache-cargo`: 0.1.10 -> 0.1.11
* `mbx-cache-store`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.10.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.2...mbx-cache-core-v0.10.3) - 2026-09-01

### Added

- *(cache)* model -fuse-ld linker selection for native links ([#254](https://github.com/jdx/mr-boxington/pull/254))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.1...mbx-cache-cc-v0.10.2) - 2026-08-31

### Added

- *(setup)* use mise command wrappers ([#249](https://github.com/jdx/mr-boxington/pull/249))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.10.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.2...mbx-cache-rustc-v0.10.3) - 2026-09-01

### Added

- *(cache)* model -fuse-ld linker selection for native links ([#254](https://github.com/jdx/mr-boxington/pull/254))
</blockquote>

## `mbx`

<blockquote>

## [1.3.1](https://github.com/jdx/mr-boxington/compare/v1.3.0...v1.3.1) - 2026-09-01

### Fixed

- avoid reentering mise Cargo wrappers ([#252](https://github.com/jdx/mr-boxington/pull/252))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.10...mbx-cache-cargo-v0.1.11) - 2026-09-01

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.10...mbx-cache-store-v0.1.11) - 2026-09-01

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships cache-key behavior for native links (`-fuse-ld`); wrong modeling could cause incorrect hits or excess misses, though the diff here is versioning and metadata only.
> 
> **Overview**
> **Release-only PR** that bumps crate versions, refreshes `Cargo.lock`, and records changelog entries for a coordinated publish—no application logic changes in this diff.
> 
> The highlighted user-facing change in the release notes is **`-fuse-ld` linker selection modeled in cache keys for native link actions** (`mbx-cache-core` / `mbx-cache-rustc` 0.10.3, from [#254](https://github.com/jdx/mr-boxington/pull/254)). Dependent crates (`mbx-cache-cargo`, `mbx-cache-store`, `mbx-cache-cc`, `mbx`) only pick up the new `mbx-cache-core` path dependency versions (0.1.11 / 0.10.3) and matching changelog “updated local packages” lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76911676d901e94081c78b53c4ad558effd42fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->