### PR TITLE
fix(setup): isolate rust-analyzer target directory

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -83,24 +83,22 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     // Placed before the session starts, because the target directory is what
     // the shim maps out of its cache keys and it has to be the one cargo will
     // actually write to.
-    let (placed, removed_target_bytes) = if migrate_existing {
+    let (placement, removed_target_bytes) = if migrate_existing {
         let outcome = target::migrate_existing(
             config,
             &roots.workspace_root,
             &roots.target_dir,
             roots.target_dir_requested,
         )?;
-        (outcome.managed, outcome.removed_bytes)
-    } else {
         (
-            target::place(
-                config,
-                &roots.workspace_root,
-                &roots.target_dir,
-                roots.target_dir_requested,
-            ),
-            None,
+            TargetViewPlacement {
+                directory: outcome.managed,
+                touch_path: roots.target_dir.clone(),
+            },
+            outcome.removed_bytes,
         )
+    } else {
+        (place_target_view(config, &roots), None)
     };
     if let Some(bytes) = removed_target_bytes {
         crate::session::note(&format!(
@@ -108,13 +106,13 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
             ByteSize::b(bytes).display().iec()
         ));
     }
-    if let Some(directory) = &placed {
+    if let Some(directory) = &placement.directory {
         roots.target_dir = directory.clone();
     } else {
         // Placement declined, but an earlier one may have left a link this
         // build is about to write through. Keep that directory's record fresh
         // so collection does not treat it as idle.
-        target::touch_managed(config, &roots.workspace_root, &roots.target_dir);
+        target::touch_managed(config, &roots.workspace_root, &placement.touch_path);
     }
 
     // Probed rather than assumed, and only on the one run that will say
@@ -146,7 +144,7 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
                 path.display().to_string(),
             );
         }
-        if let Some(directory) = &placed {
+        if let Some(directory) = &placement.directory {
             environment.insert(
                 CARGO_TARGET_DIR_ENV.into(),
                 directory.to_string_lossy().into_owned(),
@@ -197,6 +195,41 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
         Ok((status, stats))
     });
     account_session(config, settings, session_outcome, removed_target_bytes)
+}
+
+pub(super) struct TargetViewPlacement {
+    pub(super) directory: Option<PathBuf>,
+    pub(super) touch_path: PathBuf,
+}
+
+/// Place the editor's explicit target inside the checkout's managed view.
+///
+/// Cargo's `--target-dir` normally opts out of placement. The exact path that
+/// `mbx setup` writes is different: placing its `target` parent first prevents
+/// an editor-first checkout from creating a real directory that would block
+/// managed targets later. Cargo still writes into the requested child, so its
+/// directory lock remains independent from terminal builds.
+pub(super) fn place_target_view(config: &Config, roots: &Roots) -> TargetViewPlacement {
+    let default = roots.workspace_root.join("target");
+    if roots.target_dir_requested
+        && roots.target_dir == roots.workspace_root.join(super::RUST_ANALYZER_TARGET_DIR)
+    {
+        let directory = target::place(config, &roots.workspace_root, &default, false)
+            .map(|_| roots.target_dir.clone());
+        return TargetViewPlacement {
+            directory,
+            touch_path: default,
+        };
+    }
+    TargetViewPlacement {
+        directory: target::place(
+            config,
+            &roots.workspace_root,
+            &roots.target_dir,
+            roots.target_dir_requested,
+        ),
+        touch_path: roots.target_dir.clone(),
+    }
 }
 
 /// Sweep the store and record the session's savings after a build session.

--- a/crates/mbx/src/cli/cargo_tests.rs
+++ b/crates/mbx/src/cli/cargo_tests.rs
@@ -320,6 +320,30 @@ pub(super) fn managed_target_config(root: &Path) -> Config {
 }
 
 #[test]
+fn rust_analyzer_target_is_a_child_of_the_managed_view() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = managed_target_config(directory.path());
+    let workspace = directory.path().join("project");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let roots = Roots {
+        workspace_root: workspace.clone(),
+        target_dir: workspace.join(RUST_ANALYZER_TARGET_DIR),
+        target_dir_requested: true,
+    };
+
+    let placement = place_target_view(&config, &roots);
+
+    let managed = std::fs::read_link(workspace.join("target")).unwrap();
+    assert_eq!(
+        placement.directory.unwrap(),
+        workspace.join(RUST_ANALYZER_TARGET_DIR)
+    );
+    assert!(managed.starts_with(&config.target.root));
+    assert_eq!(placement.touch_path, workspace.join("target"));
+    assert_eq!(crate::target::stats(&config.target.root).unwrap().views, 1);
+}
+
+#[test]
 fn accepting_the_target_prompt_requests_migration_without_removing_outputs() {
     let directory = tempfile::tempdir().unwrap();
     let workspace = directory.path().join("project");

--- a/crates/mbx/src/cli/mod.rs
+++ b/crates/mbx/src/cli/mod.rs
@@ -24,6 +24,7 @@ mod shim;
 mod tui;
 
 const CARGO_SHIM_TARGET_FILE: &str = "mbx-target";
+const RUST_ANALYZER_TARGET_DIR: &str = "target/rust-analyzer";
 
 pub(crate) use cargo::{cargo_with_bypass_log, cargo_with_settings_and_bypass_log};
 pub(crate) use setup::{cargo_shim_is_current, setup_install_dir};

--- a/crates/mbx/src/cli/setup.rs
+++ b/crates/mbx/src/cli/setup.rs
@@ -26,7 +26,15 @@ const RUST_ANALYZER_CONFIG_FILE: &str = "rust-analyzer.toml";
 const MISE_WRAPPERS_MINIMUM_VERSION: (u64, u64, u64) = (2026, 8, 16);
 const MISE_WRAPPERS_MINIMUM_VERSION_DISPLAY: &str = "2026.8.16";
 const CARGO_WRAPPER_MODE_ENV: &str = "MBX_CARGO_SHIM_MODE";
-const RUST_ANALYZER_CHECK_ARGUMENTS: [&str; 4] = [
+const RUST_ANALYZER_CHECK_ARGUMENTS: [&str; 6] = [
+    "check",
+    "--workspace",
+    "--all-targets",
+    "--target-dir",
+    super::RUST_ANALYZER_TARGET_DIR,
+    "--message-format=json",
+];
+const LEGACY_RUST_ANALYZER_CHECK_ARGUMENTS: [&str; 4] = [
     "check",
     "--workspace",
     "--all-targets",
@@ -304,10 +312,25 @@ pub(super) fn rust_analyzer_config_path_from(scope: &MiseScope, cwd: &Path) -> R
     }
 }
 
-fn rust_analyzer_command(shim: &Path) -> Vec<String> {
+fn rust_analyzer_command<const N: usize>(shim: &Path, arguments: [&str; N]) -> Vec<String> {
     std::iter::once(shim.to_string_lossy().into_owned())
-        .chain(RUST_ANALYZER_CHECK_ARGUMENTS.map(str::to_owned))
+        .chain(arguments.map(str::to_owned))
         .collect()
+}
+
+fn rust_analyzer_command_matches(
+    configured: Option<&toml_edit::Item>,
+    expected: &[String],
+) -> bool {
+    configured
+        .and_then(toml_edit::Item::as_array)
+        .is_some_and(|command| {
+            command.len() == expected.len()
+                && command
+                    .iter()
+                    .zip(expected)
+                    .all(|(actual, expected)| actual.as_str() == Some(expected))
+        })
 }
 
 pub(super) fn configure_rust_analyzer(
@@ -323,27 +346,27 @@ pub(super) fn configure_rust_analyzer(
     let mut document = contents
         .parse::<toml_edit::DocumentMut>()
         .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
-    let expected = rust_analyzer_command(shim);
+    let expected = rust_analyzer_command(shim, RUST_ANALYZER_CHECK_ARGUMENTS);
+    let legacy = rust_analyzer_command(shim, LEGACY_RUST_ANALYZER_CHECK_ARGUMENTS);
     let check = document
         .get("check")
         .and_then(toml_edit::Item::as_table_like);
     let configured = check.and_then(|check| check.get("overrideCommand"));
     let has_check_settings = check.is_some_and(|check| !check.is_empty());
-    let owns_configuration =
-        configured
-            .and_then(toml_edit::Item::as_array)
-            .is_some_and(|command| {
-                command.len() == expected.len()
-                    && command
-                        .iter()
-                        .zip(&expected)
-                        .all(|(actual, expected)| actual.as_str() == Some(expected))
-            });
+    let owns_configuration = rust_analyzer_command_matches(configured, &expected);
+    let owns_legacy_configuration = rust_analyzer_command_matches(configured, &legacy);
 
     match action {
         SetupAction::Status if owns_configuration => {
             println!("rust-analyzer checks run through mbx: {}", path.display());
             Ok(ExitCode::SUCCESS)
+        }
+        SetupAction::Status if owns_legacy_configuration => {
+            println!(
+                "rust-analyzer checks share Cargo's target directory; run `mbx setup` to update {}",
+                path.display()
+            );
+            Ok(ExitCode::FAILURE)
         }
         SetupAction::Status if has_check_settings => {
             println!(
@@ -360,7 +383,7 @@ pub(super) fn configure_rust_analyzer(
             Ok(ExitCode::FAILURE)
         }
         SetupAction::Uninstall => {
-            if owns_configuration {
+            if owns_configuration || owns_legacy_configuration {
                 let check = document
                     .get_mut("check")
                     .and_then(toml_edit::Item::as_table_like_mut)
@@ -378,6 +401,17 @@ pub(super) fn configure_rust_analyzer(
             Ok(ExitCode::SUCCESS)
         }
         SetupAction::Install if owns_configuration => Ok(ExitCode::SUCCESS),
+        SetupAction::Install if owns_legacy_configuration => {
+            let mut command = toml_edit::Array::new();
+            command.extend(expected);
+            document["check"]["overrideCommand"] = toml_edit::value(command);
+            crate::util::write_atomic(path, document.to_string().as_bytes())?;
+            println!(
+                "rust-analyzer background checks now use a separate target directory: {}",
+                path.display()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
         SetupAction::Install if has_check_settings => {
             println!(
                 "left {} unchanged: rust-analyzer check settings are already configured",

--- a/crates/mbx/src/cli/setup_tests.rs
+++ b/crates/mbx/src/cli/setup_tests.rs
@@ -78,12 +78,41 @@ fn setup_puts_rust_analyzer_checks_through_the_stable_cargo_shim() {
         "check",
         "--workspace",
         "--all-targets",
+        "--target-dir",
+        "target/rust-analyzer",
         "--message-format=json",
     ]));
     assert_eq!(
         configure_rust_analyzer(&config, &shim, SetupAction::Status).unwrap(),
         ExitCode::SUCCESS
     );
+}
+
+#[test]
+fn setup_upgrades_its_existing_rust_analyzer_command() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = directory.path().join("rust-analyzer.toml");
+    let shim = directory.path().join("bin/cargo");
+    let mut command = toml_edit::Array::new();
+    command.extend([
+        shim.to_string_lossy().into_owned(),
+        "check".into(),
+        "--workspace".into(),
+        "--all-targets".into(),
+        "--message-format=json".into(),
+    ]);
+    let mut document = toml_edit::DocumentMut::new();
+    document["check"]["overrideCommand"] = toml_edit::value(command);
+    std::fs::write(&config, document.to_string()).unwrap();
+
+    assert_eq!(
+        configure_rust_analyzer(&config, &shim, SetupAction::Status).unwrap(),
+        ExitCode::FAILURE
+    );
+    configure_rust_analyzer(&config, &shim, SetupAction::Install).unwrap();
+
+    let written = std::fs::read_to_string(config).unwrap();
+    assert!(written.contains("target/rust-analyzer"));
 }
 
 #[test]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -174,8 +174,12 @@ running setup again.
 Setup also configures rust-analyzer's background check in the matching global
 or project scope. The editor invokes the stable Cargo shim by its absolute path,
 so its build shares mbx's cache and machine-wide compiler pool even when the
-editor did not inherit mise's `PATH`. Existing rust-analyzer check settings are
-always left unchanged rather than silently changing commands or features.
+editor did not inherit mise's `PATH`. Its outputs go to
+`target/rust-analyzer`, separate from terminal builds so the two Cargo processes
+do not contend on the target-directory lock. When `target` is managed, the
+editor directory lives inside that view and is collected with it, while the
+shared store warms both builds. Existing rust-analyzer check settings are always
+left unchanged rather than silently changing commands or features.
 
 After installing from a release archive, run `$HOME/.local/bin/mbx setup` on
 Unix. On Windows, run


### PR DESCRIPTION
## Summary

- give rust-analyzer checks their own `target/rust-analyzer` Cargo target directory
- establish or refresh the managed `target` parent for that setup-owned path, so editor-first use cannot block managed views
- upgrade the exact override command written by older mbx versions while preserving custom check settings
- document how the separate editor target avoids Cargo lock contention while sharing mbx cache warmth and target collection

## Testing

- `cargo test -p mbx --lib` (319 passed, 1 ignored)
- `cargo test -p mbx cli::setup_tests`
- `cargo test -p mbx rust_analyzer_target_is_a_child_of_the_managed_view`
- `cargo clippy -p mbx --lib -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default rust-analyzer integration and target placement for a special-cased path; behavior is covered by new tests but affects every editor check after setup upgrade.
> 
> **Overview**
> **rust-analyzer** background checks now write to **`target/rust-analyzer`** instead of sharing the default **`target/`** directory with terminal Cargo, so editor and shell builds avoid contending on Cargo’s target-directory lock while still sharing mbx’s compilation cache.
> 
> **`mbx setup`** writes that path into the rust-analyzer **`overrideCommand`** (via **`--target-dir`**). It recognizes the previous mbx-written command without **`--target-dir`**, reports it as outdated on **`setup --status`**, and upgrades it on install; uninstall clears both variants. Custom check settings that are not mbx’s override stay untouched.
> 
> Cargo session logic introduces **`TargetViewPlacement`** (**`directory`** vs **`touch_path`**) and **`place_target_view`**: for the setup-defined rust-analyzer target, mbx still establishes the managed **`target`** view (so an editor-first run cannot leave a real **`target/`** that blocks management) while Cargo keeps writing under **`target/rust-analyzer`** and GC touches the managed view path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb9326d5f93ee5ad8937b118baa080aece368a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->