### PR TITLE
fix build-script caching and doctor toolchain

### DIFF
--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -266,6 +266,13 @@ fn record_prediction(
 fn parse_prediction(stdout: &[u8]) -> Result<Option<Prediction>> {
     let text = std::str::from_utf8(stdout).wrap_err("build-script stdout is not UTF-8")?;
     let mappings = build_script_mappings();
+    parse_prediction_with_mappings(text, &mappings)
+}
+
+fn parse_prediction_with_mappings(
+    text: &str,
+    mappings: &[PathMapping],
+) -> Result<Option<Prediction>> {
     let mut inputs = BTreeSet::new();
     let mut environment = BTreeSet::new();
     for line in text.lines() {
@@ -279,7 +286,19 @@ fn parse_prediction(stdout: &[u8]) -> Result<Option<Prediction>> {
             if path.is_empty() {
                 return Ok(None);
             }
-            inputs.insert(normalize_environment_value(path, &mappings));
+            let path = normalize_environment_value(path, mappings);
+            // A generated file cannot also be an input to the execution that
+            // generated it. Build scripts use this shape to make Cargo run
+            // them every time (shadow-rs does so in release builds), and
+            // publishing it under a key derived after execution makes two
+            // different results contend for one local action. Preserve the
+            // script's always-rerun contract instead of trying to cache it.
+            if path.starts_with("${build_script_out_dir}")
+                || path.starts_with("${build_script_out_dir:")
+            {
+                return Ok(None);
+            }
+            inputs.insert(path);
         } else if let Some(name) = directive.strip_prefix("rerun-if-env-changed=")
             && !name.is_empty()
         {
@@ -882,6 +901,20 @@ mod tests {
             )
             .unwrap()
             .is_none()
+        );
+    }
+
+    #[test]
+    fn an_out_dir_changed_path_bypasses_execution_caching() {
+        let directory = tempfile::tempdir().unwrap();
+        let out_dir = directory.path().join("target/build/package/out");
+        let directive = format!("cargo:rerun-if-changed={}/shadow.rs\n", out_dir.display());
+        let mappings = [PathMapping::new(&out_dir, "build_script_out_dir")];
+
+        assert!(
+            parse_prediction_with_mappings(&directive, &mappings)
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/crates/mbx/src/cli/mod.rs
+++ b/crates/mbx/src/cli/mod.rs
@@ -154,7 +154,10 @@ pub fn run() -> Result<ExitCode> {
         args.command = original_exec_arguments(&original)?;
     }
     if let Commands::Doctor(args) = &cli.command {
-        shim::prepare_explicit_cargo()?;
+        // Doctor describes the toolchain selected at this invocation site.
+        // In particular, a mise Cargo wrapper is what resolves a project-local
+        // toolchain; excluding it first would make the version check fall
+        // through to an unrelated Cargo later on PATH.
         return doctor::run(args, toolchain);
     }
     let (config, settings) = Config::load_for_cli()?;

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -31,6 +31,22 @@ setup() {
   assert_output --partial "0 failures"
 }
 
+@test "doctor reports the Cargo selected by the active project wrapper" {
+  local wrapper_dir="$BATS_TEST_TMPDIR/command-wrappers/bin"
+  local fallback_dir="$BATS_TEST_TMPDIR/fallback-bin"
+  mkdir -p "$wrapper_dir" "$fallback_dir"
+  printf '#!/bin/sh\nprintf "cargo 1.98.0 (active)\\n"\n' >"$wrapper_dir/cargo"
+  printf '#!/bin/sh\nprintf "cargo 1.97.1 (fallback)\\n"\n' >"$fallback_dir/cargo"
+  printf '#!/bin/sh\nprintf "rustc 1.98.0 (active)\\n"\n' >"$wrapper_dir/rustc"
+  chmod +x "$wrapper_dir/cargo" "$fallback_dir/cargo" "$wrapper_dir/rustc"
+
+  run env -u CARGO PATH="$wrapper_dir:$fallback_dir:/usr/bin:/bin" "$MBX_BIN" doctor
+
+  assert_success
+  assert_output --partial "cargo 1.98.0 (active)"
+  refute_output --partial "cargo 1.97.1 (fallback)"
+}
+
 @test "a toolchain in front of a Cargo command still selects one" {
   cargo init --lib --vcs none toolchain-project
   cd toolchain-project


### PR DESCRIPTION
Fix two issues seen while building usage:

- treat `rerun-if-changed` paths inside `OUT_DIR` as an always-rerun build-script contract instead of caching the generated output as its own input
- let `doctor` query the active project Cargo wrapper before proxy exclusion, so it reports the same mise-selected toolchain that builds use

Regression coverage includes shadow-rs-style generated output directives and an active Cargo 1.98.0 wrapper ahead of a 1.97.1 fallback.

Validated with:
- `cargo test -p mbx --lib`
- `cargo clippy -p mbx --lib --tests -- -D warnings`
- focused `test/cli.bats` doctor regression
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build-script cache eligibility and doctor’s Cargo resolution path; wrong OUT_DIR handling could over- or under-cache scripts, and doctor could still misreport in edge PATH setups.
> 
> **Overview**
> Fixes two build/diagnostics mismatches: **build-script execution caching** and **`mbx doctor` Cargo reporting**.
> 
> Build scripts that emit `cargo:rerun-if-changed` for files under **OUT_DIR** (e.g. shadow-rs release builds) are now treated like Cargo’s always-rerun contract—parsing returns no cacheable prediction instead of keying the action on generated output that would collide across runs. Prediction parsing is split into `parse_prediction_with_mappings` for testability, with a unit test for normalized out-dir paths.
> 
> **`mbx doctor`** no longer runs `prepare_explicit_cargo` before toolchain checks, so the **first Cargo on PATH** (including mise/project wrappers) is what gets version-checked rather than a later fallback. A bats test asserts the wrapper’s Cargo version appears and the fallback does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3f6cc7ba14cf8400800022a35b46c1a35bcc8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->