### PR TITLE
fix: keep learned incremental state for large crates

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -206,6 +206,12 @@ fn cargo_with_settings_bypass_log_and_roots(
             if learned_incremental { "1" } else { "0" }.into(),
         );
         environment.insert(
+            session::LEARNED_INCREMENTAL_MAX_SIZE_ENV.into(),
+            settings
+                .learned_incremental_max_size
+                .map_or_else(|| "none".to_string(), |bytes| bytes.to_string()),
+        );
+        environment.insert(
             session::CACHE_LINKS_ENV.into(),
             if cache_links { "1" } else { "0" }.into(),
         );

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -126,6 +126,14 @@ pub(crate) struct RawConfig {
         default = true
     )]
     _learned_incremental: bool,
+    /// How much learned incremental state one crate may keep, or "none". State
+    /// past this is discarded before the crate compiles again.
+    #[usage(
+        key = "learned_incremental_max_size",
+        env = "MBX_LEARNED_INCREMENTAL_MAX_SIZE",
+        default = "8GiB"
+    )]
+    learned_incremental_max_size: String,
     /// Share eligible compilations that read `OUT_DIR`.
     #[usage(env = "MBX_SHARE_OUT_DIR", default = true)]
     share_out_dir: bool,
@@ -482,6 +490,15 @@ pub(crate) struct RetentionSettings {
 /// callers can construct, so a knob the binary alone reads does not belong on
 /// it: adding a field there is a breaking change to an API this crate does not
 /// mean to offer.
+/// The declared default of `learned_incremental_max_size`.
+///
+/// A crate's incremental state is roughly proportional to the crate, not to
+/// how often it is edited, because rustc discards superseded sessions itself.
+/// A large workspace binary with line tables keeps a few GiB, so the budget is
+/// generous enough that ordinary crates never hit it; discarding state on
+/// every edit would silently turn the edit loop back into full recompilation.
+pub(crate) const DEFAULT_LEARNED_INCREMENTAL_MAX_SIZE: u64 = 8 * 1024 * 1024 * 1024;
+
 #[derive(Debug, Clone)]
 pub(crate) struct CliSettings {
     pub retention: RetentionSettings,
@@ -489,6 +506,8 @@ pub(crate) struct CliSettings {
     pub summary: SummaryStyle,
     /// Whether a churning crate may compile with its own incremental state.
     pub learned_incremental: bool,
+    /// How much of that state one crate may keep, in bytes; `None` is no limit.
+    pub learned_incremental_max_size: Option<u64>,
     /// Whether natively linked programs may be cached.
     pub cache_links: bool,
 }
@@ -502,6 +521,7 @@ impl Default for CliSettings {
             savings: SavingsStyle::default(),
             summary: SummaryStyle::default(),
             learned_incremental: true,
+            learned_incremental_max_size: Some(DEFAULT_LEARNED_INCREMENTAL_MAX_SIZE),
             cache_links: true,
         }
     }
@@ -794,6 +814,10 @@ impl Config {
                 savings: raw.savings.parse().wrap_err("invalid savings")?,
                 summary: raw.summary.parse().wrap_err("invalid summary")?,
                 learned_incremental: raw._learned_incremental,
+                learned_incremental_max_size: parse_optional_byte_size(
+                    &raw.learned_incremental_max_size,
+                )
+                .wrap_err("invalid learned_incremental_max_size")?,
                 cache_links: raw.cache_links,
             },
         ))
@@ -970,7 +994,7 @@ fn parse_store_budget(value: &str) -> Result<u64> {
     parse_byte_size(value)
 }
 
-fn parse_optional_byte_size(value: &str) -> Result<Option<u64>> {
+pub(crate) fn parse_optional_byte_size(value: &str) -> Result<Option<u64>> {
     if is_no_limit(value) {
         return Ok(None);
     }
@@ -1382,6 +1406,32 @@ mod tests {
 
         let (_, settings) = configured_for_cli(None, &[("MBX_LEARNED_INCREMENTAL", "0")]).unwrap();
         assert!(!settings.learned_incremental);
+    }
+
+    /// The budget has to hold a real crate's state: rustc keeps one session's
+    /// worth per crate, and a large binary's session is a few GiB.
+    #[test]
+    fn learned_incremental_state_budget_is_generous_and_can_be_lifted() {
+        let (_, settings) = configured_for_cli(None, &[]).unwrap();
+        assert_eq!(
+            settings.learned_incremental_max_size,
+            Some(DEFAULT_LEARNED_INCREMENTAL_MAX_SIZE)
+        );
+
+        let (_, settings) =
+            configured_for_cli(None, &[("MBX_LEARNED_INCREMENTAL_MAX_SIZE", "2GiB")]).unwrap();
+        assert_eq!(
+            settings.learned_incremental_max_size,
+            Some(2 * 1024 * 1024 * 1024)
+        );
+
+        let (_, settings) =
+            configured_for_cli(None, &[("MBX_LEARNED_INCREMENTAL_MAX_SIZE", "none")]).unwrap();
+        assert_eq!(settings.learned_incremental_max_size, None);
+
+        let error =
+            configured_for_cli(None, &[("MBX_LEARNED_INCREMENTAL_MAX_SIZE", "lots")]).unwrap_err();
+        assert!(error.to_string().contains("learned_incremental_max_size"));
     }
 
     #[test]

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -47,9 +47,6 @@ const WORKSPACE_HOT_STREAK_THRESHOLD: u32 = 1;
 /// Schema version of the per-checkout churn record.
 const CHURN_STATE_VERSION: u8 = 1;
 
-/// How large one unit's incremental state may grow before it is discarded.
-const INCREMENTAL_DIR_MAX_BYTES: u64 = 1024 * 1024 * 1024;
-
 /// What a churning unit gets: its own incremental state, and no publication.
 #[derive(Clone, Debug, Default)]
 struct LearnedPlan {
@@ -65,9 +62,9 @@ struct LearnedPlan {
 
 impl LearnedPlan {
     /// Find somewhere to keep the state, for a unit that earned it.
-    fn resolved(mut self, invocation: &CacheDigest) -> Self {
+    fn resolved(mut self, invocation: &CacheDigest, crate_name: &str) -> Self {
         if self.hot {
-            self.directory = incremental_directory(invocation);
+            self.directory = incremental_directory(invocation, crate_name);
         }
         self
     }
@@ -658,13 +655,25 @@ fn learned_plan(
 /// A session gives it a persistent per-checkout root outside Cargo's target
 /// directory. A standalone shim falls back to its target directory when one is
 /// available, and compiles normally when it has nowhere to put state.
-fn incremental_directory(invocation: &CacheDigest) -> Option<PathBuf> {
+fn incremental_directory(invocation: &CacheDigest, crate_name: &str) -> Option<PathBuf> {
     let root = incremental_root()?;
     let key = invocation.key();
     let shard = key.get(..16)?;
     let directory = root.join(shard);
-    match prepare_incremental_directory(&directory) {
-        Ok(()) => Some(directory),
+    match prepare_incremental_directory(&directory, session::learned_incremental_max_size()) {
+        Ok(discarded) => {
+            if let Some(bytes) = discarded {
+                // Said out loud: the build goes on to report this compilation
+                // as incremental, and a crate whose state is discarded on
+                // every edit is indistinguishable from the outside from
+                // incremental compilation that simply does not help.
+                eprintln!(
+                    "mbx[warning]: discarded {} of incremental state for {crate_name}: it passed learned_incremental_max_size, which can be raised to keep it",
+                    bytesize::ByteSize::b(bytes).display().iec()
+                );
+            }
+            Some(directory)
+        }
         Err(error) => {
             eprintln!("mbx[warning]: incremental state was not prepared: {error:#}");
             None
@@ -672,17 +681,26 @@ fn incremental_directory(invocation: &CacheDigest) -> Option<PathBuf> {
     }
 }
 
-/// Make sure the unit's state directory exists and is not unbounded.
+/// Make sure the unit's state directory exists and is inside its budget.
 ///
-/// Incremental state grows with the edit history rather than the source, so it
-/// is discarded wholesale once it is large. Losing it costs one full
-/// recompilation, which is what this unit would have paid without it.
-fn prepare_incremental_directory(directory: &Path) -> Result<()> {
-    if directory_bytes(directory) > INCREMENTAL_DIR_MAX_BYTES {
+/// rustc keeps about one session's worth of state per crate and removes the
+/// sessions it has superseded, so the state is proportional to the crate rather
+/// than to how long it has been edited. The budget is a backstop against state
+/// rustc could not clean up, not a ceiling ordinary crates should reach: state
+/// discarded before every compile is a full recompilation reported as
+/// incremental, the opposite of what it is for. Returns how many bytes were
+/// discarded, if any.
+fn prepare_incremental_directory(directory: &Path, budget: Option<u64>) -> Result<Option<u64>> {
+    let discarded = budget.and_then(|budget| {
+        let bytes = directory_bytes(directory);
+        (bytes > budget).then_some(bytes)
+    });
+    if discarded.is_some() {
         std::fs::remove_dir_all(directory)
             .wrap_err("failed to discard oversized incremental state")?;
     }
-    std::fs::create_dir_all(directory).wrap_err("failed to create the incremental directory")
+    std::fs::create_dir_all(directory).wrap_err("failed to create the incremental directory")?;
+    Ok(discarded)
 }
 
 fn directory_bytes(directory: &Path) -> u64 {
@@ -742,7 +760,7 @@ fn plan_learned_reuse(
             record: Some((state_path, sources)),
             ..plan
         }
-        .resolved(&unit))
+        .resolved(&unit, compilation.invocation.crate_name()))
     })();
     match planned {
         Ok(plan) => plan,

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -1005,3 +1005,45 @@ fn a_ledger_answer_decides_in_place_without_reading() {
         &FixedLedger(other),
     ));
 }
+
+/// The budget is a backstop, so it removes state only once the state has
+/// actually passed it. A budget lower than what one compilation leaves behind
+/// would discard the state before every compile, and the edit loop would be a
+/// full recompilation labelled incremental.
+#[test]
+fn incremental_state_is_discarded_only_past_its_budget() {
+    let root = tempfile::tempdir().unwrap();
+    let directory = root.path().join("unit");
+    let session = directory.join("s-session");
+    std::fs::create_dir_all(&session).unwrap();
+    std::fs::write(session.join("dep-graph.bin"), vec![0_u8; 4096]).unwrap();
+
+    // Inside the budget, and without one, the state stays where it is.
+    assert_eq!(
+        prepare_incremental_directory(&directory, Some(1 << 20)).unwrap(),
+        None
+    );
+    assert!(session.join("dep-graph.bin").is_file());
+    assert_eq!(
+        prepare_incremental_directory(&directory, None).unwrap(),
+        None
+    );
+    assert!(session.join("dep-graph.bin").is_file());
+
+    // Past it, the state goes and the caller is told how much went, with the
+    // directory left ready for the compilation that follows.
+    assert_eq!(
+        prepare_incremental_directory(&directory, Some(1024)).unwrap(),
+        Some(4096)
+    );
+    assert!(directory.is_dir());
+    assert!(!session.exists());
+
+    // A directory that does not exist yet is simply created.
+    let fresh = root.path().join("fresh");
+    assert_eq!(
+        prepare_incremental_directory(&fresh, Some(1)).unwrap(),
+        None
+    );
+    assert!(fresh.is_dir());
+}

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -71,6 +71,7 @@ pub(crate) const VERIFY_ENV: &str = "MBX_VERIFY";
 pub(crate) const SHARE_OUT_DIR_ENV: &str = "MBX_SHARE_OUT_DIR";
 pub(crate) const BUILD_SCRIPT_EXECUTION_ENV: &str = "MBX_BUILD_SCRIPT_EXECUTION";
 pub(crate) const LEARNED_INCREMENTAL_ENV: &str = "MBX_LEARNED_INCREMENTAL";
+pub(crate) const LEARNED_INCREMENTAL_MAX_SIZE_ENV: &str = "MBX_LEARNED_INCREMENTAL_MAX_SIZE";
 pub(crate) const INCREMENTAL_ROOT_ENV: &str = "MBX_INCREMENTAL_ROOT";
 pub const CACHE_LINKS_ENV: &str = "MBX_CACHE_LINKS";
 /// Group completed builds for one later cache export, used by CI actions.
@@ -1527,6 +1528,21 @@ pub(crate) fn share_out_dir_requested() -> bool {
 /// state instead of publishing it. Read the same way as verify mode.
 pub(crate) fn learned_incremental_requested() -> bool {
     std::env::var_os(LEARNED_INCREMENTAL_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
+/// How much incremental state one crate may keep before the shim discards it;
+/// `None` is no limit. The session writes the resolved setting, but a shim
+/// running without one may inherit the user's own spelling, so both a byte
+/// count and a size with a unit are accepted. Anything unreadable falls back
+/// to the declared default rather than to no limit or to zero.
+pub(crate) fn learned_incremental_max_size() -> Option<u64> {
+    let default = Some(crate::config::DEFAULT_LEARNED_INCREMENTAL_MAX_SIZE);
+    match std::env::var(LEARNED_INCREMENTAL_MAX_SIZE_ENV) {
+        Ok(value) if !value.trim().is_empty() => {
+            crate::config::parse_optional_byte_size(&value).unwrap_or(default)
+        }
+        _ => default,
+    }
 }
 
 /// Tell the session that this compilation was not cacheable.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -130,6 +130,14 @@ Let local workspace members compile incrementally.
 
 Compile crates that keep missing the cache with changed content incrementally, keeping their outputs out of the shared cache.
 
+### `learned_incremental_max_size`
+
+- **Type:** `string`
+- **Default:** `8GiB`
+- **Set with:** `MBX_LEARNED_INCREMENTAL_MAX_SIZE`
+
+How much learned incremental state one crate may keep, or "none". State past this is discarded before the crate compiles again.
+
 ### `log`
 
 - **Type:** `string`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ Every value below is optional; these are shown set explicitly.
 # <config directory>/mbx/config.toml
 cache_dir = "/var/cache/mbx"
 incremental = false
+learned_incremental_max_size = "8GiB"  # or "none"
 share_out_dir = true
 build_script_execution = true
 cc = true
@@ -218,9 +219,18 @@ changes the keys of everything above it, and those crates keep compiling and
 publishing normally. So does a miss on unchanged sources, such as a wiped
 `target/` or a first build in a new checkout. The record and state are private
 to each checkout and live under `incremental/` in mbx's cache directory, so
-`cargo clean` does not discard the next edit's speedup. Each crate's
-incremental state is discarded once it passes 1 GiB, and normal garbage
+`cargo clean` does not discard the next edit's speedup. Normal garbage
 collection removes state for deleted or expired checkouts.
+
+Each crate's state is discarded, with a warning naming the crate, once it
+passes `learned_incremental_max_size` (`MBX_LEARNED_INCREMENTAL_MAX_SIZE`,
+default 8 GiB; `"none"` lifts the limit). rustc keeps about one session's worth
+of state per crate and removes the sessions it has superseded, so the state is
+proportional to the crate rather than to how long it has been edited, and the
+budget is a backstop rather than a size ordinary crates reach. A large binary
+built with debug info keeps a few GiB. Set the budget below that and every edit
+compiles from scratch while still being reported as incremental, so raise it
+rather than lower it when the warning appears.
 
 CI never does this, because a fresh runner has no earlier state to build on.
 `MBX_LEARNED_INCREMENTAL=0` turns it off. `MBX_INCREMENTAL=1` supersedes it by


### PR DESCRIPTION
## Summary

- The learned-incremental state of a crate was discarded once it passed a hard-coded 1 GiB. A large workspace binary with debug info (mise: 1.6–2.5 GiB per rustc session) had its state wiped before every compile, so every edit recompiled from scratch while the summary still reported the compilation as `incremental`.
- Replace the constant with the `learned_incremental_max_size` setting (`MBX_LEARNED_INCREMENTAL_MAX_SIZE`, default `8GiB`, `"none"` lifts it), passed to the compiler shims through the session environment.
- Warn when state is discarded, naming the crate and the setting, so this can never be silent again.
- Docs updated; `docs/cli/` regenerated.

rustc removes superseded sessions itself, so the state is proportional to the crate rather than to its edit history. The budget is a backstop against state rustc could not clean up, not a size ordinary crates should reach.

## Measurements

Trivial edit to `src/cli/version.rs` in jdx/mise, `cargo build` (dev profile), 16-core Linux box:

| | per edit |
|---|---|
| mbx before | 72s |
| raw cargo | 11s |
| mbx after | 13s |

## Test plan

- [x] `mise run lint`, `mise run test:cargo`, `mise run check:docs`
- [x] bats suite: 39/41 pass locally; the two failures are pre-existing and environmental (wasm target not installed for the pinned toolchain; `explain --last` test relies on `CI` disabling learned incremental and fails on unmodified main locally too)
- [x] Re-ran the mise edit loop with the patched binary: 3 consecutive edits at 12–14s each, incremental state kept at 2.5 GiB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes learned-incremental behavior and disk use for hot crates; mis-tuned limits can still force full recompiles, but defaults are safer and failures are now visible via warnings.
> 
> **Overview**
> Large crates were losing **learned incremental** state on every edit because a fixed **1 GiB** cap wiped directories before rustc could reuse them, while builds still reported `incremental`.
> 
> This PR replaces that constant with **`learned_incremental_max_size`** (`MBX_LEARNED_INCREMENTAL_MAX_SIZE`, default **`8GiB`**, **`none`** removes the limit). The cargo session forwards the resolved value into the rustc shim environment; **`prepare_incremental_directory`** enforces the budget and **warns with the crate name** when state is discarded.
> 
> Docs and config tests cover defaults, overrides, and invalid values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec0827533951f26877f0d34fd7b4d7b70847488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->