### PR TITLE
fix(cache): map symlinked Cargo registries

### DIFF
--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -696,7 +696,15 @@ fn restore(action: &CacheDigest, action_bytes: &[u8]) -> Result<Option<Restored>
     }))
 }
 
+/// Roots whose machine-specific spellings may appear in build-script state.
 fn build_script_mappings() -> Vec<PathMapping> {
+    build_script_mappings_with_env(|name| std::env::var_os(name).map(PathBuf::from))
+}
+
+/// Construct build-script mappings from an injectable environment lookup.
+fn build_script_mappings_with_env(
+    environment: impl Fn(&str) -> Option<PathBuf>,
+) -> Vec<PathMapping> {
     let mut mappings = Vec::new();
     for (name, placeholder) in [
         ("OUT_DIR", "build_script_out_dir"),
@@ -704,11 +712,16 @@ fn build_script_mappings() -> Vec<PathMapping> {
         (session::WORKSPACE_ROOT_ENV, "workspace"),
         (session::TARGET_DIR_ENV, "target"),
     ] {
-        if let Some(root) = std::env::var_os(name) {
+        if let Some(root) = environment(name) {
             mappings.push(PathMapping::new(root, placeholder));
         }
     }
-    if let Some(cargo_home) = std::env::var_os("CARGO_HOME").map(PathBuf::from) {
+    let cargo_home = environment("CARGO_HOME").or_else(|| {
+        ["HOME", "USERPROFILE"]
+            .into_iter()
+            .find_map(|name| environment(name).map(|home| home.join(".cargo")))
+    });
+    if let Some(cargo_home) = cargo_home {
         mappings.push(PathMapping::new(
             cargo_home.join("registry"),
             "cargo_registry",
@@ -842,6 +855,27 @@ mod tests {
             .unwrap();
         assert!(parsed.default_package);
         assert_eq!(parsed.inputs, ["${build_script_manifest_dir}"]);
+    }
+
+    #[test]
+    fn build_script_mappings_use_the_default_cargo_home() {
+        let home = PathBuf::from("/home/builder");
+        let mappings = build_script_mappings_with_env(|name| match name {
+            "HOME" => Some(home.clone()),
+            _ => None,
+        });
+
+        assert_eq!(
+            normalize_environment_value(
+                "/home/builder/.cargo/registry/src/index/widget-1.0.0/src/lib.rs",
+                &mappings,
+            ),
+            "${cargo_registry}/src/index/widget-1.0.0/src/lib.rs"
+        );
+        assert_eq!(
+            normalize_environment_value("/home/builder/.cargo/bin", &mappings),
+            "${cargo_home}/bin"
+        );
     }
 
     #[test]

--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -859,22 +859,35 @@ mod tests {
 
     #[test]
     fn build_script_mappings_use_the_default_cargo_home() {
-        let home = PathBuf::from("/home/builder");
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("home");
         let mappings = build_script_mappings_with_env(|name| match name {
             "HOME" => Some(home.clone()),
             _ => None,
         });
+        let registry_input = home
+            .join(".cargo")
+            .join("registry")
+            .join("src")
+            .join("index")
+            .join("widget-1.0.0")
+            .join("src")
+            .join("lib.rs");
+        let registry_key = PathBuf::from("${cargo_registry}")
+            .join("src")
+            .join("index")
+            .join("widget-1.0.0")
+            .join("src")
+            .join("lib.rs");
 
         assert_eq!(
-            normalize_environment_value(
-                "/home/builder/.cargo/registry/src/index/widget-1.0.0/src/lib.rs",
-                &mappings,
-            ),
-            "${cargo_registry}/src/index/widget-1.0.0/src/lib.rs"
+            normalize_environment_value(&registry_input.to_string_lossy(), &mappings),
+            registry_key.to_string_lossy()
         );
+        let cargo_bin = home.join(".cargo").join("bin");
         assert_eq!(
-            normalize_environment_value("/home/builder/.cargo/bin", &mappings),
-            "${cargo_home}/bin"
+            normalize_environment_value(&cargo_bin.to_string_lossy(), &mappings),
+            PathBuf::from("${cargo_home}").join("bin").to_string_lossy()
         );
     }
 

--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -703,11 +703,17 @@ fn build_script_mappings() -> Vec<PathMapping> {
         ("CARGO_MANIFEST_DIR", "build_script_manifest_dir"),
         (session::WORKSPACE_ROOT_ENV, "workspace"),
         (session::TARGET_DIR_ENV, "target"),
-        ("CARGO_HOME", "cargo_home"),
     ] {
         if let Some(root) = std::env::var_os(name) {
             mappings.push(PathMapping::new(root, placeholder));
         }
+    }
+    if let Some(cargo_home) = std::env::var_os("CARGO_HOME").map(PathBuf::from) {
+        mappings.push(PathMapping::new(
+            cargo_home.join("registry"),
+            "cargo_registry",
+        ));
+        mappings.push(PathMapping::new(cargo_home, "cargo_home"));
     }
     mappings
 }

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -625,12 +625,14 @@ fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
     };
     add(session_path(session::TARGET_DIR_ENV), "target");
     add(session_path(session::WORKSPACE_ROOT_ENV), "workspace");
+    let cargo_home = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cargo")));
     add(
-        std::env::var_os("CARGO_HOME")
-            .map(PathBuf::from)
-            .or_else(|| dirs::home_dir().map(|home| home.join(".cargo"))),
-        "cargo_home",
+        cargo_home.as_ref().map(|home| home.join("registry")),
+        "cargo_registry",
     );
+    add(cargo_home, "cargo_home");
     add(
         std::env::var_os("RUSTUP_HOME")
             .map(PathBuf::from)

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1856,6 +1856,7 @@ fn path_mappings(
     })
 }
 
+/// Construct compiler mappings from an injectable environment lookup.
 fn path_mappings_with_env(
     working_dir: &Path,
     target_output: Option<&Path>,

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1887,19 +1887,37 @@ fn path_mappings_with_env(
     }) {
         add_mapping(&mut mappings, &mut roots, root, "target");
     }
-    for (name, placeholder) in [
-        (session::WORKSPACE_ROOT_ENV, "workspace"),
-        ("CARGO_HOME", "cargo_home"),
-        ("RUSTUP_HOME", "rustup_home"),
-    ] {
-        if let Some(root) = environment(name).map(PathBuf::from)
-            && root.is_absolute()
-        {
-            add_mapping(&mut mappings, &mut roots, root, placeholder);
-        }
+    if let Some(root) = environment(session::WORKSPACE_ROOT_ENV)
+        .map(PathBuf::from)
+        .filter(|root| root.is_absolute())
+    {
+        add_mapping(&mut mappings, &mut roots, root, "workspace");
+    }
+    let cargo_home = environment("CARGO_HOME")
+        .map(PathBuf::from)
+        .filter(|root| root.is_absolute())
+        .or_else(|| home_roots.first().map(|home| home.join(".cargo")));
+    if let Some(root) = cargo_home {
+        // The registry is its own semantic root because container builds often
+        // mount it elsewhere and leave a symlink below CARGO_HOME. Resolving
+        // this deeper mapping follows that symlink without making arbitrary
+        // paths outside Cargo's registry portable.
+        add_mapping(
+            &mut mappings,
+            &mut roots,
+            root.join("registry"),
+            "cargo_registry",
+        );
+        add_mapping(&mut mappings, &mut roots, root, "cargo_home");
+    }
+    if let Some(root) = environment("RUSTUP_HOME")
+        .map(PathBuf::from)
+        .filter(|root| root.is_absolute())
+    {
+        add_mapping(&mut mappings, &mut roots, root, "rustup_home");
     }
     if let Some(home) = home_roots.first() {
-        for (directory, placeholder) in [(".cargo", "cargo_home"), (".rustup", "rustup_home")] {
+        for (directory, placeholder) in [(".rustup", "rustup_home")] {
             if !mappings
                 .iter()
                 .any(|mapping| mapping.placeholder == placeholder)

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -301,10 +301,42 @@ fn standalone_registry_mapping_uses_the_default_cargo_home() {
     assert!(mappings.iter().any(|mapping| {
         mapping.placeholder == "cargo_home" && mapping.root == home.join(".cargo")
     }));
+    assert!(mappings.iter().any(|mapping| {
+        mapping.placeholder == "cargo_registry" && mapping.root == home.join(".cargo/registry")
+    }));
     assert!(
         !mappings
             .iter()
             .any(|mapping| mapping.placeholder == "workspace")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cargo_registry_mapping_follows_a_child_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let cargo_home = directory.path().join("cargo-home");
+    let physical_registry = directory.path().join("host-cargo-registry");
+    std::fs::create_dir_all(&cargo_home).unwrap();
+    std::fs::create_dir_all(&physical_registry).unwrap();
+    symlink(&physical_registry, cargo_home.join("registry")).unwrap();
+    let source = physical_registry.join("src/index/widget-1.0.0/src/lib.rs");
+
+    let mappings = PathMapping::ordered(&path_mappings_with_env(
+        directory.path(),
+        None,
+        None,
+        |name| match name {
+            "CARGO_HOME" => Some(cargo_home.as_os_str().to_owned()),
+            _ => None,
+        },
+    ));
+
+    assert_eq!(
+        normalize_mapped_path(&source, directory.path(), &mappings).unwrap(),
+        "${cargo_registry}/src/index/widget-1.0.0/src/lib.rs"
     );
 }
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -74,6 +74,26 @@ start fresh:
 The operating system and architecture are included in generated keys. Advanced
 workflows can provide complete `cache-key` and `restore-keys` inputs.
 
+### Docker builds
+
+Mount the mbx store and Cargo registry into the container at stable locations.
+The registry may either be mounted directly at `$CARGO_HOME/registry` or
+mounted elsewhere and symlinked from there:
+
+```sh
+docker run --rm \
+  --env CARGO_HOME=/tmp/cargo-home \
+  --env HOME=/tmp/build-home \
+  --mount "type=bind,source=$HOME/.cargo/registry,target=/tmp/host-cargo-registry" \
+  --mount "type=bind,source=$HOME/.cache/mbx,target=/tmp/build-home/.cache/mbx" \
+  builder \
+  sh -c 'mkdir -p "$CARGO_HOME" && ln -s /tmp/host-cargo-registry "$CARGO_HOME/registry" && mbx build'
+```
+
+mbx maps the registry separately from the rest of `CARGO_HOME`, so cached
+compiler inputs remain portable when that child symlink resolves outside the
+Cargo home directory.
+
 ### Closure bundles for action transports
 
 An action can transport only the cache entries produced or used by its builds,


### PR DESCRIPTION
## Summary

- map `$CARGO_HOME/registry` as its own stable cache root
- preserve cacheability when that registry path is a child symlink to a bind mount outside `CARGO_HOME`
- apply the mapping to rustc, C/C++, and build-script caching
- document Docker registry and mbx cache mounts

Fixes the path-mapping failure reported in discussion #258.

## Tests

- `cargo test -p mbx-cache-core -p mbx-cache-rustc -p mbx-cache-cc -p mbx --lib`
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core path-normalization for all compiler caches; behavior change is scoped to Cargo home/registry layout but incorrect mapping could cause cache misses or wrong hits.
> 
> **Overview**
> Introduces a separate **`${cargo_registry}`** path root for `$CARGO_HOME/registry` alongside **`${cargo_home}`**, so compiler and build-script cache keys stay portable when the registry is bind-mounted elsewhere and only linked from under `CARGO_HOME` (e.g. Docker).
> 
> The same mapping logic is applied in **rustc**, **C/C++**, and **build-script** normalization; build-script mappings are refactored behind an injectable env helper for tests. **Docs** add a Docker example for mounting the mbx store and registry.
> 
> New tests cover default-home registry normalization and (on Unix) that paths under a symlinked registry resolve to `${cargo_registry}/…` rather than breaking cache portability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e113099a207e38896c8c029a398fa334fb3b3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved path handling for Cargo caches and registries, including registries located through symlinks.
  * Enhanced portability of cached compiler inputs across different environments.

* **Documentation**
  * Added guidance and an example for running mbx in Docker with mounted Cargo and mbx caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->