### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "blake3",
  "eyre",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.13...mbx-cache-cargo-v0.1.14) - 2026-09-02
+
+### Other
+
+- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
+
 ## [0.1.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.12...mbx-cache-cargo-v0.1.13) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.13"
+version = "0.1.14"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.0...mbx-cache-cc-v0.11.1) - 2026-09-02
+
+### Other
+
+- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
+
 ## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.10.3...mbx-cache-cc-v0.11.0) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.11.0"
+version = "0.11.1"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.0...mbx-cache-core-v0.11.1) - 2026-09-02
+
+### Other
+
+- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
+
 ## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.10.3...mbx-cache-core-v0.11.0) - 2026-09-02
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.11.0"
+version = "0.11.1"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.11" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.12" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.11...mbx-cache-protocol-v0.5.12) - 2026-09-02
+
+### Other
+
+- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
+
 ## [0.5.11](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.10...mbx-cache-protocol-v0.5.11) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.11"
+version = "0.5.12"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.0...mbx-cache-rustc-v0.11.1) - 2026-09-02
+
+### Other
+
+- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
+
 ## [0.11.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.10.3...mbx-cache-rustc-v0.11.0) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.11.0"
+version = "0.11.1"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.12...mbx-cache-store-v0.1.13) - 2026-09-02
+
+### Fixed
+
+- *(cache)* preserve grouped exports through collection ([#280](https://github.com/jdx/mr-boxington/pull/280))
+
+### Other
+
+- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
+
 ## [0.1.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.11...mbx-cache-store-v0.1.12) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.12"
+version = "0.1.13"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1](https://github.com/jdx/mr-boxington/compare/v1.4.0...v1.4.1) - 2026-09-02
+
+### Other
+
+- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
+
 ## [1.4.0](https://github.com/jdx/mr-boxington/compare/v1.3.2...v1.4.0) - 2026-09-02
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.4.0"
+version = "1.4.1"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.13", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.12", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.14", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.1", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.1", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.13", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.4.0
+**Version:** 1.4.1
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.11 -> 0.5.12 (✓ API compatible changes)
* `mbx-cache-core`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.13 -> 0.1.14 (✓ API compatible changes)
* `mbx-cache-cc`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `mbx`: 1.4.0 -> 1.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.11...mbx-cache-protocol-v0.5.12) - 2026-09-02

### Other

- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.0...mbx-cache-core-v0.11.1) - 2026-09-02

### Other

- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.13...mbx-cache-cargo-v0.1.14) - 2026-09-02

### Other

- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.0...mbx-cache-cc-v0.11.1) - 2026-09-02

### Other

- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.0...mbx-cache-rustc-v0.11.1) - 2026-09-02

### Other

- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.12...mbx-cache-store-v0.1.13) - 2026-09-02

### Fixed

- *(cache)* preserve grouped exports through collection ([#280](https://github.com/jdx/mr-boxington/pull/280))

### Other

- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
</blockquote>

## `mbx`

<blockquote>

## [1.4.1](https://github.com/jdx/mr-boxington/compare/v1.4.0...v1.4.1) - 2026-09-02

### Other

- trim the README and correct link caching claims ([#277](https://github.com/jdx/mr-boxington/pull/277))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch release with version and changelog updates only; the notable functional fix is localized store retention during collection, not broad API or protocol changes in this diff.
> 
> **Overview**
> **Release-only PR** that bumps workspace crate versions and records what shipped since the last tags. There is no new application logic in this diff—only `Cargo.toml` / `Cargo.lock` pins, per-crate `CHANGELOG.md` entries, and the generated CLI doc version (`1.4.1`).
> 
> **Versions:** `mbx` **1.4.0 → 1.4.1**; `mbx-cache-protocol` **0.5.12**; `mbx-cache-core`, `mbx-cache-cc`, `mbx-cache-rustc` **0.11.1**; `mbx-cache-cargo` **0.1.14**; `mbx-cache-store` **0.1.13**.
> 
> **What the changelogs attribute to this release:** documentation-only updates (trimmed README, corrected link-caching claims, [#277](https://github.com/jdx/mr-boxington/pull/277)) across the stack, plus **`mbx-cache-store`** noting a fix to **preserve grouped exports during cache collection** ([#280](https://github.com/jdx/mr-boxington/pull/280))—that behavior change is already on `main`; this PR just tags and publishes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92b5d3c7397660d5bc4530dde52c04baa24a0db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->