### PR TITLE
fix(setup): preserve native compiler path when disabled

### DIFF
--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -71,8 +71,11 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
         resolve_real_cargo(&shim)?
     };
     let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
-    if mbx_disabled()
-        || enclosing_session(std::env::var_os(crate::session::SOCKET_ENV).as_deref())
+    if mbx_disabled() {
+        preserve_native_compiler_paths();
+        return run_real_cargo(&real_cargo, &arguments);
+    }
+    if enclosing_session(std::env::var_os(crate::session::SOCKET_ENV).as_deref())
         || cargo_proxy_passthrough(&arguments)
     {
         return run_real_cargo(&real_cargo, &arguments);
@@ -147,6 +150,41 @@ fn mbx_disabled_value(value: Option<&OsStr>) -> bool {
         let value = value.to_string_lossy();
         value != "0" && !value.eq_ignore_ascii_case("false")
     })
+}
+
+/// Keep native build-system configuration reusable while bypassing the cache.
+///
+/// CMake records the absolute compiler path it sees. An mbx build points host
+/// C and C++ compilation at persistent shims, so handing a later disabled
+/// build the platform compiler directly makes CMake invalidate and reconfigure
+/// the same build directory. The persistent shim is already transparent
+/// without a session; preserve its path here without starting an agent or
+/// caching any compilation.
+fn preserve_native_compiler_paths() {
+    if crate::session::CC_CRATE_ENV
+        .iter()
+        .any(|name| std::env::var_os(name).is_some())
+    {
+        return;
+    }
+    let Ok((config, _)) = Config::load_for_cli() else {
+        return;
+    };
+    if !config.cc {
+        return;
+    }
+    let shims = config.cache_dir.join("shims");
+    for (variable, stem) in [
+        ("HOST_CC", crate::session::CC_SHIM_STEM),
+        ("HOST_CXX", crate::session::CXX_SHIM_STEM),
+    ] {
+        let shim = shims.join(crate::session::shim_file_name(stem));
+        if shim.is_file() {
+            // SAFETY: Cargo shim dispatch is single-threaded before its child
+            // process starts.
+            unsafe { std::env::set_var(variable, shim) };
+        }
+    }
 }
 
 fn enclosing_session(session_socket: Option<&OsStr>) -> bool {

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -37,9 +37,10 @@ use client::validate_handshake_response;
 use client::{request_agent_at, request_standalone_agent};
 pub(crate) use diagnostics::{note, report_shim_warning, reserve_stderr_for_compiler};
 use server::spawn_server;
+pub(crate) use shims::CC_CRATE_ENV;
 #[cfg(all(test, windows))]
 use shims::link_path_shim;
-use shims::{CC_CRATE_ENV, CcShims, install_cc_shims, install_session_shims};
+use shims::{CcShims, install_cc_shims, install_session_shims};
 pub use shims::{
     PathShims, ShimLink, install_path_shims, install_shim, install_shim_named, shim_file_name,
 };

--- a/crates/mbx/src/session/shims.rs
+++ b/crates/mbx/src/session/shims.rs
@@ -119,7 +119,7 @@ pub(super) fn is_target_triple(suffix: &str) -> bool {
 /// Variables the `cc` crate consults before falling back to the platform
 /// default. A build that sets any of them has chosen its own compiler, and mbx
 /// stands aside rather than redirecting it.
-pub(super) const CC_CRATE_ENV: &[&str] = &["CC", "CXX", "HOST_CC", "HOST_CXX"];
+pub(crate) const CC_CRATE_ENV: &[&str] = &["CC", "CXX", "HOST_CC", "HOST_CXX"];
 
 /// Install the C and C++ shims, resolving the compilers they will run.
 ///

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -356,6 +356,30 @@ EOF
   assert_output "1"
 }
 
+@test "disabled Cargo preserves persistent native compiler paths" {
+  local real_bin="$BATS_TEST_TMPDIR/disabled-real-bin"
+  local executable_suffix=""
+  if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
+    executable_suffix=".exe"
+  fi
+  local cc_shim="$MBX_CACHE_DIR/shims/mbx-cc$executable_suffix"
+  local cxx_shim="$MBX_CACHE_DIR/shims/mbx-cxx$executable_suffix"
+  mkdir -p "$real_bin" "$(dirname "$cc_shim")"
+  touch "$cc_shim" "$cxx_shim"
+  cat >"$real_bin/cargo" <<'EOF'
+#!/bin/sh
+printf 'HOST_CC=%s\nHOST_CXX=%s\n' "$HOST_CC" "$HOST_CXX"
+EOF
+  chmod +x "$real_bin/cargo"
+  "$MBX_BIN" setup >/dev/null
+
+  run env MBX_DISABLE=1 PATH="$MBX_SHIM_DIR:$real_bin:/usr/bin:/bin" cargo build
+
+  assert_success
+  assert_line "HOST_CC=$cc_shim"
+  assert_line "HOST_CXX=$cxx_shim"
+}
+
 @test "the Cargo shim reuses its workspace metadata probe" {
   local project="$BATS_TEST_TMPDIR/metadata-project"
   local real_bin="$BATS_TEST_TMPDIR/metadata-real-bin"

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -366,11 +366,11 @@ EOF
   local cxx_shim="$MBX_CACHE_DIR/shims/mbx-cxx$executable_suffix"
   mkdir -p "$real_bin" "$(dirname "$cc_shim")"
   touch "$cc_shim" "$cxx_shim"
-  cat >"$real_bin/cargo" <<'EOF'
+  cat >"$real_bin/cargo$executable_suffix" <<'EOF'
 #!/bin/sh
 printf 'HOST_CC=%s\nHOST_CXX=%s\n' "$HOST_CC" "$HOST_CXX"
 EOF
-  chmod +x "$real_bin/cargo"
+  chmod +x "$real_bin/cargo$executable_suffix"
   "$MBX_BIN" setup >/dev/null
 
   run env MBX_DISABLE=1 PATH="$MBX_SHIM_DIR:$real_bin:/usr/bin:/bin" cargo build


### PR DESCRIPTION
## Summary
- keep disabled Cargo builds pointed at persistent native compiler shims
- let those shims run transparently without starting a cache session
- avoid CMake invalidating a shared build directory when switching to `MBX_DISABLE=1`
- preserve explicit compiler selections and disabled C/C++ integration

## Context
A cached Cargo build configured `aws-lc-sys` with the persistent `mbx-cc` path. Retrying the same build with `MBX_DISABLE=1` changed CMake back to `/usr/bin/cc`, forcing a reconfigure in the existing Cargo build directory. The retry only succeeded after cleaning the native dependency. Keeping the stable shim path makes the bypass genuinely drop-in while the no-session shim path still invokes the real compiler without caching.

## Tests
- `mise run format`
- `mise run lint`
- `mise run test:cargo`
- `MBX_BIN="$PWD/target/mbx-bootstrap/mbx" bats test/setup.bats`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes environment variables for host C/C++ compilers on the disabled-Cargo path; behavior is gated on config and explicit CC/CXX env vars, but it affects native dependency builds that reuse existing CMake/Cargo directories.
> 
> **Overview**
> When **`MBX_DISABLE`** bypasses mbx caching, the Cargo shim now calls **`preserve_native_compiler_paths()`** before delegating to real Cargo, instead of treating disable like other passthrough paths with no extra setup.
> 
> That helper sets **`HOST_CC`** and **`HOST_CXX`** to the persistent **`mbx-cc`** / **`mbx-cxx`** shims under the cache dir when C/C++ integration is enabled, the shim files exist, and the build has not already set any **`CC_CRATE_ENV`** compiler variables—so CMake and similar tools keep the same absolute compiler paths across cached and disabled runs and avoid reconfiguring shared build trees.
> 
> **`CC_CRATE_ENV`** is **`pub(crate)`** so the shim can share the same “user chose a compiler” guard as session shim install logic. A **bats** test asserts disabled **`cargo build`** still passes those shim paths to the child process (including **`.exe`** on Windows-style hosts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f20a9b7e4aa6f02d7de701bcd2cf0f969963f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When `MBX_DISABLE` is set, Cargo now runs directly while preserving configured native C and C++ compiler paths.
  * Improved compatibility for Windows-style compiler shim paths, including `.exe` paths.

* **Tests**
  * Added coverage verifying compiler path preservation when mbx is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->