### PR TITLE
perf: make workspace edit loops incremental

### DIFF
--- a/crates/mbx/src/cli/gc.rs
+++ b/crates/mbx/src/cli/gc.rs
@@ -37,6 +37,11 @@ pub(super) fn run(
         retention.target_max_age,
         dry_run,
     );
+    let incremental = crate::incremental::prune(
+        &config.cache_dir.join("incremental"),
+        retention.target_max_age,
+        dry_run,
+    );
     let projected_target_bytes = match &pruned {
         Ok(outcome) => outcome.remaining_bytes,
         Err(_) if retention.max_total_bytes.is_some() => target::stats(&config.target.root)
@@ -79,10 +84,11 @@ pub(super) fn run(
             return Err(error);
         }
     };
+    let incremental = incremental?;
     record_collection(
         &store,
         outcome.removed_bytes,
-        pruned.as_ref().map_or(0, |pruned| pruned.removed_bytes),
+        pruned.as_ref().map_or(0, |pruned| pruned.removed_bytes) + incremental.removed_bytes,
         dry_run,
     );
     if json {
@@ -109,6 +115,14 @@ pub(super) fn run(
         let pruned = pruned?;
         if pruned.removed_views > 0 {
             println!("{}", target_removals(&pruned, dry_run));
+        }
+        if incremental.removed_directories > 0 {
+            let verb = if dry_run { "would free" } else { "freed" };
+            println!(
+                "{verb} {} learned incremental directories ({})",
+                incremental.removed_directories,
+                ByteSize::b(incremental.removed_bytes).display().iec()
+            );
         }
     }
     Ok(())
@@ -241,6 +255,18 @@ pub(super) fn prune_targets(
     // collection ever frees, and walking for it on every build would be the
     // slowest, so callers keep this inside the store sweep's throttle.
     let target_budget = target_budget(retention, store_reserve);
+    let incremental = crate::incremental::prune(
+        &config.cache_dir.join("incremental"),
+        retention.target_max_age,
+        false,
+    );
+    let incremental_bytes = match incremental {
+        Ok(outcome) => outcome.removed_bytes,
+        Err(error) => {
+            log::warn!("learned incremental state was not collected: {error}");
+            0
+        }
+    };
     match target::collect(
         &config.target.root,
         target_budget,
@@ -253,14 +279,14 @@ pub(super) fn prune_targets(
             }
             PruneReport {
                 remaining_bytes: Some(pruned.remaining_bytes),
-                freed_bytes: pruned.removed_bytes,
+                freed_bytes: pruned.removed_bytes.saturating_add(incremental_bytes),
             }
         }
         Err(error) => {
             log::warn!("target directories were not collected: {error}");
             PruneReport {
                 remaining_bytes: None,
-                freed_bytes: 0,
+                freed_bytes: incremental_bytes,
             }
         }
     }

--- a/crates/mbx/src/cli/gc.rs
+++ b/crates/mbx/src/cli/gc.rs
@@ -37,11 +37,17 @@ pub(super) fn run(
         retention.target_max_age,
         dry_run,
     );
-    let incremental = crate::incremental::prune(
+    let incremental = match crate::incremental::prune(
         &config.cache_dir.join("incremental"),
         retention.target_max_age,
         dry_run,
-    );
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            log::warn!("learned incremental state was not collected: {error}");
+            crate::incremental::PruneOutcome::default()
+        }
+    };
     let projected_target_bytes = match &pruned {
         Ok(outcome) => outcome.remaining_bytes,
         Err(_) if retention.max_total_bytes.is_some() => target::stats(&config.target.root)
@@ -68,11 +74,12 @@ pub(super) fn run(
     let outcome = match outcome {
         Ok(outcome) => outcome,
         Err(error) => {
+            let mut freed_bytes = incremental.removed_bytes;
             match pruned {
                 Ok(pruned) => {
                     // Credit what the targets gave back even though the store
                     // sweep failed: those bytes are gone from the disk either way.
-                    record_collection(&store, 0, pruned.removed_bytes, dry_run);
+                    freed_bytes = freed_bytes.saturating_add(pruned.removed_bytes);
                     if !json && pruned.removed_views > 0 {
                         println!("{}", target_removals(&pruned, dry_run));
                     }
@@ -81,10 +88,13 @@ pub(super) fn run(
                     log::warn!("target directories were not collected: {prune_error}");
                 }
             }
+            record_collection(&store, 0, freed_bytes, dry_run);
+            if !json {
+                print_incremental_removals(&incremental, dry_run);
+            }
             return Err(error);
         }
     };
-    let incremental = incremental?;
     record_collection(
         &store,
         outcome.removed_bytes,
@@ -112,20 +122,27 @@ pub(super) fn run(
         })?;
     } else {
         print_gc_store_outcome(&outcome, dry_run);
+        // This collection is independent of the managed-target walk below,
+        // so report it even if that walk failed.
+        print_incremental_removals(&incremental, dry_run);
         let pruned = pruned?;
         if pruned.removed_views > 0 {
             println!("{}", target_removals(&pruned, dry_run));
         }
-        if incremental.removed_directories > 0 {
-            let verb = if dry_run { "would free" } else { "freed" };
-            println!(
-                "{verb} {} learned incremental directories ({})",
-                incremental.removed_directories,
-                ByteSize::b(incremental.removed_bytes).display().iec()
-            );
-        }
     }
     Ok(())
+}
+
+fn print_incremental_removals(outcome: &crate::incremental::PruneOutcome, dry_run: bool) {
+    if outcome.removed_directories == 0 {
+        return;
+    }
+    let verb = if dry_run { "would free" } else { "freed" };
+    println!(
+        "{verb} {} learned incremental directories ({})",
+        outcome.removed_directories,
+        ByteSize::b(outcome.removed_bytes).display().iec()
+    );
 }
 
 /// Add what a collection reclaimed to this machine's lifetime totals.

--- a/crates/mbx/src/incremental.rs
+++ b/crates/mbx/src/incremental.rs
@@ -1,0 +1,147 @@
+//! Persistent per-checkout state for learned incremental compilation.
+
+use eyre::{Context, Result};
+use mbx_cache_core::CacheDigest;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const RECORD_FILE: &str = "checkout.json";
+const RECORD_VERSION: u8 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CheckoutRecord {
+    version: u8,
+    workspace_root: PathBuf,
+    updated_secs: u64,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PruneOutcome {
+    pub removed_directories: u64,
+    pub removed_bytes: u64,
+}
+
+/// Refresh one checkout's claim and return its private state directory.
+pub(crate) fn touch(root: &Path, workspace_root: &Path) -> Result<PathBuf> {
+    let checkout = CacheDigest::blake3(workspace_root.as_os_str().as_encoded_bytes());
+    let directory = root.join(&checkout.hash[..16]);
+    std::fs::create_dir_all(&directory).wrap_err_with(|| {
+        format!(
+            "failed to create the incremental state directory {}",
+            directory.display()
+        )
+    })?;
+    let record = CheckoutRecord {
+        version: RECORD_VERSION,
+        workspace_root: workspace_root.to_path_buf(),
+        updated_secs: now_secs(),
+    };
+    crate::util::write_atomic(&directory.join(RECORD_FILE), &serde_json::to_vec(&record)?)?;
+    Ok(directory)
+}
+
+/// Remove state for deleted or expired checkouts.
+pub(crate) fn prune(root: &Path, max_age: Option<Duration>, dry_run: bool) -> Result<PruneOutcome> {
+    let listing = match std::fs::read_dir(root) {
+        Ok(listing) => listing,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(PruneOutcome::default());
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let mut outcome = PruneOutcome::default();
+    let now = now_secs();
+    for entry in listing {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let directory = entry.path();
+        let Some(record) = read_record(&directory.join(RECORD_FILE)) else {
+            // An unreadable record is not enough evidence to delete data.
+            continue;
+        };
+        let expired =
+            max_age.is_some_and(|age| now.saturating_sub(record.updated_secs) > age.as_secs());
+        if crate::store::checkout_is_live(&record.workspace_root) && !expired {
+            continue;
+        }
+        let bytes = tree_bytes(&directory);
+        if !dry_run {
+            match std::fs::remove_dir_all(&directory) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    log::warn!(
+                        "could not remove incremental state {}: {error}",
+                        directory.display()
+                    );
+                    continue;
+                }
+            }
+        }
+        outcome.removed_directories += 1;
+        outcome.removed_bytes = outcome.removed_bytes.saturating_add(bytes);
+    }
+    Ok(outcome)
+}
+
+fn read_record(path: &Path) -> Option<CheckoutRecord> {
+    let bytes = std::fs::read(path).ok()?;
+    let record = serde_json::from_slice::<CheckoutRecord>(&bytes).ok()?;
+    (record.version == RECORD_VERSION).then_some(record)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
+fn tree_bytes(root: &Path) -> u64 {
+    let mut total = 0_u64;
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let Ok(listing) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in listing.flatten() {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.is_dir() {
+                pending.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abandoned_checkout_state_is_pruned() {
+        let cache = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let checkout = parent.path().join("checkout");
+        std::fs::create_dir(&checkout).unwrap();
+        let state = touch(cache.path(), &checkout).unwrap();
+        std::fs::write(state.join("state"), b"incremental").unwrap();
+        assert!(read_record(&state.join(RECORD_FILE)).is_some());
+
+        std::fs::remove_dir(&checkout).unwrap();
+        assert!(!crate::store::checkout_is_live(&checkout));
+        let outcome = prune(cache.path(), None, false).unwrap();
+
+        assert_eq!(outcome.removed_directories, 1);
+        assert!(outcome.removed_bytes > 0);
+        assert!(!state.exists());
+    }
+}

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -48,6 +48,7 @@ pub mod util;
 
 mod build_script;
 mod cc;
+mod incremental;
 mod linker;
 mod materialize;
 mod rustc;

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -32,12 +32,17 @@ struct CompileTiming {
     duration_ns: u64,
 }
 
-/// Consecutive misses with changed content before a unit compiles incrementally.
+/// Consecutive misses with changed content before an external unit compiles
+/// incrementally.
 ///
 /// One changed key is an edit; a run of them is a developer working here. The
 /// threshold is what separates the two, and it is small because the cost of
 /// guessing wrong is one uncached compilation the unit was going to pay anyway.
 const HOT_STREAK_THRESHOLD: u32 = 3;
+
+/// A workspace unit is hot on its first edit. Its dependent cone still uses
+/// the ordinary cache because churn is measured from each unit's own sources.
+const WORKSPACE_HOT_STREAK_THRESHOLD: u32 = 1;
 
 /// Schema version of the per-checkout churn record.
 const CHURN_STATE_VERSION: u8 = 1;
@@ -93,7 +98,7 @@ impl LearnedPlan {
 /// What one checkout last compiled for one unit, and how long its sources have
 /// been moving.
 ///
-/// Kept beside the incremental state it decides, in this checkout's target
+/// Kept beside the incremental state it decides, in a checkout-specific cache
 /// directory, rather than in the prediction manifest: a manifest is shared by
 /// every worktree resolving the same lockfile, so a streak recorded there would
 /// let one developer's edit loop mark a crate hot for a sibling worktree that
@@ -205,6 +210,9 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
                     Err(error) => {
                         eprintln!("mbx[warning]: compiler timing was not refreshed: {error:#}");
                     }
+                }
+                if source_is_in_workspace(&compilation) {
+                    record_learned_baseline(&compilation, &discovered);
                 }
                 if verify {
                     verification = Some(cached);
@@ -426,6 +434,9 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             let (candidates, discovered) = action_from_dep_info(&compilation, &outputs.dep_info)?;
             discovered.verify_not_modified_since(compilation_started)?;
             discovered.verify()?;
+            if learned.record.is_none() && source_is_in_workspace(&compilation) {
+                record_learned_baseline(&compilation, &discovered);
+            }
             // An incremental artifact carries state from this checkout's edit
             // history, so it is recorded as what the unit currently contains --
             // which is how the next build notices the churn ended -- but never
@@ -583,16 +594,17 @@ fn learned_plan(
     recorded: Option<&ChurnState>,
     sources: &CacheDigest,
     enabled: bool,
+    threshold: u32,
 ) -> LearnedPlan {
     let streak = match recorded {
         Some(recorded) if recorded.sources == sources.key() => 0,
         // Capped at the threshold: the streak is a state, not a tally, and
         // letting it climb would only delay noticing that the churn stopped.
-        Some(recorded) => recorded.streak.saturating_add(1).min(HOT_STREAK_THRESHOLD),
+        Some(recorded) => recorded.streak.saturating_add(1).min(threshold),
         None => 0,
     };
     LearnedPlan {
-        hot: enabled && streak >= HOT_STREAK_THRESHOLD,
+        hot: enabled && streak >= threshold,
         streak,
         directory: None,
         record: None,
@@ -601,17 +613,14 @@ fn learned_plan(
 
 /// Where one unit keeps its incremental state.
 ///
-/// It lives under the target directory the session already manages, so a
-/// managed target reclaims it with everything else it holds, and `cargo clean`
-/// reaches it in a checkout that owns its own. A shim with no session has
-/// nowhere of its own to put it, and compiles normally instead.
+/// A session gives it a persistent per-checkout root outside Cargo's target
+/// directory. A standalone shim falls back to its target directory when one is
+/// available, and compiles normally when it has nowhere to put state.
 fn incremental_directory(invocation: &CacheDigest) -> Option<PathBuf> {
-    let target_dir = std::env::var_os(session::TARGET_DIR_ENV)?;
+    let root = incremental_root()?;
     let key = invocation.key();
     let shard = key.get(..16)?;
-    let directory = PathBuf::from(target_dir)
-        .join("mbx-incremental")
-        .join(shard);
+    let directory = root.join(shard);
     match prepare_incremental_directory(&directory) {
         Ok(()) => Some(directory),
         Err(error) => {
@@ -676,7 +685,17 @@ fn plan_learned_reuse(
         let Some(state_path) = churn_state_path(&unit) else {
             return Result::<LearnedPlan>::Ok(LearnedPlan::default());
         };
-        let plan = learned_plan(read_churn_state(&state_path).as_ref(), &sources, enabled);
+        let threshold = if source_is_in_workspace(compilation) {
+            WORKSPACE_HOT_STREAK_THRESHOLD
+        } else {
+            HOT_STREAK_THRESHOLD
+        };
+        let plan = learned_plan(
+            read_churn_state(&state_path).as_ref(),
+            &sources,
+            enabled,
+            threshold,
+        );
         Ok(LearnedPlan {
             record: Some((state_path, sources)),
             ..plan
@@ -692,19 +711,69 @@ fn plan_learned_reuse(
     }
 }
 
+/// Whether the crate root belongs to the checkout Cargo is building.
+fn source_is_in_workspace(compilation: &Compilation<'_>) -> bool {
+    let Some(root) = std::env::var_os(session::WORKSPACE_ROOT_ENV).map(PathBuf::from) else {
+        return false;
+    };
+    let source = compilation.invocation.source();
+    let source = if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        compilation.working_dir.join(source)
+    };
+    let root = std::fs::canonicalize(&root).unwrap_or(root);
+    let source = std::fs::canonicalize(&source).unwrap_or(source);
+    source.starts_with(root)
+}
+
+/// Establish the baseline after a first successful compilation, when dep-info
+/// finally supplies the complete set of sources. The next edit can then be
+/// recognized immediately.
+fn record_learned_baseline(compilation: &Compilation<'_>, discovered: &DiscoveredInputs) {
+    let recorded = (|| {
+        let context = base_action_context(
+            compilation.rustc,
+            compilation.working_dir,
+            compilation.portable,
+        )?;
+        let unit = compilation.invocation.invocation_digest(&context)?;
+        let Some(path) = churn_state_path(&unit) else {
+            return Result::<()>::Ok(());
+        };
+        let sources = compilation.invocation.source_fingerprint(discovered);
+        write_churn_state(&path, &sources, 0)
+    })();
+    if let Err(error) = recorded {
+        eprintln!("mbx[warning]: initial churn state was not recorded: {error:#}");
+    }
+}
+
 /// Where this checkout records what it last compiled for one unit.
 ///
-/// A sibling of the unit's incremental directory, so both are reclaimed with
-/// the target directory that holds them.
+/// A sibling of the unit's incremental directory, so the decision and the
+/// state survive or disappear together.
 fn churn_state_path(unit: &CacheDigest) -> Option<PathBuf> {
-    let target_dir = std::env::var_os(session::TARGET_DIR_ENV)?;
+    let root = incremental_root()?;
     let key = unit.key();
     let shard = key.get(..16)?;
-    Some(
-        PathBuf::from(target_dir)
-            .join("mbx-incremental")
-            .join(format!("{shard}.json")),
-    )
+    Some(root.join(format!("{shard}.json")))
+}
+
+/// Persistent per-checkout storage for learned incremental state. Sessions
+/// keep it outside Cargo's target directory so `cargo clean` does not erase the
+/// edit history it is meant to accelerate. Standalone shims retain the older
+/// target-local fallback because they have no configured cache root.
+fn incremental_root() -> Option<PathBuf> {
+    std::env::var_os(session::INCREMENTAL_ROOT_ENV)
+        .or_else(|| {
+            std::env::var_os(session::TARGET_DIR_ENV).map(|target| {
+                PathBuf::from(target)
+                    .join("mbx-incremental")
+                    .into_os_string()
+            })
+        })
+        .map(PathBuf::from)
 }
 
 /// A record this version cannot read is treated as no record: the cost is one
@@ -841,6 +910,9 @@ fn restore_prediction_payload(
     match restored {
         Some((action, mut cached)) => {
             cached.restore.avoided_compiler_duration_ns = input_prediction.compiler_duration_ns;
+            if source_is_in_workspace(compilation) {
+                record_learned_baseline(compilation, &discovered);
+            }
             if restore_outputs {
                 record_action_hit(&action, cached.restore, invocation.crate_name());
             }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -211,7 +211,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
                         eprintln!("mbx[warning]: compiler timing was not refreshed: {error:#}");
                     }
                 }
-                if source_is_in_workspace(&compilation) {
+                if learned_enabled && source_is_in_workspace(&compilation) {
                     record_learned_baseline(&compilation, &discovered);
                 }
                 if verify {
@@ -434,7 +434,7 @@ pub(crate) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
             let (candidates, discovered) = action_from_dep_info(&compilation, &outputs.dep_info)?;
             discovered.verify_not_modified_since(compilation_started)?;
             discovered.verify()?;
-            if learned.record.is_none() && source_is_in_workspace(&compilation) {
+            if learned_enabled && learned.record.is_none() && source_is_in_workspace(&compilation) {
                 record_learned_baseline(&compilation, &discovered);
             }
             // An incremental artifact carries state from this checkout's edit
@@ -742,6 +742,11 @@ fn record_learned_baseline(compilation: &Compilation<'_>, discovered: &Discovere
             return Result::<()>::Ok(());
         };
         let sources = compilation.invocation.source_fingerprint(discovered);
+        if read_churn_state(&path)
+            .is_some_and(|recorded| recorded.sources == sources.key() && recorded.streak == 0)
+        {
+            return Ok(());
+        }
         write_churn_state(&path, &sources, 0)
     })();
     if let Err(error) = recorded {
@@ -910,7 +915,7 @@ fn restore_prediction_payload(
     match restored {
         Some((action, mut cached)) => {
             cached.restore.avoided_compiler_duration_ns = input_prediction.compiler_duration_ns;
-            if source_is_in_workspace(compilation) {
+            if learned_enabled && source_is_in_workspace(compilation) {
                 record_learned_baseline(compilation, &discovered);
             }
             if restore_outputs {

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -27,37 +27,51 @@ fn only_a_run_of_changed_sources_earns_incremental_state() {
 
     // Nothing recorded here yet: a first compilation in a checkout is not
     // evidence of anything, and neither is a wiped target directory.
-    assert_eq!(learned_plan(None, &now, true).streak, 0);
+    assert_eq!(
+        learned_plan(None, &now, true, HOT_STREAK_THRESHOLD).streak,
+        0
+    );
 
     // Recorded against the sources this compilation already has, so nobody
     // edited it -- something else lost the result, and recompiling normally
     // restores it for everyone.
     let unchanged = churn("current sources", HOT_STREAK_THRESHOLD);
-    let plan = learned_plan(Some(&unchanged), &now, true);
+    let plan = learned_plan(Some(&unchanged), &now, true, HOT_STREAK_THRESHOLD);
     assert_eq!(plan.streak, 0);
     assert!(!plan.hot);
 
     // Changed sources climb the streak, and only its last step is hot.
     for previous in 0..HOT_STREAK_THRESHOLD - 1 {
         let recorded = churn("older sources", previous);
-        let plan = learned_plan(Some(&recorded), &now, true);
+        let plan = learned_plan(Some(&recorded), &now, true, HOT_STREAK_THRESHOLD);
         assert_eq!(plan.streak, previous + 1);
         assert!(!plan.hot);
     }
     let recorded = churn("older sources", HOT_STREAK_THRESHOLD - 1);
-    assert!(learned_plan(Some(&recorded), &now, true).hot);
+    assert!(learned_plan(Some(&recorded), &now, true, HOT_STREAK_THRESHOLD).hot);
 
     // The streak is a state rather than a tally, so it stops at the threshold.
     let saturated = churn("older sources", HOT_STREAK_THRESHOLD);
     assert_eq!(
-        learned_plan(Some(&saturated), &now, true).streak,
+        learned_plan(Some(&saturated), &now, true, HOT_STREAK_THRESHOLD).streak,
         HOT_STREAK_THRESHOLD
     );
 
     // Disabled, the streak is still tracked so that enabling it later works.
-    let plan = learned_plan(Some(&saturated), &now, false);
+    let plan = learned_plan(Some(&saturated), &now, false, HOT_STREAK_THRESHOLD);
     assert_eq!(plan.streak, HOT_STREAK_THRESHOLD);
     assert!(!plan.hot);
+}
+
+#[test]
+fn one_changed_workspace_source_is_hot() {
+    let now = CacheDigest::blake3(b"current sources");
+    let recorded = churn("older sources", 0);
+
+    let plan = learned_plan(Some(&recorded), &now, true, WORKSPACE_HOT_STREAK_THRESHOLD);
+
+    assert_eq!(plan.streak, 1);
+    assert!(plan.hot);
 }
 
 /// The record belongs to one checkout, so a sibling worktree that cannot read

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -66,6 +66,7 @@ pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
 pub(crate) const SHARE_OUT_DIR_ENV: &str = "MBX_SHARE_OUT_DIR";
 pub(crate) const BUILD_SCRIPT_EXECUTION_ENV: &str = "MBX_BUILD_SCRIPT_EXECUTION";
 pub(crate) const LEARNED_INCREMENTAL_ENV: &str = "MBX_LEARNED_INCREMENTAL";
+pub(crate) const INCREMENTAL_ROOT_ENV: &str = "MBX_INCREMENTAL_ROOT";
 pub const CACHE_LINKS_ENV: &str = "MBX_CACHE_LINKS";
 /// Group completed builds for one later cache export, used by CI actions.
 pub const CACHE_EXPORT_GROUP_ENV: &str = "MBX_CACHE_EXPORT_GROUP";
@@ -96,6 +97,7 @@ pub struct CacheSession {
     /// What the shims need to draw compile permits from the machine-wide pool.
     scheduler_env: Vec<(String, String)>,
     store: PathBuf,
+    incremental_root: PathBuf,
     started: Instant,
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
     server: Mutex<Option<JoinHandle<Result<()>>>>,
@@ -153,6 +155,7 @@ impl CacheSession {
             events,
             scheduler_env: crate::scheduler::session_environment(config),
             store,
+            incremental_root: config.cache_dir.join("incremental"),
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),
             server: Mutex::new(Some(server)),
@@ -214,6 +217,14 @@ impl CacheSession {
         environment.insert(
             TARGET_DIR_ENV.into(),
             target_dir.to_string_lossy().into_owned(),
+        );
+        let checkout = CacheDigest::blake3(workspace_root.as_os_str().as_encoded_bytes()).key();
+        environment.insert(
+            INCREMENTAL_ROOT_ENV.into(),
+            self.incremental_root
+                .join(&checkout[..16])
+                .to_string_lossy()
+                .into_owned(),
         );
         environment.insert(SOCKET_ENV.into(), self.socket.clone());
         environment.insert(

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -218,14 +218,15 @@ impl CacheSession {
             TARGET_DIR_ENV.into(),
             target_dir.to_string_lossy().into_owned(),
         );
-        let checkout = CacheDigest::blake3(workspace_root.as_os_str().as_encoded_bytes()).key();
-        environment.insert(
-            INCREMENTAL_ROOT_ENV.into(),
-            self.incremental_root
-                .join(&checkout[..16])
-                .to_string_lossy()
-                .into_owned(),
-        );
+        match crate::incremental::touch(&self.incremental_root, workspace_root) {
+            Ok(root) => {
+                environment.insert(
+                    INCREMENTAL_ROOT_ENV.into(),
+                    root.to_string_lossy().into_owned(),
+                );
+            }
+            Err(error) => warn!("incremental state was not recorded: {error:#}"),
+        }
         environment.insert(SOCKET_ENV.into(), self.socket.clone());
         environment.insert(
             STAGING_ENV.into(),

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -218,6 +218,16 @@ impl CacheSession {
             TARGET_DIR_ENV.into(),
             target_dir.to_string_lossy().into_owned(),
         );
+        // Always replace an inherited value. If recording this checkout fails,
+        // the shim must use its target-local fallback rather than another
+        // checkout's persistent state.
+        environment.insert(
+            INCREMENTAL_ROOT_ENV.into(),
+            target_dir
+                .join("mbx-incremental")
+                .to_string_lossy()
+                .into_owned(),
+        );
         match crate::incremental::touch(&self.incremental_root, workspace_root) {
             Ok(root) => {
                 environment.insert(

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -85,6 +85,38 @@ async fn session_environment_directs_cargo_at_the_shim() {
     session.finish().await.unwrap();
 }
 
+#[tokio::test]
+async fn failed_incremental_recording_replaces_an_inherited_root() {
+    let cache = tempfile::tempdir().unwrap();
+    // A file where the checkout-state directory belongs makes `touch` fail.
+    std::fs::write(cache.path().join("incremental"), b"not a directory").unwrap();
+    let session_dir = tempfile::tempdir().unwrap();
+    let session = CacheSession::start(session_dir.path(), &test_config(cache.path()))
+        .await
+        .unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let target = workspace.path().join("target");
+    let mut values = BTreeMap::from([(
+        INCREMENTAL_ROOT_ENV.into(),
+        "/another/checkout/incremental".into(),
+    )]);
+
+    session
+        .begin(
+            workspace.path(),
+            &target,
+            &["build".to_string()],
+            &mut values,
+        )
+        .await;
+
+    assert_eq!(
+        values.get(INCREMENTAL_ROOT_ENV).map(PathBuf::from),
+        Some(target.join("mbx-incremental"))
+    );
+    session.finish().await.unwrap();
+}
+
 #[test]
 fn nested_sessions_unwrap_the_outer_rustdoc_shim() {
     let values = BTreeMap::from([

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -583,16 +583,15 @@ fn edit_project(project: &Path, revision: u32) {
 /// Directories only: the churn records that decide when to create one live
 /// beside them as files, and every compilation writes one of those whether or
 /// not it ever goes hot.
-fn learned_sessions(project: &Path) -> usize {
-    let target = project.join("target");
-    let outputs = std::fs::read_link(&target).unwrap_or(target);
-    match std::fs::read_dir(outputs.join("mbx-incremental")) {
-        Ok(entries) => entries
-            .flatten()
-            .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
-            .count(),
-        Err(_) => 0,
-    }
+fn learned_sessions(cache: &Path) -> usize {
+    std::fs::read_dir(cache.join("incremental"))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .flat_map(|checkout| std::fs::read_dir(checkout.path()).into_iter().flatten())
+        .flatten()
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+        .count()
 }
 
 fn compiled_incrementally(stats: &serde_json::Value) -> u64 {
@@ -601,51 +600,72 @@ fn compiled_incrementally(stats: &serde_json::Value) -> u64 {
         .unwrap_or(0)
 }
 
-/// A crate somebody is editing misses on every build no matter what the cache
-/// does. After enough of those in a row, it gets to keep its own incremental
+/// A workspace crate somebody is editing misses on every build no matter what
+/// the cache does. On its first edit, it gets its own incremental
 /// state -- which never reaches the store, because it describes one checkout's
 /// edit history rather than its source.
 #[test]
-fn a_churning_crate_earns_its_own_incremental_state() {
+fn a_workspace_crate_is_incremental_on_its_first_edit() {
     let store = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();
     let reports = tempfile::tempdir().unwrap();
     write_project(project.path());
 
-    let mut stats = build(
+    let cold = build(
         project.path(),
         store.path(),
         &reports.path().join("cold.json"),
     );
-    for revision in 1..=4 {
-        edit_project(project.path(), revision);
-        stats = build(
-            project.path(),
-            store.path(),
-            &reports.path().join(format!("edit-{revision}.json")),
-        );
-        // The streak has to build up first, so nothing is expected before it.
-        if revision < 3 {
-            assert_eq!(
-                compiled_incrementally(&stats),
-                0,
-                "one or two edits is not a pattern yet: {stats}"
-            );
-        }
-    }
+    assert_eq!(
+        compiled_incrementally(&cold),
+        0,
+        "a cold build should populate the shared cache: {cold}"
+    );
+
+    edit_project(project.path(), 1);
+    let stats = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("edit-1.json"),
+    );
 
     assert!(
         compiled_incrementally(&stats) > 0,
         "the edited crate should have compiled incrementally by now: {stats}"
     );
     assert!(
-        learned_sessions(project.path()) > 0,
+        learned_sessions(store.path()) > 0,
         "it should have left incremental state behind: {stats}"
     );
     assert_eq!(
         stats["stored_bytes"].as_u64(),
         Some(0),
         "an incremental artifact must never be published: {stats}"
+    );
+
+    let cleaned = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .arg("clean")
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_GC_AUTO", "0")
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("mbx clean should run");
+    assert!(
+        cleaned.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&cleaned.stderr)
+    );
+
+    edit_project(project.path(), 2);
+    let after_clean = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("edit-after-clean.json"),
+    );
+    assert!(
+        compiled_incrementally(&after_clean) > 0,
+        "cargo clean should preserve learned incremental state: {after_clean}"
     );
 }
 
@@ -1018,6 +1038,17 @@ fn a_second_checkout_starts_warm() {
     assert!(
         count(&warm, "hits") > 0,
         "a checkout at another path should reuse the first build: {warm}"
+    );
+
+    edit_project(second.path(), 1);
+    let edited = build(
+        second.path(),
+        store.path(),
+        &reports.path().join("second-edit.json"),
+    );
+    assert!(
+        compiled_incrementally(&edited) > 0,
+        "a warm checkout should recognize its first edit immediately: {edited}"
     );
 }
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1971,6 +1971,13 @@ mod target_views {
             &[("MBX_TARGET_VIEWS", "1")],
         );
         let directory = managed(gone.path());
+        assert!(
+            std::fs::read_dir(store.path().join("incremental"))
+                .unwrap()
+                .next()
+                .is_some(),
+            "the build should record learned incremental state"
+        );
         std::fs::remove_dir_all(gone.path()).unwrap();
 
         // Make the due store sweep fail after it writes its throttle stamp.
@@ -2021,9 +2028,14 @@ mod target_views {
             !output.status.success(),
             "the broken store should be reported"
         );
+        let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
-            String::from_utf8_lossy(&output.stdout).contains("freed 1 target directories"),
+            stdout.contains("freed 1 target directories"),
             "successful target collection should still be reported"
+        );
+        assert!(
+            stdout.contains("freed 1 learned incremental directories"),
+            "successful incremental collection should still be reported: {stdout}"
         );
         assert!(
             !directory.exists(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,7 +200,8 @@ and publishing normally, and so does a miss on unchanged sources (a wiped
 `target/`, a first build in a new checkout). The record and state are private
 to each checkout, living under `incremental/` in mbx's cache directory so
 `cargo clean` does not discard the next edit's speedup. Each crate's
-incremental state is discarded once it passes 1 GiB.
+incremental state is discarded once it passes 1 GiB, and normal garbage
+collection removes state for deleted or expired checkouts.
 
 CI never does this, for the same reason it never compiles incrementally: there
 is no earlier state to build on. `MBX_LEARNED_INCREMENTAL=0` turns it off, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,19 +187,20 @@ disables it because a fresh runner has no incremental state to reuse.
 ## Learned incremental reuse
 
 The crate you are editing misses the cache on every build, because its content
-is new every time. After three consecutive compilations whose sources changed,
-mbx compiles that crate with its own incremental state rather than from
-scratch, and keeps the result out of the shared cache — an incremental artifact
-describes one checkout's edit history, not its source. The build reports those
-compilations as `incremental` and says how many were held back.
+is new every time. On the first source edit to a crate inside the workspace,
+mbx compiles that crate with its own incremental state rather than from scratch,
+and keeps the result out of the shared cache — an incremental artifact describes
+one checkout's edit history, not its source. Crates outside the workspace retain
+the conservative three-change threshold. The build reports those compilations
+as `incremental` and says how many were held back.
 
 The trigger is the crate's own sources, not its cache key, so a rebuilt
 dependency — which changes the keys of everything above it — keeps compiling
 and publishing normally, and so does a miss on unchanged sources (a wiped
-`target/`, a first build in a new checkout). The record is private to each
-checkout, living in `mbx-incremental/` inside that build's target directory
-beside the incremental state itself; a managed target reclaims both, and each
-crate's incremental state is discarded once it passes 1 GiB.
+`target/`, a first build in a new checkout). The record and state are private
+to each checkout, living under `incremental/` in mbx's cache directory so
+`cargo clean` does not discard the next edit's speedup. Each crate's
+incremental state is discarded once it passes 1 GiB.
 
 CI never does this, for the same reason it never compiles incrementally: there
 is no earlier state to build on. `MBX_LEARNED_INCREMENTAL=0` turns it off, and


### PR DESCRIPTION
## Summary

- engage learned incremental compilation on the first source edit for crates under the workspace
- preserve the normal action-cache path for cold builds and dependent crates
- keep per-checkout learned records and incremental state outside Cargo's target directory so they survive `cargo clean`
- retain the conservative three-change threshold for crates outside the workspace

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p mbx --lib 'rustc::tests::'`\n- `cargo test -p mbx --test build a_workspace_crate_is_incremental_on_its_first_edit`\n- `cargo test -p mbx --test build a_second_checkout_starts_warm`\n- `cargo test -p mbx --test build editing_one_crate_leaves_its_dependents_publishing`\n- full mbx unit suite: 315 passed, 1 ignored\n- full build integration suite: 50 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when compilations use private incremental state versus the shared action cache and introduces persistent on-disk layout under the cache directory, though behavior is gated by workspace detection and existing learned-incremental flags with broad test coverage.
> 
> **Overview**
> **Workspace crates** now enter learned incremental compilation on the **first source edit** (threshold 1), while dependency and registry crates still need **three consecutive source changes**. Baseline churn state is recorded after successful compiles and cache restores for in-workspace units so the next edit is recognized without waiting for another miss streak.
> 
> Learned incremental **churn records and rustc incremental dirs** move from `target/mbx-incremental` into **per-checkout directories under** `{cache}/incremental/`, wired through **`MBX_INCREMENTAL_ROOT`** at session start (`incremental::touch`). Standalone shims keep the target-local fallback; failed recording clears an inherited root so another checkout’s state is not reused.
> 
> **GC** (`mbx gc` and automatic target pruning) independently **prunes** abandoned or expired checkout incremental trees, prints how much was freed, and counts those bytes in savings—even when the action store sweep fails.
> 
> Docs and integration tests cover **`cargo clean` preserving** learned state and first-edit behavior on warm checkouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c7dc14bb89fd230741d9eed60e33162558307c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->