### PR TITLE
fix: handle rustc workspace wrappers

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -442,10 +442,11 @@ pub(super) struct Roots {
     pub(super) target_dir_requested: bool,
 }
 
-/// Carry a `RUSTC_WRAPPER` the caller already configured into the session.
+/// Carry rustc wrappers the caller already configured into the session.
 ///
-/// The session records it so the shim can defer to it; without this it would be
-/// dropped silently and whatever it does would stop happening.
+/// The session records them so the shim can defer to them; without this a
+/// workspace wrapper is mistaken for rustc because Cargo nests it inside
+/// `RUSTC_WRAPPER`.
 pub(super) fn inherited_environment(
     get_env: impl Fn(&str) -> Option<String>,
     working_dir: &Path,
@@ -453,6 +454,9 @@ pub(super) fn inherited_environment(
     let mut environment = BTreeMap::new();
     if let Some(wrapper) = get_env("RUSTC_WRAPPER").filter(|value| !value.is_empty()) {
         environment.insert("RUSTC_WRAPPER".into(), wrapper);
+    }
+    if let Some(wrapper) = get_env("RUSTC_WORKSPACE_WRAPPER").filter(|value| !value.is_empty()) {
+        environment.insert("RUSTC_WORKSPACE_WRAPPER".into(), wrapper);
     }
     // Cargo gives every shim its own working directory, so a relative
     // destination would scatter records across crate directories -- or fail

--- a/crates/mbx/src/cli/cargo_tests.rs
+++ b/crates/mbx/src/cli/cargo_tests.rs
@@ -97,16 +97,27 @@ fn resolves_a_relative_directory_against_the_working_directory() {
 }
 
 #[test]
-fn carries_an_inherited_wrapper_into_the_session() {
+fn carries_inherited_wrappers_into_the_session() {
     let cwd = Path::new("/workspace");
     let with = inherited_environment(
-        |name| (name == "RUSTC_WRAPPER").then(|| "/usr/bin/sccache".to_string()),
+        |name| match name {
+            "RUSTC_WRAPPER" => Some("/usr/bin/sccache".to_string()),
+            "RUSTC_WORKSPACE_WRAPPER" => Some("/usr/bin/workspace-rustc".to_string()),
+            _ => None,
+        },
         cwd,
     );
     assert_eq!(with.get("RUSTC_WRAPPER").unwrap(), "/usr/bin/sccache");
+    assert_eq!(
+        with.get("RUSTC_WORKSPACE_WRAPPER").unwrap(),
+        "/usr/bin/workspace-rustc"
+    );
 
     // An empty value is how a shell unsets it in practice.
-    let empty = inherited_environment(|name| (name == "RUSTC_WRAPPER").then(String::new), cwd);
+    let empty = inherited_environment(
+        |name| matches!(name, "RUSTC_WRAPPER" | "RUSTC_WORKSPACE_WRAPPER").then(String::new),
+        cwd,
+    );
     assert!(empty.is_empty());
     assert!(inherited_environment(|_| None, cwd).is_empty());
 }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -73,6 +73,7 @@ pub(crate) const WORKSPACE_ROOT_ENV: &str = "MBX_WORKSPACE_ROOT";
 pub(crate) const TARGET_DIR_ENV: &str = "MBX_TARGET_DIR";
 pub(crate) const BUILD_SCRIPT_REAL_SUFFIX: &str = ".mbx-real";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WRAPPER";
+const PREVIOUS_RUSTC_WORKSPACE_WRAPPER_ENV: &str = "MBX_PREVIOUS_RUSTC_WORKSPACE_WRAPPER";
 const REAL_RUSTDOC_ENV: &str = "MBX_REAL_RUSTDOC";
 pub(crate) const BYPASS_LOG_ENV: &str = "MBX_BYPASS_LOG";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -253,6 +254,19 @@ impl CacheSession {
                 "RUSTC_WRAPPER is already set to {previous}; deferring to it, so this build is not cached"
             );
             environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
+        }
+        if let Some(previous) = environment.get("RUSTC_WORKSPACE_WRAPPER") {
+            // Cargo nests this inside RUSTC_WRAPPER, so the shim receives the
+            // workspace wrapper where it ordinarily receives rustc. Remember
+            // that path both to recognize the nested invocation and to avoid
+            // silently treating rustc itself as an input file.
+            warn!(
+                "RUSTC_WORKSPACE_WRAPPER is already set to {previous}; deferring to it for workspace crates, so those compilations are not cached"
+            );
+            environment.insert(
+                PREVIOUS_RUSTC_WORKSPACE_WRAPPER_ENV.into(),
+                previous.clone(),
+            );
         }
         let rustdoc = configured_rustdoc(environment);
         environment.insert(REAL_RUSTDOC_ENV.into(), rustdoc);
@@ -1069,7 +1083,9 @@ pub fn run_rustc_shim() -> ExitCode {
         return ExitCode::from(1);
     };
     let arguments = arguments.collect::<Vec<_>>();
-    if std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV).is_none() {
+    let is_workspace_wrapper = std::env::var_os(PREVIOUS_RUSTC_WORKSPACE_WRAPPER_ENV)
+        .is_some_and(|wrapper| wrapper == rustc);
+    if std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV).is_none() && !is_workspace_wrapper {
         match crate::rustc::compile(&rustc, &arguments) {
             Ok(exit_code) => return exit_code,
             Err(error) => {
@@ -1118,6 +1134,7 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
     };
     command.args(&arguments);
     command.env_remove(PREVIOUS_RUSTC_WRAPPER_ENV);
+    command.env_remove(PREVIOUS_RUSTC_WORKSPACE_WRAPPER_ENV);
 
     #[cfg(unix)]
     {

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -52,6 +52,10 @@ async fn session_environment_directs_cargo_at_the_shim() {
     let workspace = tempfile::tempdir().unwrap();
     let mut values = BTreeMap::from([
         ("RUSTC_WRAPPER".into(), "existing".into()),
+        (
+            "RUSTC_WORKSPACE_WRAPPER".into(),
+            "workspace-existing".into(),
+        ),
         ("RUSTDOC".into(), "custom-rustdoc".into()),
     ]);
     let run = session
@@ -71,6 +75,10 @@ async fn session_environment_directs_cargo_at_the_shim() {
     let wrapper = Path::new(values.get("RUSTC_WRAPPER").unwrap());
     assert_eq!(wrapper.file_stem().unwrap(), RUSTC_SHIM_STEM);
     assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
+    assert_eq!(
+        values.get(PREVIOUS_RUSTC_WORKSPACE_WRAPPER_ENV).unwrap(),
+        "workspace-existing"
+    );
     assert_eq!(values.get(REAL_RUSTDOC_ENV).unwrap(), "custom-rustdoc");
     assert_eq!(
         Path::new(values.get("RUSTDOC").unwrap())

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -163,6 +163,51 @@ fn transparent_rustc_replaces_the_shim_process() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn rustc_workspace_wrapper_is_preserved_without_becoming_the_compiler() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let store = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    write_project(project.path());
+
+    let wrapper = project.path().join("workspace-rustc");
+    let log = project.path().join("workspace-rustc.log");
+    std::fs::write(
+        &wrapper,
+        "#!/bin/sh\nprintf 'called\\n' >> \"$MBX_TEST_WORKSPACE_WRAPPER_LOG\"\nexec \"$@\"\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&wrapper, permissions).unwrap();
+
+    let (stats, stderr) = build_with(
+        project.path(),
+        store.path(),
+        &reports.path().join("stats.json"),
+        &[
+            ("RUSTC_WORKSPACE_WRAPPER", wrapper.to_str().unwrap()),
+            ("MBX_TEST_WORKSPACE_WRAPPER_LOG", log.to_str().unwrap()),
+        ],
+    );
+
+    assert!(
+        std::fs::read_to_string(log).unwrap().contains("called"),
+        "Cargo should still invoke the configured workspace wrapper"
+    );
+    assert!(
+        stderr.contains("RUSTC_WORKSPACE_WRAPPER is already set"),
+        "the uncached workspace compilation should be disclosed: {stderr}"
+    );
+    assert!(
+        stats["bypasses"].get("multiple-inputs").is_none(),
+        "the workspace wrapper must not be parsed as rustc: {stats}"
+    );
+}
+
 /// Build `project` against `store`, returning the run's statistics.
 fn build(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
     build_with(project, store, report, &[]).0


### PR DESCRIPTION
## Summary

- preserve inherited `RUSTC_WORKSPACE_WRAPPER` configuration
- recognize Cargo's nested workspace-wrapper invocation before cache qualification
- transparently defer workspace crate compilations with a warning while retaining cache coverage for other crates
- add unit and end-to-end regression coverage

## Tests

- `cargo test -p mbx carries_inherited_wrappers_into_the_session`
- `cargo test -p mbx session_environment_directs_cargo_at_the_shim`
- `cargo test -p mbx --test build rustc_workspace_wrapper_is_preserved_without_becoming_the_compiler`
- `cargo test -p mbx` (314 unit tests pass; two unrelated cache-count integration tests fail in this nested local mbx environment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path rustc shim and wrapper chaining; mistakes could break caching or mis-invoke compilers, but scope is limited to the nested workspace-wrapper case with regression tests.
> 
> **Overview**
> Fixes incorrect rustc shim behavior when **`RUSTC_WORKSPACE_WRAPPER`** is set. Cargo nests that wrapper inside **`RUSTC_WRAPPER`**, so the shim sometimes receives the workspace wrapper as its first argument instead of **`rustc`**, which led to cache bypasses such as **`multiple-inputs`** and broken builds.
> 
> **`inherited_environment`** now forwards **`RUSTC_WORKSPACE_WRAPPER`** alongside **`RUSTC_WRAPPER`**. On session start, mbx records the prior value in **`MBX_PREVIOUS_RUSTC_WORKSPACE_WRAPPER`**, logs that workspace crate compilations are not cached, and in **`run_rustc_shim`** skips the cache path when that saved path matches the invoked “compiler,” then runs it transparently (and strips the internal env vars on exec).
> 
> Unit and integration tests cover inheritance, session env wiring, and an end-to-end build with a fake workspace wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ed9e3842210da8f417871d7275c094d209f357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->