### PR TITLE
feat(scheduler): respect build CPU limits

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -128,12 +128,13 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     }
 
     let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;
+    let cargo_jobs = cargo_job_limit(arguments);
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
 
     let session_outcome = runtime.block_on(async {
-        let session = CacheSession::start(session_dir.path(), config).await?;
+        let session = CacheSession::start_with_jobs(session_dir.path(), config, cargo_jobs).await?;
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
         if let Some(path) = bypass_log {
             let path = if path.is_absolute() {
@@ -615,6 +616,74 @@ pub(super) fn flag_value<'a>(arguments: &'a [String], flag: &str) -> Option<&'a 
         if argument == flag {
             return arguments.next().map(String::as_str);
         }
+    }
+    None
+}
+
+/// Cargo's own compiler-process limit, when it narrows the scheduler pool.
+///
+/// The CLI wins over `CARGO_BUILD_JOBS`, including `default`, just as it does
+/// in Cargo. Invalid values are left for Cargo to diagnose and do not make mbx
+/// invent a second interpretation.
+fn cargo_job_limit(arguments: &[String]) -> Option<u64> {
+    cargo_job_limit_with(
+        arguments,
+        std::env::var("CARGO_BUILD_JOBS").ok().as_deref(),
+        std::thread::available_parallelism().map_or(1, |cpus| cpus.get() as u64),
+    )
+}
+
+pub(super) fn cargo_job_limit_with(
+    arguments: &[String],
+    environment: Option<&str>,
+    logical_cpus: u64,
+) -> Option<u64> {
+    let mut cli_value = None;
+    let mut cli_seen = false;
+    let mut index = 0;
+    while index < arguments.len() {
+        let argument = &arguments[index];
+        if argument == "--" {
+            break;
+        }
+        let value = if argument == "-j" || argument == "--jobs" {
+            index += 1;
+            arguments.get(index).map(String::as_str)
+        } else if let Some(value) = argument.strip_prefix("--jobs=") {
+            Some(value)
+        } else if let Some(value) = argument.strip_prefix("-j=") {
+            Some(value)
+        } else {
+            argument
+                .strip_prefix("-j")
+                .filter(|value| !value.is_empty())
+        };
+        if let Some(value) = value {
+            cli_seen = true;
+            cli_value = resolve_cargo_jobs(value, logical_cpus);
+        }
+        index += 1;
+    }
+    if cli_seen {
+        cli_value
+    } else {
+        environment.and_then(|value| resolve_cargo_jobs(value, logical_cpus))
+    }
+}
+
+fn resolve_cargo_jobs(value: &str, logical_cpus: u64) -> Option<u64> {
+    if value == "default" {
+        return None;
+    }
+    let jobs = value.parse::<i64>().ok()?;
+    if jobs > 0 {
+        return Some(jobs as u64);
+    }
+    if jobs < 0 {
+        return i128::from(logical_cpus)
+            .checked_add(i128::from(jobs))
+            .filter(|jobs| *jobs > 0)
+            .and_then(|jobs| u64::try_from(jobs).ok());
     }
     None
 }

--- a/crates/mbx/src/cli/cargo_tests.rs
+++ b/crates/mbx/src/cli/cargo_tests.rs
@@ -199,6 +199,48 @@ fn forwards_repeated_and_attached_global_flags() {
 }
 
 #[test]
+fn cargo_jobs_follow_cargo_cli_and_environment_precedence() {
+    let args = |values: &[&str]| {
+        values
+            .iter()
+            .map(|value| (*value).into())
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(
+        cargo_job_limit_with(&args(&["build"]), Some("3"), 12),
+        Some(3)
+    );
+    assert_eq!(
+        cargo_job_limit_with(&args(&["build", "-j4"]), Some("3"), 12),
+        Some(4)
+    );
+    assert_eq!(
+        cargo_job_limit_with(&args(&["build", "--jobs=-2"]), None, 12),
+        Some(10)
+    );
+    assert_eq!(
+        cargo_job_limit_with(&args(&["build", "-j", "2"]), Some("7"), 12),
+        Some(2)
+    );
+    assert_eq!(
+        cargo_job_limit_with(&args(&["build", "-j1", "-j", "5"]), None, 12),
+        Some(5),
+        "Cargo's last occurrence wins"
+    );
+    assert_eq!(
+        cargo_job_limit_with(&args(&["build", "--jobs", "default"]), Some("2"), 12),
+        None,
+        "default resets an environment limit"
+    );
+    assert_eq!(
+        cargo_job_limit_with(&args(&["test", "--", "-j1"]), Some("6"), 12),
+        Some(6),
+        "test-harness arguments are not Cargo options"
+    );
+}
+
+#[test]
 fn cargo_help_does_not_trigger_target_migration() {
     assert!(cargo_help_requested(&["build".into(), "--help".into()]));
     assert!(cargo_help_requested(&["help".into(), "build".into()]));

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -174,6 +174,9 @@ struct RawScheduler {
     /// Machine-wide concurrent compile permits.
     #[usage(env = "MBX_SCHEDULER_CPUS", default_note = "logical CPUs")]
     cpus: Option<i64>,
+    /// Logical CPUs to leave free for the rest of the machine.
+    #[usage(env = "MBX_SCHEDULER_RESERVE_CPUS", default = 0)]
+    reserve_cpus: i64,
     /// Memory budget the permits divide, or "none" for plain CPU permits.
     #[usage(env = "MBX_SCHEDULER_MEMORY", default_note = "85% of physical memory")]
     memory: Option<String>,
@@ -352,10 +355,19 @@ pub struct SchedulerSettings {
     pub enabled: bool,
     /// Machine-wide concurrent compile permits.
     pub cpus: u64,
+    /// Permits withheld from the configured CPU count.
+    pub reserve_cpus: u64,
     /// Memory the permits divide; `None` leaves plain CPU permits.
     pub memory_bytes: Option<u64>,
     /// Priority of this build's compilations against other builds.
     pub priority: SchedulerPriority,
+}
+
+impl SchedulerSettings {
+    /// Compile permits left after preserving capacity for interactive work.
+    pub(crate) fn permits(&self) -> u64 {
+        self.cpus.saturating_sub(self.reserve_cpus).max(1)
+    }
 }
 
 /// The scheduling a hand-built `Config` gets: none.
@@ -370,6 +382,7 @@ impl Default for SchedulerSettings {
         Self {
             enabled: false,
             cpus: 1,
+            reserve_cpus: 0,
             memory_bytes: None,
             priority: SchedulerPriority::Normal,
         }
@@ -684,6 +697,9 @@ impl Config {
                 .ok_or_else(|| eyre::eyre!("invalid scheduler.cpus: must be a positive count"))?,
             None => std::thread::available_parallelism().map_or(1, |cpus| cpus.get() as u64),
         };
+        let scheduler_reserve_cpus = u64::try_from(raw.scheduler.reserve_cpus).map_err(|_| {
+            eyre::eyre!("invalid scheduler.reserve_cpus: must be a non-negative count")
+        })?;
         let scheduler_memory = match raw.scheduler.memory.as_deref() {
             Some(value) => parse_optional_byte_size(value).wrap_err("invalid scheduler.memory")?,
             // Measured only when the scheduler would use the answer, like the
@@ -701,6 +717,7 @@ impl Config {
         let scheduler = SchedulerSettings {
             enabled: raw.scheduler.enabled,
             cpus: scheduler_cpus,
+            reserve_cpus: scheduler_reserve_cpus,
             memory_bytes: scheduler_memory,
             priority: raw
                 .scheduler
@@ -769,12 +786,55 @@ impl Config {
             .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
 
         for (key, value) in document.iter() {
+            if key == "scheduler" {
+                let table = value
+                    .as_table()
+                    .ok_or_else(|| eyre::eyre!("{}.scheduler must be a table", path.display()))?;
+                for (scheduler_key, value) in table.iter() {
+                    let setting = format!("scheduler.{scheduler_key}");
+                    match scheduler_key {
+                        "enabled" if !environment_contains("MBX_SCHEDULER") => {
+                            self.scheduler.enabled = workspace_bool(&path, &setting, value)?;
+                        }
+                        "cpus" if !environment_contains("MBX_SCHEDULER_CPUS") => {
+                            self.scheduler.cpus = workspace_count(&path, &setting, value, false)?;
+                        }
+                        "reserve_cpus" if !environment_contains("MBX_SCHEDULER_RESERVE_CPUS") => {
+                            self.scheduler.reserve_cpus =
+                                workspace_count(&path, &setting, value, true)?;
+                        }
+                        "memory" if !environment_contains("MBX_SCHEDULER_MEMORY") => {
+                            let memory = value.as_str().ok_or_else(|| {
+                                eyre::eyre!("{}.{} must be a string", path.display(), setting)
+                            })?;
+                            self.scheduler.memory_bytes = parse_optional_byte_size(memory)
+                                .wrap_err_with(|| {
+                                    format!("invalid {}.{setting}", path.display())
+                                })?;
+                        }
+                        "priority" if !environment_contains("MBX_SCHEDULER_PRIORITY") => {
+                            let priority = value.as_str().ok_or_else(|| {
+                                eyre::eyre!("{}.{} must be a string", path.display(), setting)
+                            })?;
+                            self.scheduler.priority = priority.parse().wrap_err_with(|| {
+                                format!("invalid {}.{setting}", path.display())
+                            })?;
+                        }
+                        "enabled" | "cpus" | "reserve_cpus" | "memory" | "priority" => {}
+                        _ => bail!(
+                            "{} contains unsupported workspace setting {setting:?}; only scheduler.enabled, scheduler.cpus, scheduler.reserve_cpus, scheduler.memory, and scheduler.priority are allowed",
+                            path.display()
+                        ),
+                    }
+                }
+                continue;
+            }
             if !matches!(
                 key,
                 "incremental" | "share_out_dir" | "build_script_execution" | "cc"
             ) {
                 bail!(
-                    "{} contains unsupported workspace setting {key:?}; only incremental, share_out_dir, build_script_execution, and cc are allowed",
+                    "{} contains unsupported workspace setting {key:?}; only incremental, share_out_dir, build_script_execution, cc, and scheduler are allowed",
                     path.display()
                 );
             }
@@ -805,6 +865,36 @@ impl Config {
     pub fn store_dir(&self) -> PathBuf {
         self.cache_dir.join("actions")
     }
+}
+
+fn workspace_bool(path: &Path, setting: &str, value: &toml_edit::Item) -> Result<bool> {
+    value
+        .as_bool()
+        .ok_or_else(|| eyre::eyre!("{}.{} must be a boolean", path.display(), setting))
+}
+
+fn workspace_count(
+    path: &Path,
+    setting: &str,
+    value: &toml_edit::Item,
+    zero_allowed: bool,
+) -> Result<u64> {
+    let count = value
+        .as_integer()
+        .and_then(|count| u64::try_from(count).ok())
+        .filter(|count| zero_allowed || *count > 0);
+    count.ok_or_else(|| {
+        let requirement = if zero_allowed {
+            "non-negative"
+        } else {
+            "positive"
+        };
+        eyre::eyre!(
+            "{}.{} must be a {requirement} count",
+            path.display(),
+            setting
+        )
+    })
 }
 
 /// Resolve a byte size, written either plainly or with a unit.
@@ -1278,6 +1368,77 @@ mod tests {
     }
 
     #[test]
+    fn workspace_policy_accepts_scheduler_settings() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join(".mbx.toml"),
+            "[scheduler]\nenabled = true\ncpus = 8\nreserve_cpus = 2\nmemory = \"6GiB\"\npriority = \"low\"\n",
+        )
+        .unwrap();
+        let mut config = configured(None, &[("MBX_SCHEDULER", "false")]).unwrap();
+
+        config
+            .apply_workspace_policy_with(directory.path(), |name| name == "MBX_SCHEDULER")
+            .unwrap();
+
+        assert!(!config.scheduler.enabled, "the environment still wins");
+        assert_eq!(config.scheduler.cpus, 8);
+        assert_eq!(config.scheduler.reserve_cpus, 2);
+        assert_eq!(config.scheduler.permits(), 6);
+        assert_eq!(config.scheduler.memory_bytes, Some(6 * GIB));
+        assert_eq!(config.scheduler.priority, SchedulerPriority::Low);
+    }
+
+    #[test]
+    fn environment_overrides_workspace_scheduler_policy() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join(".mbx.toml"),
+            "[scheduler]\ncpus = 8\nreserve_cpus = 2\nmemory = \"6GiB\"\npriority = \"low\"\n",
+        )
+        .unwrap();
+        let environment = [
+            ("MBX_SCHEDULER_CPUS", "5"),
+            ("MBX_SCHEDULER_RESERVE_CPUS", "1"),
+            ("MBX_SCHEDULER_MEMORY", "4GiB"),
+            ("MBX_SCHEDULER_PRIORITY", "normal"),
+        ];
+        let mut config = configured(None, &environment).unwrap();
+
+        config
+            .apply_workspace_policy_with(directory.path(), |name| {
+                environment.iter().any(|(key, _)| *key == name)
+            })
+            .unwrap();
+
+        assert_eq!(config.scheduler.cpus, 5);
+        assert_eq!(config.scheduler.reserve_cpus, 1);
+        assert_eq!(config.scheduler.memory_bytes, Some(4 * GIB));
+        assert_eq!(config.scheduler.priority, SchedulerPriority::Normal);
+    }
+
+    #[test]
+    fn workspace_policy_validates_scheduler_settings() {
+        for setting in [
+            "[scheduler]\ncpus = 0",
+            "[scheduler]\nreserve_cpus = -1",
+            "[scheduler]\nmemory = \"plenty\"",
+            "[scheduler]\npriority = \"urgent\"",
+            "[scheduler]\nunknown = true",
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            std::fs::write(directory.path().join(".mbx.toml"), setting).unwrap();
+            let mut config = configured(None, &[]).unwrap();
+            assert!(
+                config
+                    .apply_workspace_policy_with(directory.path(), |_| false)
+                    .is_err(),
+                "{setting:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn environment_overrides_workspace_policy() {
         let directory = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -1387,6 +1548,7 @@ mod tests {
             "the budget leaves headroom for what it cannot see"
         );
         assert_eq!(config.scheduler.priority, SchedulerPriority::Normal);
+        assert_eq!(config.scheduler.reserve_cpus, 0);
     }
 
     #[test]
@@ -1395,12 +1557,15 @@ mod tests {
             None,
             &[
                 ("MBX_SCHEDULER_CPUS", "3"),
+                ("MBX_SCHEDULER_RESERVE_CPUS", "1"),
                 ("MBX_SCHEDULER_MEMORY", "4GiB"),
                 ("MBX_SCHEDULER_PRIORITY", "low"),
             ],
         )
         .unwrap();
         assert_eq!(config.scheduler.cpus, 3);
+        assert_eq!(config.scheduler.reserve_cpus, 1);
+        assert_eq!(config.scheduler.permits(), 2);
         assert_eq!(config.scheduler.memory_bytes, Some(4 * GIB));
         assert_eq!(config.scheduler.priority, SchedulerPriority::Low);
 
@@ -1413,8 +1578,23 @@ mod tests {
             "\"none\" keeps plain CPU permits"
         );
 
+        let config = configured(
+            None,
+            &[
+                ("MBX_SCHEDULER_CPUS", "3"),
+                ("MBX_SCHEDULER_RESERVE_CPUS", "9"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(config.scheduler.permits(), 1, "one permit always remains");
+
         let error = configured(None, &[("MBX_SCHEDULER_CPUS", "0")]).unwrap_err();
         assert!(error.to_string().contains("scheduler.cpus"), "{error}");
+        let error = configured(None, &[("MBX_SCHEDULER_RESERVE_CPUS", "-1")]).unwrap_err();
+        assert!(
+            error.to_string().contains("scheduler.reserve_cpus"),
+            "{error}"
+        );
         let error = configured(None, &[("MBX_SCHEDULER_PRIORITY", "loud")]).unwrap_err();
         assert!(error.to_string().contains("scheduler.priority"), "{error}");
     }

--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -488,11 +488,19 @@ fn default_capacity() -> u64 {
 /// An explicit empty directory means "off", stated rather than omitted for the
 /// reason `VERIFY_ENV` always is: an absent key would leave a shim resolving
 /// configuration on its own, which is the standalone path, not a disabled one.
-pub(crate) fn session_environment(config: &Config) -> Vec<(String, String)> {
+/// The environment for a Cargo build whose own jobserver may be narrower.
+pub(crate) fn session_environment_with_jobs(
+    config: &Config,
+    cargo_jobs: Option<u64>,
+) -> Vec<(String, String)> {
     let scheduler = &config.scheduler;
     if !scheduler.enabled {
         return vec![(SCHED_DIR_ENV.into(), String::new())];
     }
+    let permits = cargo_jobs.map_or_else(
+        || scheduler.permits(),
+        |jobs| scheduler.permits().min(jobs.max(1)),
+    );
     vec![
         (
             SCHED_DIR_ENV.into(),
@@ -502,10 +510,10 @@ pub(crate) fn session_environment(config: &Config) -> Vec<(String, String)> {
                 .to_string_lossy()
                 .into_owned(),
         ),
-        (SCHED_SLOTS_ENV.into(), scheduler.cpus.to_string()),
+        (SCHED_SLOTS_ENV.into(), permits.to_string()),
         (
             SCHED_SLOT_BYTES_ENV.into(),
-            bytes_per_permit(scheduler.memory_bytes, scheduler.cpus).to_string(),
+            bytes_per_permit(scheduler.memory_bytes, permits).to_string(),
         ),
         (
             SCHED_PRIORITY_ENV.into(),
@@ -550,11 +558,12 @@ impl Pool {
 
     fn from_config(config: &Config) -> Option<Self> {
         let scheduler = &config.scheduler;
+        let permits = scheduler.permits();
         scheduler.enabled.then(|| {
             Self::new(
                 config.cache_dir.join(SCHEDULER_DIR),
-                scheduler.cpus,
-                bytes_per_permit(scheduler.memory_bytes, scheduler.cpus),
+                permits,
+                bytes_per_permit(scheduler.memory_bytes, permits),
                 scheduler.priority,
             )
         })

--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -80,6 +80,10 @@ pub(crate) const SCHED_SLOTS_ENV: &str = "MBX_SCHED_SLOTS";
 pub(crate) const SCHED_SLOT_BYTES_ENV: &str = "MBX_SCHED_SLOT_BYTES";
 /// Permit priority of this build's compilations.
 pub(crate) const SCHED_PRIORITY_ENV: &str = "MBX_SCHED_PRIORITY";
+/// Identity shared by every compiler shim in one Cargo build.
+const SCHED_BUILD_ID_ENV: &str = "MBX_SCHED_BUILD_ID";
+/// Most weighted permits one Cargo build may hold at once.
+const SCHED_BUILD_SLOTS_ENV: &str = "MBX_SCHED_BUILD_SLOTS";
 
 /// Schema version of one lease record.
 const LEASE_VERSION: u8 = 1;
@@ -214,6 +218,8 @@ struct Lease {
     version: u8,
     weight: u64,
     priority: String,
+    #[serde(default)]
+    build_id: Option<String>,
 }
 
 /// What one finished compilation leaves in its flight file: the prediction
@@ -435,6 +441,8 @@ struct MemoryLedger {
 pub(crate) struct Pool {
     dir: PathBuf,
     capacity: u64,
+    /// A per-Cargo-build ceiling, separate from the machine-wide capacity.
+    build: Option<(String, u64)>,
     /// Memory one permit stands for. Zero turns memory weighting and the
     /// available-memory gate off, leaving plain CPU permits.
     bytes_per_permit: u64,
@@ -456,15 +464,28 @@ pub(crate) fn pool() -> Option<&'static Pool> {
 fn resolve_pool() -> Option<Pool> {
     match std::env::var_os(SCHED_DIR_ENV) {
         Some(dir) if dir.is_empty() => None,
-        Some(dir) => Some(Pool::new(
-            PathBuf::from(dir),
-            env_number(SCHED_SLOTS_ENV).unwrap_or_else(default_capacity),
-            env_number(SCHED_SLOT_BYTES_ENV).unwrap_or(0),
-            std::env::var(SCHED_PRIORITY_ENV)
+        Some(dir) => {
+            let capacity = env_number(SCHED_SLOTS_ENV).unwrap_or_else(default_capacity);
+            let mut pool = Pool::new(
+                PathBuf::from(dir),
+                capacity,
+                env_number(SCHED_SLOT_BYTES_ENV).unwrap_or(0),
+                std::env::var(SCHED_PRIORITY_ENV)
+                    .ok()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or_default(),
+            );
+            pool.build = std::env::var(SCHED_BUILD_ID_ENV)
                 .ok()
-                .and_then(|value| value.parse().ok())
-                .unwrap_or_default(),
-        )),
+                .filter(|id| !id.is_empty())
+                .map(|id| {
+                    let slots = env_number(SCHED_BUILD_SLOTS_ENV)
+                        .unwrap_or(capacity)
+                        .clamp(1, capacity.max(1));
+                    (id, slots)
+                });
+            Some(pool)
+        }
         None => match Config::load() {
             Ok(config) => Pool::from_config(&config),
             Err(error) => {
@@ -497,10 +518,8 @@ pub(crate) fn session_environment_with_jobs(
     if !scheduler.enabled {
         return vec![(SCHED_DIR_ENV.into(), String::new())];
     }
-    let permits = cargo_jobs.map_or_else(
-        || scheduler.permits(),
-        |jobs| scheduler.permits().min(jobs.max(1)),
-    );
+    let permits = scheduler.permits();
+    let build_permits = cargo_jobs.map_or(permits, |jobs| permits.min(jobs.max(1)));
     vec![
         (
             SCHED_DIR_ENV.into(),
@@ -519,6 +538,8 @@ pub(crate) fn session_environment_with_jobs(
             SCHED_PRIORITY_ENV.into(),
             scheduler.priority.as_str().into(),
         ),
+        (SCHED_BUILD_ID_ENV.into(), crate::util::random_string(12)),
+        (SCHED_BUILD_SLOTS_ENV.into(), build_permits.to_string()),
     ]
 }
 
@@ -550,6 +571,7 @@ impl Pool {
         Self {
             dir,
             capacity: capacity.max(1),
+            build: None,
             bytes_per_permit,
             priority,
             available_memory: crate::util::memory_available_bytes,
@@ -673,7 +695,19 @@ impl Pool {
         registrar.lock()?;
         let live = scan_leases(&leases)?;
         let capacity = self.capacity - self.reserved();
-        let used: u64 = live.iter().sum();
+        let used: u64 = live.iter().map(|lease| lease.weight).sum();
+        if let Some((build_id, build_capacity)) = &self.build {
+            let build_used = live
+                .iter()
+                .filter(|lease| lease.build_id.as_ref() == Some(build_id))
+                .map(|lease| lease.weight)
+                .sum::<u64>();
+            // Like an oversized machine-wide demand, a single compilation
+            // heavier than this build's ceiling must still be able to run.
+            if build_used > 0 && build_used.saturating_add(weight) > *build_capacity {
+                return Ok(None);
+            }
+        }
         // A demand too heavy for what the pool will lend it can only ever run
         // by itself, so on an idle pool it does, rather than waiting for room
         // that nothing is going to make. Measured against the capacity left
@@ -724,6 +758,7 @@ impl Pool {
             version: LEASE_VERSION,
             weight,
             priority: self.priority.as_str().into(),
+            build_id: self.build.as_ref().map(|(id, _)| id.clone()),
         })?;
         let mut last = None;
         for _ in 0..LEASE_NAME_ATTEMPTS {
@@ -881,7 +916,7 @@ fn read_ledger(path: &Path) -> MemoryLedger {
 }
 
 /// The live lease weights, reclaiming any lease whose holder has died.
-fn scan_leases(leases: &Path) -> Result<Vec<u64>> {
+fn scan_leases(leases: &Path) -> Result<Vec<Lease>> {
     let mut live = Vec::new();
     for entry in std::fs::read_dir(leases)? {
         let path = entry?.path();
@@ -896,11 +931,22 @@ fn scan_leases(leases: &Path) -> Result<Vec<u64>> {
         }
         // A live lease that cannot be read still occupies its holder, so it
         // counts as the smallest thing it could be rather than nothing.
-        let weight = std::fs::read(&path)
+        let lease = std::fs::read(&path)
             .ok()
             .and_then(|bytes| serde_json::from_slice::<Lease>(&bytes).ok())
-            .map_or(1, |lease| lease.weight.max(1));
-        live.push(weight);
+            .map_or_else(
+                || Lease {
+                    version: LEASE_VERSION,
+                    weight: 1,
+                    priority: SchedulerPriority::Normal.as_str().into(),
+                    build_id: None,
+                },
+                |mut lease| {
+                    lease.weight = lease.weight.max(1);
+                    lease
+                },
+            );
+        live.push(lease);
     }
     Ok(live)
 }

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -649,15 +649,16 @@ fn an_oversized_payload_is_not_left_behind() {
 fn session_environment_states_off_explicitly() {
     let config = crate::config::Config::for_test(Path::new("/cache"));
     assert_eq!(
-        session_environment(&config),
+        session_environment_with_jobs(&config, None),
         vec![(SCHED_DIR_ENV.to_string(), String::new())]
     );
 
     let mut config = crate::config::Config::for_test(Path::new("/cache"));
     config.scheduler.enabled = true;
     config.scheduler.cpus = 8;
+    config.scheduler.reserve_cpus = 2;
     config.scheduler.memory_bytes = Some(8000);
-    let environment = session_environment(&config);
+    let environment = session_environment_with_jobs(&config, None);
     let value = |name: &str| {
         environment
             .iter()
@@ -669,7 +670,18 @@ fn session_environment_states_off_explicitly() {
         value(SCHED_DIR_ENV),
         Path::new("/cache").join("scheduler").to_str().unwrap()
     );
-    assert_eq!(value(SCHED_SLOTS_ENV), "8");
-    assert_eq!(value(SCHED_SLOT_BYTES_ENV), "1000");
+    assert_eq!(value(SCHED_SLOTS_ENV), "6");
+    assert_eq!(value(SCHED_SLOT_BYTES_ENV), "1333");
     assert_eq!(value(SCHED_PRIORITY_ENV), "normal");
+
+    let environment = session_environment_with_jobs(&config, Some(3));
+    let value = |name: &str| {
+        environment
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+            .unwrap()
+    };
+    assert_eq!(value(SCHED_SLOTS_ENV), "3");
+    assert_eq!(value(SCHED_SLOT_BYTES_ENV), "2666");
 }

--- a/crates/mbx/src/scheduler_tests.rs
+++ b/crates/mbx/src/scheduler_tests.rs
@@ -96,6 +96,32 @@ fn weights_count_against_capacity() {
 }
 
 #[test]
+fn a_build_limit_counts_only_that_builds_leases() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut other = pool_at(directory.path(), 6, 0);
+    other.build = Some(("other".into(), 6));
+    let elsewhere = other.try_admit(2, None).unwrap().expect("other build");
+
+    let mut limited = pool_at(directory.path(), 6, 0);
+    limited.build = Some(("limited".into(), 2));
+    let own = limited
+        .try_admit(2, None)
+        .unwrap()
+        .expect("two permits beside another build");
+    assert!(
+        limited.try_admit(1, None).unwrap().is_none(),
+        "the build cannot exceed its own ceiling even with machine capacity free"
+    );
+
+    drop(own);
+    assert!(
+        limited.try_admit(3, None).unwrap().is_some(),
+        "one demand heavier than the build ceiling still makes progress"
+    );
+    drop(elsewhere);
+}
+
+#[test]
 fn a_dead_holders_lease_is_reclaimed() {
     let directory = tempfile::tempdir().unwrap();
     let pool = pool_at(directory.path(), 1, 0);
@@ -110,6 +136,7 @@ fn a_dead_holders_lease_is_reclaimed() {
             version: LEASE_VERSION,
             weight: 1,
             priority: "normal".into(),
+            build_id: None,
         })
         .unwrap(),
     )
@@ -673,6 +700,8 @@ fn session_environment_states_off_explicitly() {
     assert_eq!(value(SCHED_SLOTS_ENV), "6");
     assert_eq!(value(SCHED_SLOT_BYTES_ENV), "1333");
     assert_eq!(value(SCHED_PRIORITY_ENV), "normal");
+    assert!(!value(SCHED_BUILD_ID_ENV).is_empty());
+    assert_eq!(value(SCHED_BUILD_SLOTS_ENV), "6");
 
     let environment = session_environment_with_jobs(&config, Some(3));
     let value = |name: &str| {
@@ -682,6 +711,7 @@ fn session_environment_states_off_explicitly() {
             .map(|(_, value)| value.as_str())
             .unwrap()
     };
-    assert_eq!(value(SCHED_SLOTS_ENV), "3");
-    assert_eq!(value(SCHED_SLOT_BYTES_ENV), "2666");
+    assert_eq!(value(SCHED_SLOTS_ENV), "6", "the machine pool stays global");
+    assert_eq!(value(SCHED_SLOT_BYTES_ENV), "1333");
+    assert_eq!(value(SCHED_BUILD_SLOTS_ENV), "3");
 }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -108,6 +108,15 @@ impl CacheSession {
     /// `session_dir` holds the shim, socket, and staging directory, and is
     /// expected to be a temporary directory owned by the caller.
     pub async fn start(session_dir: &Path, config: &Config) -> Result<Self> {
+        Self::start_with_jobs(session_dir, config, None).await
+    }
+
+    /// Start a session whose Cargo jobserver limits compiler concurrency.
+    pub(crate) async fn start_with_jobs(
+        session_dir: &Path,
+        config: &Config,
+        cargo_jobs: Option<u64>,
+    ) -> Result<Self> {
         let (shim, rustdoc_shim) = install_session_shims(session_dir)?;
         let cc_shims = if config.cc {
             // Build systems such as CMake persist HOST_CC as an absolute
@@ -152,7 +161,7 @@ impl CacheSession {
             build_script_execution: config.build_script_execution,
             agent,
             events,
-            scheduler_env: crate::scheduler::session_environment(config),
+            scheduler_env: crate::scheduler::session_environment_with_jobs(config, cargo_jobs),
             store,
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -284,6 +284,14 @@ Permit priority of this build's compilations.
 - `low`
 
 
+### `scheduler.reserve_cpus`
+
+- **Type:** `int`
+- **Default:** `0`
+- **Set with:** `MBX_SCHEDULER_RESERVE_CPUS`
+
+Logical CPUs to leave free for the rest of the machine.
+
 ### `share_out_dir`
 
 - **Type:** `bool`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,10 +141,11 @@ The pool is memory-aware. `scheduler.cpus` permits (default: logical CPUs),
 less `scheduler.reserve_cpus` (default: 0), divide `scheduler.memory` (default:
 85% of physical memory, leaving headroom for everything that is not a compiler;
 `"none"` keeps plain CPU permits). The pool always keeps at least one permit.
-Cargo's `-j`/`--jobs` or `CARGO_BUILD_JOBS` can narrow the permit count further
-for one build. In a container, "physical memory" means the cgroup's limit rather
-than the host's RAM — a build in a 4 GiB container on a large machine is
-budgeted by the 4 GiB, because the rest was never its to spend.
+Cargo's `-j`/`--jobs` or `CARGO_BUILD_JOBS` can cap how many weighted permits
+one build holds without shrinking the machine-wide pool available to other
+builds. In a container, "physical memory" means the cgroup's limit rather than
+the host's RAM — a build in a 4 GiB container on a large machine is budgeted by
+the 4 GiB, because the rest was never its to spend.
 
 `priority = "low"` (`MBX_SCHEDULER_PRIORITY`) is for builds nobody is sitting
 at — CI on a shared box, an editor's background check. While a normal-priority

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,20 +64,26 @@ retries = 3
 [scheduler]
 enabled = true
 cpus = 16                # default: logical CPUs
+reserve_cpus = 2         # default: 0
 memory = "24GiB"         # default: 85% of physical memory
 priority = "normal"      # or "low"
 ```
 
 ## Workspace policy
 
-A repository may check in a `.mbx.toml` containing only the four build-policy
-switches below:
+A repository may check in a `.mbx.toml` containing the build-policy switches
+and scheduler policy below:
 
 ```toml
 incremental = false
 share_out_dir = false
 build_script_execution = true
 cc = true
+
+[scheduler]
+reserve_cpus = 2
+memory = "12GiB"
+priority = "normal"
 ```
 
 Environment variables still win. Machine paths, remote-cache configuration,
@@ -131,12 +137,14 @@ and restores its result instead of burning a core on it. How the pool weighs
 compilations and links — and what happens when a guess is wrong — is described
 in [how it works](/how-it-works#machine-wide-scheduling).
 
-The pool is memory-aware. `scheduler.cpus` permits (default: logical CPUs)
-divide `scheduler.memory` (default: 85% of physical memory, leaving headroom
-for everything that is not a compiler; `"none"` keeps plain CPU permits). In a
-container, "physical memory" means the cgroup's limit rather than the host's
-RAM — a build in a 4 GiB container on a large machine is budgeted by the
-4 GiB, because the rest was never its to spend.
+The pool is memory-aware. `scheduler.cpus` permits (default: logical CPUs),
+less `scheduler.reserve_cpus` (default: 0), divide `scheduler.memory` (default:
+85% of physical memory, leaving headroom for everything that is not a compiler;
+`"none"` keeps plain CPU permits). The pool always keeps at least one permit.
+Cargo's `-j`/`--jobs` or `CARGO_BUILD_JOBS` can narrow the permit count further
+for one build. In a container, "physical memory" means the cgroup's limit rather
+than the host's RAM — a build in a 4 GiB container on a large machine is
+budgeted by the 4 GiB, because the rest was never its to spend.
 
 `priority = "low"` (`MBX_SCHEDULER_PRIORITY`) is for builds nobody is sitting
 at — CI on a shared box, an editor's background check. While a normal-priority


### PR DESCRIPTION
## Summary

- add `scheduler.reserve_cpus` and `MBX_SCHEDULER_RESERVE_CPUS`, preserving at least one compile permit
- let Cargo `-j` / `--jobs` and `CARGO_BUILD_JOBS` narrow the scheduler for one build
- allow validated scheduler policy in workspace `.mbx.toml`, while keeping environment precedence
- document the new controls and cover parsing, validation, and scheduler environment behavior

## Validation

- `cargo test -p mbx config::tests:: --lib`
- `cargo test -p mbx cargo_jobs_follow_cargo_cli_and_environment_precedence --lib`
- `cargo test -p mbx session_environment --lib`
- `mise run lint`
- full Rust test suite through `mise run ci` (generated-doc cleanliness check reports the intentional tracked docs change in a dirty worktree)

The local Bats suite could not start because this worktree does not have `test/test_helper/bats-support` populated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core compile-scheduler admission and permit accounting; mis-parsing jobs or build caps could affect concurrency on shared machines, though failures degrade to unscheduled compiles.
> 
> **Overview**
> Adds **`scheduler.reserve_cpus`** (`MBX_SCHEDULER_RESERVE_CPUS`) so the machine-wide pool uses `cpus − reserve` permits (always at least one), and wires that through pool sizing and session env vars.
> 
> **Cargo parallelism** is parsed from `-j` / `--jobs` and `CARGO_BUILD_JOBS` (CLI wins, stops at `--`, matches Cargo semantics). That limit caps **per-build** weighted permits via `MBX_SCHED_BUILD_ID` / `MBX_SCHED_BUILD_SLOTS` while the global pool size stays unchanged; leases now carry an optional `build_id` for enforcement.
> 
> Workspace **`.mbx.toml`** may include a validated `[scheduler]` table (env still overrides). Docs and tests cover job parsing, reserve CPUs, workspace policy, and build-level limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f06c0929532e589f35ddb8b161c9e9e29ec7cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->