### PR TITLE
perf: verify compiler inputs by identity after compiling

### DIFF
--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -339,9 +339,10 @@ impl CcDiscoveredInputs {
     /// input to a miss rather than storing an object under a stale key.
     ///
     /// A file still wearing the identity `collect` recorded is confirmed by
-    /// that stat alone, for the same reason the ledger lookup in `collect`
-    /// skips hashing it; one whose identity moved, or that had none, is read
-    /// and hashed again.
+    /// that stat alone where the identity carries a change time, which cannot
+    /// be set from user space and so shows a rewrite that restored the old
+    /// modification time. One whose identity moved, that had none, or that a
+    /// platform without change times described, is read and hashed again.
     pub fn verify(&self) -> Result<(), CcBypassReason> {
         for (index, input) in self.inputs.iter().enumerate() {
             if is_manifest_input(&input.path) {
@@ -352,6 +353,7 @@ impl CcDiscoveredInputs {
                 message: error.to_string(),
             };
             if let Some(Some(identity)) = self.identities.get(index)
+                && identity.changed.is_some()
                 && identity.still_describes().map_err(read_error)?
             {
                 continue;

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -188,6 +188,10 @@ pub struct CcDiscoveredInputs {
     working_dir: PathBuf,
     /// Content-addressed inputs, including include-directory manifests.
     pub inputs: Vec<CcActionInput>,
+    /// What each file input looked like on disk when its digest was
+    /// established, index-aligned with `inputs`; `None` for manifests and
+    /// where the filesystem gave nothing to compare against later.
+    identities: Vec<Option<FileIdentity>>,
 }
 
 impl CcDiscoveredInputs {
@@ -245,8 +249,10 @@ impl CcDiscoveredInputs {
             .filter_map(|(_, identity)| identity.clone())
             .collect::<Vec<_>>();
         let mut recorded = digests.find(FileDigestScope::CcInput, &queries).into_iter();
+        let mut identities = Vec::with_capacity(inputs.capacity());
         let mut fresh = Vec::new();
         for (path, identity) in identified {
+            identities.push(identity.clone());
             let remembered = identity
                 .as_ref()
                 .and_then(|_| recorded.next().flatten())
@@ -290,10 +296,12 @@ impl CcDiscoveredInputs {
                 path: PathBuf::from(format!("{INCLUDE_MANIFEST_PREFIX}{}", directory.display())),
                 digest,
             });
+            identities.push(None);
         }
         Ok(Self {
             working_dir,
             inputs,
+            identities,
         })
     }
 
@@ -327,10 +335,27 @@ impl CcDiscoveredInputs {
         Ok(())
     }
 
-    /// Rehash every discovered file before publication, degrading a changed
+    /// Confirm every discovered file before publication, degrading a changed
     /// input to a miss rather than storing an object under a stale key.
+    ///
+    /// A file still wearing the identity `collect` recorded is confirmed by
+    /// that stat alone, for the same reason the ledger lookup in `collect`
+    /// skips hashing it; one whose identity moved, or that had none, is read
+    /// and hashed again.
     pub fn verify(&self) -> Result<(), CcBypassReason> {
-        for input in self.files() {
+        for (index, input) in self.inputs.iter().enumerate() {
+            if is_manifest_input(&input.path) {
+                continue;
+            }
+            let read_error = |error: std::io::Error| CcBypassReason::InputRead {
+                path: input.path.clone(),
+                message: error.to_string(),
+            };
+            if let Some(Some(identity)) = self.identities.get(index)
+                && identity.still_describes().map_err(read_error)?
+            {
+                continue;
+            }
             let matches = input.digest.matches_file(&input.path).map_err(|error| {
                 CcBypassReason::InputRead {
                     path: input.path.clone(),

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -466,3 +466,57 @@ fn parses_msvc_source_dependencies() {
         ]
     );
 }
+
+/// A ledger that answers one known identity with a fixed digest.
+struct SentinelLedger {
+    known: FileIdentity,
+    digest: CacheDigest,
+}
+
+impl FileDigestCache for SentinelLedger {
+    fn find(&self, _scope: FileDigestScope, files: &[FileIdentity]) -> Vec<Option<CacheDigest>> {
+        files
+            .iter()
+            .map(|file| (*file == self.known).then(|| self.digest.clone()))
+            .collect()
+    }
+
+    fn record(&self, _scope: FileDigestScope, _entries: Vec<RecordedFileDigest>) {}
+}
+
+/// Verification confirms an input by the identity `collect` recorded rather
+/// than by reading it again, and reads it again once that identity has moved.
+#[test]
+fn verification_trusts_an_unchanged_identity_and_rereads_a_changed_one() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let root = directory.path();
+    let header = write(root, "a.h", "int a(void);\n");
+    let metadata = std::fs::metadata(&header).expect("metadata");
+    // Hashing could never produce the sentinel, so a verify that passes can
+    // only have trusted the identity.
+    let sentinel = CacheDigest {
+        algorithm: "blake3".into(),
+        hash: "c".repeat(64),
+        size: metadata.len(),
+    };
+    let ledger = SentinelLedger {
+        known: FileIdentity::describe(&header, &metadata).expect("identity"),
+        digest: sentinel.clone(),
+    };
+    let discovered = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([header.clone()]),
+        BTreeSet::from([root.to_path_buf()]),
+        &ledger,
+    )
+    .expect("discovery");
+    assert_eq!(discovered.files().next().expect("input").digest, sentinel);
+
+    discovered.verify().expect("an unchanged identity verifies");
+
+    // Same length, new bytes: the write moves the identity, so the file is
+    // read again and the sentinel no longer describes it.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    std::fs::write(&header, "int b(void);\n").expect("rewrite");
+    assert_eq!(discovered.verify().unwrap_err().kind(), "input-changed");
+}

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -486,6 +486,8 @@ impl FileDigestCache for SentinelLedger {
 
 /// Verification confirms an input by the identity `collect` recorded rather
 /// than by reading it again, and reads it again once that identity has moved.
+/// Only where the identity carries a change time.
+#[cfg(unix)]
 #[test]
 fn verification_trusts_an_unchanged_identity_and_rereads_a_changed_one() {
     let directory = tempfile::tempdir().expect("tempdir");

--- a/crates/mbx-cache-core/src/agent/file_digest.rs
+++ b/crates/mbx-cache-core/src/agent/file_digest.rs
@@ -37,6 +37,21 @@ impl FileIdentity {
             changed: change_token(metadata),
         })
     }
+
+    /// Whether the file at this identity's path still has exactly this
+    /// identity, so the digest recorded against it still describes the bytes on
+    /// disk without reading them again.
+    ///
+    /// Length alone would miss an overwrite that keeps the size, and the
+    /// modification time can be put back by whoever rewrote the file. The
+    /// change time cannot be set from user space, so where the platform reports
+    /// one a rewrite that restores the old modification time still shows. A
+    /// file that has vanished is an error rather than a change, so the caller
+    /// can tell the two apart.
+    pub fn still_describes(&self) -> std::io::Result<bool> {
+        let metadata = std::fs::metadata(&self.path)?;
+        Ok(Self::describe(&self.path, &metadata).as_ref() == Some(self))
+    }
 }
 
 /// The metadata-change time as an opaque token, where the platform has one.
@@ -101,4 +116,25 @@ impl FileDigestCache for NoFileDigestCache {
     }
 
     fn record(&self, _scope: FileDigestScope, _entries: Vec<RecordedFileDigest>) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_identity_describes_the_file_until_it_is_written_or_removed() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("input.rs");
+        std::fs::write(&path, b"fn main() {}").unwrap();
+        let identity = FileIdentity::describe(&path, &std::fs::metadata(&path).unwrap()).unwrap();
+        assert!(identity.still_describes().unwrap());
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&path, b"fn main() { }").unwrap();
+        assert!(!identity.still_describes().unwrap());
+
+        std::fs::remove_file(&path).unwrap();
+        assert!(identity.still_describes().is_err());
+    }
 }

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -261,13 +261,16 @@ impl DiscoveredInputs {
             };
             // An input still wearing the identity discovery recorded -- length,
             // modification time, and change time -- is confirmed by that stat
-            // alone. It is the same evidence the session ledger already accepts
-            // in place of hashing, and the change time cannot be set from user
-            // space, so a rewrite that puts the old modification time back still
-            // shows. Reading everything again here cost as much as keying the
-            // compilation did: a large binary's dependency rlibs, a gigabyte of
-            // them, read twice for every edit.
+            // alone. The change time is what makes this as good as reading: it
+            // cannot be set from user space, so a rewrite that puts the old
+            // modification time back still shows, where a platform that reports
+            // none would let a same-length rewrite inside one timestamp tick
+            // through. Such an identity is not trusted here, and neither is an
+            // input that had none. Reading everything again cost as much as
+            // keying the compilation did: a large binary's dependency rlibs, a
+            // gigabyte of them, read twice for every edit.
             if let Some(Some(identity)) = self.identities.get(index)
+                && identity.changed.is_some()
                 && identity.still_describes().map_err(read_error)?
             {
                 continue;
@@ -1025,7 +1028,9 @@ mod tests {
 
     /// Verification after the compiler runs confirms an input by its recorded
     /// identity rather than by reading it again; a file that has moved on is
-    /// still read and still fails.
+    /// still read and still fails. Only where the identity carries a change
+    /// time, which is what makes the stat as good as the read.
+    #[cfg(unix)]
     #[test]
     fn verification_trusts_an_unchanged_identity_and_rereads_a_changed_one() {
         let directory = tempfile::tempdir().unwrap();

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -136,6 +136,11 @@ pub struct DiscoveredInputs {
     pub inputs: Vec<ActionInput>,
     /// Environment inputs captured from dep-info.
     pub environment: BTreeMap<String, Option<String>>,
+    /// What each input looked like on disk when its digest was established,
+    /// index-aligned with `inputs`; `None` where the filesystem gave nothing to
+    /// compare against later. Lets `verify` confirm an input by stat instead of
+    /// by reading it again.
+    identities: Vec<Option<FileIdentity>>,
 }
 
 impl DiscoveredInputs {
@@ -177,8 +182,10 @@ impl DiscoveredInputs {
             .collect::<Vec<_>>();
         let mut recorded = digests.find(FileDigestScope::Content, &queries).into_iter();
         let mut inputs = Vec::with_capacity(identified.len());
+        let mut identities = Vec::with_capacity(identified.len());
         let mut fresh = Vec::new();
         for (path, identity) in identified {
+            identities.push(identity.clone());
             let remembered = identity
                 .as_ref()
                 .and_then(|_| recorded.next().flatten())
@@ -216,6 +223,7 @@ impl DiscoveredInputs {
             working_dir,
             inputs,
             environment,
+            identities,
         })
     }
 
@@ -246,7 +254,24 @@ impl DiscoveredInputs {
     /// This closes the discovery/compile race by degrading changed inputs to a
     /// cache miss rather than storing outputs beneath a stale action key.
     pub fn verify(&self) -> Result<(), BypassReason> {
-        for input in &self.inputs {
+        for (index, input) in self.inputs.iter().enumerate() {
+            let read_error = |error: std::io::Error| BypassReason::InputRead {
+                path: input.path.clone(),
+                message: error.to_string(),
+            };
+            // An input still wearing the identity discovery recorded -- length,
+            // modification time, and change time -- is confirmed by that stat
+            // alone. It is the same evidence the session ledger already accepts
+            // in place of hashing, and the change time cannot be set from user
+            // space, so a rewrite that puts the old modification time back still
+            // shows. Reading everything again here cost as much as keying the
+            // compilation did: a large binary's dependency rlibs, a gigabyte of
+            // them, read twice for every edit.
+            if let Some(Some(identity)) = self.identities.get(index)
+                && identity.still_describes().map_err(read_error)?
+            {
+                continue;
+            }
             let matches = input.digest.matches_file(&input.path).map_err(|error| {
                 BypassReason::InputRead {
                     path: input.path.clone(),
@@ -996,6 +1021,54 @@ mod tests {
         assert_eq!(recorded.len(), 1, "only the fresh hash is recorded");
         assert_eq!(recorded[0].file.path, fresh_path);
         assert_eq!(recorded[0].digest, by_path(&fresh_path));
+    }
+
+    /// Verification after the compiler runs confirms an input by its recorded
+    /// identity rather than by reading it again; a file that has moved on is
+    /// still read and still fails.
+    #[test]
+    fn verification_trusts_an_unchanged_identity_and_rereads_a_changed_one() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let known_path = root.join("libdep.rlib");
+        std::fs::write(&known_path, b"rlib bytes").unwrap();
+        let metadata = std::fs::metadata(&known_path).unwrap();
+        // The sentinel could never come from hashing the file, so a verify
+        // that passes can only have trusted the identity.
+        let sentinel = CacheDigest {
+            algorithm: "blake3".into(),
+            hash: "c".repeat(64),
+            size: metadata.len(),
+        };
+        let ledger = SentinelLedger {
+            known: FileIdentity::describe(&known_path, &metadata).unwrap(),
+            digest: sentinel,
+            recorded: std::sync::Mutex::new(Vec::new()),
+        };
+        let discovered = DiscoveredInputs::from_paths(
+            root,
+            BTreeSet::from([known_path.clone()]),
+            BTreeMap::new(),
+            &ledger,
+        )
+        .unwrap();
+
+        discovered.verify().unwrap();
+
+        // Rewritten with the same length: the identity moves with the write,
+        // so the file is read again and the sentinel no longer matches it.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&known_path, b"RLIB BYTES").unwrap();
+        assert_eq!(
+            discovered.verify(),
+            Err(BypassReason::InputChanged(known_path.clone()))
+        );
+
+        std::fs::remove_file(&known_path).unwrap();
+        assert!(matches!(
+            discovered.verify(),
+            Err(BypassReason::InputRead { path, .. }) if path == known_path
+        ));
     }
 
     /// A rewrite that restores length and modification time must still be


### PR DESCRIPTION
## Summary

- After the compiler runs, `DiscoveredInputs::verify` (and the cc `CcDiscoveredInputs::verify`) re-read and re-hashed every input to confirm nothing changed during compilation. That costs as much as keying the compilation did: for a large binary, a gigabyte of dependency rlibs read twice per edit.
- Discovery already records each input's `FileIdentity` (length, mtime, ctime) for the session ledger and trusts it in place of hashing. Verification now applies the same rule on platforms whose identity carries a change time: an input whose identity is exactly what discovery recorded is confirmed by the stat alone; one whose identity moved, or had none, is read and hashed as before.
- Where the platform reports no change time (Windows), verification keeps hashing: without a ctime, a same-length rewrite inside one timestamp tick would keep its identity. The Windows CI run of the existing cc discovery test caught exactly that, and the second commit restricts the shortcut accordingly.
- Adds `FileIdentity::still_describes` to `mbx-cache-core` (additive). `DiscoveredInputs`/`CcDiscoveredInputs` gain a private, index-aligned `identities` field; both already had a private field, so no public literal breaks.

## Measurements

Shim phase timing for the `mise` unit on a trivial edit (16-core Linux, release build of mbx):

| phase | before | after |
|---|---|---|
| post-compile (rediscover + verify + record) | 0.70s | 0.08s |

## Test plan

- [x] New tests (unix): rustc and cc verification trusts an unchanged identity (proved with a sentinel digest hashing could never produce) and re-reads after a same-length rewrite; `still_describes` unit test on all platforms
- [x] `mise run lint`, `mise run test:cargo`
- [x] Re-measured on jdx/mise with temporary phase instrumentation (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache correctness logic for when stale keys are rejected; the ctime-gated fast path is safety-critical on Unix, while Windows keeps the old hashing path.
> 
> **Overview**
> Post-compile **input verification** for rustc and C/C++ no longer re-reads and re-hashes every discovered file when nothing on disk has moved. Discovery already captured each file’s `FileIdentity`; manifests now keep an index-aligned `identities` vector, and **`FileIdentity::still_describes`** in `mbx-cache-core` re-stat’s the path to see if length, mtime, and (on Unix) ctime still match.
> 
> **`DiscoveredInputs::verify`** and **`CcDiscoveredInputs::verify`** skip `matches_file` when the stored identity has a change token and `still_describes()` is true; otherwise behavior is unchanged (full read/hash, same bypass reasons). On **Windows**, identities lack a usable change time, so verification still hashes everything to avoid same-length rewrites within one mtime tick.
> 
> Unix tests use a sentinel digest from a fake ledger to prove verify can pass without re-reading, and that a same-length rewrite still fails after the identity moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b09e4fbe596382e79b12f73d72f9d36063d8e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->