### PR TITLE
perf: preserve Cargo rustc probe cache

### DIFF
--- a/crates/mbx-cache-cargo/src/lib.rs
+++ b/crates/mbx-cache-cargo/src/lib.rs
@@ -36,6 +36,36 @@ pub fn resolve(
 ) -> CargoInvocation {
     let cargo_args = cargo_arguments(arguments);
     let reported = cargo_roots(cargo, cargo_args, target_dir_env.as_deref());
+    resolve_with_reported(arguments, working_dir, target_dir_env, reported)
+}
+
+/// Resolve one Cargo invocation only when Cargo successfully reports its roots.
+///
+/// Persistent Cargo shims use this form to distinguish a usable build from an
+/// invocation they should pass through, while retaining the successful
+/// metadata result for the session instead of probing twice.
+pub fn resolve_reported(
+    cargo: &OsStr,
+    arguments: &[String],
+    working_dir: &Path,
+    target_dir_env: Option<OsString>,
+) -> Option<CargoInvocation> {
+    let reported = cargo_roots(cargo, cargo_arguments(arguments), target_dir_env.as_deref())?;
+    Some(resolve_with_reported(
+        arguments,
+        working_dir,
+        target_dir_env,
+        Some(reported),
+    ))
+}
+
+fn resolve_with_reported(
+    arguments: &[String],
+    working_dir: &Path,
+    target_dir_env: Option<OsString>,
+    reported: Option<(PathBuf, PathBuf)>,
+) -> CargoInvocation {
+    let cargo_args = cargo_arguments(arguments);
     let invocation_dir = invocation_dir(cargo_args, working_dir);
     let workspace_root = reported
         .as_ref()
@@ -425,9 +455,23 @@ mod tests {
             format!("build.target-dir='{}'", configured.display()),
         ];
 
-        let resolved = resolve(OsStr::new("cargo"), &arguments, root, None);
+        let resolved = resolve_reported(OsStr::new("cargo"), &arguments, root, None).unwrap();
 
         assert_eq!(resolved.target_dir, configured);
         assert!(resolved.target_dir_requested);
+    }
+
+    #[test]
+    fn reported_resolution_requires_a_successful_metadata_probe() {
+        let directory = cargo_fixture();
+        assert!(
+            resolve_reported(
+                OsStr::new("cargo-that-does-not-exist"),
+                &["build".into()],
+                directory.path(),
+                None,
+            )
+            .is_none()
+        );
     }
 }

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -570,17 +570,33 @@ impl CacheAgent {
 
     /// Load the last committed action manifest for a task into this session.
     pub async fn begin_task(&self, task: &str) -> Result<String> {
-        self.begin_task_with_remote_errors(task, false).await
+        self.begin_task_with_remote_errors(task, false, None).await
+    }
+
+    /// Load a task using its identity as the run key.
+    ///
+    /// A task-scoped process has only one run for an identity, so it can defer
+    /// this work until its first client connects while putting the identity in
+    /// the client's environment ahead of time.
+    pub async fn begin_session_task(&self, task: &str) -> Result<()> {
+        self.begin_task_with_remote_errors(task, false, Some(task.to_string()))
+            .await?;
+        Ok(())
     }
 
     /// Load a task and finish its prefetch, surfacing remote lookup failures.
     pub async fn prefetch_task(&self, task: &str) -> Result<String> {
-        let run = self.begin_task_with_remote_errors(task, true).await?;
+        let run = self.begin_task_with_remote_errors(task, true, None).await?;
         self.wait_for_prefetches().await;
         Ok(run)
     }
 
-    async fn begin_task_with_remote_errors(&self, task: &str, strict: bool) -> Result<String> {
+    async fn begin_task_with_remote_errors(
+        &self,
+        task: &str,
+        strict: bool,
+        run: Option<String>,
+    ) -> Result<String> {
         validate_task_identity(task)?;
         // The local manifest is already enough to start useful work. Do not
         // leave those predictions idle while a high-latency remote answers the
@@ -657,10 +673,11 @@ impl CacheAgent {
                 ..TaskActionState::default()
             }
         };
-        let sequence = self.next_task_run.fetch_add(1, Ordering::Relaxed);
-        let run =
+        let run = run.unwrap_or_else(|| {
+            let sequence = self.next_task_run.fetch_add(1, Ordering::Relaxed);
             CacheDigest::blake3(format!("{task}\0{}\0{sequence}", std::process::id()).as_bytes())
-                .hash;
+                .hash
+        });
         // The largest baseline rather than a sum: beginning the same task again
         // in one session reloads the same manifest, and counting it twice would
         // overstate what there was to match.

--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -23,7 +23,22 @@ pub(super) fn run(
     settings: &CliSettings,
     arguments: &[String],
 ) -> Result<ExitCode> {
-    cargo_with_settings_and_bypass_log(config, settings, arguments, None)
+    cargo_with_settings_bypass_log_and_roots(config, settings, arguments, None, None)
+}
+
+/// Run Cargo with roots an earlier probe already resolved.
+///
+/// The persistent Cargo shim probes before loading configuration so an
+/// invocation outside a usable workspace can pass through untouched. Reusing
+/// that result here keeps the shim from running the same `cargo metadata`
+/// command twice.
+pub(super) fn run_with_roots(
+    config: &Config,
+    settings: &CliSettings,
+    arguments: &[String],
+    roots: Roots,
+) -> Result<ExitCode> {
+    cargo_with_settings_bypass_log_and_roots(config, settings, arguments, None, Some(roots))
 }
 
 pub(crate) fn cargo_with_bypass_log(
@@ -31,7 +46,13 @@ pub(crate) fn cargo_with_bypass_log(
     arguments: &[String],
     bypass_log: Option<&Path>,
 ) -> Result<ExitCode> {
-    cargo_with_settings_and_bypass_log(config, &CliSettings::default(), arguments, bypass_log)
+    cargo_with_settings_bypass_log_and_roots(
+        config,
+        &CliSettings::default(),
+        arguments,
+        bypass_log,
+        None,
+    )
 }
 
 pub(crate) fn cargo_with_settings_and_bypass_log(
@@ -39,6 +60,16 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
     settings: &CliSettings,
     arguments: &[String],
     bypass_log: Option<&Path>,
+) -> Result<ExitCode> {
+    cargo_with_settings_bypass_log_and_roots(config, settings, arguments, bypass_log, None)
+}
+
+fn cargo_with_settings_bypass_log_and_roots(
+    config: &Config,
+    settings: &CliSettings,
+    arguments: &[String],
+    bypass_log: Option<&Path>,
+    roots: Option<Roots>,
 ) -> Result<ExitCode> {
     let retention = &settings.retention;
     let summary = if cargo_is_quiet(arguments) {
@@ -57,7 +88,7 @@ pub(crate) fn cargo_with_settings_and_bypass_log(
         log::warn!("caching native links is not supported on this platform");
     }
     let working_dir = std::env::current_dir()?;
-    let mut roots = resolve_roots(&cargo, arguments, &working_dir);
+    let mut roots = roots.unwrap_or_else(|| resolve_roots(&cargo, arguments, &working_dir));
     let mut config = config.clone();
     config.apply_workspace_policy(&roots.workspace_root)?;
     let incremental = policy::incremental_allowed(config.incremental);
@@ -573,15 +604,13 @@ pub(super) fn absolute(working_dir: &Path, value: &str) -> PathBuf {
 /// metadata` would report. `-C` moves the whole invocation, and `--config` can
 /// set `build.target-dir` outright, so a probe that drops them describes a
 /// different tree than the one being built.
+#[cfg(test)]
 pub(super) const PROBE_GLOBAL_FLAGS: [&str; 3] = ["-C", "--config", "-Z"];
-/// Options cargo accepts only after the subcommand. The network flags matter
-/// because a probe left to itself may reach the registry the build was told to
-/// stay away from.
-pub(super) const PROBE_MANIFEST_TOGGLES: [&str; 3] = ["--offline", "--frozen", "--locked"];
 
 /// Collect the occurrences of `flags` from `arguments`, preserving order and
 /// repeats. Cargo allows `--flag value`, `--flag=value`, and, for the short
 /// forms, `-Zvalue`.
+#[cfg(test)]
 pub(super) fn forwarded_flags(arguments: &[String], flags: &[&str]) -> Vec<String> {
     let mut forwarded = Vec::new();
     let mut remaining = arguments.iter();
@@ -612,34 +641,21 @@ pub(super) fn cargo_roots(
     arguments: &[String],
     target_dir_env: Option<&std::ffi::OsStr>,
 ) -> Option<Roots> {
-    let mut command = Command::new(cargo);
-    // Say what the probe should see rather than letting it inherit: cargo lets
-    // this variable outrank configuration, so a probe that disagrees with the
-    // caller about it describes a different target directory than the build's.
-    match target_dir_env {
-        Some(dir) => command.env(CARGO_TARGET_DIR_ENV, dir),
-        None => command.env_remove(CARGO_TARGET_DIR_ENV),
-    };
-    // Globals come first; cargo rejects them after the subcommand.
-    command.args(forwarded_flags(arguments, &PROBE_GLOBAL_FLAGS));
-    command.args(["metadata", "--no-deps", "--format-version", "1"]);
-    // Describe the project the build will actually operate on.
-    if let Some(manifest) = flag_value(arguments, "--manifest-path") {
-        command.args(["--manifest-path", manifest]);
-    }
-    for toggle in arguments
-        .iter()
-        .filter(|argument| PROBE_MANIFEST_TOGGLES.contains(&argument.as_str()))
-    {
-        command.arg(toggle);
-    }
-    let output = command.output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    parse_cargo_roots(&output.stdout)
+    let working_dir = std::env::current_dir().ok()?;
+    let resolved = mbx_cache_cargo::resolve_reported(
+        cargo,
+        arguments,
+        &working_dir,
+        target_dir_env.map(std::ffi::OsStr::to_os_string),
+    )?;
+    Some(Roots {
+        workspace_root: resolved.workspace_root,
+        target_dir: resolved.target_dir,
+        target_dir_requested: resolved.target_dir_requested,
+    })
 }
 
+#[cfg(test)]
 pub(super) fn parse_cargo_roots(metadata: &[u8]) -> Option<Roots> {
     let metadata: serde_json::Value = serde_json::from_slice(metadata).ok()?;
     Some(Roots {
@@ -651,22 +667,6 @@ pub(super) fn parse_cargo_roots(metadata: &[u8]) -> Option<Roots> {
         target_dir_requested: false,
     })
 }
-
-/// Read `--flag <value>` or `--flag=<value>` out of cargo's arguments.
-pub(super) fn flag_value<'a>(arguments: &'a [String], flag: &str) -> Option<&'a str> {
-    let joined = format!("{flag}=");
-    let mut arguments = arguments.iter();
-    while let Some(argument) = arguments.next() {
-        if let Some(value) = argument.strip_prefix(&joined) {
-            return Some(value);
-        }
-        if argument == flag {
-            return arguments.next().map(String::as_str);
-        }
-    }
-    None
-}
-
 /// Cargo's own compiler-process limit, when it narrows the scheduler pool.
 ///
 /// The CLI wins over `CARGO_BUILD_JOBS`, including `default`, just as it does

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -80,13 +80,11 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
     let Ok(string_arguments) = super::strings(&arguments) else {
         return run_real_cargo(&real_cargo, &arguments);
     };
-    if cargo_roots(
+    let Some(roots) = cargo_roots(
         &real_cargo,
         &string_arguments,
         std::env::var_os(CARGO_TARGET_DIR_ENV).as_deref(),
-    )
-    .is_none()
-    {
+    ) else {
         return run_real_cargo(
             &real_cargo,
             &string_arguments
@@ -94,11 +92,11 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
                 .map(OsString::from)
                 .collect::<Vec<_>>(),
         );
-    }
+    };
     // Every probe and the final child must name Cargo directly.
     unsafe { std::env::set_var("CARGO", &real_cargo) };
     let (config, settings) = Config::load_for_cli()?;
-    super::cargo::run(&config, &settings, &string_arguments)
+    super::cargo::run_with_roots(&config, &settings, &string_arguments, roots)
 }
 
 fn resolve_active_cargo_shim(

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -105,6 +105,13 @@ pub struct CacheSession {
     started: Instant,
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
     server: Mutex<Option<JoinHandle<Result<()>>>>,
+    task: Arc<SessionTask>,
+}
+
+/// The Cargo task is loaded only if a compiler shim connects.
+pub(super) struct SessionTask {
+    identity: std::sync::OnceLock<String>,
+    initialized: tokio::sync::OnceCell<bool>,
 }
 
 impl CacheSession {
@@ -122,7 +129,8 @@ impl CacheSession {
         config: &Config,
         cargo_jobs: Option<u64>,
     ) -> Result<Self> {
-        let (shim, rustdoc_shim) = install_session_shims(session_dir)?;
+        let (shim, rustdoc_shim) =
+            install_session_shims(session_dir, &config.cache_dir.join("shims"))?;
         let cc_shims = if config.cc {
             // Build systems such as CMake persist HOST_CC as an absolute
             // compiler path. Keep the C/C++ shims outside the temporary
@@ -153,7 +161,12 @@ impl CacheSession {
             None => agent,
         };
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let (socket, server) = spawn_server(session_dir, agent.clone(), shutdown_rx).await?;
+        let task = Arc::new(SessionTask {
+            identity: std::sync::OnceLock::new(),
+            initialized: tokio::sync::OnceCell::new(),
+        });
+        let (socket, server) =
+            spawn_server(session_dir, agent.clone(), Arc::clone(&task), shutdown_rx).await?;
         Ok(Self {
             socket,
             rustc_shim: shim,
@@ -172,6 +185,7 @@ impl CacheSession {
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),
             server: Mutex::new(Some(server)),
+            task,
         })
     }
 
@@ -203,23 +217,16 @@ impl CacheSession {
         {
             warn!("this checkout was not recorded as a cache root: {error}");
         }
-        let (protocol_build, action_run) = match self.agent.begin_task(&identity).await {
-            Ok(run) => (
-                run.clone(),
-                Some(ActionRun {
-                    run,
-                    identity: identity.clone(),
-                    workspace_root: workspace_root.to_path_buf(),
-                    export_group: std::env::var(CACHE_EXPORT_GROUP_ENV).ok(),
-                    store: self.store.clone(),
-                    agent: self.agent.clone(),
-                }),
-            ),
-            Err(error) => {
-                warn!("build action manifest was not loaded: {error}");
-                (identity, None)
-            }
-        };
+        let _ = self.task.identity.set(identity.clone());
+        let action_run = Some(ActionRun {
+            run: identity.clone(),
+            identity: identity.clone(),
+            workspace_root: workspace_root.to_path_buf(),
+            export_group: std::env::var(CACHE_EXPORT_GROUP_ENV).ok(),
+            store: self.store.clone(),
+            agent: self.agent.clone(),
+            initialized: Some(Arc::clone(&self.task)),
+        });
         let shim = self.rustc_shim.to_string_lossy().into_owned();
         // The shim maps these roots out of its cache keys; a dependency compiles
         // with its working directory in the registry, so it cannot find them.
@@ -255,7 +262,7 @@ impl CacheSession {
             STAGING_ENV.into(),
             self.staging.to_string_lossy().into_owned(),
         );
-        environment.insert(BUILD_ENV.into(), protocol_build);
+        environment.insert(BUILD_ENV.into(), identity);
         // Always state this explicitly: removing the key would leave the shim
         // inheriting whatever the parent environment had.
         environment.insert(
@@ -417,6 +424,7 @@ impl CacheSession {
                     export_group: std::env::var(CACHE_EXPORT_GROUP_ENV).ok(),
                     store: self.store.clone(),
                     agent: self.agent.clone(),
+                    initialized: None,
                 }),
             ),
             Err(error) => {
@@ -656,10 +664,18 @@ pub struct ActionRun {
     export_group: Option<String>,
     store: PathBuf,
     agent: CacheAgent,
+    initialized: Option<Arc<SessionTask>>,
 }
 
 impl ActionRun {
     pub async fn commit(self) -> Result<()> {
+        if self
+            .initialized
+            .as_ref()
+            .is_some_and(|task| task.initialized.get() != Some(&true))
+        {
+            return Ok(());
+        }
         let predictions = self.agent.commit_task_actions(&self.run).await?;
         crate::store::record_build_receipt(
             &self.store,

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -220,6 +220,7 @@ impl CacheSession {
         let _ = self.task.identity.set(identity.clone());
         let action_run = Some(ActionRun {
             run: identity.clone(),
+            receipt: build_receipt_run(&identity),
             identity: identity.clone(),
             workspace_root: workspace_root.to_path_buf(),
             export_group: std::env::var(CACHE_EXPORT_GROUP_ENV).ok(),
@@ -418,6 +419,7 @@ impl CacheSession {
             Ok(run) => (
                 run.clone(),
                 Some(ActionRun {
+                    receipt: run.clone(),
                     run,
                     identity: identity.clone(),
                     workspace_root: project_root.to_path_buf(),
@@ -659,6 +661,7 @@ impl AgentEventObserver for EventStream {
 /// An in-flight build's completed action manifest.
 pub struct ActionRun {
     run: String,
+    receipt: String,
     identity: String,
     workspace_root: PathBuf,
     export_group: Option<String>,
@@ -679,13 +682,26 @@ impl ActionRun {
         let predictions = self.agent.commit_task_actions(&self.run).await?;
         crate::store::record_build_receipt(
             &self.store,
-            &self.run,
+            &self.receipt,
             &self.identity,
             &self.workspace_root,
             self.export_group.as_deref(),
             predictions,
         )
     }
+}
+
+/// A unique receipt name for one invocation of a stable Cargo task.
+fn build_receipt_run(identity: &str) -> String {
+    CacheDigest::blake3(
+        format!(
+            "{identity}\0{}\0{}",
+            std::process::id(),
+            crate::util::random_string(12)
+        )
+        .as_bytes(),
+    )
+    .hash
 }
 
 /// Identity for this build's prefetch manifest.

--- a/crates/mbx/src/session/server.rs
+++ b/crates/mbx/src/session/server.rs
@@ -4,6 +4,7 @@ use eyre::Result;
 use log::debug;
 use mbx_cache_core::CacheAgent;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -11,6 +12,7 @@ use tokio::task::JoinHandle;
 pub(super) async fn spawn_server(
     session_dir: &Path,
     agent: CacheAgent,
+    task: Arc<super::SessionTask>,
     mut shutdown: oneshot::Receiver<()>,
 ) -> Result<(String, JoinHandle<Result<()>>)> {
     use std::os::unix::fs::PermissionsExt as _;
@@ -30,7 +32,9 @@ pub(super) async fn spawn_server(
                         Err(error) => break Err(eyre::Report::from(error)),
                     };
                     let agent = agent.clone();
+                    let task = Arc::clone(&task);
                     connections.spawn(async move {
+                        initialize_task(&agent, &task).await;
                         if let Err(error) = agent.handle_connection(stream).await {
                             debug!("cache agent connection failed: {error}");
                         }
@@ -64,6 +68,7 @@ impl Drop for SocketCleanup {
 pub(super) async fn spawn_server(
     _session_dir: &Path,
     agent: CacheAgent,
+    task: Arc<super::SessionTask>,
     mut shutdown: oneshot::Receiver<()>,
 ) -> Result<(String, JoinHandle<Result<()>>)> {
     let endpoint = format!(
@@ -90,7 +95,9 @@ pub(super) async fn spawn_server(
                         Err(error) => break Err(error),
                     }
                     let agent = agent.clone();
+                    let task = Arc::clone(&task);
                     connections.spawn(async move {
+                        initialize_task(&agent, &task).await;
                         if let Err(error) = agent.handle_connection(pipe).await {
                             debug!("cache agent connection failed: {error}");
                         }
@@ -108,6 +115,23 @@ pub(super) async fn spawn_server(
         outcome
     });
     Ok((endpoint, server))
+}
+
+async fn initialize_task(agent: &CacheAgent, task: &super::SessionTask) {
+    let Some(identity) = task.identity.get() else {
+        return;
+    };
+    task.initialized
+        .get_or_init(|| async {
+            match agent.begin_session_task(identity).await {
+                Ok(()) => true,
+                Err(error) => {
+                    log::warn!("build action manifest was not loaded: {error}");
+                    false
+                }
+            }
+        })
+        .await;
 }
 
 #[cfg(windows)]

--- a/crates/mbx/src/session/shims.rs
+++ b/crates/mbx/src/session/shims.rs
@@ -6,6 +6,7 @@ use super::{
 use eyre::{Context, Result};
 use log::debug;
 use mbx_cache_cc::CcLanguage;
+use mbx_cache_core::CacheDigest;
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -387,9 +388,15 @@ fn canonical(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-pub(super) fn install_session_shims(session_dir: &Path) -> Result<(PathBuf, PathBuf)> {
+pub(super) fn install_session_shims(
+    session_dir: &Path,
+    persistent_shims: &Path,
+) -> Result<(PathBuf, PathBuf)> {
     let executable = std::env::current_exe().wrap_err("failed to locate the running mbx binary")?;
-    let rustc = install_shim(&executable, session_dir, ShimLink::Tracking)?;
+    let binary_shims = binary_shims_dir(persistent_shims, &executable)?;
+    std::fs::create_dir_all(&binary_shims)?;
+    let rustc = binary_shims.join(shim_file_name(RUSTC_SHIM_STEM));
+    link_path_shim(&executable, &rustc)?;
     let rustdoc = install_shim_named(
         &executable,
         session_dir,
@@ -397,6 +404,37 @@ pub(super) fn install_session_shims(session_dir: &Path) -> Result<(PathBuf, Path
         ShimLink::Tracking,
     )?;
     Ok((rustc, rustdoc))
+}
+
+/// A stable shim directory for exactly one installed mbx executable.
+///
+/// Cargo keys its cached rustc probes by the wrapper path. A session-local
+/// wrapper makes every invocation look like a different compiler, while a
+/// single machine-wide name would conceal upgrades. The executable's path and
+/// file identity give repeated runs of one binary the same name and a replaced
+/// binary a new one without reading the whole executable at startup.
+fn binary_shims_dir(shims: &Path, executable: &Path) -> Result<PathBuf> {
+    let executable = std::path::absolute(executable)?;
+    let metadata = std::fs::metadata(&executable)?;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok());
+    let mut identity = executable.as_os_str().as_encoded_bytes().to_vec();
+    identity.push(0);
+    identity.extend_from_slice(&metadata.len().to_le_bytes());
+    identity.extend_from_slice(
+        &modified
+            .map_or(0, |duration| duration.as_secs())
+            .to_le_bytes(),
+    );
+    identity.extend_from_slice(
+        &modified
+            .map_or(0, |duration| duration.subsec_nanos())
+            .to_le_bytes(),
+    );
+    let digest = CacheDigest::blake3(&identity);
+    Ok(shims.join("rust").join(digest.hash))
 }
 
 /// How an installed shim refers to the mbx binary behind it.

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -156,6 +156,63 @@ async fn failed_incremental_recording_replaces_an_inherited_root() {
     session.finish().await.unwrap();
 }
 
+/// Cargo caches rustc target and capability probes under the wrapper path. A
+/// temporary path makes an otherwise no-op build repeat all of them, so the
+/// rustc wrapper belongs to the mbx binary rather than the session.
+#[tokio::test]
+async fn rustc_shim_path_survives_and_is_reused_across_sessions() {
+    let cache = tempfile::tempdir().unwrap();
+    let config = test_config(cache.path());
+
+    let first_path = {
+        let session_dir = tempfile::tempdir().unwrap();
+        let session = CacheSession::start(session_dir.path(), &config)
+            .await
+            .unwrap();
+        let path = session.rustc_shim.clone();
+        session.finish().await.unwrap();
+        path
+    };
+
+    assert!(
+        first_path.is_file(),
+        "the wrapper path cached by Cargo must survive its mbx session"
+    );
+
+    let second_dir = tempfile::tempdir().unwrap();
+    let second = CacheSession::start(second_dir.path(), &config)
+        .await
+        .unwrap();
+    assert_eq!(second.rustc_shim, first_path);
+    second.finish().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_session_with_no_shim_connection_does_not_load_a_manifest() {
+    let cache = tempfile::tempdir().unwrap();
+    let session_dir = tempfile::tempdir().unwrap();
+    let session = CacheSession::start(session_dir.path(), &test_config(cache.path()))
+        .await
+        .unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let mut environment = BTreeMap::new();
+
+    let run = session
+        .begin(
+            workspace.path(),
+            &workspace.path().join("target"),
+            &["build".to_string()],
+            &mut environment,
+        )
+        .await
+        .unwrap();
+
+    assert!(session.task.initialized.get().is_none());
+    run.commit().await.unwrap();
+    assert!(session.task.initialized.get().is_none());
+    assert_eq!(session.finish().await.unwrap().predictions_loaded, 0);
+}
+
 #[test]
 fn nested_sessions_unwrap_the_outer_rustdoc_shim() {
     let values = BTreeMap::from([

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -617,13 +617,19 @@ fn a_ci_export_group_collects_every_build_in_the_job() {
         first.path(),
         source_store.path(),
         &reports.path().join("first.json"),
-        &[(mbx::session::CACHE_EXPORT_GROUP_ENV, group)],
+        &[
+            (mbx::session::CACHE_EXPORT_GROUP_ENV, group),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+        ],
     );
     build_with(
         second.path(),
         source_store.path(),
         &reports.path().join("second.json"),
-        &[(mbx::session::CACHE_EXPORT_GROUP_ENV, group)],
+        &[
+            (mbx::session::CACHE_EXPORT_GROUP_ENV, group),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+        ],
     );
     wipe_target(first.path());
     wipe_target(second.path());
@@ -632,17 +638,35 @@ fn a_ci_export_group_collects_every_build_in_the_job() {
         first.path(),
         source_store.path(),
         &reports.path().join("first-warm.json"),
-        &[(mbx::session::CACHE_EXPORT_GROUP_ENV, warm_group)],
+        &[
+            (mbx::session::CACHE_EXPORT_GROUP_ENV, warm_group),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+        ],
+    )
+    .0;
+    edit_project(first.path(), 1);
+    let first_changed = build_with(
+        first.path(),
+        source_store.path(),
+        &reports.path().join("first-changed.json"),
+        &[
+            (mbx::session::CACHE_EXPORT_GROUP_ENV, warm_group),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+        ],
     )
     .0;
     let second_warm = build_with(
         second.path(),
         source_store.path(),
         &reports.path().join("second-warm.json"),
-        &[(mbx::session::CACHE_EXPORT_GROUP_ENV, warm_group)],
+        &[
+            (mbx::session::CACHE_EXPORT_GROUP_ENV, warm_group),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+        ],
     )
     .0;
     assert!(count(&first_warm, "hits") > 0);
+    assert!(count(&first_changed, "misses") > 0);
     assert!(count(&second_warm, "hits") > 0);
     let archive = reports.path().join("job.tar");
 
@@ -675,8 +699,8 @@ fn a_ci_export_group_collects_every_build_in_the_job() {
     ))
     .unwrap();
     assert!(
-        stats["action_results"].as_u64().unwrap() >= 2,
-        "both builds should seed the destination store: {stats}; export: {}; import: {}",
+        stats["action_results"].as_u64().unwrap() >= 3,
+        "every grouped build should seed the destination store: {stats}; export: {}; import: {}",
         String::from_utf8_lossy(&export.stdout),
         String::from_utf8_lossy(&import.stdout),
     );

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -356,6 +356,34 @@ EOF
   assert_output "1"
 }
 
+@test "the Cargo shim reuses its workspace metadata probe" {
+  local project="$BATS_TEST_TMPDIR/metadata-project"
+  local real_bin="$BATS_TEST_TMPDIR/metadata-real-bin"
+  local cargo_log="$BATS_TEST_TMPDIR/metadata-cargo.log"
+  write_project "$project"
+  mkdir -p "$real_bin"
+  cat >"$real_bin/cargo" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$MBX_TEST_CARGO_LOG"
+case " $* " in
+  *" metadata "*)
+    printf '{"workspace_root":"%s","target_directory":"%s","packages":[]}' \
+      "$MBX_TEST_PROJECT" "$MBX_TEST_PROJECT/target"
+    ;;
+esac
+EOF
+  chmod +x "$real_bin/cargo"
+  "$MBX_BIN" setup >/dev/null
+
+  run env PATH="$MBX_SHIM_DIR:$real_bin:/usr/bin:/bin" \
+    MBX_TEST_CARGO_LOG="$cargo_log" MBX_TEST_PROJECT="$project" \
+    cargo build --manifest-path "$project/Cargo.toml"
+  assert_success
+  run grep -c 'metadata --no-deps --format-version 1' "$cargo_log"
+  assert_success
+  assert_output "1"
+}
+
 @test "explicit mbx Cargo commands do not reenter the installed shim" {
   local project="$BATS_TEST_TMPDIR/explicit-mbx-project"
   write_project "$project"


### PR DESCRIPTION
## Summary

- install rustc shims at a stable path scoped to the mbx executable so Cargo can reuse compiler probes
- reuse the persistent Cargo shim metadata result instead of running `cargo metadata` twice
- defer prediction-manifest initialization until a compiler shim actually connects, making no-op builds cheaper

## Testing

- `cargo check --workspace --all-targets`
- `cargo test -p mbx --lib`
- `cargo test -p mbx-cache-core --lib`
- `cargo test -p mbx-cache-cargo`
- `cargo test -p mbx --test build restores_a_wiped_target_directory_from_the_store`
- `test/bats/bin/bats test/setup.bats --filter "the Cargo shim reuses its workspace metadata probe"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session lifecycle, cache run/receipt keys, and when manifests load—could affect builds that start a session but never compile, or commit behavior if shim connection timing differs from before.
> 
> **Overview**
> This PR speeds up Cargo builds by **reusing compiler and workspace probes** and **loading prediction manifests only when caching actually runs**.
> 
> The **rustc wrapper** is installed under a stable, per-mbx-binary path in the cache (not a temp session dir) so Cargo can keep its rustc capability/target probes across runs. **Rustdoc** stays session-local.
> 
> The **persistent Cargo shim** runs `cargo metadata` once, then hands those roots into `run_with_roots` so the full mbx Cargo path does not probe again. Failed probes still pass through to real Cargo via `resolve_reported` in `mbx-cache-cargo`.
> 
> **Session startup** no longer blocks on `begin_task`: the build identity is put in the environment immediately, and the cache agent loads the task manifest on the **first compiler-shim connection** (`begin_session_task` uses the identity as the run key). Builds that never hit the shim skip manifest work and no-op `commit` when nothing initialized.
> 
> Cargo root resolution in the CLI is centralized on `mbx-cache-cargo` instead of duplicating probe logic locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f16b16431f41d2f4cca5771b452b4edf96d1a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Cargo build handling by reusing workspace information from the initial probe.
  * Added session-aware task tracking for more consistent cache behavior.
  * Persisted Rust compiler shims across sessions and reused them when possible.

* **Bug Fixes**
  * Avoided unnecessary repeated Cargo metadata probes.
  * Correctly handled failed metadata probes without continuing resolution.

* **Tests**
  * Added coverage for shim reuse, metadata probe counts, failed resolution, and grouped build exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->