### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "blake3",
  "eyre",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.12...mbx-cache-cargo-v0.1.13) - 2026-09-02
+
+### Fixed
+
+- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
+- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
+
+### Other
+
+- preserve Cargo rustc probe cache ([#268](https://github.com/jdx/mr-boxington/pull/268))
+
 ## [0.1.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.11...mbx-cache-cargo-v0.1.12) - 2026-09-01
 
 ### Fixed

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.12"
+version = "0.1.13"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.3...mbx-cache-cc-v0.11.0) - 2026-09-02
+
+### Fixed
+
+- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
+- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
+- *(cache)* model no-input assembler options ([#266](https://github.com/jdx/mr-boxington/pull/266))
+
 ## [0.10.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.1...mbx-cache-cc-v0.10.2) - 2026-08-31
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.10.3"
+version = "0.11.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.3...mbx-cache-core-v0.11.0) - 2026-09-02
+
+### Added
+
+- explain cache misses from session history ([#274](https://github.com/jdx/mr-boxington/pull/274))
+
+### Fixed
+
+- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
+- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
+- cache clippy workspace compilations ([#273](https://github.com/jdx/mr-boxington/pull/273))
+- *(cache)* include remote error response details ([#275](https://github.com/jdx/mr-boxington/pull/275))
+
+### Other
+
+- preserve Cargo rustc probe cache ([#268](https://github.com/jdx/mr-boxington/pull/268))
+
 ## [0.10.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.2...mbx-cache-core-v0.10.3) - 2026-09-01
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.10.3"
+version = "0.11.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.10" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.11" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.10...mbx-cache-protocol-v0.5.11) - 2026-09-02
+
+### Fixed
+
+- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
+- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
+
 ## [0.5.10](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.9...mbx-cache-protocol-v0.5.10) - 2026-08-31
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.10"
+version = "0.5.11"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.3...mbx-cache-rustc-v0.11.0) - 2026-09-02
+
+### Fixed
+
+- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
+- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
+- cache clippy workspace compilations ([#273](https://github.com/jdx/mr-boxington/pull/273))
+
 ## [0.10.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.2...mbx-cache-rustc-v0.10.3) - 2026-09-01
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.11...mbx-cache-store-v0.1.12) - 2026-09-02
+
+### Fixed
+
+- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
+- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
+
 ## [0.1.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.10...mbx-cache-store-v0.1.11) - 2026-09-01
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.11"
+version = "0.1.12"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/jdx/mr-boxington/compare/v1.3.2...v1.4.0) - 2026-09-02
+
+### Added
+
+- explain cache misses from session history ([#274](https://github.com/jdx/mr-boxington/pull/274))
+- add quiet build summaries ([#264](https://github.com/jdx/mr-boxington/pull/264))
+- *(scheduler)* respect build CPU limits ([#267](https://github.com/jdx/mr-boxington/pull/267))
+
+### Fixed
+
+- avoid racing persistent Windows shims ([#276](https://github.com/jdx/mr-boxington/pull/276))
+- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
+- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
+- fix build-script caching and doctor toolchain ([#272](https://github.com/jdx/mr-boxington/pull/272))
+- *(setup)* isolate rust-analyzer target directory ([#261](https://github.com/jdx/mr-boxington/pull/261))
+- cache clippy workspace compilations ([#273](https://github.com/jdx/mr-boxington/pull/273))
+- reuse enclosing sessions for nested cargo ([#265](https://github.com/jdx/mr-boxington/pull/265))
+- handle rustc workspace wrappers ([#263](https://github.com/jdx/mr-boxington/pull/263))
+- *(cache)* map symlinked Cargo registries ([#259](https://github.com/jdx/mr-boxington/pull/259))
+
+### Other
+
+- preserve Cargo rustc probe cache ([#268](https://github.com/jdx/mr-boxington/pull/268))
+- make workspace edit loops incremental ([#271](https://github.com/jdx/mr-boxington/pull/271))
+
 ## [1.3.2](https://github.com/jdx/mr-boxington/compare/v1.3.1...v1.3.2) - 2026-09-01
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.3.2"
+version = "1.4.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.10.3", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.12", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.10.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.13", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.0", default-features = false }
 mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.11", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.12", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.3.2
+**Version:** 1.4.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.10 -> 0.5.11 (✓ API compatible changes)
* `mbx-cache-core`: 0.10.3 -> 0.11.0 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `mbx-cache-cc`: 0.10.3 -> 0.11.0 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.10.3 -> 0.11.0
* `mbx-cache-store`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `mbx`: 1.3.2 -> 1.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.10...mbx-cache-protocol-v0.5.11) - 2026-09-02

### Fixed

- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.3...mbx-cache-core-v0.11.0) - 2026-09-02

### Added

- explain cache misses from session history ([#274](https://github.com/jdx/mr-boxington/pull/274))

### Fixed

- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
- cache clippy workspace compilations ([#273](https://github.com/jdx/mr-boxington/pull/273))
- *(cache)* include remote error response details ([#275](https://github.com/jdx/mr-boxington/pull/275))

### Other

- preserve Cargo rustc probe cache ([#268](https://github.com/jdx/mr-boxington/pull/268))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.12...mbx-cache-cargo-v0.1.13) - 2026-09-02

### Fixed

- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))

### Other

- preserve Cargo rustc probe cache ([#268](https://github.com/jdx/mr-boxington/pull/268))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.3...mbx-cache-cc-v0.11.0) - 2026-09-02

### Fixed

- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
- *(cache)* model no-input assembler options ([#266](https://github.com/jdx/mr-boxington/pull/266))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.3...mbx-cache-rustc-v0.11.0) - 2026-09-02

### Fixed

- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
- cache clippy workspace compilations ([#273](https://github.com/jdx/mr-boxington/pull/273))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.11...mbx-cache-store-v0.1.12) - 2026-09-02

### Fixed

- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
</blockquote>

## `mbx`

<blockquote>

## [1.4.0](https://github.com/jdx/mr-boxington/compare/v1.3.2...v1.4.0) - 2026-09-02

### Added

- explain cache misses from session history ([#274](https://github.com/jdx/mr-boxington/pull/274))
- add quiet build summaries ([#264](https://github.com/jdx/mr-boxington/pull/264))
- *(scheduler)* respect build CPU limits ([#267](https://github.com/jdx/mr-boxington/pull/267))

### Fixed

- avoid racing persistent Windows shims ([#276](https://github.com/jdx/mr-boxington/pull/276))
- fix managed target lifecycle edges ([#269](https://github.com/jdx/mr-boxington/pull/269))
- release cache pinned by phantom checkouts ([#270](https://github.com/jdx/mr-boxington/pull/270))
- fix build-script caching and doctor toolchain ([#272](https://github.com/jdx/mr-boxington/pull/272))
- *(setup)* isolate rust-analyzer target directory ([#261](https://github.com/jdx/mr-boxington/pull/261))
- cache clippy workspace compilations ([#273](https://github.com/jdx/mr-boxington/pull/273))
- reuse enclosing sessions for nested cargo ([#265](https://github.com/jdx/mr-boxington/pull/265))
- handle rustc workspace wrappers ([#263](https://github.com/jdx/mr-boxington/pull/263))
- *(cache)* map symlinked Cargo registries ([#259](https://github.com/jdx/mr-boxington/pull/259))

### Other

- preserve Cargo rustc probe cache ([#268](https://github.com/jdx/mr-boxington/pull/268))
- make workspace edit loops incremental ([#271](https://github.com/jdx/mr-boxington/pull/271))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical versioning, changelog, and lockfile updates only; functional risk lives in the already-merged changes this release tags.
> 
> **Overview**
> **Release-plz** cut that bumps workspace crate versions, refreshes `Cargo.lock`, and adds dated changelog sections—no application source changes in this diff.
> 
> **`mbx` 1.3.2 → 1.4.0** (CLI docs version string updated to match). Documented user-facing work includes cache-miss explanations from session history, quiet build summaries, scheduler CPU limits, plus fixes for managed-target lifecycle, phantom-checkout cache pins, clippy workspace caching, nested Cargo sessions, Windows shim races, build-script caching, and related cache/setup behavior.
> 
> **Library crates** move in lockstep: `mbx-cache-core` / `mbx-cache-cc` / `mbx-cache-rustc` **0.11.0**, `mbx-cache-cargo` **0.1.13**, `mbx-cache-store` **0.1.12**, `mbx-cache-protocol` **0.5.11**, with inter-crate `Cargo.toml` dependency version pins updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad78d5a0a8b7a28c920e56cc1145a1bb7531488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->