### PR TITLE
feat: add quiet build summaries

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -1,5 +1,5 @@
 use super::gc::sweep_store;
-use crate::config::{CliSettings, Config, RetentionSettings};
+use crate::config::{CliSettings, Config, RetentionSettings, SummaryStyle};
 use crate::session::{self, CacheSession};
 use crate::{policy, target};
 use bytesize::ByteSize;
@@ -41,6 +41,11 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     bypass_log: Option<&Path>,
 ) -> Result<ExitCode> {
     let retention = &settings.retention;
+    let summary = if cargo_is_quiet(arguments) {
+        SummaryStyle::Off
+    } else {
+        settings.summary
+    };
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     // Only where mbx can identify the linker precisely enough to key what it
     // produced. Said out loud only to somebody who asked for it: this is on
@@ -186,7 +191,7 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
 
         let stats = match session.finish().await {
             Ok(stats) => {
-                crate::session::display_stats(&stats, config);
+                crate::session::display_stats(&stats, config, summary);
                 Some(stats)
             }
             Err(error) => {
@@ -403,6 +408,15 @@ pub(super) fn run_cargo(
         .status()
         .wrap_err_with(|| format!("failed to run {}", cargo.to_string_lossy()))?;
     Ok(exit_code(status))
+}
+
+/// Cargo's quiet flag applies to mbx's build summary as well as Cargo's own
+/// progress. Arguments after `--` belong to rustc or the program being run.
+pub(super) fn cargo_is_quiet(arguments: &[String]) -> bool {
+    arguments
+        .iter()
+        .take_while(|argument| argument.as_str() != "--")
+        .any(|argument| matches!(argument.as_str(), "-q" | "--quiet"))
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/cli/cargo_tests.rs
+++ b/crates/mbx/src/cli/cargo_tests.rs
@@ -1,6 +1,17 @@
 use super::*;
 
 #[test]
+fn cargo_quiet_only_applies_before_the_argument_separator() {
+    assert!(cargo_is_quiet(&["build".into(), "-q".into()]));
+    assert!(cargo_is_quiet(&["test".into(), "--quiet".into()]));
+    assert!(!cargo_is_quiet(&[
+        "run".into(),
+        "--".into(),
+        "--quiet".into()
+    ]));
+}
+
+#[test]
 fn prefers_the_outermost_lockfile_as_the_workspace_root() {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path();

--- a/crates/mbx/src/cli/exec.rs
+++ b/crates/mbx/src/cli/exec.rs
@@ -69,7 +69,7 @@ pub(super) fn run(config: &Config, settings: &CliSettings, args: &ExecArgs) -> R
         }
         let stats = match session.finish().await {
             Ok(stats) => {
-                crate::session::display_stats(&stats, config);
+                crate::session::display_stats(&stats, config, settings.summary);
                 Some(stats)
             }
             Err(error) => {

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -102,6 +102,13 @@ pub(crate) struct RawConfig {
     /// Write a JSON build report to this path.
     #[usage(env = "MBX_STATS_REPORT")]
     stats_report: Option<PathBuf>,
+    /// Detail printed after a build: one line, the full breakdown, or nothing.
+    #[usage(
+        env = "MBX_SUMMARY",
+        default = "short",
+        choices("off", "short", "full")
+    )]
+    summary: String,
     /// Compile and consult the cache, then compare outputs.
     #[usage(env = "MBX_VERIFY", default = false, scope = "env")]
     verify: bool,
@@ -463,6 +470,7 @@ pub(crate) struct RetentionSettings {
 pub(crate) struct CliSettings {
     pub retention: RetentionSettings,
     pub savings: SavingsStyle,
+    pub summary: SummaryStyle,
     /// Whether a churning crate may compile with its own incremental state.
     pub learned_incremental: bool,
     /// Whether natively linked programs may be cached.
@@ -476,8 +484,33 @@ impl Default for CliSettings {
         Self {
             retention: RetentionSettings::default(),
             savings: SavingsStyle::default(),
+            summary: SummaryStyle::default(),
             learned_incremental: true,
             cache_links: true,
+        }
+    }
+}
+
+/// How much of the per-build cache summary is printed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum SummaryStyle {
+    Off,
+    #[default]
+    Short,
+    Full,
+}
+
+impl std::str::FromStr for SummaryStyle {
+    type Err = eyre::Report;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "off" => Ok(Self::Off),
+            "short" => Ok(Self::Short),
+            "full" => Ok(Self::Full),
+            other => Err(eyre::eyre!(
+                "summary must be off, short, or full, not {other:?}"
+            )),
         }
     }
 }
@@ -739,6 +772,7 @@ impl Config {
             CliSettings {
                 retention,
                 savings: raw.savings.parse().wrap_err("invalid savings")?,
+                summary: raw.summary.parse().wrap_err("invalid summary")?,
                 learned_incremental: raw._learned_incremental,
                 cache_links: raw.cache_links,
             },
@@ -1368,6 +1402,20 @@ mod tests {
         assert_eq!(settings.savings, SavingsStyle::Off);
         assert!(
             configured_for_cli(None, &[("MBX_SAVINGS", "sarcastic")]).is_err(),
+            "an unknown style is an error, not a silent default"
+        );
+    }
+
+    #[test]
+    fn summaries_default_to_short_with_off_and_full_as_choices() {
+        let (_, settings) = configured_for_cli(None, &[]).unwrap();
+        assert_eq!(settings.summary, SummaryStyle::Short);
+        let (_, settings) = configured_for_cli(None, &[("MBX_SUMMARY", "off")]).unwrap();
+        assert_eq!(settings.summary, SummaryStyle::Off);
+        let (_, settings) = configured_for_cli(None, &[("MBX_SUMMARY", "full")]).unwrap();
+        assert_eq!(settings.summary, SummaryStyle::Full);
+        assert!(
+            configured_for_cli(None, &[("MBX_SUMMARY", "verbose")]).is_err(),
             "an unknown style is an error, not a silent default"
         );
     }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -47,10 +47,13 @@ use shims::{
     targeted_compiler_language,
 };
 use stats::StatsReport;
-pub use stats::display_stats;
+pub(crate) use stats::display_stats;
 pub(crate) use stats::session_was_active;
 #[cfg(test)]
-use stats::{cache_misses, should_display_stats, stale_manifest_note, write_stats_report};
+use stats::{
+    cache_misses, short_summary, should_display_short_stats, should_display_stats,
+    stale_manifest_note,
+};
 
 pub const RUSTC_SHIM_STEM: &str = "mbx-rustc";
 pub const RUSTDOC_SHIM_STEM: &str = "mbx-rustdoc";

--- a/crates/mbx/src/session/stats.rs
+++ b/crates/mbx/src/session/stats.rs
@@ -1,5 +1,5 @@
 use super::note;
-use crate::config::Config;
+use crate::config::{Config, SummaryStyle};
 use crate::util::{format_duration, write_atomic};
 use bytesize::ByteSize;
 use eyre::Result;
@@ -139,7 +139,7 @@ impl From<&AgentStats> for StatsReport {
 }
 
 /// Report a finished session to stderr, and to a JSON file when configured.
-pub fn display_stats(stats: &AgentStats, config: &Config) {
+pub(crate) fn display_stats(stats: &AgentStats, config: &Config, style: SummaryStyle) {
     if let Some(path) = &config.stats_report
         && let Err(error) = write_stats_report(path, stats)
     {
@@ -147,6 +147,16 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
             "the statistics report could not be written to {}: {error}",
             path.display()
         );
+    }
+    match style {
+        SummaryStyle::Off => return,
+        SummaryStyle::Short => {
+            if should_display_short_stats(stats) {
+                note(&short_summary(stats));
+            }
+            return;
+        }
+        SummaryStyle::Full => {}
     }
     if !should_display_stats(stats) {
         return;
@@ -284,6 +294,66 @@ pub fn display_stats(stats: &AgentStats, config: &Config) {
             stats.verifications, stats.divergences,
         ));
     }
+}
+
+/// The one-line result leaves routine compiler probes out of both its bypass
+/// count and its activity gate. Cargo and build scripts make these calls to
+/// identify a compiler or feed it source, so a no-op build should remain a
+/// no-op to somebody reading its output.
+pub(super) fn short_summary(stats: &AgentStats) -> String {
+    let unexpected_bypasses = unexpected_bypasses(stats);
+    let mut outcomes = vec![
+        format!("{} hits", stats.hits),
+        format!("{} misses", cache_misses(stats)),
+    ];
+    if stats.unconsulted > 0 {
+        outcomes.push(format!("{} not looked up", stats.unconsulted));
+    }
+    if stats.prefetched_actions > 0 {
+        outcomes.push(format!("{} prefetched", stats.prefetched_actions));
+    }
+    if unexpected_bypasses > 0 {
+        outcomes.push(format!("{unexpected_bypasses} bypassed"));
+    }
+    if stats.verifications > 0 {
+        outcomes.push(format!(
+            "{} verified, {} diverged",
+            stats.verifications, stats.divergences
+        ));
+    }
+    if stats.remote_failures > 0 {
+        outcomes.push(format!("{} remote failures", stats.remote_failures));
+    }
+    format!(
+        "mbx[cache]: {}; {} downloaded, {} uploaded, {} stored locally",
+        outcomes.join(", "),
+        ByteSize::b(stats.downloaded_bytes).display().iec(),
+        ByteSize::b(stats.uploaded_bytes).display().iec(),
+        ByteSize::b(stats.stored_bytes).display().iec(),
+    )
+}
+
+fn unexpected_bypasses(stats: &AgentStats) -> u64 {
+    stats
+        .bypasses
+        .iter()
+        .filter(|(kind, _)| !matches!(kind.as_str(), "compiler-query" | "standard-input"))
+        .map(|(_, count)| count)
+        .sum()
+}
+
+pub(super) fn should_display_short_stats(stats: &AgentStats) -> bool {
+    stats.lookups > 0
+        || stats.unconsulted > 0
+        || stats.prefetched_actions > 0
+        || stats.stores > 0
+        || stats.verifications > 0
+        || stats.downloaded_bytes > 0
+        || stats.uploaded_bytes > 0
+        || stats.background_uploads > 0
+        || unexpected_bypasses(stats) > 0
+        || stats.avoided_compiler_duration_ns > 0
+        || stats.remote_failures > 0
 }
 
 /// Explain a session that loaded a full manifest and matched none of it.

--- a/crates/mbx/src/session/stats.rs
+++ b/crates/mbx/src/session/stats.rs
@@ -337,7 +337,12 @@ fn unexpected_bypasses(stats: &AgentStats) -> u64 {
     stats
         .bypasses
         .iter()
-        .filter(|(kind, _)| !matches!(kind.as_str(), "compiler-query" | "standard-input"))
+        .filter(|(kind, _)| {
+            !matches!(
+                kind.as_str(),
+                "compiler-query" | "standard-input" | "cc-compiler-query" | "cc-standard-input"
+            )
+        })
         .map(|(_, count)| count)
         .sum()
 }

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config::SummaryStyle;
 
 #[test]
 fn ambiguous_build_script_sidecars_are_refused() {
@@ -532,7 +533,33 @@ fn a_session_that_only_failed_its_remote_is_reportable() {
 }
 
 #[test]
-fn writes_versioned_stats_report() {
+fn short_summary_omits_routine_compiler_probe_bypasses() {
+    let routine = agent_stats(|stats| {
+        stats.bypasses =
+            BTreeMap::from([("compiler-query".into(), 2), ("standard-input".into(), 1)]);
+    });
+    assert!(!should_display_short_stats(&routine));
+
+    let mixed = agent_stats(|stats| {
+        stats.lookups = 4;
+        stats.hits = 3;
+        stats.bypasses = BTreeMap::from([
+            ("compiler-query".into(), 2),
+            ("standard-input".into(), 1),
+            ("native-library".into(), 5),
+        ]);
+    });
+    let summary = short_summary(&mixed);
+    assert!(
+        summary.contains("3 hits, 1 misses, 5 bypassed"),
+        "{summary}"
+    );
+    assert!(!summary.contains("compiler-query"), "{summary}");
+    assert!(!summary.contains("standard-input"), "{summary}");
+}
+
+#[test]
+fn an_off_summary_still_writes_the_versioned_stats_report() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("nested").join("stats.json");
     let stats = agent_stats(|stats| {
@@ -559,7 +586,9 @@ fn writes_versioned_stats_report() {
         stats.predictions_loaded = 11;
     });
 
-    write_stats_report(&path, &stats).unwrap();
+    let mut config = Config::for_test(directory.path());
+    config.stats_report = Some(path.clone());
+    display_stats(&stats, &config, SummaryStyle::Off);
     let report: serde_json::Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
 
     // Bumped whenever the report grows a field, so a reader can tell from the

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -535,8 +535,12 @@ fn a_session_that_only_failed_its_remote_is_reportable() {
 #[test]
 fn short_summary_omits_routine_compiler_probe_bypasses() {
     let routine = agent_stats(|stats| {
-        stats.bypasses =
-            BTreeMap::from([("compiler-query".into(), 2), ("standard-input".into(), 1)]);
+        stats.bypasses = BTreeMap::from([
+            ("compiler-query".into(), 2),
+            ("standard-input".into(), 1),
+            ("cc-compiler-query".into(), 3),
+            ("cc-standard-input".into(), 4),
+        ]);
     });
     assert!(!should_display_short_stats(&routine));
 
@@ -546,6 +550,8 @@ fn short_summary_omits_routine_compiler_probe_bypasses() {
         stats.bypasses = BTreeMap::from([
             ("compiler-query".into(), 2),
             ("standard-input".into(), 1),
+            ("cc-compiler-query".into(), 3),
+            ("cc-standard-input".into(), 4),
             ("native-library".into(), 5),
         ]);
     });

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -1,6 +1,7 @@
 # Cache results
 
-The summary separates work mbx handled from work it could not safely cache.
+The short summary separates work mbx handled from work it could not safely
+cache. Set `MBX_SUMMARY=full` for the detailed breakdown described below.
 
 ## Hit
 
@@ -21,8 +22,9 @@ compilation, so calling it a miss would overstate the number of failed lookups.
 ## Bypass
 
 mbx recognized that it could not model the action exactly and ran the real
-compiler without caching it. Reasons are grouped in the summary; set
-`MBX_BYPASS_LOG` to a file path for the full per-action record.
+compiler without caching it. Reasons are grouped in the full summary
+(`MBX_SUMMARY=full`); set `MBX_BYPASS_LOG` to a file path for the full
+per-action record.
 
 Run a Cargo command through `mbx explain` to collect those records temporarily,
 group identical causes, and print guidance for every bypass category:
@@ -68,7 +70,8 @@ A remote cache request failed and the build carried on without it: unreachable
 host, refused credentials, or a response this client would not accept. mbx never
 fails a build over a remote cache, so these only ever cost hit rate — but a
 remote that is failing every request reports the same hits, misses, and bytes as
-one that was merely empty, which is why the summary counts them:
+one that was merely empty, which is why the summary counts them. The short
+summary includes the count inline; the full summary explains it:
 
 ```text
 mbx[cache]: the remote cache failed 4 of its requests; this build ran without what it could not reach, and the warnings above say why
@@ -80,16 +83,17 @@ on a cache that has quietly stopped serving.
 
 ## Watching a build instead
 
-Everything above describes the summary printed after a build. To see the same
+Everything above describes results reported after a build. To see the same
 outcomes as they are decided — one row per compilation, with the crate it
-belongs to — run [`mbx tui`](/tui) in another terminal. It reads every build on
-the machine, including ones already running.
+belongs to — run [`mbx tui`](/tui) in another terminal. It reads every build
+on the machine, including ones already running.
 
 ## Reading the hit rate
 
 A build can report a high hit rate among attempted lookups while spending most
 of its time on actions that were not looked up or were bypassed. Read all three
-summary lines together, and compare wall-clock time when evaluating the cache.
+summary counts together, and compare wall-clock time when evaluating the
+cache. Set `MBX_SUMMARY=full` when the one-line counts need a breakdown.
 
 A link mbx cannot describe always runs, so its downstream crates may have work
 to do on an otherwise warm build. Native executables, tests, and proc macros on

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -300,6 +300,20 @@ Share eligible compilations that read `OUT_DIR`.
 
 Write a JSON build report to this path.
 
+### `summary`
+
+- **Type:** `string`
+- **Default:** `short`
+- **Set with:** `MBX_SUMMARY`
+
+Detail printed after a build: one line, the full breakdown, or nothing.
+
+**Choices:**
+- `off`
+- `short`
+- `full`
+
+
 ### `target.max_age`
 
 - **Type:** `duration`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ incremental = false
 share_out_dir = true
 build_script_execution = true
 cc = true
+summary = "short"        # or "off", "full"
 savings = "quips"        # or "plain", "off"
 
 [gc]
@@ -176,6 +177,16 @@ before relying on it.
 from a pool of dry one-liners, `plain` states the same facts in the register
 of the other `mbx[...]` lines, and `off` keeps the totals without printing
 anything.
+
+## Build summaries
+
+`summary` controls the cache report printed to stderr after a build
+(`MBX_SUMMARY` from the environment). `short` — the default — prints one line,
+leaving routine `compiler-query` and `standard-input` probes out of its bypass
+count. `full` prints the detailed timing, compiler, bypass, transfer, and
+materialization breakdown. `off` prints no cache summary, while still writing
+`MBX_STATS_REPORT` when configured. Cargo's `-q` and `--quiet` also suppress
+the summary for that invocation.
 
 ## Incremental builds
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -317,17 +317,17 @@ unsuccessfully.
 
 ## Read the result
 
-After a build that used the cache, mbx prints a summary to stderr:
+After a build that used the cache, mbx prints a one-line summary to stderr:
 
 ```text
-mbx[cache]: 139 hits, 8 misses, 147 prefetched; 312.4 MiB downloaded, 0 B uploaded, 280.1 MiB stored locally
-mbx[cache]: could not look up 4 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from
-mbx[cache]: bypassed 7 compilations: 5 unsupported-crate-type, 2 unsupported-search-path
+mbx[cache]: 139 hits, 8 misses, 4 not looked up, 147 prefetched, 7 bypassed; 312.4 MiB downloaded, 0 B uploaded, 280.1 MiB stored locally
 ```
 
 These are three different outcomes: a miss means mbx looked up an action and
 found nothing, “could not look up” means it had no key yet, and a bypass means
 mbx deliberately declined to cache the action. See [Cache results](/cache-results).
+Set `MBX_SUMMARY=full` for the detailed breakdown, `MBX_SUMMARY=off` for none,
+or use Cargo's `-q`/`--quiet` for a quiet invocation.
 
 ## Inspect the store
 

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -64,8 +64,8 @@ real compiler without using the cache.
 mbx caches ordinary gcc-, clang-, and MSVC-style compile commands that compile
 one C or C++ source file into an object. It does not cache links,
 multi-source compiler calls, or commands whose behavior it cannot model
-safely. Those commands still run normally; the session summary reports why
-they bypassed the cache.
+safely. Those commands still run normally; the session summary counts their
+bypasses, and `MBX_SUMMARY=full` reports the grouped reasons.
 
 `mbx exec` only intercepts the unversioned compiler names listed above. It
 leaves commands such as `gcc-13`, absolute compiler paths, and explicitly


### PR DESCRIPTION
## Summary

- default build summaries to a compact one-line `short` mode
- add `MBX_SUMMARY=off|short|full` and honor Cargo `-q`/`--quiet`
- omit routine `compiler-query` and `standard-input` probes from short summaries
- preserve JSON statistics reports when human summaries are disabled
- document the modes and regenerate the CLI configuration reference

## Validation

- `cargo test -p mbx --lib`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `mise run render:docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible stderr and new config only; core caching and stats JSON behavior are unchanged aside from default verbosity.
> 
> **Overview**
> Post-build cache output is now **tiered** instead of always printing the full multi-line breakdown. **`MBX_SUMMARY`** / config **`summary`** accepts **`off`**, **`short`** (default), or **`full`**. **`short`** emits a single **`mbx[cache]:`** line that folds hits, misses, “not looked up”, prefetched, non-routine bypasses, verification, and remote failures together with transfer bytes; **`full`** keeps the previous detailed stderr report; **`off`** suppresses human summaries only.
> 
> For **`mbx cargo`**, **`-q` / `--quiet`** (before **`--`**) forces **`off`** so quiet Cargo runs stay quiet. **`MBX_STATS_REPORT`** JSON is still written when summaries are off.
> 
> Short mode treats routine **`compiler-query`** / **`standard-input`** (and CC equivalents) bypasses as noise—they no longer trigger a line or inflate the bypass count. Docs and CLI config reference describe the modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66917fa7db7e1200c3677880a6f7063d1ee59316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->