### PR TITLE
fix: release cache pinned by phantom checkouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ startup files.
 Collection runs after a build, at most once an hour, and needs no
 configuration. Both size budgets default to a share of the disk holding the
 cache — 5% for the action store and 10% for managed `target/` directories,
-each from its floor (5 GiB and 10 GiB) up to 100 GiB and rounded down to a
-whole 5 GiB — and a managed directory is also collected once its checkout is
-gone or it has sat unused for 30 days.
+from floors of 5 GiB and 10 GiB up to 500 GiB and 100 GiB respectively, and
+rounded down to a whole 5 GiB — and a managed directory is also collected once
+its checkout is gone or it has sat unused for 30 days.
 
 mbx keeps a running total of what that has been worth and reports one line of
 it after a build:

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -19,6 +19,9 @@ serde_json = "1"
 tar = { version = "0.4", default-features = false }
 tempfile = "3"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 filetime = "0.2"
 

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -1037,7 +1037,7 @@ pub fn checkout_is_live_on(store: &Path, workspace_root: &Path) -> bool {
     for ancestor in workspace_root.ancestors().skip(1) {
         match std::fs::metadata(ancestor) {
             Ok(ancestor_metadata) => {
-                return !same_filesystem(&store_metadata, &ancestor_metadata);
+                return !same_filesystem(store, &store_metadata, ancestor, &ancestor_metadata);
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(_) => return true,
@@ -1059,20 +1059,67 @@ pub fn checkout_is_live(workspace_root: &Path) -> bool {
 }
 
 #[cfg(unix)]
-fn same_filesystem(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
+fn same_filesystem(
+    _a_path: &Path,
+    a: &std::fs::Metadata,
+    _b_path: &Path,
+    b: &std::fs::Metadata,
+) -> bool {
     use std::os::unix::fs::MetadataExt as _;
     a.dev() == b.dev()
 }
 
 #[cfg(windows)]
-fn same_filesystem(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt as _;
-    a.volume_serial_number()
-        .is_some_and(|volume| b.volume_serial_number() == Some(volume))
+fn same_filesystem(
+    a_path: &Path,
+    _a: &std::fs::Metadata,
+    b_path: &Path,
+    _b: &std::fs::Metadata,
+) -> bool {
+    windows_volume_name(a_path).is_some_and(|volume| windows_volume_name(b_path) == Some(volume))
+}
+
+#[cfg(windows)]
+fn windows_volume_name(path: &Path) -> Option<Vec<u16>> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetVolumeNameForVolumeMountPointW, GetVolumePathNameW,
+    };
+
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    // Both APIs document MAX_PATH-sized output buffers for volume paths and
+    // names. Failure is uncertainty, which deliberately keeps the checkout
+    // live.
+    let mut mount = vec![0_u16; 261];
+    // SAFETY: `path` is nul-terminated and `mount` is writable for the stated
+    // number of UTF-16 code units.
+    if unsafe { GetVolumePathNameW(path.as_ptr(), mount.as_mut_ptr(), mount.len() as u32) } == 0 {
+        return None;
+    }
+    let mut volume = vec![0_u16; 261];
+    // SAFETY: the successful call above left `mount` nul-terminated, and
+    // `volume` is writable for the stated number of UTF-16 code units.
+    if unsafe {
+        GetVolumeNameForVolumeMountPointW(mount.as_ptr(), volume.as_mut_ptr(), volume.len() as u32)
+    } == 0
+    {
+        return None;
+    }
+    volume.truncate(volume.iter().position(|unit| *unit == 0)?);
+    Some(volume)
 }
 
 #[cfg(not(any(unix, windows)))]
-fn same_filesystem(_a: &std::fs::Metadata, _b: &std::fs::Metadata) -> bool {
+fn same_filesystem(
+    _a_path: &Path,
+    _a: &std::fs::Metadata,
+    _b_path: &Path,
+    _b: &std::fs::Metadata,
+) -> bool {
     false
 }
 

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -601,7 +601,7 @@ pub fn projects(store: &Path) -> Result<Vec<ProjectUsage>> {
                 continue;
             };
             let project = projects.entry(record.workspace_root.clone()).or_default();
-            if claim_is_live(&record) {
+            if claim_is_live(store, &record) {
                 project.0.insert(identity.clone());
                 project.1 = true;
             }
@@ -979,7 +979,7 @@ fn scan_checkouts(store: &Path) -> Result<CheckoutScan> {
         }
         for record in walk_files(&entry.path())? {
             match read_checkout_record(&record.path) {
-                Some(checkout) if claim_is_live(&checkout) => {
+                Some(checkout) if claim_is_live(store, &checkout) => {
                     scan.live_identities.insert(name.clone());
                     scan.live_records += 1;
                 }
@@ -1001,8 +1001,8 @@ fn read_checkout_record(path: &Path) -> Option<CheckoutRecord> {
 
 /// Whether a recorded claim still speaks for a checkout that is using this
 /// store.
-fn claim_is_live(record: &CheckoutRecord) -> bool {
-    checkout_is_live(&record.workspace_root) && !claim_has_expired(record)
+fn claim_is_live(store: &Path, record: &CheckoutRecord) -> bool {
+    checkout_is_live_on(store, &record.workspace_root) && !claim_has_expired(record)
 }
 
 fn claim_has_expired(record: &CheckoutRecord) -> bool {
@@ -1016,26 +1016,64 @@ fn claim_has_expired(record: &CheckoutRecord) -> bool {
 
 /// Whether the checkout a record names is still on disk.
 ///
-/// Absence is believed only when the checkout is definitely absent *and* its
-/// parent directory is definitely still there. Deleting a worktree, or a whole
-/// project directory, leaves the parent behind; a volume being ejected or a
-/// network mount going away takes several levels with it, and that is the case
-/// worth being careful about -- a temporarily absent mount must not un-root a
-/// checkout that is really there.
+/// Absence is believed only when the checkout is definitely absent and its
+/// nearest existing ancestor is on the same filesystem as the store. Walking
+/// all the way to that ancestor matters for worktree managers and temporary
+/// directories, which commonly remove a checkout together with one or more of
+/// its otherwise-empty parents.
 ///
-/// So both questions are asked the same way: only a definite answer counts, and
-/// an error at either step means live. Being wrong in that direction only
-/// delays collection; the other way round throws away a warm cache someone is
-/// still using.
-pub fn checkout_is_live(workspace_root: &Path) -> bool {
+/// A different filesystem can be a mount whose contents are temporarily
+/// unavailable, so uncertainty there remains live. Errors are treated the same
+/// way: being wrong in that direction only delays collection; the other way
+/// round throws away a warm cache someone is still using.
+pub fn checkout_is_live_on(store: &Path, workspace_root: &Path) -> bool {
     if !matches!(workspace_root.try_exists(), Ok(false)) {
         return true;
     }
-    match workspace_root.parent() {
-        Some(parent) => !matches!(parent.try_exists(), Ok(true)),
-        // A root directory has no parent to corroborate anything with.
-        None => true,
+
+    let Ok(store_metadata) = std::fs::metadata(store) else {
+        return true;
+    };
+    for ancestor in workspace_root.ancestors().skip(1) {
+        match std::fs::metadata(ancestor) {
+            Ok(ancestor_metadata) => {
+                return !same_filesystem(&store_metadata, &ancestor_metadata);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return true,
+        }
     }
+    true
+}
+
+/// Whether a checkout is still on disk, corroborating absence through its
+/// immediate parent.
+///
+/// Prefer [`checkout_is_live_on`] when an existing store or managed-target
+/// root is available to distinguish deletion from an unavailable filesystem.
+pub fn checkout_is_live(workspace_root: &Path) -> bool {
+    let Some(parent) = workspace_root.parent() else {
+        return true;
+    };
+    checkout_is_live_on(parent, workspace_root)
+}
+
+#[cfg(unix)]
+fn same_filesystem(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+    a.dev() == b.dev()
+}
+
+#[cfg(windows)]
+fn same_filesystem(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+    a.volume_serial_number()
+        .is_some_and(|volume| b.volume_serial_number() == Some(volume))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_filesystem(_a: &std::fs::Metadata, _b: &std::fs::Metadata) -> bool {
+    false
 }
 
 /// CAS paths reachable from the builds that live checkouts still depend on.

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -812,12 +812,16 @@ fn treats_a_store_with_no_checkout_records_as_plain_lru() {
 fn drops_checkout_records_whose_worktree_is_gone() {
     let directory = tempfile::tempdir().unwrap();
     let store = directory.path().join("store");
-    let gone = directory.path().join("gone");
+    let discarded_parent = directory.path().join("temporary");
+    let gone = discarded_parent.join("codex/worktree");
     std::fs::create_dir_all(&gone).unwrap();
     record_checkout(&store, &"e".repeat(64), &gone, &gone.join("target")).unwrap();
 
     assert_eq!(stats(&store).unwrap().live_checkouts, 1);
-    std::fs::remove_dir_all(&gone).unwrap();
+    // Codex and temporary-worktree managers discard the checkout together
+    // with its parent hierarchy. The surviving temp directory is the nearest
+    // ancestor that can corroborate the deletion.
+    std::fs::remove_dir_all(&discarded_parent).unwrap();
     let after = stats(&store).unwrap();
     assert_eq!(after.stale_checkouts, 1);
     assert_eq!(after.live_checkouts, 0);
@@ -917,24 +921,36 @@ fn ignores_what_it_did_not_write_beside_the_checkout_records() {
 }
 
 #[test]
-fn keeps_a_checkout_whose_absence_it_cannot_corroborate() {
+fn corroborates_a_removed_checkout_through_its_nearest_existing_ancestor() {
     let directory = tempfile::tempdir().unwrap();
+    let store = directory.path().join("store");
+    std::fs::create_dir_all(&store).unwrap();
 
-    // A checkout that is gone from a parent that is still there is the one
-    // case worth believing: that is what deleting a worktree looks like.
+    // A checkout that is gone from a parent on the store's filesystem is worth
+    // believing: that is what deleting a worktree looks like.
     let parent = directory.path().join("worktrees");
     std::fs::create_dir_all(&parent).unwrap();
-    assert!(!checkout_is_live(&parent.join("removed")));
+    assert!(!checkout_is_live_on(&store, &parent.join("removed")));
 
-    // A checkout whose parent went with it looks like an ejected volume or a
-    // mount that is temporarily away, and un-rooting those would throw away
-    // a cache somebody is still using.
-    assert!(checkout_is_live(
+    // Worktree managers remove their empty parent hierarchy too. The nearest
+    // remaining ancestor still corroborates that this checkout was deleted.
+    assert!(!checkout_is_live_on(
+        &store,
         &directory.path().join("gone/deeper/still")
     ));
 
     // And anything still on disk is live whatever its parent says.
-    assert!(checkout_is_live(directory.path()));
+    assert!(checkout_is_live_on(&store, directory.path()));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn keeps_a_missing_checkout_beneath_a_different_filesystem() {
+    let directory = tempfile::tempdir().unwrap();
+    assert!(checkout_is_live_on(
+        directory.path(),
+        Path::new("/proc/mbx-checkout-that-does-not-exist")
+    ));
 }
 
 #[test]

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -20,11 +20,11 @@ const DEFAULT_TARGET_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
 const GIB: u64 = 1024 * 1024 * 1024;
 
-/// The largest a budget nobody configured will grow to.
-///
-/// Scaling without a ceiling would hand a 4TB workstation hundreds of
-/// gigabytes it never asked to give up.
-const MAX_SCALED_BUDGET: u64 = 100 * GIB;
+/// The largest the action-store budget nobody configured will grow to.
+const MAX_STORE_BUDGET: u64 = 500 * GIB;
+
+/// The largest the managed-target budget nobody configured will grow to.
+const MAX_TARGET_BUDGET: u64 = 100 * GIB;
 
 /// Scaled budgets are rounded down to a multiple of this.
 ///
@@ -45,6 +45,7 @@ struct ScaledBudget {
     /// Percent of the whole disk.
     percent: u64,
     floor: u64,
+    ceiling: u64,
     /// Used when the disk cannot be measured. Guessing a disk size would be
     /// worse: this is the budget mbx shipped with before it scaled them.
     fallback: u64,
@@ -53,6 +54,7 @@ struct ScaledBudget {
 const STORE_BUDGET: ScaledBudget = ScaledBudget {
     percent: 5,
     floor: 5 * GIB,
+    ceiling: MAX_STORE_BUDGET,
     fallback: 20 * GIB,
 };
 
@@ -61,6 +63,7 @@ const STORE_BUDGET: ScaledBudget = ScaledBudget {
 const TARGET_BUDGET: ScaledBudget = ScaledBudget {
     percent: 10,
     floor: 10 * GIB,
+    ceiling: MAX_TARGET_BUDGET,
     fallback: 30 * GIB,
 };
 
@@ -73,7 +76,7 @@ impl ScaledBudget {
         // Floors and the ceiling are whole increments themselves, so clamping
         // cannot reintroduce a ragged number.
         let whole = share - (share % BUDGET_INCREMENT);
-        whole.clamp(self.floor, MAX_SCALED_BUDGET)
+        whole.clamp(self.floor, self.ceiling)
     }
 }
 
@@ -258,7 +261,7 @@ struct RawGc {
     /// Action-store and per-session remote-download budget.
     #[usage(
         env = "MBX_GC_MAX_SIZE",
-        default_note = "5% of the cache disk, from 5GiB to 100GiB"
+        default_note = "5% of the cache disk, from 5GiB to 500GiB"
     )]
     max_size: Option<String>,
     /// Combined action-store and managed-target budget, or "none".
@@ -1018,10 +1021,13 @@ mod tests {
             (Some(32 * GIB), STORE_BUDGET.floor, TARGET_BUDGET.floor),
             (Some(400 * GIB), 20 * GIB, 40 * GIB),
             // 5% and 10% of 1TiB are 51.2 and 102.4 GiB: the first rounds down
-            // to a whole increment, the second meets the ceiling.
-            (Some(1_024 * GIB), 50 * GIB, MAX_SCALED_BUDGET),
-            // A large disk stops at the ceiling on both counts.
-            (Some(8_000 * GIB), MAX_SCALED_BUDGET, MAX_SCALED_BUDGET),
+            // to a whole increment, the second meets its ceiling.
+            (Some(1_024 * GIB), 50 * GIB, MAX_TARGET_BUDGET),
+            // A large shared disk can give the store more than the old 100GiB
+            // ceiling while managed targets remain capped there.
+            (Some(8_000 * GIB), 400 * GIB, MAX_TARGET_BUDGET),
+            // The store still has a ceiling on exceptionally large disks.
+            (Some(20_000 * GIB), MAX_STORE_BUDGET, MAX_TARGET_BUDGET),
             // An unmeasurable disk uses the fixed fallbacks.
             (None, STORE_BUDGET.fallback, TARGET_BUDGET.fallback),
         ];
@@ -1050,7 +1056,7 @@ mod tests {
                     "{resolved} is not a whole increment for a {disk_gib}GiB disk"
                 );
                 assert!(resolved >= budget.floor);
-                assert!(resolved <= MAX_SCALED_BUDGET);
+                assert!(resolved <= budget.ceiling);
             }
         }
     }
@@ -1105,7 +1111,7 @@ mod tests {
         assert_eq!(config.gc.max_bytes, STORE_BUDGET.floor, "5% of 64GiB");
         assert_eq!(
             settings.retention.target_max_bytes,
-            Some(MAX_SCALED_BUDGET),
+            Some(MAX_TARGET_BUDGET),
             "10% of 4TiB, at the ceiling"
         );
     }

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -466,7 +466,10 @@ fn replaceable_managed_link(existing: &Path, managed: &Path, workspace_root: &Pa
         && view_key(&record.workspace_root) == name
     {
         return record.workspace_root == workspace_root
-            || !crate::store::checkout_is_live(&record.workspace_root);
+            || !crate::store::checkout_is_live_on(
+                managed.parent().unwrap_or(managed),
+                &record.workspace_root,
+            );
     }
     // A collector removes the record and directory together. With neither
     // left, a digest-shaped dangling link under this root is safe to recover;
@@ -588,7 +591,7 @@ pub(crate) fn collect(
             directory,
             record.updated_secs,
             bytes,
-            crate::store::checkout_is_live(&record.workspace_root),
+            crate::store::checkout_is_live_on(root, &record.workspace_root),
         ));
     }
     let mut remaining = entries

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -77,7 +77,7 @@ Minimum interval between automatic sweeps.
 
 - **Type:** `option<string>`
 - **Optional:** true
-- **Default:** 5% of the cache disk, from 5GiB to 100GiB
+- **Default:** 5% of the cache disk, from 5GiB to 500GiB
 - **Set with:** `MBX_GC_MAX_SIZE`
 
 Action-store and per-session remote-download budget.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,9 +17,9 @@ misspelled setting is an error rather than a silent no-op.
 
 mbx bounds its own disk use without being configured. The two size budgets
 default to a share of the disk holding the cache — 5% for the action store and
-10% for managed target directories — each from its floor (5 GiB and 10 GiB) up
-to 100 GiB, rounded down to a whole 5 GiB. Managed targets are also collected
-after 30 days unused.
+10% for managed target directories — from floors of 5 GiB and 10 GiB up to
+500 GiB and 100 GiB respectively, rounded down to a whole 5 GiB. Managed
+targets are also collected after 30 days unused.
 
 Setting any of them outright overrides the scaling; `"none"` disables
 `target.max_size`, `target.max_age`, and `gc.max_total_size`. See

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -44,7 +44,7 @@ a build server do not need the same configuration:
 
 | Budget | Default | Bounds |
 | --- | --- | --- |
-| `gc.max_size` (action store) | 5% of the disk | 5 GiB to 100 GiB |
+| `gc.max_size` (action store) | 5% of the disk | 5 GiB to 500 GiB |
 | `target.max_size` (managed targets) | 10% of the disk | 10 GiB to 100 GiB |
 
 Scaled budgets are rounded down to a whole 5 GiB. When the disk cannot be


### PR DESCRIPTION
## Summary

- walk missing checkout paths to their nearest existing ancestor and trust deletion when it shares the store filesystem
- retain conservative liveness for paths whose ancestor is on another filesystem or cannot be inspected
- raise the action-store default ceiling from 100 GiB to 500 GiB while keeping managed targets capped at 100 GiB

## Validation

- `cargo test -p mbx-cache-store`
- `cargo test -p mbx --lib`
- `cargo clippy -p mbx-cache-store -p mbx --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- generated documentation reproduced only the committed configuration-reference update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when checkout claims and managed targets are considered abandoned, which directly affects GC and disk reclamation; errors and cross-filesystem cases are handled conservatively, but wrong filesystem comparison could delay or accelerate deletion of warm cache data.
> 
> **Overview**
> Fixes **phantom live checkouts** that pinned cache and managed `target/` when a worktree manager removed the checkout together with empty parent directories. **Checkout liveness** now walks missing paths to the nearest existing ancestor and treats the checkout as gone only when that ancestor is on the **same filesystem** as the store (device ID on Unix, volume name on Windows via `windows-sys`). Paths whose nearest ancestor is on another filesystem or cannot be inspected stay **live**, so a temporarily unavailable mount does not trigger collection.
> 
> `claim_is_live`, GC/checkout scans, and **managed-target collection** pass the store or managed root into `checkout_is_live_on` instead of relying on the immediate parent only.
> 
> Separately, **disk-scaled defaults** split the old shared 100 GiB cap: the action-store budget (`gc.max_size`) can scale up to **500 GiB** on large disks while managed targets remain capped at **100 GiB**. README and configuration docs match the new bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d1e8a6080157e496fbd8d493f76432b97ad51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->