### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "dirs",
  "mbx-cache-core",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.11...mbx-cache-cargo-v0.1.12) - 2026-09-01
+
+### Fixed
+
+- share predictions across Cargo commands ([#256](https://github.com/jdx/mr-boxington/pull/256))
+
 ## [0.1.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.10...mbx-cache-cargo-v0.1.11) - 2026-09-01
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.11"
+version = "0.1.12"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2](https://github.com/jdx/mr-boxington/compare/v1.3.1...v1.3.2) - 2026-09-01
+
+### Fixed
+
+- share predictions across Cargo commands ([#256](https://github.com/jdx/mr-boxington/pull/256))
+
 ## [1.3.1](https://github.com/jdx/mr-boxington/compare/v1.3.0...v1.3.1) - 2026-09-01
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.3.1"
+version = "1.3.2"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -25,7 +25,7 @@ fslock = "0.2"
 log = "0.4"
 memchr = "2"
 mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.11", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.12", default-features = false }
 mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.3", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.10.3", default-features = false }
 mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.11", default-features = false }

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.3.1
+**Version:** 1.3.2
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-cargo`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `mbx`: 1.3.1 -> 1.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-cargo`

<blockquote>

## [0.1.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.11...mbx-cache-cargo-v0.1.12) - 2026-09-01

### Fixed

- share predictions across Cargo commands ([#256](https://github.com/jdx/mr-boxington/pull/256))
</blockquote>

## `mbx`

<blockquote>

## [1.3.2](https://github.com/jdx/mr-boxington/compare/v1.3.1...v1.3.2) - 2026-09-01

### Fixed

- share predictions across Cargo commands ([#256](https://github.com/jdx/mr-boxington/pull/256))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog updates only; no runtime code changes in this diff.
> 
> **Overview**
> **Release-only PR** (release-plz) that publishes **mbx 1.3.2** and **mbx-cache-cargo 0.1.12** with matching `Cargo.lock` and dependency version pins.
> 
> Both changelogs record one fix from [#256](https://github.com/jdx/mr-boxington/pull/256): **Cargo action predictions are shared across commands** (e.g. `build`, `test`, Clippy) instead of being keyed per subcommand, so equivalent dependency compilations can reuse the same prediction manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15cc1fe51b80ea54290acff7a76abdd8289641e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->