### PR TITLE
fix(cache): preserve grouped exports through collection

### DIFF
--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -254,13 +254,29 @@ pub fn export_group(store: &Path, group: &str, archive: &Path) -> Result<Transfe
         .join(group_key(group));
     let receipts = walk_files(&root)?
         .into_iter()
-        .filter_map(|entry| read_build_receipt(&entry.path))
-        .filter(|receipt| receipt.group.as_deref() == Some(group))
+        .filter_map(|entry| read_build_receipt(&entry.path).map(|receipt| (entry.path, receipt)))
+        .filter(|(_, receipt)| receipt.group.as_deref() == Some(group))
         .collect::<Vec<_>>();
     if receipts.is_empty() {
         eyre::bail!("no completed mbx builds are recorded for export group {group:?}");
     }
-    export_receipts(store, receipts, archive)
+    let outcome = export_receipts(
+        store,
+        receipts
+            .iter()
+            .map(|(_, receipt)| receipt.clone())
+            .collect(),
+        archive,
+    )?;
+    // A receipt is a pending-export root. Retire only the files this export
+    // consumed, and only after its complete archive has been published. A
+    // concurrent build can add another uniquely named receipt to the group
+    // without this cleanup deleting work the archive did not include.
+    for (path, _) in receipts {
+        std::fs::remove_file(path)?;
+    }
+    let _ = std::fs::remove_dir(root);
+    Ok(outcome)
 }
 
 fn export_receipts(
@@ -1009,6 +1025,7 @@ fn read_checkout_record(path: &Path) -> Option<CheckoutRecord> {
     (record.version == CHECKOUT_RECORD_VERSION).then_some(record)
 }
 
+/// Actions whose successful grouped export has not retired its receipts yet.
 fn grouped_receipt_actions(store: &Path) -> Result<BTreeSet<CacheDigest>> {
     let root = store.join(BUILD_RECEIPTS_DIR).join("groups");
     Ok(walk_files(&root)?
@@ -1167,6 +1184,7 @@ fn rooted_objects(store: &Path, identities: &BTreeSet<String>) -> Result<HashSet
     Ok(rooted_action_objects(store, actions))
 }
 
+/// Return every local CAS path needed to restore the supplied actions.
 fn rooted_action_objects(
     store: &Path,
     actions: impl IntoIterator<Item = CacheDigest>,

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -819,7 +819,17 @@ fn gc_with_mode(store: &Path, max_bytes: u64, dry_run: bool) -> Result<GcOutcome
         // Reachability costs a read per action result and per output tree, so
         // it is computed only when something is actually about to be evicted.
         // Under budget a sweep stays a directory walk and nothing more.
-        let rooted = rooted_objects(store, &checkouts.live_identities)?;
+        let mut rooted = rooted_objects(store, &checkouts.live_identities)?;
+        // A grouped CI export deliberately retains the exact actions from
+        // every command in the job. Later commands can replace the current
+        // task-manifest prediction for the same invocation, but the earlier
+        // receipt still has to remain exportable until the post-job step runs.
+        // Receipt bookkeeping is not part of the cache budget, so consult it
+        // only when a sweep is already necessary and root its object closure.
+        rooted.extend(rooted_action_objects(
+            store,
+            grouped_receipt_actions(store)?,
+        ));
         // `false` sorts first, so unrooted objects go before rooted ones and
         // each class goes oldest-first. A store with no records at all roots
         // nothing and this is exactly the LRU it was before.
@@ -999,6 +1009,16 @@ fn read_checkout_record(path: &Path) -> Option<CheckoutRecord> {
     (record.version == CHECKOUT_RECORD_VERSION).then_some(record)
 }
 
+fn grouped_receipt_actions(store: &Path) -> Result<BTreeSet<CacheDigest>> {
+    let root = store.join(BUILD_RECEIPTS_DIR).join("groups");
+    Ok(walk_files(&root)?
+        .into_iter()
+        .filter_map(|entry| read_build_receipt(&entry.path))
+        .flat_map(|receipt| receipt.predictions.into_iter())
+        .map(|prediction| prediction.action)
+        .collect())
+}
+
 /// Whether a recorded claim still speaks for a checkout that is using this
 /// store.
 fn claim_is_live(store: &Path, record: &CheckoutRecord) -> bool {
@@ -1131,44 +1151,53 @@ fn same_filesystem(
 /// tolerant -- a blob that has already been evicted, or that no longer parses,
 /// simply roots less, and rooting less can only mean collecting sooner.
 fn rooted_objects(store: &Path, identities: &BTreeSet<String>) -> Result<HashSet<PathBuf>> {
-    let cas = LocalCas::new(store);
-    let mut rooted = HashSet::new();
-    let mut visited = BTreeSet::new();
+    let mut actions = BTreeSet::new();
     for identity in identities {
         // One manifest this build cannot read is not worth abandoning a sweep
         // over. It roots nothing, which can only mean collecting sooner.
-        let actions = match task_manifest_actions(store, identity) {
+        let manifest_actions = match task_manifest_actions(store, identity) {
             Ok(actions) => actions,
             Err(error) => {
                 log::debug!("could not read the manifest for {identity}: {error}");
                 continue;
             }
         };
-        for action in actions {
-            let Some(result) = read_action_result(store, &action) else {
-                continue;
-            };
-            root_digest(&cas, &mut rooted, &result.action);
-            if let Some(metadata) = &result.metadata {
-                root_digest(&cas, &mut rooted, metadata);
-                // The metadata blob is a descriptor too: it names the captured
-                // stdout and stderr, and a restore reads both. Stopping at the
-                // descriptor would leave the diagnostics of every action
-                // unrooted -- including the one empty blob that every silent
-                // compilation shares, which is enough on its own to turn a
-                // rooted hit back into a miss.
-                if let Some(rustc) = read_rustc_metadata(&cas, metadata) {
-                    root_digest(&cas, &mut rooted, &rustc.stdout);
-                    root_digest(&cas, &mut rooted, &rustc.stderr);
-                }
-            }
-            if let Some(output_root) = &result.output_root {
-                root_digest(&cas, &mut rooted, output_root);
-                root_tree(&cas, output_root, &mut rooted, &mut visited);
+        actions.extend(manifest_actions);
+    }
+    Ok(rooted_action_objects(store, actions))
+}
+
+fn rooted_action_objects(
+    store: &Path,
+    actions: impl IntoIterator<Item = CacheDigest>,
+) -> HashSet<PathBuf> {
+    let cas = LocalCas::new(store);
+    let mut rooted = HashSet::new();
+    let mut visited = BTreeSet::new();
+    for action in actions {
+        let Some(result) = read_action_result(store, &action) else {
+            continue;
+        };
+        root_digest(&cas, &mut rooted, &result.action);
+        if let Some(metadata) = &result.metadata {
+            root_digest(&cas, &mut rooted, metadata);
+            // The metadata blob is a descriptor too: it names the captured
+            // stdout and stderr, and a restore reads both. Stopping at the
+            // descriptor would leave the diagnostics of every action
+            // unrooted -- including the one empty blob that every silent
+            // compilation shares, which is enough on its own to turn a
+            // rooted hit back into a miss.
+            if let Some(rustc) = read_rustc_metadata(&cas, metadata) {
+                root_digest(&cas, &mut rooted, &rustc.stdout);
+                root_digest(&cas, &mut rooted, &rustc.stderr);
             }
         }
+        if let Some(output_root) = &result.output_root {
+            root_digest(&cas, &mut rooted, output_root);
+            root_tree(&cas, output_root, &mut rooted, &mut visited);
+        }
     }
-    Ok(rooted)
+    rooted
 }
 
 fn read_action_result(store: &Path, action: &CacheDigest) -> Option<RemoteActionResult> {

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -91,7 +91,7 @@ fn record_build_in_group(
         .join("v1")
         .join(format!("{identity}.json"));
     write_atomic(&path, &serde_json::to_vec(&manifest).unwrap()).unwrap();
-    let run = CacheDigest::blake3(format!("run-{identity}-{group:?}").as_bytes()).hash;
+    let run = CacheDigest::blake3(format!("run-{identity}-{group:?}-{actions:?}").as_bytes()).hash;
     record_build_receipt(store, &run, identity, workspace_root, group, predictions).unwrap();
 }
 
@@ -514,6 +514,80 @@ fn grouped_export_unions_parallel_build_receipts() {
     assert!(cache.find(&first_action).unwrap().is_some());
     assert!(cache.find(&second_action).unwrap().is_some());
     assert!(cache.find(&unrelated_action).unwrap().is_none());
+}
+
+#[test]
+fn collection_preserves_grouped_receipts_replaced_in_the_task_manifest() {
+    let source = tempfile::tempdir().unwrap();
+    let destination = tempfile::tempdir().unwrap();
+    let workspace = source.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let group = "github-run-42/repeated-task";
+    let identity = "2".repeat(64);
+
+    let first_output = store_object(source.path(), b"first compiled artifact");
+    let first_action = store_result(
+        source.path(),
+        "first command action",
+        std::slice::from_ref(&first_output),
+    );
+    record_build_in_group(
+        source.path(),
+        &identity,
+        &workspace,
+        std::slice::from_ref(&first_action),
+        Some(group),
+    );
+
+    // A later Cargo command shares this task identity and replaces the current
+    // manifest. Its earlier receipt still belongs to the grouped CI export.
+    let second_output = store_object(source.path(), b"second compiled artifact");
+    let second_action = store_result(
+        source.path(),
+        "second command action",
+        std::slice::from_ref(&second_output),
+    );
+    record_build_in_group(
+        source.path(),
+        &identity,
+        &workspace,
+        std::slice::from_ref(&second_action),
+        Some(group),
+    );
+
+    // Make the replaced action older than an unrelated object. Without the
+    // receipt root, collection evicts its closure first and export fails with
+    // "action result is missing".
+    age(source.path(), &first_action, Duration::from_secs(60 * 60));
+    age(source.path(), &first_output, Duration::from_secs(60 * 60));
+    let spare = store_object(source.path(), b"unrelated spare");
+    let before = stats(source.path()).unwrap().total_bytes();
+
+    gc(source.path(), before - 1).unwrap();
+
+    assert!(
+        LocalActionCache::new(source.path())
+            .find(&first_action)
+            .unwrap()
+            .is_some(),
+        "a grouped receipt must keep a replaced action exportable"
+    );
+    assert!(
+        LocalCas::new(source.path())
+            .find(&first_output)
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        LocalCas::new(source.path()).find(&spare).unwrap().is_none(),
+        "collection should still reclaim objects no receipt needs"
+    );
+
+    let archive = source.path().join("job.tar");
+    let exported = export_group(source.path(), group, &archive).unwrap();
+    let imported = import_archive(destination.path(), &archive).unwrap();
+    assert_eq!(exported.actions, 2);
+    assert_eq!(imported.actions, 2);
 }
 
 #[test]

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -593,9 +593,17 @@ fn collection_preserves_grouped_receipts_replaced_in_the_task_manifest() {
         "a successful export should retire the receipts it consumed"
     );
 
+    let first_closure_bytes =
+        rooted_action_objects(source.path(), std::iter::once(first_action.clone()))
+            .into_iter()
+            .map(|path| std::fs::metadata(path).unwrap().len())
+            .sum::<u64>();
     gc(
         source.path(),
-        stats(source.path()).unwrap().total_bytes() - 1,
+        stats(source.path())
+            .unwrap()
+            .total_bytes()
+            .saturating_sub(first_closure_bytes),
     )
     .unwrap();
     assert!(

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -588,6 +588,51 @@ fn collection_preserves_grouped_receipts_replaced_in_the_task_manifest() {
     let imported = import_archive(destination.path(), &archive).unwrap();
     assert_eq!(exported.actions, 2);
     assert_eq!(imported.actions, 2);
+    assert!(
+        grouped_receipt_actions(source.path()).unwrap().is_empty(),
+        "a successful export should retire the receipts it consumed"
+    );
+
+    gc(
+        source.path(),
+        stats(source.path()).unwrap().total_bytes() - 1,
+    )
+    .unwrap();
+    assert!(
+        LocalActionCache::new(source.path())
+            .find(&first_action)
+            .unwrap()
+            .is_none(),
+        "retired receipts must stop rooting replaced actions"
+    );
+}
+
+#[test]
+fn failed_group_export_keeps_its_receipts_pending() {
+    let source = tempfile::tempdir().unwrap();
+    let workspace = source.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let group = "github-run-42/retry";
+    let action = store_result(source.path(), "missing action", &[]);
+    record_build_in_group(
+        source.path(),
+        &"3".repeat(64),
+        &workspace,
+        std::slice::from_ref(&action),
+        Some(group),
+    );
+    let action_path = LocalActionCache::new(source.path())
+        .path_for(&action)
+        .unwrap();
+    std::fs::remove_file(action_path).unwrap();
+
+    let _ = export_group(source.path(), group, &source.path().join("job.tar")).unwrap_err();
+
+    assert_eq!(
+        grouped_receipt_actions(source.path()).unwrap(),
+        BTreeSet::from([action]),
+        "a failed export must leave its receipts available for retry"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- root the object closure referenced by grouped CI export receipts during collection
- keep earlier actions exportable when a later Cargo command replaces the current task-manifest prediction
- add a regression test covering collection followed by grouped export and import

This fixes the mise `github runner cache` failure where post-job export reported `action result is missing` after Ubuntu crossed the 5 GiB GC budget.

## Validation
- `mise exec -- cargo test -p mbx-cache-store`
- `mise exec -- cargo clippy -p mbx-cache-store --all-features --all-targets -- -D warnings`
- `mise run ci` (format, build, generated-docs check, lint, and Rust tests passed; the existing `explain --last diagnoses a miss from recorded inputs` e2e fixture failed because it recorded no miss)
- `MBX_DISABLE=1 mise run test:e2e` (the same `explain --last` fixture still failed; setup tests that require the disabled wrapper also failed as expected)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache eviction and export receipt lifecycle; incorrect rooting could retain too much data or break CI cache export, but behavior is narrowly scoped to grouped receipts and over-budget sweeps with new regression tests.
> 
> **Overview**
> Fixes post-job **grouped CI export** failing with missing action results when cache collection runs before export (e.g. after crossing a GC budget).
> 
> **Collection** now treats pending grouped build receipts like extra roots: when a sweep must evict, it extends the live-checkout rooted set with the CAS closure of every action still listed on receipts under `build-receipts/groups`, including actions dropped from the current task manifest by a later Cargo command in the same job.
> 
> **`export_group`** retires only the receipt files included in a **successful** archive write, then removes the group directory; failed exports leave receipts in place for retry.
> 
> Reachability logic is factored into **`rooted_action_objects`** so manifest and receipt rooting share one path. New tests cover GC → export/import, receipt retirement, and failed-export retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92757b3d1f5e6db07d801c8f57e1d30710240f9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved earlier command receipts from grouped CI builds until post-job export completes.
  * Prevented active grouped build receipts from being incorrectly removed during cache cleanup.
  * Ensured unrelated, unneeded cache objects continue to be reclaimed.

* **Tests**
  * Added coverage for receipt replacement, garbage collection, and export/import workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->