### PR TITLE
fix(cache): model no-input assembler options

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -167,6 +167,10 @@ fn actionable_bypasses_carry_remediation() {
         .remediation()
         .unwrap();
     assert!(remediation.contains("Unset"));
+    let remediation = CcBypassReason::ToolPassthrough("-Wa,--reads-input".into())
+        .remediation()
+        .unwrap();
+    assert!(remediation.contains("If you control the build script"));
     assert!(CcBypassReason::CompilerQuery.remediation().is_none());
 }
 
@@ -290,7 +294,11 @@ fn unlisted_f_and_m_flags_bypass_with_the_flag_text() {
 
 #[test]
 fn tool_passthrough_flags_bypass_even_with_admitted_prefixes() {
-    for flag in ["-Wl,-z,now", "-Wa,--noexecstack", "-Wp,-D_FORTIFY_SOURCE=2"] {
+    for flag in [
+        "-Wl,-z,now",
+        "-Wa,--defsym,version=1",
+        "-Wp,-D_FORTIFY_SOURCE=2",
+    ] {
         let arguments = argv(&[flag, "-c", "-o", "a.o", "a.c"]);
         assert_eq!(
             CcInvocation::parse(&arguments).unwrap_err().kind(),
@@ -308,6 +316,14 @@ fn tool_passthrough_flags_bypass_even_with_admitted_prefixes() {
         CcInvocation::parse(&arguments).unwrap_err().kind(),
         "tool-passthrough"
     );
+}
+
+#[test]
+fn no_input_assembler_options_stay_admitted_key_material() {
+    let flag = "-Wa,--noexecstack";
+    let arguments = argv(&[flag, "-c", "-o", "a.o", "a.c"]);
+    let invocation = CcInvocation::parse(&arguments).expect("option should be admitted");
+    assert!(invocation.arguments.contains(&Argument::Plain(flag.into())));
 }
 
 #[test]

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -189,6 +189,12 @@ const SEPARATE_PATH_FLAGS: &[&str] = &[
 
 const TOOL_PASSTHROUGH_FLAGS: &[&str] = &["-Xassembler", "-Xclang", "-Xlinker", "-Xpreprocessor"];
 
+/// Assembler options whose effects are completely described by their text.
+///
+/// Other assembler options can name files that dependency discovery does not
+/// report, so they remain conservative passthrough bypasses.
+const SUPPORTED_ASSEMBLER_OPTIONS: &[&str] = &["--noexecstack"];
+
 const COMPILER_QUERY_FLAGS: &[&str] = &[
     "--help",
     "--version",
@@ -241,7 +247,7 @@ impl CcBypassReason {
                 "Generate headers before compilation instead of changing an include directory while the compiler is running.",
             ),
             Self::UnknownFlag(_) | Self::ToolPassthrough(_) => Some(
-                "Remove the reported compiler option, or upgrade mbx if the option should be modeled.",
+                "Upgrade mbx or report the unmodeled compiler option. If you control the build script, removing the option can also make the compilation cacheable.",
             ),
             Self::UnmappedAbsolutePath(_) => Some(
                 "Move the input under a mapped project or system root, or keep this compilation uncached.",
@@ -1259,6 +1265,15 @@ impl<'a> Parser<'a> {
         }
         if value == "--coverage" {
             return Err(CcBypassReason::CoverageInstrumentation(value.into()));
+        }
+        if let Some(options) = value.strip_prefix("-Wa,")
+            && !options.is_empty()
+            && options
+                .split(',')
+                .all(|option| SUPPORTED_ASSEMBLER_OPTIONS.contains(&option))
+        {
+            self.parsed.push(Argument::Plain(value.into()));
+            return Ok(());
         }
         if TOOL_PASSTHROUGH_FLAGS.contains(&value)
             || value.starts_with("-Wp,")

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -144,9 +144,11 @@ with the wrong compiler. A value that is a command rather than a path, such as
 Only a plain single-source object compile through a gcc-, clang-, or MSVC-style
 driver is admitted. Linking, preprocessing, assembly, Objective-C, precompiled
 headers, coverage instrumentation, compiler plugins, options forwarded to a
-sub-tool with `-Wp,`/`-Wa,`/`-Wl,`/`-Xclang`, and response files all bypass,
-as does any flag the adapter does not model. MSVC compiler PDBs, modules, and
-other extra outputs also bypass. A source or header that
+sub-tool with `-Wp,`/`-Wl,`/`-Xclang`, unmodeled `-Wa,` assembler options, and
+response files all bypass, as does any flag the adapter does not model. Known
+assembler options that add no inputs, such as `-Wa,--noexecstack`, are keyed
+and admitted. MSVC compiler PDBs, modules, and other extra outputs also bypass.
+A source or header that
 expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__` bypasses too: its object is
 not a function of its inputs.
 


### PR DESCRIPTION
## Summary

- admit `-Wa,--noexecstack` as keyed C/C++ action material
- keep unmodeled assembler passthrough options on the conservative bypass path
- improve `mbx explain` guidance for flags owned by dependencies
- document the supported assembler-option exception

## Validation

- `cargo test -p mbx-cache-cc`
- `cargo clippy -p mbx-cache-cc --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows bypass rules for `-Wa,` flags; incorrect allowlisting could cache compiles whose assembler side effects are not fully keyed, though the change stays conservative for unlisted options.
> 
> **Overview**
> **`-Wa,--noexecstack` (and other allowlisted assembler-only flags) can be cached** instead of always hitting the conservative `tool-passthrough` bypass. The cc adapter now admits `-Wa,…` when every comma-separated option is in `SUPPORTED_ASSEMBLER_OPTIONS` (starting with `--noexecstack`) and keys the full flag as plain argv material; anything else under `-Wa,` still bypasses because it may reference files dep discovery does not see.
> 
> **`mbx explain` remediation** for unknown flags and tool passthrough now tells users to upgrade or report the option, and notes that build-script authors can remove the flag to regain cacheability.
> 
> **Tests and docs** split “admitted” vs “bypass” `-Wa,` behavior (`--defsym` stays passthrough; `--noexecstack` is admitted) and document the exception in `limits.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2bb7abd5ccd7d9a1cf157ccab77d636314e82de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->