### PR TITLE
perf: carry the file-digest ledger across sessions

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -276,6 +276,19 @@ pub struct CacheAgent {
     uploads: Option<UploadQueue>,
 }
 
+/// What every file-digest record must satisfy before the ledger will answer
+/// with it, whether a shim sent it or an earlier session left it behind.
+fn validate_file_digest_record(entry: &RecordedFileDigest) -> Result<()> {
+    if !entry.file.path.is_absolute() {
+        bail!("file-digest records need absolute paths");
+    }
+    entry.digest.validate()?;
+    if entry.file.len != entry.digest.size {
+        bail!("file-digest record length does not match its digest");
+    }
+    Ok(())
+}
+
 /// Records background upload activity against a session's statistics.
 struct AgentUploadSink {
     stats: Arc<AtomicAgentStats>,
@@ -1688,13 +1701,7 @@ impl CacheAgent {
             bail!("too many file-digest records in one request");
         }
         for entry in &entries {
-            if !entry.file.path.is_absolute() {
-                bail!("file-digest records need absolute paths");
-            }
-            entry.digest.validate()?;
-            if entry.file.len != entry.digest.size {
-                bail!("file-digest record length does not match its digest");
-            }
+            validate_file_digest_record(entry)?;
         }
         let mut ledger = self.file_digests.lock().unwrap();
         for entry in entries {
@@ -1706,6 +1713,45 @@ impl CacheAgent {
             ledger.insert((scope, entry.file.path.clone()), entry);
         }
         Ok(AgentResponse::FileDigestsRecorded)
+    }
+
+    /// Start the file-digest ledger from entries an earlier session left
+    /// behind, so a file nothing has touched since is not read again by the
+    /// first compilation of this session that names it.
+    ///
+    /// Each entry stands only while its recorded identity still matches the
+    /// disk, the same rule a lookup applies to what this session recorded, so
+    /// a stale seed costs a hash and nothing else. Entries this session has
+    /// already recorded are kept over seeded ones. Returns how many were taken.
+    pub fn seed_file_digests(&self, entries: Vec<(FileDigestScope, RecordedFileDigest)>) -> usize {
+        let mut ledger = self.file_digests.lock().unwrap();
+        let mut seeded = 0;
+        for (scope, entry) in entries {
+            if ledger.len() >= MAX_FILE_DIGEST_ENTRIES {
+                break;
+            }
+            if validate_file_digest_record(&entry).is_err() {
+                continue;
+            }
+            if let std::collections::btree_map::Entry::Vacant(slot) =
+                ledger.entry((scope, entry.file.path.clone()))
+            {
+                slot.insert(entry);
+                seeded += 1;
+            }
+        }
+        seeded
+    }
+
+    /// Everything the file-digest ledger holds, for a later session to start
+    /// from.
+    pub fn file_digests(&self) -> Vec<(FileDigestScope, RecordedFileDigest)> {
+        self.file_digests
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|((scope, _), entry)| (*scope, entry.clone()))
+            .collect()
     }
 
     fn find_action_prediction(

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -3966,3 +3966,94 @@ async fn file_digest_records_are_validated() {
         "a length that disagrees with the digest must be refused"
     );
 }
+
+/// A seeded ledger answers like one this session filled, drops what it cannot
+/// vouch for, and never overrides what this session recorded itself.
+#[test]
+fn seeded_file_digests_answer_lookups_and_yield_to_this_sessions_records() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+    let file = directory.path().join("libdep.rlib");
+    std::fs::write(&file, b"rlib bytes").unwrap();
+    let identity = FileIdentity::describe(&file, &std::fs::metadata(&file).unwrap()).unwrap();
+    let digest = CacheDigest::blake3(b"rlib bytes");
+    // A digest hashing could never produce, sized like the file so the ledger
+    // accepts it: whichever entry answers is then unambiguous.
+    let own = RecordedFileDigest {
+        file: identity.clone(),
+        digest: CacheDigest {
+            algorithm: "blake3".into(),
+            hash: "a".repeat(64),
+            size: identity.len,
+        },
+    };
+    let wrong_length = RecordedFileDigest {
+        file: FileIdentity {
+            len: identity.len + 1,
+            ..identity.clone()
+        },
+        digest: digest.clone(),
+    };
+    let relative = RecordedFileDigest {
+        file: FileIdentity {
+            path: "relative/libdep.rlib".into(),
+            ..identity.clone()
+        },
+        digest: digest.clone(),
+    };
+
+    // Recorded by a shim first: the seed must not replace it.
+    agent
+        .record_file_digests(FileDigestScope::Content, vec![own.clone()])
+        .unwrap();
+    let seeded = agent.seed_file_digests(vec![
+        (
+            FileDigestScope::Content,
+            RecordedFileDigest {
+                file: identity.clone(),
+                digest: digest.clone(),
+            },
+        ),
+        (
+            FileDigestScope::CcInput,
+            RecordedFileDigest {
+                file: identity.clone(),
+                digest: digest.clone(),
+            },
+        ),
+        (FileDigestScope::Content, wrong_length),
+        (FileDigestScope::Content, relative),
+    ]);
+    assert_eq!(seeded, 1, "only the cc entry was new and valid");
+
+    let AgentResponse::FileDigests { digests } = agent
+        .find_file_digests(FileDigestScope::Content, vec![identity.clone()])
+        .unwrap()
+    else {
+        panic!("expected digests");
+    };
+    assert_eq!(digests, vec![Some(own.digest.clone())]);
+    let AgentResponse::FileDigests { digests } = agent
+        .find_file_digests(FileDigestScope::CcInput, vec![identity.clone()])
+        .unwrap()
+    else {
+        panic!("expected digests");
+    };
+    assert_eq!(digests, vec![Some(digest.clone())]);
+
+    let mut exported = agent.file_digests();
+    exported.sort_by_key(|(scope, _)| *scope);
+    assert_eq!(
+        exported,
+        vec![
+            (FileDigestScope::Content, own),
+            (
+                FileDigestScope::CcInput,
+                RecordedFileDigest {
+                    file: identity,
+                    digest
+                }
+            ),
+        ]
+    );
+}

--- a/crates/mbx/src/digest_ledger.rs
+++ b/crates/mbx/src/digest_ledger.rs
@@ -1,0 +1,213 @@
+//! The file-digest ledger a checkout carries from one session to the next.
+//!
+//! Within a session the cache agent remembers the digest of every file a shim
+//! hashed, keyed by the file's identity (length, modification time, and change
+//! time), so a dependency rlib is read once however many crates link it. The
+//! agent exits with the build, and without this file the next session would
+//! start from nothing: the crate being edited would read every one of its
+//! unchanged dependencies again before it could look anything up, a gigabyte
+//! of rlibs for a large binary. Persisting the ledger beside the checkout's
+//! other private state makes that first lookup as cheap as the second.
+//!
+//! Every entry is still checked against the disk before it answers, so a
+//! stale file here costs one hash and nothing else; the ledger is a shortcut,
+//! never a dependency, and every failure in this module degrades to an empty
+//! one.
+
+use eyre::{Context, Result};
+use mbx_cache_core::{CacheDigest, FileDigestScope, FileIdentity, RecordedFileDigest};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const LEDGER_FILE: &str = "file-digests.json";
+const LEDGER_VERSION: u8 = 1;
+
+/// Entries kept on disk. Far above what a workspace and its dependency
+/// graph name, and a bound on a checkout that keeps renaming its outputs.
+const MAX_PERSISTED_ENTRIES: usize = 256 * 1024;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Ledger {
+    version: u8,
+    entries: Vec<LedgerEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LedgerEntry {
+    scope: FileDigestScope,
+    file: FileIdentity,
+    digest: CacheDigest,
+}
+
+impl LedgerEntry {
+    fn new(scope: FileDigestScope, record: RecordedFileDigest) -> Self {
+        Self {
+            scope,
+            file: record.file,
+            digest: record.digest,
+        }
+    }
+
+    fn into_record(self) -> (FileDigestScope, RecordedFileDigest) {
+        (
+            self.scope,
+            RecordedFileDigest {
+                file: self.file,
+                digest: self.digest,
+            },
+        )
+    }
+}
+
+/// Where a checkout's ledger lives, inside its private state directory.
+pub(crate) fn path(state_dir: &Path) -> PathBuf {
+    state_dir.join(LEDGER_FILE)
+}
+
+/// The entries an earlier session left in `state_dir`, or nothing.
+///
+/// A ledger this version cannot read is no ledger: the cost is rehashing what
+/// one session would have hashed anyway.
+pub(crate) fn load(state_dir: &Path) -> Vec<(FileDigestScope, RecordedFileDigest)> {
+    read(&path(state_dir))
+        .map(|ledger| {
+            ledger
+                .entries
+                .into_iter()
+                .map(LedgerEntry::into_record)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Leave `entries` in `state_dir` for the next session.
+///
+/// Merged with whatever is there now rather than replacing it: two sessions
+/// in one checkout can run at once, and the one to finish second would
+/// otherwise discard everything the first learned. Where both have an entry
+/// for a path this session's wins, which is safe either way because an entry
+/// answers only while its identity still matches the file. Entries whose file
+/// is gone are dropped here, once per session, so a checkout that keeps
+/// rebuilding its outputs under new names does not carry every old name
+/// forever.
+pub(crate) fn save(
+    state_dir: &Path,
+    entries: Vec<(FileDigestScope, RecordedFileDigest)>,
+) -> Result<usize> {
+    let path = path(state_dir);
+    let mut merged: BTreeMap<(FileDigestScope, PathBuf), RecordedFileDigest> = read(&path)
+        .map(|ledger| {
+            ledger
+                .entries
+                .into_iter()
+                .map(LedgerEntry::into_record)
+                .map(|(scope, record)| ((scope, record.file.path.clone()), record))
+                .collect()
+        })
+        .unwrap_or_default();
+    for (scope, record) in entries {
+        merged.insert((scope, record.file.path.clone()), record);
+    }
+    let mut entries = merged
+        .into_iter()
+        .filter(|(_, record)| record.file.path.is_file())
+        .map(|((scope, _), record)| LedgerEntry::new(scope, record))
+        .collect::<Vec<_>>();
+    if entries.len() > MAX_PERSISTED_ENTRIES {
+        // Nothing here says which entries matter more, so the newest write is
+        // simply the one that has to fit: keep what sorts last, which for
+        // outputs in one target directory is the most recently named.
+        entries.drain(..entries.len() - MAX_PERSISTED_ENTRIES);
+    }
+    let count = entries.len();
+    let ledger = Ledger {
+        version: LEDGER_VERSION,
+        entries,
+    };
+    crate::util::write_atomic(&path, &serde_json::to_vec(&ledger)?)
+        .wrap_err_with(|| format!("failed to write the file-digest ledger {}", path.display()))?;
+    Ok(count)
+}
+
+fn read(path: &Path) -> Option<Ledger> {
+    let bytes = std::fs::read(path).ok()?;
+    let ledger = serde_json::from_slice::<Ledger>(&bytes).ok()?;
+    (ledger.version == LEDGER_VERSION).then_some(ledger)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mbx_cache_core::{CacheDigest, FileIdentity};
+
+    fn record(path: &Path) -> RecordedFileDigest {
+        let metadata = std::fs::metadata(path).unwrap();
+        RecordedFileDigest {
+            file: FileIdentity::describe(path, &metadata).unwrap(),
+            digest: CacheDigest::blake3_file(path).unwrap(),
+        }
+    }
+
+    #[test]
+    fn a_saved_ledger_loads_back_without_entries_for_vanished_files() {
+        let state = tempfile::tempdir().unwrap();
+        let files = tempfile::tempdir().unwrap();
+        let kept = files.path().join("libkept.rlib");
+        let gone = files.path().join("libgone.rlib");
+        std::fs::write(&kept, b"kept").unwrap();
+        std::fs::write(&gone, b"gone").unwrap();
+        let entries = vec![
+            (FileDigestScope::Content, record(&kept)),
+            (FileDigestScope::CcInput, record(&gone)),
+        ];
+        std::fs::remove_file(&gone).unwrap();
+
+        assert_eq!(save(state.path(), entries.clone()).unwrap(), 1);
+        assert_eq!(load(state.path()), vec![entries[0].clone()]);
+    }
+
+    #[test]
+    fn saving_merges_with_what_another_session_left() {
+        let state = tempfile::tempdir().unwrap();
+        let files = tempfile::tempdir().unwrap();
+        let theirs = files.path().join("libtheirs.rlib");
+        let shared = files.path().join("libshared.rlib");
+        std::fs::write(&theirs, b"theirs").unwrap();
+        std::fs::write(&shared, b"shared").unwrap();
+        let stale_shared = RecordedFileDigest {
+            digest: CacheDigest::blake3(b"an older shared"),
+            ..record(&shared)
+        };
+        save(
+            state.path(),
+            vec![
+                (FileDigestScope::Content, record(&theirs)),
+                (FileDigestScope::Content, stale_shared),
+            ],
+        )
+        .unwrap();
+
+        let ours = record(&shared);
+        assert_eq!(
+            save(state.path(), vec![(FileDigestScope::Content, ours.clone())]).unwrap(),
+            2
+        );
+        let loaded = load(state.path());
+        assert_eq!(loaded.len(), 2);
+        assert!(loaded.contains(&(FileDigestScope::Content, record(&theirs))));
+        assert!(loaded.contains(&(FileDigestScope::Content, ours)));
+    }
+
+    #[test]
+    fn an_unreadable_or_foreign_ledger_is_an_empty_one() {
+        let state = tempfile::tempdir().unwrap();
+        assert!(load(state.path()).is_empty());
+        std::fs::write(path(state.path()), b"not json").unwrap();
+        assert!(load(state.path()).is_empty());
+        std::fs::write(path(state.path()), br#"{"version":99,"entries":[]}"#).unwrap();
+        assert!(load(state.path()).is_empty());
+    }
+}

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -48,6 +48,7 @@ pub mod util;
 
 mod build_script;
 mod cc;
+mod digest_ledger;
 mod incremental;
 mod linker;
 mod materialize;

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -104,6 +104,9 @@ pub struct CacheSession {
     scheduler_env: Vec<(String, String)>,
     store: PathBuf,
     incremental_root: PathBuf,
+    /// The checkout's private state directory once `begin` has claimed it,
+    /// where the file-digest ledger is saved when the session finishes.
+    ledger_dir: Mutex<Option<PathBuf>>,
     started: Instant,
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
     server: Mutex<Option<JoinHandle<Result<()>>>>,
@@ -184,6 +187,7 @@ impl CacheSession {
             scheduler_env: crate::scheduler::session_environment_with_jobs(config, cargo_jobs),
             store,
             incremental_root: config.cache_dir.join("incremental"),
+            ledger_dir: Mutex::new(None),
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),
             server: Mutex::new(Some(server)),
@@ -257,6 +261,14 @@ impl CacheSession {
                     INCREMENTAL_ROOT_ENV.into(),
                     root.to_string_lossy().into_owned(),
                 );
+                // Seeded before any shim can ask: the first compilation of the
+                // crate being edited is the one that would otherwise read every
+                // unchanged dependency again.
+                let seeded = self
+                    .agent
+                    .seed_file_digests(crate::digest_ledger::load(&root));
+                debug!("file-digest ledger seeded with {seeded} entries");
+                *self.ledger_dir.lock().unwrap() = Some(root);
             }
             Err(error) => warn!("incremental state was not recorded: {error:#}"),
         }
@@ -494,6 +506,15 @@ impl CacheSession {
         // downloads were holding.
         self.agent.wait_for_uploads().await;
         served?;
+        // Saved after the shims are done and before the summary, so the next
+        // session in this checkout starts from everything this one hashed.
+        // Best-effort like the ledger itself.
+        if let Some(ledger_dir) = self.ledger_dir.lock().unwrap().take() {
+            match crate::digest_ledger::save(&ledger_dir, self.agent.file_digests()) {
+                Ok(count) => debug!("file-digest ledger saved with {count} entries"),
+                Err(error) => warn!("the file-digest ledger was not saved: {error:#}"),
+            }
+        }
         let mut stats = self.agent.stats();
         stats.session_duration_ns = duration_ns(self.started.elapsed());
         // The same totals the summary reports, so a reader of a finished stream

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -65,6 +65,15 @@ prediction for later invocations. A cold compilation may therefore have no key
 to look up yet. It still gets stored after compiling and can warm the next
 build.
 
+Hashing those files is shared too. The agent keeps a ledger of every file a
+shim has hashed, keyed by the file's length, modification time, and change
+time, so a dependency's rlib is read once however many crates link it. The
+ledger is saved with the checkout's private state when the build finishes and
+loaded by its next build, so the crate being edited does not read its unchanged
+dependencies again before it can look anything up. An entry answers only while
+the file on disk still has the identity it was recorded with; anything else is
+hashed as if never seen.
+
 ## Rustdoc actions
 
 Cargo invokes rustdoc through a separate shim. Each documentation action keys


### PR DESCRIPTION
## Summary

- The agent's file-digest ledger (digest keyed by a file's length, mtime, and ctime) only lived in memory, so every session re-hashed every input the first time a shim named it. For the crate being edited that is all of its dependency rlibs: on mise, 1.1 GiB and 0.7s before rustc even starts.
- Save the ledger as `file-digests.json` in the checkout's private state directory (beside the learned-incremental state, pruned with it) when the session finishes, and seed the agent from it when the next session begins.
- Entries still answer only while the file on disk matches the recorded identity, so a stale entry costs one hash and nothing else. Save merges with whatever a concurrent session in the same checkout wrote, drops entries whose files are gone, and caps the file.
- `CacheAgent::seed_file_digests` and `CacheAgent::file_digests` are additive; seeding runs the same validation as shim records and never overrides what this session recorded itself.

## Measurements

Shim phase timing for the `mise` unit on a trivial edit, keying from dep-info before the compiler runs:

| session | keying phase |
|---|---|
| first (no ledger yet) | 0.71s |
| next ones | 0.31s |

Ledger for the mise checkout: 3507 entries, 1.3 MB.

## Test plan

- [x] Ledger round-trips, drops vanished files, merges with a concurrent writer, and treats unreadable or foreign versions as empty
- [x] Agent seeding answers lookups, rejects invalid records, and yields to this session's own records
- [x] `mise run lint`, `mise run test:cargo`
- [x] Measured on jdx/mise across three consecutive sessions with temporary phase instrumentation (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort local cache acceleration with identity checks; failures degrade to empty ledger and extra hashing, not correctness changes to cache keys.
> 
> **Overview**
> **Persists the in-memory file-digest ledger** so unchanged dependency rlibs are not re-hashed at the start of every new build session.
> 
> On session start, the agent is **seeded** from `file-digests.json` in the checkout’s private state (alongside incremental state). On shutdown, the session **exports** the agent ledger and **merges** it into that file (concurrent sessions keep both; this session wins on path conflicts). Entries are still trusted only when on-disk **file identity** (path, len, mtime/ctime) matches; invalid or missing files are skipped on load/save.
> 
> `CacheAgent` gains **`seed_file_digests`** / **`file_digests`**, with shared **`validate_file_digest_record`** used for shim records and seeds (seeds never overwrite records from the current session). The new **`digest_ledger`** module handles versioned JSON I/O, atomic write, pruning vanished paths, and a 256k entry cap.
> 
> Docs describe cross-session hashing; tests cover persistence merge/prune and agent seeding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293d6f3d11e0d06f7545585d041a94cf1cfe8f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->