### PR TITLE
fix: cache dependencies of LTO builds

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -116,6 +116,7 @@ const SUPPORTED_CODEGEN_OPTIONS: &[&str] = &[
     "link-args",
     "link-dead-code",
     "link-self-contained",
+    "linker-plugin-lto",
     "lto",
     "metadata",
     "no-prepopulate-passes",
@@ -1506,6 +1507,22 @@ impl<'a> Parser<'a> {
             && !(cfg!(windows) && name == "linker")
         {
             return Err(BypassReason::UnknownCodegenOption(name.into()));
+        }
+        // Cargo compiles every dependency of an LTO build with this flag, so
+        // the rlibs carry bitcode for the final link to optimize across. The
+        // switch is keyed as text like any other option. A value naming the
+        // linker plugin is a host file the key does not describe, so that
+        // spelling still bypasses.
+        if name == "linker-plugin-lto"
+            && let Some((_, selection)) = value.split_once('=')
+            && !matches!(
+                selection,
+                "" | "y" | "yes" | "on" | "true" | "n" | "no" | "off" | "false"
+            )
+        {
+            return Err(BypassReason::UnknownCodegenOption(format!(
+                "linker-plugin-lto={selection}"
+            )));
         }
         // `-fuse-ld=<name>` selects the linker the driver invokes. Parsed
         // rather than keyed as text so the linker identity probe can pin the

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -2005,3 +2005,50 @@ fn a_covering_oso_prefix_makes_a_debug_link_portable() {
         Err(BypassReason::UnportableNativeLink("debuginfo=2".into())),
     );
 }
+
+/// Cargo passes `-C linker-plugin-lto` to every dependency of a build whose
+/// profile turns LTO on, so bypassing it left such builds without a cache for
+/// anything but the workspace. The switch is keyed; a plugin path is a host
+/// file the key does not describe and still bypasses.
+#[test]
+fn linker_plugin_lto_is_keyed_and_a_plugin_path_bypasses() {
+    let plain = RustcInvocation::parse(&args(&[
+        "--crate-type=lib",
+        "--emit=dep-info,metadata,link",
+        "-Cembed-bitcode=yes",
+        "src/lib.rs",
+    ]))
+    .unwrap();
+    for flag in ["-Clinker-plugin-lto", "-Clinker-plugin-lto=yes"] {
+        let with_lto = RustcInvocation::parse(&args(&[
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "-Cembed-bitcode=yes",
+            flag,
+            "src/lib.rs",
+        ]))
+        .unwrap();
+        assert_ne!(
+            with_lto.arguments, plain.arguments,
+            "{flag} is part of the key"
+        );
+        assert!(
+            with_lto
+                .arguments
+                .contains(&Argument::Plain(format!("--codegen={}", &flag[2..]))),
+            "{flag} is keyed as text"
+        );
+    }
+
+    assert_eq!(
+        RustcInvocation::parse(&args(&[
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "-Clinker-plugin-lto=/usr/lib/LLVMgold.so",
+            "src/lib.rs",
+        ])),
+        Err(BypassReason::UnknownCodegenOption(
+            "linker-plugin-lto=/usr/lib/LLVMgold.so".into()
+        ))
+    );
+}


### PR DESCRIPTION
## Summary

- Cargo passes `-C linker-plugin-lto` to every dependency of a build whose profile enables LTO (`lto = "fat"` or `"thin"`). The rustc adapter did not model the option, so every one of those compilations bypassed with `unknown-codegen-option`. A fat-LTO release build cached nothing but its build scripts; this repo's own release profile is one such build (192 bypasses in a `cargo build --release` of the workspace).
- Admit the switch and key it as text like the other codegen options. `-C linker-plugin-lto=<path>` names the linker plugin, a host file the key does not describe, so that spelling still bypasses.

## Test plan

- [x] Unit test: bare and `=yes` forms parse and are part of the key; a plugin path bypasses with `linker-plugin-lto=<path>`
- [x] `mise run lint`, `mise run test:cargo`
- [x] End to end on a small crate with `lto = "fat"`, `codegen-units = 1`, `panic = "abort"`: cold build stores 15 compilations; a rebuild into a fresh target restores 14 hits and the binary runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser-only change to admit and key one rustc flag; plugin-path values remain uncached; behavior covered by a focused unit test.
> 
> **Overview**
> **Fixes rustc action-cache bypasses on LTO profiles** by teaching the adapter about Cargo’s `-C linker-plugin-lto` flag on dependency crates (previously every such compile failed with `unknown-codegen-option`, so fat/thin LTO builds barely cached).
> 
> `linker-plugin-lto` is added to supported codegen options and included in the cache key as plain `--codegen=…` text for the usual on/off spellings (`-Clinker-plugin-lto`, `=yes`, etc.). **`-Clinker-plugin-lto=<path>`** still bypasses, because the plugin path is host-specific and isn’t normalized into the key.
> 
> A unit test checks that bare/`=yes` forms affect the key and that a plugin path errors with `UnknownCodegenOption`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224dcb443791df2d5bfacdae123d3ae698f27333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-cache handling for the `linker-plugin-lto` compiler option.
  * Boolean forms of the option are now recognized and included in cache matching.
  * Builds specifying a linker plugin path safely bypass caching when that plugin input cannot be modeled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->