### PR TITLE
fix: avoid racing persistent Windows shims

### DIFF
--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -37,6 +37,8 @@ use client::validate_handshake_response;
 use client::{request_agent_at, request_standalone_agent};
 pub(crate) use diagnostics::{note, report_shim_warning, reserve_stderr_for_compiler};
 use server::spawn_server;
+#[cfg(all(test, windows))]
+use shims::link_path_shim;
 use shims::{CC_CRATE_ENV, CcShims, install_cc_shims, install_session_shims};
 pub use shims::{
     PathShims, ShimLink, install_path_shims, install_shim, install_shim_named, shim_file_name,

--- a/crates/mbx/src/session/shims.rs
+++ b/crates/mbx/src/session/shims.rs
@@ -325,20 +325,26 @@ fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
+pub(super) fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
     // Windows cannot replace an executable while another process has it open,
     // so a stable existing shim is preferable to a racy in-place upgrade. A
     // missing shim is pinned to this binary by hard link, with copy fallback.
     if destination.is_file() {
         return Ok(());
     }
-    if let Err(link_error) = std::fs::hard_link(executable, destination) {
-        std::fs::copy(executable, destination).wrap_err_with(|| {
-            format!(
-                "failed to install the shim {} by hard link ({link_error}) or copy",
-                destination.display()
-            )
-        })?;
+    match std::fs::hard_link(executable, destination) {
+        Ok(()) => {}
+        // Another session won the installation race. Copying onto that hard
+        // link would copy the executable onto itself and can truncate it.
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(link_error) => {
+            std::fs::copy(executable, destination).wrap_err_with(|| {
+                format!(
+                    "failed to install the shim {} by hard link ({link_error}) or copy",
+                    destination.display()
+                )
+            })?;
+        }
     }
     Ok(())
 }

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -187,6 +187,33 @@ async fn rustc_shim_path_survives_and_is_reused_across_sessions() {
     second.finish().await.unwrap();
 }
 
+#[cfg(windows)]
+#[test]
+fn concurrent_persistent_shim_installation_keeps_the_binary_intact() {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory.path().join("mbx.exe");
+    let destination = directory.path().join("mbx-rustc.exe");
+    let contents = vec![0x5a; 1024 * 1024];
+    std::fs::write(&executable, &contents).unwrap();
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(32));
+    let mut installers = Vec::new();
+    for _ in 0..32 {
+        let executable = executable.clone();
+        let destination = destination.clone();
+        let barrier = std::sync::Arc::clone(&barrier);
+        installers.push(std::thread::spawn(move || {
+            barrier.wait();
+            link_path_shim(&executable, &destination)
+        }));
+    }
+    for installer in installers {
+        installer.join().unwrap().unwrap();
+    }
+
+    assert_eq!(std::fs::read(&executable).unwrap(), contents);
+    assert_eq!(std::fs::read(&destination).unwrap(), contents);
+}
+
 #[tokio::test]
 async fn a_session_with_no_shim_connection_does_not_load_a_manifest() {
     let cache = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Follow-up to #268.

Concurrent Windows sessions can both observe a missing persistent rustc shim. Once one creates the hard link, the other receives `AlreadyExists`; falling through to `std::fs::copy` can then copy the executable onto its own hard link and truncate it.

Treat `AlreadyExists` as a successful concurrent installation and cover the path with 32 synchronized installers that verify both source and destination remain intact.

Local verification:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p mbx --lib rustc_shim_path_survives_and_is_reused_across_sessions`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistent shim installation on Windows under concurrency; incorrect handling could still corrupt the mbx binary, but the fix is narrow and regression-tested.
> 
> **Overview**
> Fixes a **concurrency bug** when multiple Windows mbx sessions install the same persistent PATH shim (e.g. `mbx-rustc.exe`) at once. If one thread creates the hard link and another gets `AlreadyExists`, the old code still ran `std::fs::copy`, which can copy the executable onto its own hard link and **truncate** the binary.
> 
> `link_path_shim` on Windows now treats `AlreadyExists` from `hard_link` as a successful install (another session won the race) and only falls back to copy for other errors. The helper is exposed to Windows tests, and a new test runs **32 synchronized threads** through that path and asserts source and destination bytes stay intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a36a5606b5157a61300ce94a7d3e8a1775c7c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->