### PR TITLE
docs: plain-prose pass over every page

### DIFF
--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -6,8 +6,8 @@ kache.
 ## Cargo
 
 [Cargo](https://github.com/rust-lang/cargo) resolves dependencies, plans
-builds, and orchestrates rustc. Its `RUSTC_WRAPPER` integration is what allows
-mbx and other Rust compiler caches to wrap compiler invocations.
+builds, and orchestrates rustc. Its `RUSTC_WRAPPER` integration lets mbx and
+other Rust compiler caches wrap compiler invocations.
 
 ## sccache
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,9 +1,8 @@
 # Benchmarks
 
-The subject is [jdx/hk](https://github.com/jdx/hk) — a mid-size Rust CLI with C
-dependencies, pinned to a fixed commit — rather than mbx's own workspace, which
-is too small to measure anything useful against. Every scenario is one CI
-actually hits.
+The subject is [jdx/hk](https://github.com/jdx/hk), a mid-size Rust CLI with C
+dependencies, pinned to a fixed commit. mbx's own workspace is too small to
+measure anything useful against. Every scenario is one CI actually hits.
 
 The build scenarios run the same `cargo build --locked` through plain Cargo,
 [mbx](/), and [kache](https://github.com/kunobi-ninja/kache), where each tool
@@ -11,8 +10,8 @@ can make a meaningful comparison. Timings are wall clock around one build.
 When Cargo appears, it is an uncached baseline measured in that same scenario;
 cache rows compare only with that result. The warm and worktree scenarios omit
 Cargo because a fresh `target/` or a different checkout gives it nothing to
-reuse. The contention scenario is the exception, comparing sequential and
-parallel lint strategies and measuring the machine rather than a single build.
+reuse. The contention scenario compares sequential and parallel lint
+strategies and measures the machine instead of a single build.
 
 <BenchmarkResults />
 
@@ -20,44 +19,40 @@ parallel lint strategies and measuring the machine rather than a single build.
 
 ### cold
 
-An empty store and a fresh `target/`. What a new machine, or a CI
-job with no cache to restore, actually does. There is nothing to hit, so a
-cache can only cost time here, and the gap to cargo is the overhead every cold
-build pays.
+An empty store and a fresh `target/`: a new machine, or a CI job with no cache
+to restore. There is nothing to hit, so a cache can only cost time here, and
+the gap to cargo is the overhead every cold build pays.
 
 ### warm
 
-The store from the cold build, a fresh `target/`. This is the
-common CI shape: a runner restores a cache, then builds a commit it has
-already seen. cargo is not run, because with a wiped `target/` it would just
-repeat its cold number.
+The store from the cold build, a fresh `target/`. This is the common CI shape:
+a runner restores a cache, then builds a commit it has already seen. cargo is
+not run, because with a wiped `target/` it would repeat its cold number.
 
 ### commit
 
-The store is warmed at one commit and the build runs at the next
-one. Push-to-push CI: most of the dependency graph is unchanged, a few crates
-are not. cargo's baseline here is a cold build, because that is what cargo
-does with an empty `target/`.
+The store is warmed at one commit and the build runs at the next one.
+Push-to-push CI: most of the dependency graph is unchanged, a few crates are
+not. cargo's baseline here is a cold build, because that is what cargo does
+with an empty `target/`.
 
 ### worktree
 
-The store is warmed in one checkout, and the timed build runs
-in a second checkout at a different path. This is the claim that absolute
-paths did not enter the keys. A cache that keys on paths reports a cold build
-here.
+The store is warmed in one checkout, and the timed build runs in a second
+checkout at a different path. This checks that absolute paths did not enter
+the keys. A cache that keys on paths reports a cold build here.
 
 ### toolchain
 
-Not a timing. The store is warmed on the pinned Rust and the
-build reruns on a different one, and the run fails unless essentially none of
-the predicted compilations were even looked up. A compiler change invalidates
-every invocation digest at once; the failure mode worth guarding against is a
-cache that claims a hit anyway. Not *zero* hits, though: a handful of actions
-do not depend on rustc — a build script's C object is compiled by the C
-compiler, which did not change — and those legitimately survive.
+Not a timing. The store is warmed on the pinned Rust and the build reruns on a
+different one. The run fails unless almost none of the predicted compilations
+were looked up. A compiler change invalidates every invocation digest at once,
+and the failure this guards against is a cache that claims a hit anyway. A
+handful of hits are expected: a build script's C object is compiled by the C
+compiler, which did not change, so those actions survive.
 
-It also explains the opposite surprise: a warm build that reports no hits after
-a runner image picked up a new Rust is not a broken store, it is this.
+This also explains a warm build that reports no hits after a runner image
+picked up a new Rust. The store is not broken; the compiler changed.
 
 ### contention
 
@@ -65,35 +60,33 @@ Six overlapping Rust CI jobs from a cold store: default and all-targets/all-
 features variants of `cargo check`, Clippy, and test compilation. The
 `sequential` row is context, with the commands sharing one target directory.
 The parallel rows use separate targets so Cargo's target lock does not
-serialize them, matching separate CI steps. The apples-to-apples scheduler
-comparison is between those two parallel rows.
+serialize them, matching separate CI steps. The scheduler comparison is
+between those two parallel rows.
 
 All three rows use the same mbx binary. The `mbx` and `mbx-unscheduled` rows
 run the parallel shape with the
 [machine-wide scheduler](/configuration#machine-wide-compile-scheduling) on
 and off, which isolates what mbx contributes from parallelism itself. Cargo
-bounds only the compilers *it* starts and knows nothing about the Cargo process
+bounds only the compilers it starts and knows nothing about the Cargo process
 beside it; the scheduler gives both processes one machine-wide permit pool and
 deduplicates identical work in flight. The wall clock shows whether the switch
 beats the sequential baseline. Peak compilers and lowest free memory show
-whether it got there by safely sharing the machine or merely oversubscribing
-it.
+whether it got there by sharing the machine or by oversubscribing it.
 
 ## How the comparison is kept fair
 
-- **The registry is fetched once**, before any timed build, into a shared
+- The registry is fetched once, before any timed build, into a shared
   `CARGO_HOME`. No cell is timed while it downloads crates.
-- **The toolchain is pinned** per subject. hk does not pin one itself, and a
-  runner-image Rust bump changes every invocation digest simultaneously — that
-  reads as a cache that stopped working, and it would land in the series as a
-  step change.
-- **Each cell gets its own store and `target/`**, created fresh. No tool ever
-  benefits from another's leftovers.
-- **`CARGO_INCREMENTAL=0`**, matching what CI does, and any `RUSTC_WRAPPER`
-  inherited from the caller is cleared so the uncached baseline is really
-  uncached.
-- **Both caches run local-only.** A remote would measure a network.
-- **Every scenario's rows come from one CI run**, so the tools within it are
+- The toolchain is pinned per subject. hk does not pin one itself, and a
+  runner-image Rust bump changes every invocation digest at once, which would
+  land in the series as a step change that looks like a cache that stopped
+  working.
+- Each cell gets its own store and `target/`, created fresh. No tool benefits
+  from another's leftovers.
+- `CARGO_INCREMENTAL=0` is set, matching CI, and any `RUSTC_WRAPPER` inherited
+  from the caller is cleared so the uncached baseline is uncached.
+- Both caches run local-only. A remote would measure a network.
+- Every scenario's rows come from one CI run, so the tools within it are
   comparable. A scenario refreshed separately carries its own run link;
   otherwise the provenance line below the cards applies.
 
@@ -102,18 +95,17 @@ it.
 A benchmark that measured nothing still renders numbers, so the run fails and
 nothing publishes unless:
 
-- the warm and cross-worktree builds report cache hits *and* restored output
-  files — a fast build that restored nothing was fast for some other reason;
+- the warm and cross-worktree builds report cache hits and restored output
+  files; a fast build that restored nothing was fast for some other reason;
 - each warm build beat its own cold build;
-- the toolchain-change build loaded predictions and then looked up almost
-  none of them — and that it ran at all, because a guard that was skipped is
-  not a guard that passed;
+- the toolchain-change build ran, loaded predictions, and then looked up
+  almost none of them; a guard that was skipped is not a guard that passed;
 - the contention run sampled the machine, saw compilers running, and kept the
-  scheduled batch inside its permits — *and* that the unscheduled batch went
-  past them, because a bound nothing pushed against proves nothing.
+  scheduled batch inside its permits, and the unscheduled batch went past
+  them; a bound nothing pushed against proves nothing.
 
-A run that fails these is not rendered here at all — the page shows its empty
-state rather than numbers it cannot stand behind.
+A run that fails these is not rendered here at all. The page shows its empty
+state instead.
 
 ## Running it yourself
 
@@ -122,25 +114,24 @@ mise run bench
 ```
 
 That builds mbx, clones the pinned subject, and runs the cold, warm, and
-next-commit scenarios. kache is included automatically when it is on `PATH`
-and skipped with a note when it is not. `mise run bench:refresh` is what CI
-runs: every scenario, writing `benchmarks/results.json`. It also needs
-`MBX_BENCH_ALTERNATE_TOOLCHAIN` set to a second installed Rust, since that is
-what the compiler-change guard switches to.
+next-commit scenarios. kache is included when it is on `PATH` and skipped
+with a note when it is not. `mise run bench:refresh` is what CI runs: every
+scenario, writing `benchmarks/results.json`. It needs
+`MBX_BENCH_ALTERNATE_TOOLCHAIN` set to a second installed Rust, which is what
+the compiler-change guard switches to.
 
 The numbers on this page are refreshed by the
 [bench-refresh workflow](https://github.com/jdx/mr-boxington/actions/workflows/bench-refresh.yml),
 which runs weekly, only when the published numbers were measured with an older
-mbx than the one on `main`, and opens a pull request rather than publishing
+mbx than the one on `main`, and opens a pull request instead of publishing
 directly. Nobody's laptop numbers reach this page.
 
 ## What this does not measure
 
-Everything hk does not do. hk is a mid-size CLI; it is not Firefox, and a
-project with a very different dependency shape — heavy proc macros, a large C
-component, many small leaf crates — will see different ratios. It is also
-Linux-only: [the limits page](/limits) covers what changes on macOS and
-Windows.
+Everything hk does not do. hk is a mid-size CLI, and a project with a very
+different dependency shape (heavy proc macros, a large C component, many small
+leaf crates) will see different ratios. It is also Linux-only:
+[the limits page](/limits) covers what changes on macOS and Windows.
 
 For instruction-counted measurements of mbx's own startup path, and
 cold/warm correctness runs against this workspace, see

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -16,15 +16,18 @@ and its successful result was stored.
 ## Could not look up
 
 mbx did not yet have usable dep-info or a prediction from which to derive the
-key. This is common on a genuinely cold build. The action is still stored after
+key. This is common on a cold build. The action is still stored after
 compilation, so calling it a miss would overstate the number of failed lookups.
+The short summary counts these as `not looked up`; the full summary prints a
+`could not look up` line with the reason.
 
 ## Bypass
 
 mbx recognized that it could not model the action exactly and ran the real
-compiler without caching it. Reasons are grouped in the full summary
-(`MBX_SUMMARY=full`); set `MBX_BYPASS_LOG` to a file path for the full
-per-action record.
+compiler without caching it. The short summary's `bypassed` count leaves out
+routine compiler probes (`compiler-query`, `standard-input`, and their `cc-`
+counterparts). Reasons are grouped in the full summary (`MBX_SUMMARY=full`);
+set `MBX_BYPASS_LOG` to a file path for the per-action record.
 
 Run a Cargo command through `mbx explain` to collect those records temporarily,
 group identical causes, and print guidance for every bypass category:
@@ -68,10 +71,10 @@ not bypass counts, because mbx never observed the compiler invocations.
 
 A remote cache request failed and the build carried on without it: unreachable
 host, refused credentials, or a response this client would not accept. mbx never
-fails a build over a remote cache, so these only ever cost hit rate — but a
-remote that is failing every request reports the same hits, misses, and bytes as
-one that was merely empty, which is why the summary counts them. The short
-summary includes the count inline; the full summary explains it:
+fails a build over a remote cache, so these only cost hit rate. The summary
+counts them because a remote that is failing every request reports the same
+hits, misses, and bytes as one that was empty. The short summary includes the
+count inline; the full summary explains it:
 
 ```text
 mbx[cache]: the remote cache failed 4 of its requests; this build ran without what it could not reach, and the warnings above say why
@@ -84,26 +87,26 @@ on a cache that has quietly stopped serving.
 ## Watching a build instead
 
 Everything above describes results reported after a build. To see the same
-outcomes as they are decided — one row per compilation, with the crate it
-belongs to — run [`mbx tui`](/tui) in another terminal. It reads every build
+outcomes as they are decided, one row per compilation with the crate it
+belongs to, run [`mbx tui`](/tui) in another terminal. It reads every build
 on the machine, including ones already running.
 
 ## Reading the hit rate
 
 A build can report a high hit rate among attempted lookups while spending most
-of its time on actions that were not looked up or were bypassed. Read all three
+of its time on actions that were not looked up or were bypassed. Read all the
 summary counts together, and compare wall-clock time when evaluating the
 cache. Set `MBX_SUMMARY=full` when the one-line counts need a breakdown.
 
 A link mbx cannot describe always runs, so its downstream crates may have work
 to do on an otherwise warm build. Native executables, tests, and proc macros on
-Linux, macOS, and Windows, plus binaries, tests, and `cdylib`s for supported self-contained
-WebAssembly targets, may be restored as hits; see
+Linux, macOS, and Windows, plus binaries, tests, and `cdylib`s for supported
+self-contained WebAssembly targets, may be restored as hits; see
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 
 ## Troubleshooting a low hit rate
 
-Run the build through `mbx explain` first — it collects the per-action
+Run the build through `mbx explain` first. It collects the per-action
 records, groups identical causes, and prints guidance for each category:
 
 ```sh
@@ -112,42 +115,43 @@ mbx explain build --workspace
 
 The usual causes, roughly in the order they show up:
 
-- **The store is cold.** A first build has no dep-info to derive keys from, so
-  "could not look up" dominates and everything is stored rather than restored.
-  Read the hit rate off the second build.
-- **Incremental builds are enabled.** With `MBX_INCREMENTAL=1`, workspace
+- The store is cold. A first build has no dep-info to derive keys from, so
+  "could not look up" dominates and everything is stored. Read the hit rate
+  off the second build.
+- Incremental builds are enabled. With `MBX_INCREMENTAL=1`, workspace
   members compile incrementally, those compilations bypass the cache, and the
   changed artifacts make crates above them miss too. See
   [limits](/limits#incremental-compilations-are-not-cached).
-- **A link could not be described.** Native executables, tests, and proc macros
-  are cached on Linux, macOS, and Windows, and self-contained WebAssembly targets
-  everywhere, but native links with custom or unmodeled inputs still run. A rebuilt dylib can also change the keys of its
-  downstream crates. `mbx explain` reports why the link bypassed; see
+- A link could not be described. Native executables, tests, and proc macros
+  are cached on Linux, macOS, and Windows, and self-contained WebAssembly
+  targets everywhere, but native links with custom or unmodeled inputs still
+  run. A rebuilt dylib can also change the keys of its downstream crates.
+  `mbx explain` reports why the link bypassed; see
   [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
-- **The inputs actually differ.** A different toolchain, feature set, profile,
-  or `RUSTFLAGS` between two checkouts is a different key, and the summary
+- The inputs differ. A different toolchain, feature set, profile, or
+  `RUSTFLAGS` between two checkouts is a different key, and the summary
   reports it as an ordinary miss. Run `mbx explain --last` to replay the most
-  recent recorded build and list, per missed crate, the key inputs that changed
-  since its last recorded hit. Session history stores hashes rather than source
-  contents or environment values.
-- **Build-script output paths.** A crate that embeds its `OUT_DIR` produces
+  recent recorded build and list, per missed crate, the key inputs that
+  changed since its last recorded hit. Session history stores hashes, not
+  source contents or environment values.
+- Build-script output paths. A crate that embeds its `OUT_DIR` produces
   checkout-specific inputs for its dependents. mbx remaps this by default;
   `MBX_SHARE_OUT_DIR=0` disables that sharing. See
   [limits](/limits#out-dir-sharing-remaps-generated-source-paths).
-- **A build chose its own C compiler, or is cross-compiling.** Setting `CC`,
+- A build chose its own C compiler, or is cross-compiling. Setting `CC`,
   `HOST_CC`, or a target-specific variant leaves that build's C and C++
   compilations uncached, and so does `--target`. Bypass kinds beginning `cc-`
   report anything the C adapter declined to model. See
   [limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
-- **CI restored nothing.** On GitHub Actions, check that the cache step
-  actually restored an entry — a changed `cache-generation` or a fresh
-  repository starts empty by design. With a remote cache configured, check the
-  [remote failure](#remote-failure) count too: a remote that is failing every
-  request reports the same zeros as one that is merely empty.
+- CI restored nothing. On GitHub Actions, check that the cache step restored
+  an entry; a changed `cache-generation` or a fresh repository starts empty.
+  With a remote cache configured, check the [remote failure](#remote-failure)
+  count too: a remote that is failing every request reports the same zeros as
+  one that is empty.
 
 ## Compiler time
 
-The session summary reports real compiler time by outcome and an estimate of
+The full summary reports real compiler time by outcome and an estimate of
 the compiler time avoided by cache hits:
 
 ```text
@@ -157,10 +161,10 @@ mbx[cache]: slowest uncached crates: syn 8.90s, regex-syntax 4.90s, serde_derive
 
 The estimate comes from the duration recorded with the successful compilation
 that populated the action prediction; older predictions without a timing hint
-contribute zero rather than being guessed. The five crates with the largest
-cumulative uncached compiler time are listed so optimization work can target
-wall-clock cost instead of action count.
+contribute zero. The five crates with the largest cumulative uncached compiler
+time are listed so optimization work can target wall-clock cost instead of
+action count.
 
-The version 2 JSON statistics report exposes the same data in
+The JSON statistics report exposes the same data in
 `estimated_compiler_duration_avoided_ns`, `compiler`, and
 `slow_compilations`.

--- a/docs/cache-server.md
+++ b/docs/cache-server.md
@@ -2,8 +2,8 @@
 
 [`jdx/mr-boxington-cache`](https://github.com/jdx/mr-boxington-cache) is the
 self-hostable remote cache server. It implements version 1 of the mbx
-action-cache protocol — immutable blobs, atomic action-result commits,
-namespace isolation, and streaming blob packs — and also serves
+action-cache protocol: immutable blobs, atomic action-result commits,
+namespace isolation, and streaming blob packs. It also serves
 [mise](https://mise.jdx.dev)'s task cache. Any server implementing the
 [protocol](/protocol-compatibility) works with mbx; this page documents the
 reference implementation.
@@ -45,13 +45,13 @@ Every option has a matching environment variable and CLI flag; run
 | `MBX_CACHE_STORAGE` | `filesystem` | `filesystem` or `s3` |
 | `MBX_CACHE_DATA_DIR` | `/var/lib/mbx-cache` | Filesystem blob root |
 | `MBX_CACHE_DATABASE_URL` | `memory://` | PostgreSQL URL or development memory store |
-| `MBX_CACHE_S3_BUCKET` | — | Required for S3 storage |
+| `MBX_CACHE_S3_BUCKET` | none | Required for S3 storage |
 | `MBX_CACHE_S3_PREFIX` | `v1` | Object-key prefix |
 | `MBX_CACHE_S3_ENDPOINT` | AWS default | S3-compatible endpoint |
 | `MBX_CACHE_S3_REGION` | `us-east-1` | S3 region |
 | `MBX_CACHE_S3_PATH_STYLE` | `false` | Enable for MinIO and similar services |
-| `MBX_CACHE_TOKENS_JSON` | — | Static token grants |
-| `MBX_CACHE_OIDC_PROVIDERS_JSON` | — | Trusted OIDC providers and claim grants |
+| `MBX_CACHE_TOKENS_JSON` | none | Static token grants |
+| `MBX_CACHE_OIDC_PROVIDERS_JSON` | none | Trusted OIDC providers and claim grants |
 | `MBX_CACHE_ALLOW_ANONYMOUS` | `false` | Allow access without configured grants |
 | `MBX_CACHE_MAX_BLOB_BYTES` | `5368709120` | Maximum upload size |
 
@@ -78,8 +78,8 @@ Authorization is deny-by-default. Namespace patterns may be an exact name,
 ```
 
 Rotate tokens by deploying the old and new grants together, moving clients to
-the new token, then removing the old grant. Inject the JSON through a secret
-rather than writing it into deployment configuration.
+the new token, then removing the old grant. Inject the JSON through a secret,
+not through deployment configuration.
 
 ### OIDC
 
@@ -109,9 +109,10 @@ The server discovers the issuer's JWKS endpoint and verifies the signature,
 issuer, audience, expiry, not-before time, and subject before applying the
 first matching rule. Rules are alternatives; every claim within a rule must
 match exactly. Pin stable identity claims such as GitHub's numeric
-`repository_owner_id` alongside the repository name — names can be reclaimed,
-the ID cannot — and add `ref` or `environment` claims when only a narrower
-workflow identity should write. Symmetric JWT algorithms are never accepted.
+`repository_owner_id` alongside the repository name, since names can be
+reclaimed and the ID cannot. Add `ref` or `environment` claims when only a
+narrower workflow identity should write. Symmetric JWT algorithms are never
+accepted.
 
 On the client side, mbx acquires the GitHub Actions job token itself: set
 `MBX_REMOTE_OIDC_AUDIENCE`, or use
@@ -128,28 +129,28 @@ mbx-cache --sweep-metadata-older-than-days 35
 ```
 
 Keep the sweep age longer than the storage lifecycle so objects expire first.
-A dangling reference is never fatal — a client that cannot fetch a blob treats
+A dangling reference is never fatal: a client that cannot fetch a blob treats
 the action as a miss and recompiles.
 
 Multiple stateless replicas can run against the same PostgreSQL database and
 S3 bucket. Readiness and liveness probes use `/v1/status`, and `/metrics`
 exposes Prometheus counters for actions, blobs, and blob-pack transfers with
-fixed, low-cardinality labels — namespaces, tokens, and digests never appear
-as labels. The server has no deletion endpoint; retention and disaster
-recovery are administrative concerns (back up PostgreSQL, use bucket
-versioning or replication as required).
+fixed, low-cardinality labels. Namespaces, tokens, and digests never appear as
+labels. The server has no deletion endpoint. Retention and disaster recovery
+are administrative concerns: back up PostgreSQL, and use bucket versioning or
+replication as required.
 
 A server advertising action promises can coordinate identical cold
 compilations across replicas. Claims are short-lived database leases scoped by
 namespace and invocation digest; completion is accepted only after the named
-action result is durable. This state is coordination rather than cache content:
-abandoned claims expire, completed promises are immutable for their retention
-window, and no promise endpoint bypasses the namespace's write authorization.
+action result is durable. Abandoned claims expire, completed promises are
+immutable for their retention window, and no promise endpoint bypasses the
+namespace's write authorization.
 
 ## Protocol
 
-The wire protocol — endpoints, media types, canonical hashing, and the
-evolution rules — is documented in
+The wire protocol (endpoints, media types, canonical hashing, and the
+evolution rules) is documented in
 [protocol compatibility](/protocol-compatibility). The
 [repository README](https://github.com/jdx/mr-boxington-cache) covers
 implementation details beyond it, including blob-pack framing and validation

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -6,51 +6,47 @@
 cache and predates mbx. It aims wider: it caches CUDA alongside Rust, C, and
 C++, and can distribute compilation across machines. mbx caches rustc, the C
 and C++ that cargo build scripts compile, the C and C++ of builds outside
-cargo through [`mbx exec`](/standalone-builds), and native links. That scope
-is narrower, and mbx spends the difference on the parts of caching that are
-not the cache: what it costs to operate, what it does to your disk, and what
-it is safe to let CI write.
+cargo through [`mbx exec`](/standalone-builds), and native links. mbx spends
+the narrower scope on what it costs to operate, what it does to your disk, and
+what it is safe to let CI write.
 
-- **No daemon.** sccache builds talk to a background server. It starts
-  itself, but it outlives the build, keeps the configuration it was started
-  with — so changing a setting means remembering to restart it — and a build
-  that cannot reach it fails unless you have opted into falling back. mbx
-  starts an in-process agent for each command and exits with it: nothing
-  outlives the build, so there is no stale configuration and nothing to
-  restart.
-- **`target/` stops growing.** sccache caches compilations, but each
-  checkout's `target/` is still yours to hold and yours to clean. mbx stores
-  outputs once in a content-addressed store, reflinks them into each
-  checkout's `target/`, and collects the directories whose checkout is gone,
-  so a dozen worktrees cost roughly what one does.
-- **Several Cargo builds at once.** sccache hands a GNU make jobserver down
-  to the compilers it spawns, which keeps one build from oversubscribing the
-  machine. mbx budgets across builds rather than inside one: Cargo commands
-  started independently — clippy beside tests, or two lint configurations —
-  draw their compilers from a single machine-wide CPU and memory pool, and a
-  compilation identical to one already running anywhere on the machine waits
-  for that one instead of burning a core on it. See [machine-wide compile
+- Nothing to restart after a settings change. sccache builds talk to a
+  background server that outlives the build and keeps the configuration it
+  was started with, and a build that cannot reach it fails unless you have
+  opted into falling back. mbx starts an in-process agent for each command
+  and exits with it, so a changed setting applies to the next build.
+- `target/` stops growing. sccache caches compilations, but each checkout's
+  `target/` is still yours to hold and yours to clean. mbx stores outputs once
+  in a content-addressed store, reflinks them into each checkout's `target/`,
+  and collects the directories whose checkout is gone, so a dozen worktrees
+  cost roughly what one does.
+- Several Cargo builds fit on one machine. sccache hands a GNU make jobserver
+  down to the compilers it spawns, which keeps one build from oversubscribing
+  the machine. mbx budgets across builds: Cargo commands started
+  independently, such as clippy beside tests, draw their compilers from a
+  single machine-wide CPU and memory pool, and a compilation identical to one
+  already running anywhere on the machine waits for that one instead of
+  repeating it. See [machine-wide compile
   scheduling](/configuration#machine-wide-compile-scheduling).
-- **Sharing between checkouts is the default, not a setting.** sccache
-  matches on absolute paths until you set `SCCACHE_BASEDIRS` to the
-  directories to strip, and a path you forget to list is a cache miss you
-  never hear about. mbx derives the placeholders itself — workspace, target,
-  registry, toolchain, and sysroot — so a new worktree is warm without being
-  told where anything lives.
-- **A hit rate you can act on.** Every build reports hits, misses, lookups it
-  could not attempt, and deliberate bypasses, so a disappointing build points
-  at its own cause instead of moving a global counter.
-- **A remote that limits what CI can write.** sccache's backends are buckets and
+- A new worktree is warm without configuration. sccache matches on absolute
+  paths until you set `SCCACHE_BASEDIRS` to the directories to strip, and a
+  path you forget to list is a cache miss you never hear about. mbx derives
+  the placeholders itself: workspace, target, registry, toolchain, and
+  sysroot.
+- A disappointing build points at its own cause. Every build reports hits,
+  misses, lookups it could not attempt, and bypasses, instead of moving a
+  global counter.
+- CI can be given a cache it cannot damage. sccache's backends are buckets and
   services reached with a credential; what holds that credential can write,
   and usually delete. mbx's remote is a [cache server](/cache-server) with
   deny-by-default grants, separate read and write namespace patterns,
-  immutable blobs, and no deletion endpoint, so a job that should never
-  publish cannot, and one that may publish still cannot rewrite or remove
-  what an earlier build wrote.
+  immutable blobs, and no deletion endpoint. A job that should never publish
+  cannot, and one that may publish cannot rewrite or remove what an earlier
+  build wrote.
 
-If you need CUDA or distributed compilation,
-sccache is the right tool. Both wrap rustc through `RUSTC_WRAPPER`, so they
-cannot be combined for the same build.
+If you need CUDA or distributed compilation, sccache is the right tool. Both
+wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for the same
+build.
 
 ## kache
 
@@ -58,75 +54,71 @@ cannot be combined for the same build.
 predates mbx and directly inspired its design, though the projects share no
 code. mbx began as the Rust cache inside the
 [mise](https://github.com/jdx/mise) task runner and was extracted into its
-own CLI to chase three things: less to operate, a better day-to-day
-experience, and tight limits on what CI can write to a shared cache — the
-concern that matters most in a public repository that takes fork pull
-requests. The differences below are mostly those three goals.
+own CLI for three things: less to operate, a better day-to-day experience,
+and tight limits on what CI can write to a shared cache, which matters most
+in a public repository that takes fork pull requests. The differences below
+follow from those three goals.
 
 Like mbx, kache is a content-addressed `RUSTC_WRAPPER` cache built for sharing
 compilations across worktrees, with C and C++ compiler shims, S3-compatible
 and filesystem remotes, and executable caching on Linux, macOS, and Windows.
 
-- **Nothing to install or keep running.** `kache init` installs an OS service
-  by default, with a `--no-service` opt-out. mbx starts an in-process agent
-  with each command and exits with it: nothing to bring back after a reboot,
-  nothing to restart when it misbehaves, and no state on the machine that
-  outlives the build.
-- **Nobody has to remember to prune.** kache hardlinks outputs into place, so
-  a checkout's `target/` shares disk with the store but stays where it is,
-  cleaned up by `kache gc` when someone runs it. mbx owns the directories it
-  creates: outputs live once in the store, appear in each checkout by
-  reflink, and a `target/` whose checkout is gone is collected without being
-  asked. Reflinks are copy-on-write clones that diverge the moment something
-  writes to them, so a build that scribbles into `target/` cannot damage the
-  cache the way a shared inode can. Where the filesystem cannot clone, mbx
-  copies the bytes — still never a hardlink.
-- **Several Cargo builds at once.** Cargo plans one build at a time, so two
-  started together each size themselves to the whole machine and both finish
-  late. kache does not stop you running them, but it does not coordinate
-  them either: it starts each compiler as Cargo asks for it, with no shared
-  budget and nothing that notices two builds compiling the same crate at the
-  same moment. mbx's shims sit in front of every compiler on the machine and
-  hand out permits from one memory-aware pool, so a lint job and a test job
-  run side by side without overloading the box, and a compilation identical
-  to one already running anywhere waits for it instead of repeating it.
-  Either way, give each command its own `CARGO_TARGET_DIR`: Cargo's target
-  directory lock is what serializes them otherwise. See [machine-wide
-  compile scheduling](/configuration#machine-wide-compile-scheduling).
-- **A public repository can share one cache.** This is the difference that
-  shaped mbx most. kache's remotes are S3-compatible buckets or a filesystem
-  path, and a bucket has one question to ask: does this credential write? So
-  whatever can publish can also overwrite or remove what an earlier build
-  published, and one leaked credential is the whole cache. mbx's remote is a
-  protocol server, which puts those rules somewhere they can be expressed:
-  grants are deny-by-default with separate read and write namespace patterns;
-  CI authenticates with a short-lived OIDC token pinned to a repository and
-  its immutable numeric owner ID, narrowable to a `ref` or `environment`,
-  instead of a stored secret; blobs are immutable and results commit
-  atomically; and there is no deletion endpoint, so a writer adds results and
-  can never rewrite or remove one. Fork pull requests hold no credentials at
-  all and fall back to a read-only platform cache — see [fork
-  PRs](/cookbook/fork-prs). mbx's client refuses to publish from pull
-  requests, unprotected branches, and tag builds too, but that is a
-  convenience that catches a misconfigured grant early; the server is what
-  makes the guarantee.
-- **Caching C and C++ is opt-in per command.** Both put shims on `PATH` so
-  make, CMake, or anything else that resolves its compiler there gets cached.
-  kache installs them alongside its service, so once they are on `PATH` every
-  build on the machine goes through the cache; mbx puts them on `PATH` for a
-  single [`mbx exec`](/standalone-builds) command, so a build is cached when
-  it asks to be and untouched otherwise. Both cover Windows; mbx intercepts
-  `cl.exe` there and the plain gcc/clang driver names on Unix.
-- **Linked binaries.** Both cache them on Linux, macOS, and Windows. mbx keys on the
-  resolved linker, startup objects, libc, and SDK rather than dep-info alone,
-  because a binary linked against a different libc or SDK is a different
-  binary. On a host mbx cannot describe that precisely, it links normally
-  rather than handing back one it cannot vouch for.
+- Nothing to install or keep running. `kache init` installs an OS service by
+  default, with a `--no-service` opt-out. mbx starts an in-process agent with
+  each command and exits with it: nothing to bring back after a reboot,
+  nothing to restart, and no state on the machine that outlives the build.
+- Nobody has to remember to prune. kache hardlinks outputs into place, so a
+  checkout's `target/` shares disk with the store but stays where it is until
+  someone runs `kache gc`. mbx owns the directories it creates: outputs live
+  once in the store, appear in each checkout by reflink, and a `target/`
+  whose checkout is gone is collected without being asked. Reflinks are
+  copy-on-write clones that diverge the moment something writes to them, so a
+  build that scribbles into `target/` cannot damage the cache the way a
+  shared inode can. Where the filesystem cannot clone, mbx copies the bytes.
+- Several Cargo builds fit on one machine. Cargo plans one build at a time,
+  so two started together each size themselves to the whole machine and both
+  finish late. kache does not stop you running them, but it does not
+  coordinate them either: it starts each compiler as Cargo asks for it, with
+  no shared budget and nothing that notices two builds compiling the same
+  crate at the same moment. mbx's shims sit in front of every compiler on the
+  machine and hand out permits from one memory-aware pool, so a lint job and
+  a test job run side by side without overloading the box, and a compilation
+  identical to one already running anywhere waits for it. Either way, give
+  each command its own `CARGO_TARGET_DIR`: Cargo's target directory lock
+  serializes them otherwise. See [machine-wide compile
+  scheduling](/configuration#machine-wide-compile-scheduling).
+- A public repository can share one cache. This is the difference that shaped
+  mbx most. kache's remotes are S3-compatible buckets or a filesystem path,
+  and a bucket has one question to ask: does this credential write? Whatever
+  can publish can also overwrite or remove what an earlier build published,
+  and one leaked credential is the whole cache. mbx's remote is a protocol
+  server, which can express finer rules: grants are deny-by-default with
+  separate read and write namespace patterns; CI authenticates with a
+  short-lived OIDC token pinned to a repository and its immutable numeric
+  owner ID, narrowable to a `ref` or `environment`, instead of a stored
+  secret; blobs are immutable and results commit atomically; and there is no
+  deletion endpoint, so a writer adds results and can never rewrite or remove
+  one. Fork pull requests hold no credentials at all and fall back to a
+  read-only platform cache; see [fork PRs](/cookbook/fork-prs). mbx's client
+  also refuses to publish from pull requests, unprotected branches, and tag
+  builds, which catches a misconfigured grant early; the server is what makes
+  the guarantee.
+- A build is cached only when it asks to be. Both tools put C and C++ shims on
+  `PATH` so make, CMake, or anything else that resolves its compiler there
+  gets cached. kache installs them alongside its service, so every build on
+  the machine goes through the cache. mbx puts them on `PATH` for a single
+  [`mbx exec`](/standalone-builds) command and leaves other builds untouched.
+  Both cover Windows; mbx intercepts `cl.exe` there and the plain gcc/clang
+  driver names on Unix.
+- A restored binary matches the machine it runs on. Both tools cache linked
+  binaries on Linux, macOS, and Windows. mbx keys on the resolved linker,
+  startup objects, libc, and SDK as well as dep-info, because a binary linked
+  against a different libc or SDK is a different binary. On a host mbx cannot
+  describe that precisely, it links normally.
 
-If you want the C and C++ shims installed once rather than wrapping the
-commands that should use them, kache is worth evaluating.
-Both tools wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
-the same build.
+If you want the C and C++ shims installed once instead of wrapping the
+commands that should use them, kache is worth evaluating. Both tools wrap
+rustc through `RUSTC_WRAPPER`, so they cannot be combined for the same build.
 
 ## Tarball CI caches
 
@@ -146,15 +138,14 @@ size cap, and stale artifacts accumulate inside it.
 
 mbx restores exactly the actions a build needs from a store it prunes itself.
 [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) uses
-GitHub Actions cache as the transport for that store, so it composes the
-per-action granularity with the platform cache you already have. See
+GitHub Actions cache as the transport for that store, so per-action
+granularity rides on the platform cache you already have. See
 [GitHub Actions](/github-action).
 
 ## Cargo's incremental compilation
 
 Incremental compilation speeds up recompiling the crate you are editing inside
 one checkout. It does nothing across checkouts, worktrees, or CI runners, and
-its artifacts are checkout-specific by design. mbx solves the complementary
-problem — the dependency graph, everywhere — and leaves the inner loop to
-rustc. The two interact: see
+its artifacts are checkout-specific by design. mbx caches the dependency
+graph everywhere and leaves the inner loop to rustc. The two interact: see
 [incremental builds](/configuration#incremental-builds).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 mbx reads configuration from three places; the first value found wins:
 
 1. Environment variables (`MBX_*`).
-2. `.mbx.toml` at the resolved Cargo workspace root — the
+2. `.mbx.toml` at the resolved Cargo workspace root, for the
    [build-policy switches](#workspace-policy) only.
 3. `mbx/config.toml` in the platform configuration directory:
    - Linux: `~/.config/mbx/config.toml`, honoring `$XDG_CONFIG_HOME`
@@ -11,19 +11,19 @@ mbx reads configuration from three places; the first value found wins:
    - Windows: `%APPDATA%\mbx\config.toml`
 
 Anything still unset takes its default. Unknown TOML keys are rejected, so a
-misspelled setting is an error rather than a silent no-op.
+misspelled setting is an error.
 
 ## Disk-scaled defaults
 
-mbx bounds its own disk use without being configured. The two size budgets
-default to a share of the disk holding the cache — 5% for the action store and
-10% for managed target directories — from floors of 5 GiB and 10 GiB up to
-500 GiB and 100 GiB respectively, rounded down to a whole 5 GiB. Managed
-targets are also collected after 30 days unused.
+The two size budgets default to a share of the disk holding the cache: 5% for
+the action store (`gc.max_size`) and 10% for managed target directories
+(`target.max_size`), each bounded at both ends. Managed targets are also
+collected after 30 days unused. The table in
+[managed target directories](/managed-targets#budgets-scale-with-the-disk)
+lists the bounds and what collection removes.
 
 Setting any of them outright overrides the scaling; `"none"` disables
-`target.max_size`, `target.max_age`, and `gc.max_total_size`. See
-[managed target directories](/managed-targets) for what collection removes.
+`target.max_size`, `target.max_age`, and `gc.max_total_size`.
 
 ## Example
 
@@ -89,13 +89,13 @@ priority = "normal"
 
 Environment variables still win. Machine paths, remote-cache configuration,
 credentials, diagnostics, target placement, and garbage collection are not
-accepted from a repository-owned file. mbx reports an error instead of applying
-an unsafe or misspelled workspace setting.
+accepted from a repository-owned file. mbx reports an error for an unsupported
+or misspelled workspace setting.
 
 `share_out_dir = true` is the global default. A workspace may set it to false
-when generated source paths must remain literal in debug information — for
-C and C++ objects as well as Rust artifacts, since a build script's generated
-headers reach both.
+when generated source paths must remain literal in debug information. This
+applies to C and C++ objects as well as Rust artifacts, because a build
+script's generated headers reach both.
 
 `build_script_execution = true` (`MBX_BUILD_SCRIPT_EXECUTION`) caches eligible
 `build.rs` executions. Set it to false to keep compilation caching while every
@@ -134,9 +134,9 @@ by the kernel if a process dies, so a crashed build cannot wedge its siblings.
 
 Builds running at the same time also stop repeating each other: a compilation
 identical to one already running anywhere on the machine waits for that one
-and restores its result instead of burning a core on it. How the pool weighs
-compilations and links — and what happens when a guess is wrong — is described
-in [how it works](/how-it-works#machine-wide-scheduling).
+and restores its result. How the pool weighs compilations and links, and what
+happens when a guess is wrong, is described in
+[how it works](/how-it-works#machine-wide-scheduling).
 
 The pool is memory-aware. `scheduler.cpus` permits (default: logical CPUs),
 less `scheduler.reserve_cpus` (default: 0), divide `scheduler.memory` (default:
@@ -144,24 +144,23 @@ less `scheduler.reserve_cpus` (default: 0), divide `scheduler.memory` (default:
 `"none"` keeps plain CPU permits). The pool always keeps at least one permit.
 Cargo's `-j`/`--jobs` or `CARGO_BUILD_JOBS` can cap how many weighted permits
 one build holds without shrinking the machine-wide pool available to other
-builds. In a container, "physical memory" means the cgroup's limit rather than
-the host's RAM — a build in a 4 GiB container on a large machine is budgeted by
-the 4 GiB, because the rest was never its to spend.
+builds. In a container, physical memory means the cgroup's limit, so a build in
+a 4 GiB container on a large machine is budgeted by the 4 GiB.
 
 `priority = "low"` (`MBX_SCHEDULER_PRIORITY`) is for builds nobody is sitting
-at — CI on a shared box, an editor's background check. While a normal-priority
-build is waiting for permits, low-priority builds leave a quarter of the pool
-free for it.
+at, such as CI on a shared box or an editor's background check. While a
+normal-priority build is waiting for permits, low-priority builds leave a
+quarter of the pool free for it.
 
-Two limits are worth knowing: a single compilation larger than the machine is
-still too large when it runs alone, and crates that have never been measured
-start at one permit until the pool has seen them once.
+Two limits apply: a single compilation larger than the machine is still too
+large when it runs alone, and crates that have never been measured start at one
+permit until the pool has seen them once.
 
 ## Verify mode
 
 `MBX_VERIFY=1` compiles and consults the cache side by side and compares the
-results. It is deliberately expensive — use it to qualify correctness, not for
-everyday builds.
+results. It is expensive; use it to qualify correctness, not for everyday
+builds.
 
 The build reports what it found:
 
@@ -169,10 +168,10 @@ The build reports what it found:
 mbx[cache]: qualification: 24 verified, 0 diverged
 ```
 
-Run it in the checkout that filled the cache, so that what is being measured
-is whether a compilation reproduces itself rather than whether two checkouts
-embed the same paths. Anything above zero divergences is a modeling bug worth
-reporting; `MBX_BYPASS_LOG` and `mbx explain` show what was left out.
+Run it in the checkout that filled the cache. Artifacts restored from another
+checkout embed that checkout's paths and would be reported as divergences. Any
+divergence in the same checkout is a modeling bug; please report it.
+`MBX_BYPASS_LOG` and `mbx explain` show what was left out.
 
 This is how to qualify a setting whose tier you want to check against your
 own workload, such as
@@ -182,20 +181,20 @@ before relying on it.
 ## The savings line
 
 `savings` controls the one-line report of accumulated savings after a build
-(`MBX_SAVINGS` from the environment). `quips` — the default — draws the line
-from a pool of dry one-liners, `plain` states the same facts in the register
-of the other `mbx[...]` lines, and `off` keeps the totals without printing
+(`MBX_SAVINGS` from the environment). `quips`, the default, draws the line
+from a pool of dry one-liners. `plain` states the same facts in the register
+of the other `mbx[...]` lines. `off` keeps the totals without printing
 anything.
 
 ## Build summaries
 
 `summary` controls the cache report printed to stderr after a build
-(`MBX_SUMMARY` from the environment). `short` — the default — prints one line,
-leaving routine `compiler-query` and `standard-input` probes out of its bypass
-count. `full` prints the detailed timing, compiler, bypass, transfer, and
-materialization breakdown. `off` prints no cache summary, while still writing
-`MBX_STATS_REPORT` when configured. Cargo's `-q` and `--quiet` also suppress
-the summary for that invocation.
+(`MBX_SUMMARY` from the environment). `short`, the default, prints one line
+and leaves routine `compiler-query` and `standard-input` probes out of its
+bypass count. `full` prints the detailed timing, compiler, bypass, transfer,
+and materialization breakdown. `off` prints no cache summary, while still
+writing `MBX_STATS_REPORT` when configured. Cargo's `-q` and `--quiet` also
+suppress the summary for that invocation.
 
 ## Incremental builds
 
@@ -208,25 +207,25 @@ disables it because a fresh runner has no incremental state to reuse.
 
 The crate you are editing misses the cache on every build, because its content
 is new every time. On the first source edit to a crate inside the workspace,
-mbx compiles that crate with its own incremental state rather than from scratch,
-and keeps the result out of the shared cache — an incremental artifact describes
-one checkout's edit history, not its source. Crates outside the workspace retain
-the conservative three-change threshold. The build reports those compilations
-as `incremental` and says how many were held back.
+mbx compiles that crate with its own incremental state and keeps the result out
+of the shared cache, since an incremental artifact describes one checkout's
+edit history. A crate outside the workspace switches after three consecutive
+misses with changed sources. The build reports those compilations as
+`incremental` and says how many were held back.
 
-The trigger is the crate's own sources, not its cache key, so a rebuilt
-dependency — which changes the keys of everything above it — keeps compiling
-and publishing normally, and so does a miss on unchanged sources (a wiped
-`target/`, a first build in a new checkout). The record and state are private
-to each checkout, living under `incremental/` in mbx's cache directory so
+The trigger is the crate's own sources, not its cache key. A rebuilt dependency
+changes the keys of everything above it, and those crates keep compiling and
+publishing normally. So does a miss on unchanged sources, such as a wiped
+`target/` or a first build in a new checkout. The record and state are private
+to each checkout and live under `incremental/` in mbx's cache directory, so
 `cargo clean` does not discard the next edit's speedup. Each crate's
 incremental state is discarded once it passes 1 GiB, and normal garbage
 collection removes state for deleted or expired checkouts.
 
-CI never does this, for the same reason it never compiles incrementally: there
-is no earlier state to build on. `MBX_LEARNED_INCREMENTAL=0` turns it off, and
-`MBX_INCREMENTAL=1` supersedes it by handing the whole decision back to
-cargo.
+CI never does this, because a fresh runner has no earlier state to build on.
+`MBX_LEARNED_INCREMENTAL=0` turns it off. `MBX_INCREMENTAL=1` supersedes it by
+handing incremental compilation back to cargo, and `MBX_VERIFY=1` disables it
+for the build being verified.
 
 ## Sizes and durations
 

--- a/docs/cookbook/fork-prs.md
+++ b/docs/cookbook/fork-prs.md
@@ -4,10 +4,10 @@ Open-source repositories take pull requests from forks, and forks change what
 a CI run may hold: GitHub withholds secrets and OIDC tokens from
 fork-triggered runs, so a fork's job cannot authenticate to a
 [cache server](/remote-cache). mbx's own [write policy](/remote-cache#read-and-write-policy)
-already keeps every pull request read-only — the remaining question is which
+already keeps every pull request read-only. The remaining question is which
 backend each run should use.
 
-The recipe: trusted runs talk to the cache server, fork pull requests fall
+The recipe: trusted runs talk to the cache server, and fork pull requests fall
 back to GitHub Actions cache, which needs no credentials.
 
 ```yaml
@@ -54,34 +54,33 @@ jobs:
 
 ## How it works
 
-- **The backend expression** treats pushes and same-repository pull requests
-  as trusted — both come from people with push access — and everything else
+- The backend expression treats pushes and same-repository pull requests as
+  trusted, since both come from people with push access, and everything else
   as a fork. Fork runs get the [GitHub Actions cache backend](/github-action),
   which restores without credentials and never lets a pull request save.
-- **`id-token: write` is safe to declare at the workflow level.** GitHub
-  refuses to issue OIDC tokens to fork-triggered runs regardless of the
-  declared permission, which is exactly why the fork path must not pick the
-  server backend: it would fail asking for a token it can never have.
-- **The mirror step** is what keeps fork PRs warm. Their runs can restore only
-  from GitHub Actions cache, and nothing would ever populate it if every
-  trusted build used the server alone. Running the github backend alongside
-  the server on `main` pushes saves the store after the build (action steps
-  clean up in reverse order, so the mirror's save runs last), and fork PRs
-  restore that entry.
+- `id-token: write` is safe to declare at the workflow level. GitHub refuses
+  to issue OIDC tokens to fork-triggered runs regardless of the declared
+  permission. That is also why the fork path must not pick the server
+  backend: it would fail asking for a token it can never have.
+- The mirror step keeps fork PRs warm. Their runs can restore only from GitHub
+  Actions cache, and nothing would populate it if every trusted build used
+  the server alone. Running the github backend alongside the server on `main`
+  pushes saves the store after the build (action steps clean up in reverse
+  order, so the mirror's save runs last), and fork PRs restore that entry.
 
 ## Hardening
 
 The single-workflow recipe above trusts the platform to withhold fork
-credentials. Projects that want the trust boundary to be structural rather
-than conditional split it in two: a router workflow whose `trusted` and
-`untrusted` jobs are mutually exclusive, each calling a shared
-`workflow_call` implementation with different permissions and inputs.
+credentials. To make the trust boundary structural, split it in two: a router
+workflow whose `trusted` and `untrusted` jobs are mutually exclusive, each
+calling a shared `workflow_call` implementation with different permissions and
+inputs.
 [tak's ci.yml](https://github.com/jdx/tak/blob/main/.github/workflows/ci.yml)
 is a living example. What the split buys:
 
 - An untrusted run never declares `id-token: write` at all, and its first step
-  can assert `ACTIONS_ID_TOKEN_REQUEST_URL` is absent rather than assume it.
-- Trust can be narrower than "same repository" — tak only trusts one account,
+  can assert `ACTIONS_ID_TOKEN_REQUEST_URL` is absent.
+- Trust can be narrower than "same repository": tak only trusts one account,
   so a compromised collaborator token still cannot reach the server.
 - Each trust level can use its own runner pool, keeping fork code off
   self-hosted runners.
@@ -89,4 +88,4 @@ is a living example. What the split buys:
   branch protection a single required check.
 
 Whichever shape you use, pin third-party actions to full commit SHAs in a real
-workflow — a mutable tag can be retargeted at any time.
+workflow; a mutable tag can be retargeted at any time.

--- a/docs/cookbook/local-development.md
+++ b/docs/cookbook/local-development.md
@@ -60,8 +60,8 @@ the identical action, mbx waits for it and restores that result instead of
 running a duplicate compiler. The TUI makes both decisions visible by crate.
 
 An editor background check and a watcher may request much of the same work.
-That is safe, but Cargo still plans both builds; keep both only when the watcher
-runs a meaningfully different command such as tests, Clippy, or another feature
+That is safe, but Cargo still plans both builds; keep both only when the
+watcher runs a different command such as tests, Clippy, or another feature
 set.
 
 Do not add `cargo clean` to a watch loop. Cargo already rebuilds changed inputs,
@@ -88,7 +88,7 @@ cpus = 4
 memory = "8GiB"
 ```
 
-Choose values for the machine rather than copying those numbers blindly. The
+Choose values for the machine; those numbers are an example. The
 CPU setting limits concurrent real compiler work across every terminal and
 worktree; cache hits do not consume permits. The memory setting prevents known
 large compilations from filling all CPU permits at once.
@@ -134,8 +134,7 @@ CARGO_TARGET_DIR=target/debugger-uncached MBX_DISABLE=1 \
   cargo build --bin my-program
 ```
 
-This is deliberately cold and is best reserved for path-sensitive debugger or
+This build is cold and is best reserved for path-sensitive debugger or
 artifact investigations. Remove the extra target directory when finished; the
-shared action cache remains intact. To investigate whether restored bytes
-diverge rather than merely obtain a local debug build, use
-[`MBX_VERIFY=1`](/configuration#verify-mode).
+shared action cache remains intact. To check whether restored bytes diverge,
+use [`MBX_VERIFY=1`](/configuration#verify-mode).

--- a/docs/cookbook/migrate.md
+++ b/docs/cookbook/migrate.md
@@ -2,9 +2,9 @@
 
 ## From rust-cache or `actions/cache` over `target/`
 
-A tarball cache and mbx solve the same problem, so replace the step rather
-than stacking them — an archived `target/` restored over a managed one is
-exactly the stale, ever-growing entry mbx exists to replace (see
+A tarball cache and mbx solve the same problem, so replace the step instead of
+stacking them. An archived `target/` restored over a managed one is the stale,
+ever-growing entry mbx replaces (see
 [tarball CI caches](/compared#tarball-ci-caches)).
 
 Before:
@@ -31,16 +31,16 @@ registry. To keep those cached too, use the
 [manual GitHub cache setup](/github-action#manual-github-cache-setup), which
 shares one entry between Cargo's download caches and the mbx store.
 
-Leave release jobs out of the migration entirely: a production release should
-not restore any compiler cache, mbx's or the one being removed. See the
+Leave release jobs out of the migration: a production release should not
+restore any compiler cache, mbx's or the one being removed. See the
 [release warning](/github-action#s3-compatible-bucket).
 
 ## From sccache
 
 Both tools wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for
-the same build. mbx does not fight for the seat: with `RUSTC_WRAPPER` already
-set it defers to the existing wrapper and warns that the build is not cached.
-Migration is therefore removal — take sccache out of:
+the same build. With `RUSTC_WRAPPER` already set, mbx defers to the existing
+wrapper and warns that the build is not cached. Migration is removal: take
+sccache out of
 
 - `RUSTC_WRAPPER` in CI environments and shell profiles,
 - `build.rustc-wrapper` in `~/.cargo/config.toml`,
@@ -57,6 +57,6 @@ mbx doctor
 
 However you arrive, the first mbx build has an empty store: it restores
 nothing, stores everything, and the summary's
-[could not look up](/cache-results#could-not-look-up) line dominates. Compare
+[could not look up](/cache-results#could-not-look-up) count dominates. Compare
 the second build, and
 [`mbx explain`](/cache-results#bypass) says what any remaining gap is made of.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@ build, never a wrong one. See [stability](/stability#the-store-is-disposable).
 
 ## Why wasn't my first build faster?
 
-A first build has an empty store — there is nothing to hit, so it can only
+A first build has an empty store. There is nothing to hit, so it can only
 cost time, and the summary's "could not look up" line dominates. Time the
 second build instead. See
 [cache results](/cache-results#troubleshooting-a-low-hit-rate) and the cold
@@ -17,19 +17,19 @@ scenario in [benchmarks](/benchmarks#cold).
 
 ## Why does a fully warm build still take time?
 
-Links mbx cannot describe always run — a large binary re-links even when every
-compilation hit. Host binaries and tests are restored on Linux, macOS, and Windows, and
-self-contained WebAssembly targets everywhere; the rest is
+Links mbx cannot describe always run, so a large binary re-links even when
+every compilation hit. Host binaries and tests are restored on Linux, macOS,
+and Windows, and self-contained WebAssembly targets everywhere. The rest is
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 
 ## The cache stopped hitting after a Rust update. Is it broken?
 
-No — the compiler is part of every key, so a toolchain roll invalidates every
+No. The compiler is part of every key, so a toolchain roll invalidates every
 rustc action at once, and the build says so:
 `a manifest predicting N compilations was loaded, but none matched this build`.
 The benchmarks cover this in the [toolchain scenario](/benchmarks#toolchain).
 Actions that do not depend on rustc, such as a build script's C objects,
-legitimately survive.
+survive.
 
 ## Can I use mbx together with sccache?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,8 +150,7 @@ where.exe cargo
 mise activation supplies the command-wrapper path to shells where mise is active.
 The wrapper invokes `mbx` with Cargo shim mode enabled, then mise removes its
 dispatch directories before mbx delegates to the configured or system Cargo.
-SSH
-commands, coding agents, editors, and other non-interactive tools may use a
+SSH commands, coding agents, editors, and other non-interactive tools may use a
 startup path that does not activate mise. In that case, prepend the directory
 printed by `mbx setup` in a startup file those processes read. For zsh,
 `~/.zshenv` applies to interactive and non-interactive shells:
@@ -162,8 +161,8 @@ export PATH="$HOME/.local/share/mbx/bin:$PATH"
 
 Start a new process and run `command -v cargo` again. Once it resolves to the
 shim, ordinary `cargo build`, `cargo test`, and `cargo check` commands use mbx
-automatically. Explicit `mbx cargo …` commands remain supported, but users and
-tools do not need to remember a special prefix.
+automatically. Prefixing a Cargo command with `mbx`, as in `mbx build`, still
+works.
 
 Outside mise activation, the stable `cargo` launcher uses the setup-time mbx
 while it exists, then resolves the active `mbx` from `PATH` after an upgrade
@@ -178,8 +177,8 @@ editor did not inherit mise's `PATH`. Its outputs go to
 `target/rust-analyzer`, separate from terminal builds so the two Cargo processes
 do not contend on the target-directory lock. When `target` is managed, the
 editor directory lives inside that view and is collected with it, while the
-shared store warms both builds. Existing rust-analyzer check settings are always
-left unchanged rather than silently changing commands or features.
+shared store warms both builds. Existing rust-analyzer check settings are left
+unchanged.
 
 After installing from a release archive, run `$HOME/.local/bin/mbx setup` on
 Unix. On Windows, run
@@ -195,18 +194,16 @@ Release binaries cover:
 
 Other platforms with a Rust toolchain can build from source with
 `cargo install mbx --locked`. mbx wraps whichever Cargo and rustc are active,
-including rustup-managed toolchains — `mbx doctor` reports the pair it found.
+including rustup-managed toolchains. `mbx doctor` reports the pair it found.
 
 Reflinked output restoration needs a filesystem with copy-on-write file
 cloning: APFS on macOS, btrfs or XFS on Linux, ReFS (Dev Drive) on Windows.
-mbx probes the actual cache and target locations rather than assuming from
-the platform, and copies bytes where cloning is unavailable — caching still
-works on ext4 or NTFS, it just spends the disk twice.
+mbx probes the cache and target locations and copies bytes where cloning is
+unavailable. Caching still works on ext4 or NTFS but spends the disk twice.
 
 ### Windows
 
-Windows is a supported release platform with a narrower caching tier. The
-differences, which the pages they belong to also note in place:
+Windows is a supported release platform. The differences from Linux and macOS:
 
 - Reflinks need ReFS, which usually means a Dev Drive; on NTFS mbx copies
   bytes instead.
@@ -272,7 +269,7 @@ mise run lint:default ::: lint:all
 
 Separate target directories keep Cargo's directory lock from serializing the
 commands. mbx shares one machine-wide compiler pool and deduplicates identical
-work in flight without further configuration — see
+work in flight without further configuration. See
 [how it works](/how-it-works#machine-wide-scheduling) for the mechanism and
 the same shape [inside GitHub Actions](/github-action#parallel-cargo-steps).
 
@@ -327,9 +324,9 @@ After a build that used the cache, mbx prints a one-line summary to stderr:
 mbx[cache]: 139 hits, 8 misses, 4 not looked up, 147 prefetched, 7 bypassed; 312.4 MiB downloaded, 0 B uploaded, 280.1 MiB stored locally
 ```
 
-These are three different outcomes: a miss means mbx looked up an action and
-found nothing, “could not look up” means it had no key yet, and a bypass means
-mbx deliberately declined to cache the action. See [Cache results](/cache-results).
+A miss means mbx looked up an action and found nothing. “Not looked up” means
+it had no key yet. A bypass means mbx declined to cache the action. See
+[Cache results](/cache-results).
 Set `MBX_SUMMARY=full` for the detailed breakdown, `MBX_SUMMARY=off` for none,
 or use Cargo's `-q`/`--quiet` for a quiet invocation.
 
@@ -361,8 +358,7 @@ mbx gc --json
 
 ## Reporting a problem
 
-Three things describe almost any mbx problem, and a bug report that carries
-them rarely needs a follow-up question:
+Three things describe almost any mbx problem:
 
 ```sh
 mbx doctor --json           # environment, store, and setup state
@@ -372,8 +368,8 @@ MBX_BYPASS_LOG=bypass.log cargo build   # why each compilation was not cached
 
 All three describe your machine: `mbx doctor --json` reports absolute cache
 paths and the URL and namespace of any configured remote, and the logs name
-the crates you build. Credentials themselves are never printed, but remove
-whatever else you would rather not publish before posting.
+the crates you build. Credentials are never printed. Remove anything else you
+would rather not publish before posting.
 
 `MBX_LOG` takes an [env_logger](https://docs.rs/env_logger) filter, so
 `debug`, `trace`, or a per-module filter such as `mbx=trace` all work; it
@@ -387,9 +383,8 @@ Report a problem in
 and propose a change in
 [Ideas](https://github.com/jdx/mr-boxington/discussions/categories/ideas).
 A suspected vulnerability goes through
-[private advisory reporting](https://github.com/jdx/mr-boxington/security/advisories/new)
-rather than a public thread; see
-[SECURITY.md](https://github.com/jdx/mr-boxington/blob/main/SECURITY.md).
+[private advisory reporting](https://github.com/jdx/mr-boxington/security/advisories/new);
+see [SECURITY.md](https://github.com/jdx/mr-boxington/blob/main/SECURITY.md).
 
 ## Next steps
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -51,9 +51,9 @@ steps:
 ```
 
 Each command needs a separate `CARGO_TARGET_DIR`; otherwise Cargo's target
-directory lock serializes the supposedly parallel steps. The mbx store and
-scheduler stay shared, so the steps run side by side on one CPU and memory
-budget rather than each Cargo process trying to fill the runner on its own.
+directory lock serializes the parallel steps. The mbx store and scheduler stay
+shared, so the steps run side by side on one CPU and memory budget instead of
+each Cargo process filling the runner on its own.
 
 We saw mise's own lint job finish up to 45% sooner this way. Tuning and
 failure behavior are covered under
@@ -209,15 +209,15 @@ steps:
   - run: mbx build --workspace --all-features
 ```
 
-mbx is installed rather than set up through
-[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) here,
+This example installs mbx with `jdx/mise-action` instead of
+[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action),
 because the action's GitHub Actions cache backend would store the same actions
 a second time. Use one or the other.
 
-mbx still refuses to publish from a pull request. Because a bucket has no
-server to authorize anything, make IAM agree: scope the role's trust policy to
-the branches allowed to assume it, and give pull request jobs a role that can
-only read. See [remote cache](/remote-cache#who-may-publish).
+mbx still refuses to publish from a pull request. A bucket has no server to
+authorize anything, so make IAM agree: scope the role's trust policy to the
+branches allowed to assume it, and give pull request jobs a role that can only
+read. See [remote cache](/remote-cache#who-may-publish).
 
 ::: warning Do not use remote caches for production releases
 A production release may still use `mbx` and its local cache, but should not use
@@ -226,6 +226,6 @@ Release jobs should also avoid restoring or saving the mbx store through
 `actions/cache`.
 :::
 
-For a repository that combines both backends — the server for trusted runs, the
-GitHub cache for fork pull requests — see
+For a repository that combines both backends, the server for trusted runs and
+the GitHub cache for fork pull requests, see
 [CI with fork pull requests](/cookbook/fork-prs).

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,8 +1,7 @@
 # How it works
 
-mbx is a Cargo wrapper, not a Cargo replacement. Run Cargo subcommands directly
-through it: `cargo build`, `cargo test`, `cargo clippy`, or any installed Cargo
-subcommand.
+mbx is a Cargo wrapper. Run Cargo subcommands directly through it: `cargo
+build`, `cargo test`, `cargo clippy`, or any installed Cargo subcommand.
 
 1. mbx resolves the workspace and target roots through Cargo metadata.
 2. It starts an in-process cache agent and creates shims for the build.
@@ -42,11 +41,11 @@ Unlike rustc, a C compile leaves no dependency record behind for a later build
 to read, and publishing one would add a file the uncached build never produced.
 So the shim asks for its own dependency list, keeps it private, and keys the
 compilation on the files that list names. A cold compilation therefore has no
-key to look up yet — it is stored after compiling and warms the next build. The
+key to look up yet; it is stored after compiling and warms the next build. The
 directories the compile searched also contribute a manifest of the names in
 them that could answer an `#include`, so a header appearing where it would
 *shadow* one that was read changes the key even though every file that was read
-is unchanged; what a manifest counts and leaves out is covered in
+is unchanged. What a manifest counts and leaves out is covered in
 [limits](/limits#shadowing-is-modeled-by-name-not-by-content).
 
 ## Portable keys
@@ -56,15 +55,15 @@ to stable placeholders before they enter a key. That is what lets equivalent
 worktrees share an action even though their absolute paths differ.
 
 The key also covers compiler inputs and relevant environment. If mbx cannot
-model something exactly, it bypasses the action instead of guessing.
+model something exactly, it bypasses the action.
 
 ## Prediction and dep-info
 
 A rustc action key depends on the files that compilation actually reads. mbx
 learns that set from Cargo/rustc dep-info left by an earlier build and records a
-prediction for later invocations. A genuinely cold compilation may therefore
-have no key to look up yet. It still gets stored after compiling and can warm
-the next build.
+prediction for later invocations. A cold compilation may therefore have no key
+to look up yet. It still gets stored after compiling and can warm the next
+build.
 
 ## Rustdoc actions
 
@@ -90,10 +89,10 @@ the CAS object.
 
 Reflinks require support from the filesystem and generally require the cache
 and target directory to be on the same filesystem. When cloning is unavailable,
-mbx transparently copies the bytes instead. The session summary reports the
-file count and logical size handled by each path; `MBX_STATS_REPORT` includes
-the same values as `reflinked_output_files`, `reflinked_output_bytes`,
-`copied_output_files`, and `copied_output_bytes`.
+mbx copies the bytes instead. The session summary reports the file count and
+logical size handled by each path; `MBX_STATS_REPORT` includes the same values
+as `reflinked_output_files`, `reflinked_output_bytes`, `copied_output_files`,
+and `copied_output_bytes`.
 
 This is filesystem copy-on-write, not a placeholder or userspace on-demand
 filesystem. Restored paths retain normal file semantics on every supported
@@ -110,24 +109,21 @@ crashed build cannot wedge its siblings.
 Concurrent builds also stop repeating each other. Four CI jobs building one
 commit compile the same dependency graph four times; under the scheduler, a
 compilation identical to one already running anywhere on the machine waits for
-that one to finish and restores its result from the cache instead of burning a
-core on it. The finished compilation also leaves its input list behind, so a
-job arriving after it is already done can build the cache key it would
-otherwise lack and hit where it would have compiled cold. Both paths rehash
-every input before trusting anything, so the worst a stale record can do is
-fall back to compiling.
+that one to finish and restores its result from the cache. The finished
+compilation also leaves its input list behind, so a job arriving after it is
+already done can build the cache key it would otherwise lack and hit where it
+would have compiled cold. Both paths rehash every input before trusting
+anything, so the worst a stale record can do is fall back to compiling.
 
 Permits are weighted by memory. Native links start at two permits, and every
 compilation is thereafter weighted by what it actually used, so the predicted
-memory of everything running stays inside the budget; a link that turns out to
-fit in one permit stops being charged for two, which is what keeps the
-link-heavy tail of a build from running at half concurrency. A link mbx has
-never seen is weighed by the heaviest of this machine's recent links —
-guessing low costs an out-of-memory kill and guessing high costs a wait, and
-test binaries make the case for remembering: each is its own crate name, so a
-cold `cargo test --no-run` has no per-crate history for the links in front of
-it. A compilation the Linux OOM killer stops is recorded heavier than it
-measured, so its retry runs with more room instead of repeating the crash.
+memory of everything running stays inside the budget. A link that turns out to
+fit in one permit stops being charged for two, which keeps the link-heavy tail
+of a build from running at half concurrency. A link mbx has never seen is
+weighed by the heaviest of this machine's recent links; test binaries each
+have their own crate name, so a cold `cargo test --no-run` has no per-crate
+history for the links in front of it. A compilation the Linux OOM killer stops
+is recorded heavier than it measured, so its retry runs with more room.
 
 The pool size, memory budget, and priority are settings; see
 [machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling).
@@ -135,15 +131,16 @@ The pool size, memory budget, and priority are settings; see
 ## Correctness first
 
 Unsupported crate types, unmodeled search paths, and incremental compilations
-bypass the shared action cache. A compilation that links nothing is cached
-whatever its crate type — `cargo check` and clippy compile every binary and
-test target that way, and metadata is metadata. A native link is admitted only
-when its linker can be described: host binaries, tests, and proc macros on Linux,
-macOS, and Windows, where mbx puts the resolved linker, startup objects, C
-runtime, and SDK into the key, and a fixed allowlist of built-in WebAssembly
-targets whose default linker and system inputs ship with rustc. Everything else —
-native libraries, custom linkers, unrecognized toolchains — links as it always
-did; see
+bypass the shared action cache. That includes the private incremental state of
+[learned incremental reuse](/configuration#learned-incremental-reuse), which is
+never published. A compilation that links nothing is cached whatever its crate
+type: `cargo check` and clippy compile every binary and test target that way.
+A native link is admitted only when its linker can be described: host binaries,
+tests, and proc macros on Linux, macOS, and Windows, where mbx puts the
+resolved linker, startup objects, C runtime, and SDK into the key, and a fixed
+allowlist of built-in WebAssembly targets whose default linker and system
+inputs ship with rustc. Everything else (native libraries, custom linkers,
+unrecognized toolchains) links as it always did; see
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
-`MBX_VERIFY=1` compiles while also consulting the cache and compares the result,
-providing a deliberately expensive qualification mode.
+`MBX_VERIFY=1` compiles while also consulting the cache and compares the
+result, an expensive qualification mode.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1,6 +1,7 @@
 # Limits
 
-mr boxington favors correct uncached work over risky cache reuse.
+When mbx cannot model a compilation exactly, it runs the compiler and does not
+cache the result. This page lists those cases.
 
 ## Build-script execution follows Cargo's freshness inputs
 
@@ -32,9 +33,14 @@ when the build later runs under plain Cargo, outside an mbx session.
 
 ## Incremental compilations are not cached
 
-Cargo's normal incremental workspace compilations bypass the action cache.
-Dependencies, which Cargo builds non-incrementally, remain cacheable — and they
-are the bulk of a cold build. See [incremental
+Incremental compilations bypass the action cache. Dependencies, which Cargo
+builds non-incrementally, remain cacheable, and they are the bulk of a cold
+build.
+
+By default mbx forces `CARGO_INCREMENTAL=0` and instead gives a crate whose
+sources keep changing its own private incremental state; see [learned
+incremental reuse](/configuration#learned-incremental-reuse). Those
+compilations are never published to the shared cache. See [incremental
 builds](/configuration#incremental-builds) for the trade `MBX_INCREMENTAL=1`
 makes.
 
@@ -45,9 +51,9 @@ objects, and system libraries that rustc dep-info does not enumerate. mbx
 caches such a link only when it can put all of that into the key, and bypasses
 it otherwise.
 
-WebAssembly is the case that needs nothing extra: a binary, test, or `cdylib`
-for one of these built-in targets uses its compiler-bundled self-contained
-linker, so it is cached on every platform:
+WebAssembly needs nothing extra: a binary, test, or `cdylib` for one of these
+built-in targets uses its compiler-bundled self-contained linker, so it is
+cached on every platform:
 
 - `wasm32-unknown-unknown`
 - `wasm32-wasip1` and `wasm32-wasip1-threads`
@@ -61,37 +67,35 @@ identity. Custom target specifications, external WebAssembly toolchains,
 native libraries, unrecognized custom linkers, disabled WASI CRT bundling, and
 non-affirmative `link-self-contained` modes remain uncached.
 
-Host test binaries and executables are cached on Linux, macOS, and Windows, by putting
-the rest of the link into the key: the resolved `cc` driver and its version,
-the linker it selects, the startup objects and libc it resolves (hashed), and
-on macOS the SDK. On Windows the key identifies `link.exe` or `lld-link`, the
-MSVC toolset and Windows SDK versions, and the selected VC and Universal CRT
-libraries. Two hosts that differ in any of those produce different keys
-and miss, rather than sharing a binary neither of them built. `cache_links`
-(`MBX_CACHE_LINKS=0`) turns it off.
+Host test binaries, executables, and proc macros are cached on Linux, macOS,
+and Windows by putting the rest of the link into the key: the resolved `cc`
+driver and its version, the linker it selects, the startup objects and libc it
+resolves (hashed), and on macOS the SDK. On Windows the key identifies
+`link.exe` or `lld-link`, the MSVC toolset and Windows SDK versions, and the
+selected VC and Universal CRT libraries. Two hosts that differ in any of those
+produce different keys and miss. `cache_links` (`MBX_CACHE_LINKS=0`) turns it
+off.
 
-Some hosts cannot be described at all. mbx asks the driver to place a startup
-object and a libc, and a host where neither resolves gets no linker identity
-and therefore no cached links — refusing is the only safe answer, because two
-hosts failing the same probe would otherwise agree on a key without either of
-them having pinned what it stood for. The same goes for a driver that names no
-linker or reports no version. Those links appear in `mbx explain` like any
-other bypass.
+Some hosts cannot be described. mbx asks the driver to place a startup object
+and a libc; a host where neither resolves gets no linker identity and no cached
+links, because two hosts failing the same probe would otherwise agree on a key
+without either having pinned what it stood for. The same goes for a driver that
+names no linker or reports no version. Those links appear in `mbx explain` like
+any other bypass.
 
 Even then, a link bypasses if it names a native library, overrides the linker,
 or carries a flag that would embed this checkout's paths (`-Crpath`,
 `-Cprefer-dynamic`) or leave a file beside the binary that mbx does not store
 (`-Csplit-debuginfo`). On macOS a debug-info link records absolute object
 paths and their timestamps in the binary's debug map, so the shim passes ld64
-`-oso_prefix` for its own output directory, which is what lets those links
-cache rather than bypass. An explicit
-`--target` bypasses too, even when it spells the host triple: rustc without one
-links for the host by construction, and that is the only linker mbx identifies.
+`-oso_prefix` for its own output directory, which lets those links cache. An
+explicit `--target` bypasses too, even when it spells the host triple: rustc
+without one links for the host, and that is the only linker mbx identifies.
 
 ## Restored artifacts are equivalent, not always identical
 
 A restore writes this checkout's spelling of the outputs that describe where a
-compilation ran — its dep-info and its diagnostics — so the files cargo reads
+compilation ran, its dep-info and its diagnostics, so the files cargo reads
 name the directory it is building into.
 
 The compiled artifacts are reused as they were produced, and a few things can
@@ -104,41 +108,38 @@ the compiler ran in.
 A C or C++ object also records the absolute include directories it was given,
 which is how a `-sys` crate whose build script generates headers into
 `OUT_DIR` used to produce a different object in every target directory. With
-[`OUT_DIR` sharing](/configuration#share-out-dir) on — the default — mbx
-passes the compiler `-fdebug-prefix-map` for that directory, so the object
-records the same placeholder the key does and two target directories produce
-the same bytes. An object that keeps the path anyway, in a string the source
-holds rather than in debug information, is not published at all rather than
-shared under a key that says the path does not matter. The object path alone
-never did this on Linux or macOS; on Windows it does, because the debug
-information records where the object was written as well.
+[`OUT_DIR` sharing](/configuration#share-out-dir) on (the default), mbx passes
+the compiler `-fdebug-prefix-map` for that directory, so the object records the
+same placeholder the key does and two target directories produce the same
+bytes. An object that keeps the path anyway, in a string the source holds, is
+not published. The object path alone never did this on Linux or macOS; on
+Windows it does, because the debug information also records where the object
+was written.
 
 None of these changes what the artifact does. All of them are visible to
 `MBX_VERIFY=1`, which compares bytes: a divergence it reports for a
 compilation restored from another checkout, or from another target directory
-whose paths the object records, is that difference rather than a fault. The
+whose paths the object records, is that difference and not a fault. The
 divergence names the file and what differed about it, so a run's divergences
-can be told apart from one another rather than counted together.
+can be told apart.
 
 ## C and C++ caching covers the host compiles mbx drives
 
 mbx caches the C and C++ a cargo build script compiles for the host through
 the `cc` crate, and the C and C++ of a command run under
 [`mbx exec`](/standalone-builds), which puts shims for the plain driver names
-on `PATH` for that command alone. A compile mbx never stood in for — one
-outside both paths — is not
-reached. Neither are cross compilations: a cargo build installs the shims as
-`HOST_CC` and `HOST_CXX`, which the `cc` crate consults only when host and
-target agree, and `mbx exec` shims only `cc`, `c++`, `gcc`, `g++`, `clang`,
-and `clang++` on Unix, plus `cl.exe` on Windows, leaving a versioned toolchain
-to the build that chose it.
+on `PATH` for that command alone. A compile outside both paths is not reached.
+Neither are cross compilations the build did not name a compiler for: a cargo
+build installs the shims as `HOST_CC` and `HOST_CXX`, which the `cc` crate
+consults only when host and target agree, and `mbx exec` shims only `cc`,
+`c++`, `gcc`, `g++`, `clang`, and `clang++` on Unix, plus `cl.exe` on Windows,
+leaving a versioned toolchain to the build that chose it.
 
-A cross compile is cached when the build names its own compiler, through
-`CC_<target>`, `CXX_<target>`, `TARGET_CC`, or `TARGET_CXX`: mbx wraps what
-was named rather than replacing it. A cross build that names nothing is left
-alone, because which compiler a target implies lives in the `cc` crate's own
-tables — guessing wrong would not cost a cache hit, it would build the object
-with the wrong compiler. A value that is a command rather than a path, such as
+A cross compile is cached when the build names its own compiler through
+`CC_<target>`, `CXX_<target>`, `TARGET_CC`, or `TARGET_CXX`: mbx wraps what was
+named. A cross build that names nothing is left alone, because which compiler a
+target implies lives in the `cc` crate's own tables, and a wrong guess would
+build the object with the wrong compiler. A value that is a command, such as
 `ccache gcc`, is left alone for the same reason.
 
 Only a plain single-source object compile through a gcc-, clang-, or MSVC-style
@@ -148,39 +149,38 @@ sub-tool with `-Wp,`/`-Wl,`/`-Xclang`, unmodeled `-Wa,` assembler options, and
 response files all bypass, as does any flag the adapter does not model. Known
 assembler options that add no inputs, such as `-Wa,--noexecstack`, are keyed
 and admitted. MSVC compiler PDBs, modules, and other extra outputs also bypass.
-A source or header that
-expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__` bypasses too: its object is
-not a function of its inputs.
+A source or header that expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__`
+bypasses too: its object is not a function of its inputs.
 
-A flag that tunes for the machine's own processor — `-march=native` and its
-relatives — bypasses as well, since the object it produces is not a function
-of anything the key names.
+A flag that tunes for the machine's own processor, such as `-march=native` and
+its relatives, bypasses as well, because the object depends on the host CPU and
+the key does not name it.
 
 ## Shadowing is modeled by name, not by content
 
 An include directory contributes the names in it that could answer an
-`#include`: headers, sources — `#include "generated.c"` is unusual but legal —
+`#include`: headers, sources (`#include "generated.c"` is unusual but legal),
 names without an extension, and precompiled headers, which GCC prefers over
 the header they were built from without anything on the command line saying so.
 
-What is left out is what cannot answer an `#include` at all: an object, a
-dependency file, an archive. That distinction is what keeps the key stable,
-because a build writes those into the very directory a generated header lives
-in, and counting them would make the key depend on how many sibling
-compilations had finished rather than on anything about this one.
+Objects, dependency files, and archives are left out, because they cannot
+answer an `#include`. A build writes those into the directory a generated
+header lives in, and counting them would make the key depend on how many
+sibling compilations had finished.
 
 Manifests are taken once before the compiler runs and again before publishing.
-A header that appeared while the compilation was in flight is one the compiler
-never saw, so recording it would claim a state that did not produce this
-object.
+If a search directory changed in between, the compilation bypasses: a header
+that appeared while the compiler ran is one it never saw, and the key would
+otherwise claim a state that did not produce this object.
 
-System roots are exempt from manifests entirely: enumerating an SDK on every
-compile costs more than the risk, and anything actually read from one is
-digested like any other input.
+System roots are exempt from manifests. Enumerating an SDK on every compile
+costs more than the risk, and anything read from one is digested like any other
+input.
 
-The shims are only installed when the build has not chosen its own compiler.
-Setting `CC`, `CXX`, `HOST_CC`, `HOST_CXX`, `TARGET_CC`, or `TARGET_CXX` leaves
-that build's C compilations uncached, and `MBX_CC=0` disables the feature.
+The host shims are only installed when the build has not chosen its own host
+compiler. Setting `CC`, `CXX`, `HOST_CC`, or `HOST_CXX` leaves that build's
+host C compilations uncached; `TARGET_CC`, `TARGET_CXX`, `CC_<target>`, and
+`CXX_<target>` are wrapped as described above. `MBX_CC=0` disables the feature.
 
 ## `OUT_DIR` sharing remaps generated source paths
 
@@ -193,10 +193,10 @@ cross-checkout cache sharing for their dependent crates.
 
 This covers C and C++ as well as Rust. A build script that generates headers
 into `OUT_DIR` passes that directory to its own compilations, which record it
-in debug information, so the same remapping applies — rustc is told
-`--remap-path-prefix` and the C compiler `-fdebug-prefix-map`, and in both
-cases an output that kept the literal path is left uncached rather than
-shared. `MBX_SHARE_OUT_DIR=0` turns both off together.
+in debug information, so the same remapping applies: rustc is told
+`--remap-path-prefix` and the C compiler `-fdebug-prefix-map`. In both cases an
+output that kept the literal path is left uncached. `MBX_SHARE_OUT_DIR=0` turns
+both off together.
 
 ## Incremental output reduces sharing
 

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -31,16 +31,14 @@ mbx records the checkout associated with each target view. Collection runs
 after a build, at most once an hour, and needs no configuration. A target
 directory is removed when any of these is true:
 
-- **Its checkout is gone.** Nothing can ask for those outputs again, so this
-  happens regardless of the limits below.
-- **It has gone unused for `target.max_age`** — 30 days by default. The next
-  build in that checkout starts warm from the shared store rather than from
-  scratch, so this costs a re-link rather than a rebuild.
-- **The managed directories together exceed `target.max_size`**, in which case
-  the least recently used go first. The most recently used directory is never
-  collected for being over budget — it is the checkout you are working in, and
-  deleting it would only make the next build recreate it. If the budget cannot
-  be met without it, mbx says so and keeps it.
+- Its checkout is gone. This happens regardless of the limits below.
+- It has gone unused for `target.max_age`, 30 days by default. The next build
+  in that checkout restores from the shared store, so this costs a re-link
+  rather than a rebuild.
+- The managed directories together exceed `target.max_size`. The least
+  recently used go first. The most recently used directory is never collected
+  for being over budget; if the budget cannot be met without it, mbx says so
+  and keeps it.
 
 Cached compilations shared with a live checkout remain protected throughout.
 
@@ -72,17 +70,16 @@ max_total_size = "50GiB"
 ```
 
 `"none"` turns off `target.max_size`, `target.max_age`, or
-`gc.max_total_size`. A value that is neither a size nor `"none"` is an error
-rather than a silently ignored setting, so a typo cannot disable collection.
-`gc.max_size` has no `"none"`: an unbounded action store is the problem
-collection exists to prevent. `MBX_TARGET_VIEWS=0` opts out of managed target
-directories altogether, and a directory that is still reached through an
-existing `target` symlink keeps counting as in use, so turning placement off
-does not schedule existing outputs for deletion.
+`gc.max_total_size`. A value that is neither a size nor `"none"` is an error,
+so a typo cannot disable collection. `gc.max_size` has no `"none"`; the action
+store is always bounded. `MBX_TARGET_VIEWS=0` opts out of managed target
+directories altogether. A directory that is still reached through an existing
+`target` symlink keeps counting as in use, so turning placement off does not
+schedule existing outputs for deletion.
 
-Each budget is measured against the disk that actually holds it, so putting
+Each budget is measured against the disk that holds it, so putting
 [`target.root`](/configuration#target-root) on a large scratch volume sizes
-the target budget from that volume rather than from the cache disk.
+the target budget from that volume.
 
 ## When mbx leaves a target alone
 

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -1,7 +1,6 @@
 # Protocol compatibility
 
-mr-boxington has two versioned protocols. They have deliberately different
-compatibility rules.
+mr-boxington has two versioned protocols with different compatibility rules.
 
 ## Shim/agent protocol
 
@@ -22,16 +21,16 @@ Agent protocol v2 adds compiler-duration accounting to hits and real compiler
 invocations. v3 adds the crate name to a recorded hit plus `begin_task` and
 `commit_task`, allowing an embedded Cargo shim to create one prediction manifest
 for each real Cargo invocation. v4 adds `record_warning`, which is how a shim
-reports a diagnostic at all: a C or C++ shim stands in for a compiler whose
-stderr its caller reads as an answer, so it cannot write there itself, and the
-agent prints each distinct message once from the process that owns the build.
-v5 adds `find_file_digests` and `record_file_digests`, which let a shim reuse
-the digest of a file the session already read in full instead of rehashing it.
-v6 adds `join_action_promise` and `complete_action_promise`, carrying the local
+reports a diagnostic: a C or C++ shim stands in for a compiler whose stderr its
+caller reads as an answer, so it cannot write there itself, and the agent
+prints each distinct message once from the process that owns the build. v5 adds
+`find_file_digests` and `record_file_digests`, which let a shim reuse the
+digest of a file the session already read in full instead of rehashing it. v6
+adds `join_action_promise` and `complete_action_promise`, carrying the local
 shim's invocation identity and the server lease or completed prediction needed
-for fleet-wide in-flight deduplication.
-The client and agent still require exact protocol and application-version
-equality, including when different applications ship them.
+for fleet-wide in-flight deduplication. The client and agent still require
+exact protocol and application-version equality, including when different
+applications ship them.
 
 ## Remote cache protocol
 
@@ -56,12 +55,13 @@ uses these resources:
 | blob pack | `POST /v1/blobs:pack` | `application/vnd.mbx.cache-blob-pack.v1` |
 | blob pack upload | `POST /v1/blobs:pack-upload` | `application/vnd.mbx.cache-blob-pack-receipt.v1+json` |
 
-Both batched resources are extensions, gated on their own capability
-(`features.action_batch` and `features.blob_pack_uploads`) and bounded by
-`limits.max_batch_items` and `limits.max_pack_bytes`. A client falls back to the
-single-object resources when a feature is not advertised, and also when an
-advertised endpoint answers `404`, `405`, or `501` — after which it stops asking
-for the rest of the session. Neither is required to serve the baseline.
+The batched and packed resources are extensions, each gated on its own
+capability (`features.action_batch`, `features.blob_packs`, and
+`features.blob_pack_uploads`) and bounded by `limits.max_batch_items` and
+`limits.max_pack_bytes`. A client falls back to the single-object resources
+when a feature is not advertised, and also when an advertised endpoint answers
+`404`, `405`, or `501`, after which it stops asking for the rest of the
+session. None of them is required to serve the baseline.
 
 Action promises are gated by `features.action_promises`. `POST` atomically
 returns a claim token, a bounded retry delay while another lease is live, or a
@@ -73,20 +73,19 @@ bearer values and clients cap them at 256 bytes. As with other extensions,
 `404`, `405`, or `501` disables promises for the rest of the client session.
 
 A batched action-result response carries only the records the service holds, in
-no order, so each one is bound to its request by the action digest inside it
-rather than by position: a client refuses a batch naming an action it did not
-ask for. An uploaded pack repeats the `MBXPACK1` framing of a downloaded one and
-declares its contents in the pack headers; because every blob in it is
-content-addressed and immutable, a rejected pack may leave an accepted prefix
-stored, and the client republishes its blobs individually rather than relying on
-that.
+no order, so each one is bound to its request by the action digest inside it,
+not by position: a client refuses a batch naming an action it did not ask for.
+An uploaded pack repeats the `MBXPACK1` framing of a downloaded one and declares
+its contents in the pack headers. Every blob in it is content-addressed and
+immutable, so a rejected pack may leave an accepted prefix stored; the client
+then republishes its blobs individually.
 
 The capabilities endpoint is optional: `404`, `405`, or `501` selects the v1
 baseline without extensions. Advertised capabilities must report the same
 protocol major. Optional response fields may be added only when existing
 clients ignore them; the canonical persisted records use
-`#[serde(deny_unknown_fields)]`, so their shape or meaning requires a new media
-type and protocol major.
+`#[serde(deny_unknown_fields)]`, so changing their shape or meaning requires a
+new media type and protocol major.
 
 Content-addressed records are serialized with the JSON Canonicalization Scheme
 before hashing. The conformance fixture locks their canonical v1 bytes, the
@@ -97,12 +96,12 @@ Action manifests are updated conditionally: a `GET` returns a strong `ETag` that
 the following `PUT` sends back as `If-Match`, and a first write uses
 `If-None-Match: *`. That entity tag is **opaque**. A client must echo it
 unchanged and must not read content from it, because a manifest can reach the
-client through an intermediary — RFC 9110 section 8.8.3.3 requires a proxy that
+client through an intermediary. RFC 9110 section 8.8.3.3 requires a proxy that
 compresses a response to vary the strong tag along with the coding, and Caddy
-does so by appending the coding name. What the body is gets established by
-comparing it against its canonical JSON and validating the task identity it
-claims, never by the tag. A server may therefore choose any strong tag; a weak
-one leaves the manifest readable but not updatable.
+does so by appending the coding name. The body is validated by comparing it
+against its canonical JSON and checking the task identity it claims, never by
+the tag. A server may therefore choose any strong tag; a weak one leaves the
+manifest readable but not updatable.
 
 ## Rust API compatibility
 
@@ -111,12 +110,12 @@ protocols. Pull requests that touch workspace crates run `cargo-semver-checks`
 against the pull request's base commit with all features enabled. Wire format
 changes still require the protocol-version steps above.
 
-A breaking API change is *declared*, not numbered by hand: the commit carries
+A breaking API change is declared, not numbered by hand: the commit carries
 `feat!:` or a `BREAKING CHANGE:` footer, and release-plz prices it into the
-version when it opens the release PR. What that means for contributors —
-including why a deliberate break leaves the semver check red until the release
-PR exists — is covered in
-[RELEASING.md](https://github.com/jdx/mr-boxington/blob/main/RELEASING.md).
+version when it opens the release PR.
+[RELEASING.md](https://github.com/jdx/mr-boxington/blob/main/RELEASING.md)
+covers what that means for contributors, including why an intended break
+leaves the semver check red until the release PR exists.
 
 The published crates do not all share a version, because they do not promise
 the same things:
@@ -133,22 +132,20 @@ the same things:
 
 The embedding crates stay on `0.x`, where a minor bump is allowed to break.
 `mbx-cache-core`, `mbx-cache-rustc`, and `mbx-cache-cc` move together; the
-smaller Cargo and store crates release independently. Pin compatible minors and expect an
-upgrade to require source changes.
+Cargo and store crates release independently. Pin compatible minors and expect
+an upgrade to require source changes.
 
 The Rust types mirror which wire records are open to extension and which are
 not. Capability records are `#[non_exhaustive]`, so a newly advertised feature
-or limit is a minor release rather than a major one; build them with
-`Capabilities::new` and assign the fields a service actually supports. The
-canonical persisted records are deliberately left exhaustive, because their
-shape is covered by a digest and a change to it requires a new media type and
-protocol major rather than an added field. `BypassReason` is also
-`#[non_exhaustive]`: the set of uncacheable invocations shifts as the adapter
-learns to model more of them, so aggregate on `BypassReason::kind` rather than
-matching every variant.
+or limit is a minor release; build them with `Capabilities::new` and assign the
+fields a service supports. The canonical persisted records are exhaustive,
+because their shape is covered by a digest and a change to it requires a new
+media type and protocol major. `BypassReason` is also `#[non_exhaustive]`: the
+set of uncacheable invocations shifts as the adapter learns to model more of
+them, so aggregate on `BypassReason::kind` instead of matching every variant.
 
 The same rule sorts the statistics types. `AgentStats` and `CompilerStats`
-accumulate whatever a session turns out to be worth measuring, so both are open
-to extension; build them from `default` or `CompilerStats::new`. `RestoreStats`
-stays constructible, because the shim reports one on every compilation — it is
-an input to the crate rather than something the crate hands back.
+gain counters as sessions measure more, so both are open to extension; build
+them from `default` or `CompilerStats::new`. `RestoreStats`
+stays constructible, because the shim reports one on every compilation; it is
+an input to the crate.

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -40,9 +40,9 @@ Anything that mints temporary credentials must export them there first. On
 GitHub Actions that is
 [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials),
 which exchanges the runner's OIDC token for a role, so no long-lived secret has
-to exist. Credential sources that are not environment variables — EKS IRSA,
-EC2 and ECS instance roles, `~/.aws/config` profiles, SSO — are not read
-directly; export the variables and they all work.
+to exist. mbx does not read other credential sources: EKS IRSA, EC2 and ECS
+instance roles, `~/.aws/config` profiles, and SSO all work once their
+credentials are exported as those variables.
 
 The URL may carry a prefix, as `s3://acme-build-cache/teams/backend`, to share
 one bucket between projects. Keys are laid out under
@@ -50,16 +50,15 @@ one bucket between projects. Keys are laid out under
 prefix.
 
 An IAM policy needs `s3:GetObject` and `s3:PutObject` on that prefix. Add
-`s3:ListBucket` on the bucket if you can: mbx never lists anything, but AWS
-answers `403` rather than `404` for an object that is not there unless the
-caller holds it, and that permission is what lets a miss be told apart from a
-refusal.
+`s3:ListBucket` on the bucket as well. mbx never lists anything, but without
+that permission AWS answers `403` instead of `404` for an absent object, so a
+miss cannot be told apart from a refusal.
 
-Without it mbx still works — a refused read is treated as a miss, and it says
-so once — but a credential that genuinely cannot read the cache then looks the
-same as a cold one, and only the warning distinguishes them. Credentials that
-S3 itself rejects, such as a wrong secret or an expired token, are always
-reported as errors either way.
+Without it mbx still works: a refused read is treated as a miss, and it says so
+once. A credential that cannot read the cache then looks the same as a cold
+one, and only the warning distinguishes them. Credentials that S3 itself
+rejects, such as a wrong secret or an expired token, are reported as errors
+either way.
 
 ### Cloudflare R2 and MinIO
 
@@ -81,30 +80,29 @@ in transit without TLS.
 
 A cache server verifies every blob against the digest in its URL before storing
 it. A bucket stores what it is given, so a corrupted object in the local store
-can be published under a key naming different content, and because writes are
-create-only nothing later overwrites it: every machine that downloads it fails
+can be published under a key naming different content. Writes are create-only,
+so nothing later overwrites it: every machine that downloads it fails
 verification and recompiles. `mbx cache verify` finds such an object locally.
 
 A bucket also does not coordinate in-flight compilations, answer batched
 lookups, stream blob packs, or negotiate compression. mbx asks for none of
-them against S3 and falls back
-to per-object requests, which is what every version of the protocol has done
-against a server without the extensions. Expect more requests for the same
-build, and no compression on the wire.
+them against S3 and falls back to per-object requests, the same requests it
+makes against a server without the extensions. Expect more requests for the
+same build, and no compression on the wire.
 
-The one record mbx updates in place — the task action manifest that drives
-[prefetch](#prefetch) — needs conditional writes. AWS S3, R2, and current MinIO
-all implement them. Against a store that does not, mbx says so once and
-continues without: blobs and action results are content-addressed, so writing
-one twice is harmless, but concurrent manifest updates can then lose each
-other's predictions, which costs prefetch coverage on later builds and nothing
-else. `MBX_REMOTE_S3_CONDITIONAL_WRITES=required` refuses such a store instead.
+The one record mbx updates in place is the task action manifest that drives
+[prefetch](#prefetch), and it needs conditional writes. AWS S3, R2, and current
+MinIO all implement them. Against a store that does not, mbx says so once and
+continues without them. Blobs and action results are content-addressed, so
+writing one twice is harmless, but concurrent manifest updates can then lose
+each other's predictions, which costs prefetch coverage on later builds.
+`MBX_REMOTE_S3_CONDITIONAL_WRITES=required` refuses such a store instead.
 
 ### Who may publish
 
 A cache server authenticates and authorizes every request. A bucket does not:
 whatever the credentials may write, mbx may write. The client-side [write
-policy](#read-and-write-policy) still applies — pull requests never publish —
+policy](#read-and-write-policy) still applies, so pull requests never publish,
 but with a bucket that policy is the only thing between an untrusted build and
 your cache unless IAM agrees.
 
@@ -138,7 +136,7 @@ Configured mode is constrained by the environment:
 
 This policy prevents untrusted code from publishing objects that later builds
 would trust. The server should still authenticate and authorize requests; the
-client-side policy is defense in depth, not an access-control boundary.
+client-side policy is not an access-control boundary.
 
 ### In-flight deduplication
 
@@ -175,8 +173,8 @@ build:
     - mbx build --workspace
 ```
 
-Set `MBX_REMOTE_TOKEN` in the project's CI/CD variables (masked, and limited
-to protected branches) rather than in the YAML.
+Set `MBX_REMOTE_TOKEN` in the project's CI/CD variables, masked and limited to
+protected branches, not in the YAML.
 
 ## Prefetch
 
@@ -198,25 +196,25 @@ prefetched 161 actions; 214.8 MiB downloaded and 214.8 MiB stored locally
 
 A workspace and command nobody has published a manifest for print
 `no recorded actions for this workspace and Cargo command` and exit
-successfully — there was nothing to fetch, which is normal for a first build.
-A lookup that *fails* — unreachable host, refused credentials — is an error,
-so CI can tell an empty cache from a broken one. A typical place for the
+successfully. There was nothing to fetch, which is normal for a first build.
+A lookup that fails, such as an unreachable host or refused credentials, is an
+error, so CI can tell an empty cache from a broken one. A typical place for the
 command is a runner or devcontainer image's start-up hook, so the store is
 warm before anyone builds.
 
 ## Deferred publication
 
-Uploads are not on the critical path of the build that produced them: they are
-queued while the build continues and drained before the session exits, and an
+Uploads are not on the critical path of the build that produced them. They are
+queued while the build continues and drained before the session exits. An
 action result is published only after every blob it references, so a reader
 never fetches a result whose outputs it cannot restore. A command killed part
-way through publishes less than it stored, which costs only hit rate — the
-next build recomputes what never landed.
+way through publishes less than it stored; the next build recomputes what never
+landed.
 
 A failed upload is reported, counted in `remote_failures`, and recovered from;
 the build keeps its local result either way. The session summary reports what
-was published and what the drain cost, and where the server accepts them,
-queued blobs are published several to a request rather than one at a time:
+was published and what the drain cost. Where the server accepts them, queued
+blobs are published several to a request:
 
 ```text
 mbx[cache]: uploads: 143 published (118 of them in 2 packs), 0 not published; 412.0ms waited for after the build
@@ -230,23 +228,24 @@ mbx[cache]: uploads: 143 published (118 of them in 2 packs), 0 not published; 41
 
 A prefetch knows every action it wants before it asks for any of them, so where
 the server offers batched lookups it asks for them together instead of once per
-action. `remote_action_lookups` counts requests rather than actions, so the same
-build reports far fewer of them against a server with the extension.
+action. `remote_action_lookups` counts requests, not actions, so the same build
+reports far fewer of them against a server with the extension.
 
 Both extensions are negotiated. A server without them, or one that advertises an
 endpoint it does not serve, gets the single-object requests every version of mbx
-has made; nothing needs configuring either way.
+has made. Nothing needs configuring either way.
 
 ## Transfer behavior
 
-Remote blobs are compressed with zstd. Failed requests are retried according
-to `MBX_HTTP_RETRIES`, and a stalled attempt is cut short by
-`MBX_HTTP_TIMEOUT`.
+Blobs travel zstd-compressed when the server supports it: the client accepts
+compressed downloads, and it compresses uploads when the server's capabilities
+list `zstd` among its compressors. Failed requests are retried according to
+`MBX_HTTP_RETRIES`, and a stalled attempt is cut short by `MBX_HTTP_TIMEOUT`.
 
 `MBX_HTTP_DOWNLOAD_TIMEOUT` exists separately because artifacts can be much
-larger than metadata responses. It is a deadline for the whole download, not a
-budget per attempt — it spans every retry and the backoff between them, which
-bounds how long one blob can hold a build open. A packed request scales the
-deadline up with the bytes and object count it asks for, since the configured
-value describes a single blob. Raise it if a slow link makes large artifacts
-run out of time before their retries are spent.
+larger than metadata responses. It is a deadline for the whole download and
+spans every retry and the backoff between them, which bounds how long one blob
+can hold a build open. A packed request scales the deadline up with the bytes
+and object count it asks for, since the configured value describes a single
+blob. Raise it if a slow link makes large artifacts run out of time before
+their retries are spent.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -17,8 +17,8 @@ the `target` symlink in each checkout keeps working across upgrades.
 `mbx doctor --json`, `mbx cache stats --json`, `mbx gc --json`, and
 `MBX_STATS_REPORT` emit versioned documents; fields are added compatibly and a
 shape change bumps the version. Scripts should read the version field and
-parse JSON rather than the human-readable `mbx[...]` stderr lines, which are
-written for people and may be reworded at any time.
+parse the JSON. The `mbx[...]` stderr lines are written for people and may be
+reworded at any time.
 
 ### Session event streams are not
 
@@ -30,7 +30,7 @@ parses them but mbx itself. Scripts should read `MBX_STATS_REPORT`.
 ## Configuration
 
 Unknown TOML keys and invalid values are errors, so an upgrade that renames or
-retires a setting fails loudly instead of silently ignoring what you wrote.
+retires a setting fails instead of ignoring what you wrote.
 
 ## Wire protocols and crates
 
@@ -43,6 +43,6 @@ follow semantic versioning enforced by `cargo-semver-checks` in CI. See
 
 `mbx-cache-cargo`, `mbx-cache-store`, `mbx-cache-core`, `mbx-cache-rustc`, and
 `mbx-cache-cc` are supported building blocks for coordinated embedding.
-They intentionally stay on `0.x`: their public APIs can change in a new minor
+They stay on `0.x`: their public APIs can change in a new minor
 release, and embedders should pin a compatible minor. Store and wire formats
 remain independently versioned and treat unfamiliar records as cache misses.

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -98,7 +98,7 @@ Set `MBX_CC=0` to run the command without C or C++ caching:
 MBX_CC=0 mbx exec make
 ```
 
-Because C and C++ compilation is the only work cached by `mbx exec`, this makes
-the command equivalent to running it directly. Production release builds may
-use the local cache, but should not use a remote cache; this prevents remote
-cache poisoning from affecting published artifacts.
+C and C++ compilation is the only work `mbx exec` caches, so this runs the
+command as if it were invoked directly. Production release builds may use the
+local cache but should not use a remote cache, which keeps remote cache
+poisoning away from published artifacts.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -9,28 +9,29 @@ mbx tui
 
 The end-of-build summary tells you what a build did once it is over, and
 [cache results](/cache-results) explains how to read it. It cannot tell you what
-a build is doing right now, and it cannot tell you which crate any of its
-numbers belonged to. That is what this is for: one row per compilation, named,
-with the outcome mbx chose for it.
+a build is doing right now, or which crate any of its numbers belonged to.
+`mbx tui` shows one row per compilation, named, with the outcome mbx chose for
+it.
 
-Because mbx has no daemon, `mbx tui` is not talking to anything. Each build
-appends its decisions to a stream under the cache, and the dashboard reads those
-streams. It therefore shows builds in other terminals, builds that started
-before you opened it, and any number of builds at once.
+mbx has no daemon, so `mbx tui` is not talking to anything. Each build appends
+its decisions to a stream under the cache, and the dashboard reads those
+streams. It shows builds in other terminals, builds that started before you
+opened it, and any number of builds at once.
 
 ## Screens
 
 **Live** lists the builds it knows about and, for the selected one, the
 compilations as they are decided. Outcomes are colored: green for a hit, red for
 a miss, grey for a compilation no lookup was possible for, yellow for one mbx
-deliberately bypassed, cyan for a shadow verification.
+bypassed, cyan for a shadow verification that matched, and magenta for one that
+diverged.
 
 The hit rate shown is over *attempted lookups*, the same as the summary's. A
-cold build that looked nothing up shows `-` rather than `0%`, because those are
+cold build that looked nothing up shows `-`, not `0%`, because those are
 different facts.
 
-**Sessions** lists finished builds with the totals each one ended with — the same
-numbers `MBX_STATS_REPORT` would have written.
+**Sessions** lists finished builds with the totals each one ended with, the
+same numbers `MBX_STATS_REPORT` would have written.
 
 **Store** shows what the store holds and what mbx has saved on this machine
 since it started counting.
@@ -44,8 +45,8 @@ A build's state is one of:
 | `abandoned` | the build died before it could record them |
 
 `abandoned` is not an error mbx reports; it is what a stream looks like when the
-process writing it is gone. A build killed mid-compile shows up this way rather
-than appearing to run forever.
+process writing it is gone. A build killed mid-compile shows up this way instead
+of appearing to run forever.
 
 ## Keys
 
@@ -79,10 +80,10 @@ mbx build                           finished        0      0            3       
 ## Recording
 
 Recording is on by default. A build appends one short line per compilation
-directly to its stream — no buffering, so the dashboard is live — which costs
-one small append against a compilation measured in milliseconds. Turn it off
-with `events = false`, or `MBX_EVENTS=0`, and a build will record nothing and
-leave nothing behind.
+directly to its stream, with no buffering, so the dashboard is live. The cost
+is one small append against a compilation measured in milliseconds. Turn it
+off with `events = false`, or `MBX_EVENTS=0`, and a build records nothing and
+leaves nothing behind.
 
 Streams live beside the rest of the store's bookkeeping:
 
@@ -97,9 +98,9 @@ system releases the lock with the process either way.
 
 Collection bounds them without any configuration: a stream is dropped once it is
 a week old or once it is not among the newest 256, and a single build stops
-adding rows after 16 MiB — its totals are still recorded. A stream a build is
-still writing is never collected. `mbx gc --dry-run` reports what it would drop
-alongside everything else.
+adding rows after 16 MiB, though its totals are still recorded. A stream a build
+is still writing is never collected. `mbx gc --dry-run` reports what it would
+drop alongside everything else.
 
 Streams are history, not cache content. Nothing keys on them, they are never
 weighed against the store's size budget, and deleting them costs a row in a list.


### PR DESCRIPTION
Follow-up to #277, applying the same treatment to every page under `docs/` (not `docs/cli/`, which is generated).

## Prose

- Every em-dash, bold-lead bullet, and piece of meta-commentary ("worth knowing", "deliberately", "genuinely", "rather than X" padding) is gone.
- Justification paragraphs are cut to a sentence. Detail another page already carries is reduced to a link (configuration's budget arithmetic now points at the managed-targets table).
- No heading changed, so no anchor moved. `mise run check:links` passes on the built site.
- compared.md bullets now lead with what each difference buys the user.

## Facts corrected against the source

- **limits.md**: `TARGET_CC`, `TARGET_CXX`, and `CC_<target>` are wrapped by targeted shims, not left uncached (`session/shims.rs` `apply_targeted`). A search directory that changes mid-compile is a bypass (`cc.rs` `SearchPathModifiedDuringCompilation`), not an unrecorded header. Proc macros join the cached host-link list. The incremental section describes learned incremental reuse.
- **configuration.md**: the out-of-workspace threshold is three consecutive changed-source misses (`HOT_STREAK_THRESHOLD`); `MBX_VERIFY=1` disables learned incremental reuse.
- **cache-results.md**: compiler-time and slowest-crate lines are printed by the full summary only; the short summary says `not looked up` and leaves `compiler-query`/`standard-input` probes out of its bypass count; the stats report version is no longer hard-coded to 2 (it is 4).
- **getting-started.md**: `mbx cargo build` is not a spelling that works, since the leading word is forwarded to cargo unchanged; the example now says `mbx build`. Windows caches rustc, native links, and MSVC C/C++, so "narrower caching tier" is dropped.
- **remote-cache.md**: zstd applies only when the server's capabilities list it.
- **protocol-compatibility.md**: `features.blob_packs` gates `POST /v1/blobs:pack` alongside the two extensions already named.
- **tui.md**: magenta marks a diverged shadow verification; cyan is the matched case.
- **cookbook/migrate.md**: the short summary reports a count, not a line.

## Not verified locally

Inputs and behavior of `jdx/mr-boxington-action` and the cache server (separate repos), sccache and kache claims in compared.md, and the 45% figure. The `parallel:` step key in github-action.md is real: mise's own `test-impl.yml` uses it in four places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to user-facing documentation with no runtime or protocol code touched; incorrect facts could mislead operators, but the PR explicitly realigns several sections with implementation behavior.
> 
> **Overview**
> **Documentation-only** refresh of every hand-written page under `docs/` (excluding generated `docs/cli/`): shorter plain prose, no em-dash-heavy style, bold-lead bullets reworked (especially in `compared.md`), and duplicated detail trimmed in favor of cross-links (e.g. disk budget math in `configuration.md` now points at `managed-targets`).
> 
> Beyond wording, several pages **correct behavior descriptions** to match the product: cache summaries (`not looked up`, probe exclusions from short `bypassed`, compiler-time lines only in `full`); **learned incremental reuse** (out-of-workspace threshold of three changed-source misses, disabled under `MBX_VERIFY=1`); **limits** (proc macros in cached host links, mid-compile search-path changes as bypass, targeted `CC_*` / `TARGET_*` wrapping); **getting-started** (`mbx build` vs invalid `mbx cargo build`, Windows caching scope); **remote-cache** (zstd when capabilities advertise it); **protocol-compatibility** (`features.blob_packs`); and **tui** (cyan = matched verify, magenta = diverged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e46d90eb90b03e21c5cc8c7d4c4c77db7884ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->