### PR TITLE
fix: share predictions across Cargo commands

### DIFF
--- a/crates/mbx-cache-cargo/src/lib.rs
+++ b/crates/mbx-cache-cargo/src/lib.rs
@@ -70,18 +70,22 @@ pub fn resolve(
 struct ActionIdentity<'a> {
     version: u8,
     workspace: &'a str,
-    command: &'a [String],
     os: &'static str,
     arch: &'static str,
 }
 
 /// Derive the prediction-manifest identity used by mbx for a Cargo command.
-pub fn build_identity(workspace_root: &Path, command: &[String]) -> String {
+///
+/// The command is accepted for API compatibility but deliberately does not
+/// enter the identity. rustc invocation digests distinguish profiles,
+/// features, targets, and compiler toolchains; keeping the surrounding Cargo
+/// command here would prevent equivalent dependency compilations from sharing
+/// predictions across `build`, `test`, and Clippy.
+pub fn build_identity(workspace_root: &Path, _command: &[String]) -> String {
     let workspace = workspace_marker(workspace_root);
     let bytes = canonical_json(&ActionIdentity {
-        version: 2,
+        version: 3,
         workspace: &workspace,
-        command,
         os: std::env::consts::OS,
         arch: std::env::consts::ARCH,
     })
@@ -299,6 +303,25 @@ mod tests {
         assert_eq!(
             build_identity(left.path(), &command),
             build_identity(right.path(), &command)
+        );
+    }
+
+    #[test]
+    fn cargo_commands_and_toolchain_selectors_share_predictions() {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join("Cargo.lock"), "same").unwrap();
+
+        let build = vec!["build".to_string()];
+        let test = vec!["test".to_string(), "--workspace".to_string()];
+        let msrv = vec!["+1.91".to_string(), "check".to_string()];
+
+        assert_eq!(
+            build_identity(project.path(), &build),
+            build_identity(project.path(), &test),
+        );
+        assert_eq!(
+            build_identity(project.path(), &build),
+            build_identity(project.path(), &msrv),
         );
     }
 

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -266,9 +266,10 @@ fn identity_follows_the_dependency_graph_not_the_path() {
         build_identity(first.path(), &command),
         build_identity(second.path(), &command),
     );
-    assert_ne!(
+    assert_eq!(
         build_identity(first.path(), &command),
         build_identity(first.path(), &["test".to_string()]),
+        "Cargo commands in one dependency graph should share predictions",
     );
 }
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -196,10 +196,20 @@ fn build_with(
     report: &Path,
     settings: &[(&str, &str)],
 ) -> (serde_json::Value, String) {
+    cargo_with(project, store, report, &["build", "--offline"], settings)
+}
+
+fn cargo_with(
+    project: &Path,
+    store: &Path,
+    report: &Path,
+    arguments: &[&str],
+    settings: &[(&str, &str)],
+) -> (serde_json::Value, String) {
     let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
     command
         .current_dir(project)
-        .args(["build", "--offline"])
+        .args(arguments)
         .env("MBX_CACHE_DIR", store)
         .env("MBX_STATS_REPORT", report)
         // Cargo's own environment for this test would otherwise redirect the
@@ -918,6 +928,40 @@ fn restores_a_wiped_target_directory_from_the_store() {
     assert!(
         count(&warm, "estimated_compiler_duration_avoided_ns") > 0,
         "a warm build should report the compiler time recorded by its cold build: {warm}"
+    );
+}
+
+#[test]
+fn restores_predictions_across_equivalent_cargo_commands() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    build(
+        project.path(),
+        store.path(),
+        &reports.path().join("cold.json"),
+    );
+    wipe_target(project.path());
+
+    let warm = cargo_with(
+        project.path(),
+        store.path(),
+        &reports.path().join("warm.json"),
+        &["build", "--offline", "--workspace"],
+        &[],
+    )
+    .0;
+
+    assert!(
+        count(&warm, "hits") > 0,
+        "adding a Cargo selector should not discard learned predictions: {warm}"
+    );
+    assert_eq!(
+        count(&warm, "unconsulted"),
+        0,
+        "equivalent compilations should all have predictions: {warm}"
     );
 }
 


### PR DESCRIPTION
## Summary

- scope prediction manifests to the workspace dependency graph instead of the full Cargo command
- let equivalent compilations reuse learned predictions across build, test, Clippy, and toolchain selectors
- add unit and integration coverage for cross-command restores

The rustc action digest still includes the compiler identity, arguments, environment, and inputs, so toolchains, features, profiles, and targets remain isolated at the artifact level.

## Tests

- `cargo test -p mbx-cache-cargo`
- `cargo test -p mbx --test build restores_predictions_across_equivalent_cargo_commands -- --nocapture`
- `cargo test -p mbx-cache-cargo -p mbx` (314 unit tests and 48/50 concurrent integration tests passed; the two failures passed when rerun individually outside the outer mbx Cargo shim)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumping manifest identity version invalidates existing prediction manifests until rebuilt; broader manifest sharing could theoretically reuse predictions across commands that compile differently, though rustc-level digests are intended to keep artifacts isolated.
> 
> **Overview**
> **Prediction manifests are now keyed by workspace dependency graph (lockfile + host OS/arch), not the full Cargo argv.**
> 
> `build_identity` bumps identity **version 3** and drops `command` from the hashed `ActionIdentity`, so `build`, `test`, Clippy, and toolchain selectors like `+1.91 check` reuse the same manifest when the workspace is unchanged. The `command` parameter remains for API compatibility only; per-invocation isolation still comes from rustc action digests (profile, features, toolchain, etc.).
> 
> Tests assert equal identities across commands, flip session expectations from `build` ≠ `test`, and add an e2e case: cold `build`, wipe `target`, warm `build --workspace` must hit with zero `unconsulted`. Integration helpers gain `cargo_with` for arbitrary mbx/cargo argument lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71462fde7ff0f202c3e8d4127fdc75ca530dd9be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->