### PR TITLE
fix: bound remote download cost per build

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -131,6 +131,7 @@ struct AtomicAgentStats {
     remote_blob_pack_requests: AtomicU64,
     remote_blob_pack_blobs: AtomicU64,
     remote_blob_transfer_duration_ns: AtomicU64,
+    remote_download_budget_exhausted: AtomicU64,
     local_cas_write_duration_ns: AtomicU64,
     prefetch_runs: AtomicU64,
     prefetch_duration_ns: AtomicU64,
@@ -262,6 +263,7 @@ pub struct CacheAgent {
     remote_staging_dir: Arc<PathBuf>,
     remote_download_limit: u64,
     remote_download_bytes: Arc<AtomicU64>,
+    remote_download_time_budget: Option<Arc<RemoteDownloadTimeBudget>>,
     pending_remote_actions: Arc<Mutex<BTreeMap<CacheDigest, RemoteActionResult>>>,
     remote_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_transfers: Arc<tokio::sync::Semaphore>,
@@ -367,6 +369,60 @@ struct RemoteDownloadReservation {
     committed: bool,
 }
 
+#[derive(Debug, Default)]
+struct RemoteDownloadTimeState {
+    active: u64,
+    active_since: Option<Instant>,
+    elapsed: Duration,
+}
+
+#[derive(Debug)]
+struct RemoteDownloadTimeBudget {
+    limit: Duration,
+    state: Mutex<RemoteDownloadTimeState>,
+}
+
+struct RemoteDownloadTimePermit {
+    budget: Arc<RemoteDownloadTimeBudget>,
+    remaining: Duration,
+}
+
+impl RemoteDownloadTimeBudget {
+    fn start(self: &Arc<Self>) -> Option<RemoteDownloadTimePermit> {
+        let now = Instant::now();
+        let mut state = self.state.lock().unwrap();
+        let elapsed = state.elapsed.saturating_add(
+            state
+                .active_since
+                .map_or(Duration::ZERO, |started| now.duration_since(started)),
+        );
+        let remaining = self.limit.checked_sub(elapsed)?;
+        if remaining.is_zero() {
+            return None;
+        }
+        if state.active == 0 {
+            state.active_since = Some(now);
+        }
+        state.active += 1;
+        Some(RemoteDownloadTimePermit {
+            budget: self.clone(),
+            remaining,
+        })
+    }
+}
+
+impl Drop for RemoteDownloadTimePermit {
+    fn drop(&mut self) {
+        let now = Instant::now();
+        let mut state = self.budget.state.lock().unwrap();
+        if let Some(started) = state.active_since {
+            state.elapsed = state.elapsed.saturating_add(now.duration_since(started));
+        }
+        state.active = state.active.saturating_sub(1);
+        state.active_since = (state.active > 0).then_some(now);
+    }
+}
+
 impl RemoteDownloadReservation {
     fn bytes(&self) -> u64 {
         self.reserved
@@ -397,7 +453,7 @@ struct ExecutableIdentityKey {
 impl CacheAgent {
     /// Create an agent backed by the cache rooted at `cache_dir`.
     pub fn new(cache_dir: impl Into<PathBuf>, version: impl Into<Arc<str>>) -> Self {
-        Self::build(cache_dir.into(), version.into(), None, 0)
+        Self::build(cache_dir.into(), version.into(), None, 0, None)
     }
 
     /// Create an agent with local-first access to a remote action cache.
@@ -411,6 +467,7 @@ impl CacheAgent {
             version.into(),
             Some(remote),
             DEFAULT_MAX_REMOTE_DOWNLOAD_BYTES,
+            None,
         )
     }
 
@@ -426,6 +483,25 @@ impl CacheAgent {
             version.into(),
             Some(remote),
             max_remote_download_bytes,
+            None,
+        )
+    }
+
+    /// Create a remote agent with cumulative data and active-transfer-time
+    /// budgets for the session.
+    pub fn new_remote_with_download_limits(
+        cache_dir: impl Into<PathBuf>,
+        version: impl Into<Arc<str>>,
+        remote: AgentRemoteCache,
+        max_remote_download_bytes: u64,
+        max_remote_download_time: Duration,
+    ) -> Self {
+        Self::build(
+            cache_dir.into(),
+            version.into(),
+            Some(remote),
+            max_remote_download_bytes,
+            Some(max_remote_download_time),
         )
     }
 
@@ -434,6 +510,7 @@ impl CacheAgent {
         version: Arc<str>,
         remote: Option<AgentRemoteCache>,
         remote_download_limit: u64,
+        remote_download_time_limit: Option<Duration>,
     ) -> Self {
         let remote_mode = remote
             .as_ref()
@@ -479,6 +556,12 @@ impl CacheAgent {
             remote_staging_dir: Arc::new(remote_staging_dir),
             remote_download_limit,
             remote_download_bytes: Arc::new(AtomicU64::new(0)),
+            remote_download_time_budget: remote_download_time_limit.map(|limit| {
+                Arc::new(RemoteDownloadTimeBudget {
+                    limit,
+                    state: Mutex::new(RemoteDownloadTimeState::default()),
+                })
+            }),
             pending_remote_actions: Arc::new(Mutex::new(BTreeMap::new())),
             remote_transfers,
             prefetch_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_PREFETCH_TRANSFERS)),
@@ -520,6 +603,7 @@ impl CacheAgent {
                 .checked_add(bytes)
                 .ok_or_else(|| eyre::eyre!("remote cache download budget overflowed"))?;
             if next > self.remote_download_limit {
+                self.note_remote_download_budget_exhausted();
                 bail!(
                     "remote cache download budget exceeded: {} bytes requested with {} of {} bytes already used",
                     bytes,
@@ -545,6 +629,16 @@ impl CacheAgent {
         }
     }
 
+    fn begin_remote_download(&self) -> Result<Option<RemoteDownloadTimePermit>> {
+        let Some(budget) = &self.remote_download_time_budget else {
+            return Ok(None);
+        };
+        budget.start().map(Some).ok_or_else(|| {
+            self.note_remote_download_budget_exhausted();
+            eyre::eyre!("remote cache download time budget exhausted")
+        })
+    }
+
     fn reserve_remote_download_up_to(&self, requested: u64) -> Result<RemoteDownloadReservation> {
         let mut current = self.remote_download_bytes.load(Ordering::Acquire);
         loop {
@@ -557,6 +651,9 @@ impl CacheAgent {
                 Ordering::Acquire,
             ) {
                 Ok(_) => {
+                    if requested > 0 && reserved == 0 {
+                        self.note_remote_download_budget_exhausted();
+                    }
                     return Ok(RemoteDownloadReservation {
                         counter: self.remote_download_bytes.clone(),
                         reserved,
@@ -1027,6 +1124,11 @@ impl CacheAgent {
                 .stats
                 .remote_blob_transfer_duration_ns
                 .load(Ordering::Relaxed),
+            remote_download_budget_exhausted: self
+                .stats
+                .remote_download_budget_exhausted
+                .load(Ordering::Relaxed)
+                != 0,
             local_cas_write_duration_ns: self
                 .stats
                 .local_cas_write_duration_ns
@@ -1518,6 +1620,12 @@ impl CacheAgent {
     /// Record that a remote operation failed and the build carried on without it.
     fn note_remote_failure(&self) {
         self.stats.remote_failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn note_remote_download_budget_exhausted(&self) {
+        self.stats
+            .remote_download_budget_exhausted
+            .store(1, Ordering::Relaxed);
     }
 
     async fn get_remote_action_result(

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -639,6 +639,20 @@ impl CacheAgent {
         })
     }
 
+    fn ensure_remote_download_budget_available(&self) -> Result<()> {
+        if self.remote_download_budget_exhausted() {
+            bail!("remote cache download budget exhausted");
+        }
+        Ok(())
+    }
+
+    fn remote_download_budget_exhausted(&self) -> bool {
+        self.stats
+            .remote_download_budget_exhausted
+            .load(Ordering::Relaxed)
+            != 0
+    }
+
     fn reserve_remote_download_up_to(&self, requested: u64) -> Result<RemoteDownloadReservation> {
         let mut current = self.remote_download_bytes.load(Ordering::Acquire);
         loop {
@@ -1124,11 +1138,7 @@ impl CacheAgent {
                 .stats
                 .remote_blob_transfer_duration_ns
                 .load(Ordering::Relaxed),
-            remote_download_budget_exhausted: self
-                .stats
-                .remote_download_budget_exhausted
-                .load(Ordering::Relaxed)
-                != 0,
+            remote_download_budget_exhausted: self.remote_download_budget_exhausted(),
             local_cas_write_duration_ns: self
                 .stats
                 .local_cas_write_duration_ns

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -615,14 +615,31 @@ impl CacheAgent {
                         break;
                     }
                 };
+                let download_time = match self.begin_remote_download() {
+                    Ok(timer) => timer,
+                    Err(error) => {
+                        warn!("remote cache blob pack skipped: {error}");
+                        break;
+                    }
+                };
                 let transfer_started = Instant::now();
-                let pack = remote
+                let download = remote
                     .get_blob_pack_with_limit(
                         &requested,
                         self.remote_staging_dir.as_path(),
                         pack_reservation.bytes(),
                     )
-                    .await;
+                    .boxed();
+                let pack = match &download_time {
+                    Some(timer) => tokio::time::timeout(timer.remaining, download)
+                        .await
+                        .map_err(|_| {
+                            self.note_remote_download_budget_exhausted();
+                            eyre::eyre!("remote cache download time budget exhausted")
+                        })
+                        .and_then(std::convert::identity),
+                    None => download.await,
+                };
                 (pack, duration_ns(transfer_started))
             };
             let pack = match pack {
@@ -887,15 +904,26 @@ impl CacheAgent {
         };
         let _permit = self.remote_transfers.acquire().await?;
         let reservation = self.reserve_remote_download(digest.size)?;
+        let download_time = self.begin_remote_download()?;
         self.stats
             .remote_blob_requests
             .fetch_add(1, Ordering::Relaxed);
         let transfer_timer =
             AtomicDurationTimer::start(&self.stats.remote_blob_transfer_duration_ns);
-        let temporary = remote
+        let download = remote
             .get_blob_file(digest, self.remote_staging_dir.as_path())
-            .await?;
+            .boxed();
+        let temporary = match &download_time {
+            Some(timer) => tokio::time::timeout(timer.remaining, download)
+                .await
+                .map_err(|_| {
+                    self.note_remote_download_budget_exhausted();
+                    eyre::eyre!("remote cache download time budget exhausted")
+                })??,
+            None => download.await?,
+        };
         drop(transfer_timer);
+        drop(download_time);
         let _cas_timer = AtomicDurationTimer::start(&self.stats.local_cas_write_duration_ns);
         let path = self.cas.store_verified_file(digest, temporary.path())?;
         reservation.commit(digest.size);

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -537,9 +537,15 @@ impl CacheAgent {
         if missing.is_empty() {
             return verified;
         }
+        if self.remote_download_budget_exhausted() {
+            return verified;
+        }
 
         let mut pack_candidates = missing.clone();
         while !pack_candidates.is_empty() {
+            if self.remote_download_budget_exhausted() {
+                return verified;
+            }
             let candidates = match blob_pack_chunk(
                 &pack_candidates.keys().cloned().collect::<Vec<_>>(),
                 BlobPackLimits {
@@ -582,6 +588,9 @@ impl CacheAgent {
             if requested.is_empty() {
                 continue;
             }
+            if self.remote_download_budget_exhausted() {
+                return verified;
+            }
             let requested_bytes = requested
                 .iter()
                 .fold(0_u64, |total, digest| total.saturating_add(digest.size));
@@ -615,6 +624,10 @@ impl CacheAgent {
                         break;
                     }
                 };
+                if let Err(error) = self.ensure_remote_download_budget_available() {
+                    warn!("remote cache blob pack skipped: {error}");
+                    break;
+                }
                 let download_time = match self.begin_remote_download() {
                     Ok(timer) => timer,
                     Err(error) => {
@@ -701,6 +714,10 @@ impl CacheAgent {
                     ),
                 }
             }
+        }
+
+        if self.remote_download_budget_exhausted() {
+            return verified;
         }
 
         let mut transfers = stream::iter(missing.into_keys().map(|digest| {
@@ -893,18 +910,25 @@ impl CacheAgent {
         digest: &CacheDigest,
         prefetch_limit: Option<&tokio::sync::Semaphore>,
     ) -> Result<PathBuf> {
+        if let Some(path) = self.find_verified_blob(digest)? {
+            return Ok(path);
+        }
+        self.ensure_remote_download_budget_available()?;
         let lock = self.write_lock(digest);
         let _guard = lock.lock().await;
         if let Some(path) = self.find_verified_blob(digest)? {
             return Ok(path);
         }
+        self.ensure_remote_download_budget_available()?;
         let _prefetch_permit = match prefetch_limit {
             Some(limit) => Some(limit.acquire().await?),
             None => None,
         };
+        self.ensure_remote_download_budget_available()?;
         let _permit = self.remote_transfers.acquire().await?;
-        let reservation = self.reserve_remote_download(digest.size)?;
+        self.ensure_remote_download_budget_available()?;
         let download_time = self.begin_remote_download()?;
+        let reservation = self.reserve_remote_download(digest.size)?;
         self.stats
             .remote_blob_requests
             .fetch_add(1, Ordering::Relaxed);

--- a/crates/mbx-cache-core/src/agent/stats.rs
+++ b/crates/mbx-cache-core/src/agent/stats.rs
@@ -91,6 +91,9 @@ pub struct AgentStats {
     pub remote_blob_pack_blobs: u64,
     /// Cumulative time spent downloading and verifying remote blobs.
     pub remote_blob_transfer_duration_ns: u64,
+    /// Whether the configured remote download size or active-time budget stopped
+    /// further restores during this session.
+    pub remote_download_budget_exhausted: bool,
     /// Cumulative time spent ingesting downloaded blobs into the local CAS.
     pub local_cas_write_duration_ns: u64,
     /// Number of speculative prefetch runs started for task manifests.

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -3242,6 +3242,38 @@ fn remote_agent_url_with_limit(
     )
 }
 
+fn remote_agent_url_with_limits(
+    base_url: url::Url,
+    cache_dir: PathBuf,
+    mode: RemoteCacheMode,
+    max_remote_download_bytes: u64,
+    max_remote_download_time: Duration,
+) -> CacheAgent {
+    let client = RemoteCacheClient::new(crate::RemoteCacheConfig {
+        base_url,
+        namespace: "test".into(),
+        token: None,
+        token_file: None,
+        oidc_audience: None,
+        connect_timeout: Duration::from_secs(1),
+        read_timeout: Duration::from_secs(1),
+        download_timeout: Duration::from_secs(1),
+        retries: 0,
+    })
+    .unwrap();
+    CacheAgent::new_remote_with_download_limits(
+        &cache_dir,
+        "test-version",
+        AgentRemoteCache {
+            client,
+            mode,
+            staging_dir: cache_dir.join("remote"),
+        },
+        max_remote_download_bytes,
+        max_remote_download_time,
+    )
+}
+
 #[tokio::test]
 async fn a_read_write_agent_claims_an_advertised_action_promise() {
     let directory = tempfile::tempdir().unwrap();
@@ -3501,8 +3533,32 @@ async fn bounds_cumulative_remote_downloads_for_a_session() {
         agent.remote_download_bytes.load(Ordering::Relaxed),
         first.size
     );
+    assert!(agent.stats().remote_download_budget_exhausted);
     first_download.assert_async().await;
     second_download.assert_async().await;
+}
+
+#[tokio::test]
+async fn bounds_active_remote_download_time_for_a_session() {
+    let directory = tempfile::tempdir().unwrap();
+    let digest = CacheDigest::blake3(b"slow");
+    let responses = BTreeMap::from([(blob_path(&digest), b"slow".to_vec())]);
+    let (base_url, _, server) = delayed_blob_server(responses, Duration::from_millis(100)).await;
+    let agent = remote_agent_url_with_limits(
+        base_url,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+        u64::MAX,
+        Duration::from_millis(10),
+    );
+
+    assert!(matches!(
+        agent.respond(AgentRequest::FindBlob { digest }).await,
+        AgentResponse::Blob { path: None }
+    ));
+    assert!(agent.stats().remote_download_budget_exhausted);
+    assert_eq!(agent.stats().downloaded_bytes, 0);
+    server.abort();
 }
 
 #[tokio::test]

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -3562,6 +3562,42 @@ async fn bounds_active_remote_download_time_for_a_session() {
 }
 
 #[tokio::test]
+async fn exhausted_remote_download_budget_does_not_wait_for_transfer_capacity() {
+    let directory = tempfile::tempdir().unwrap();
+    let server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"missing");
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+    agent.note_remote_download_budget_exhausted();
+    let _held_transfers = agent
+        .remote_transfers
+        .acquire_many(MAX_REMOTE_TRANSFERS as u32)
+        .await
+        .unwrap();
+    let remote = agent.remote.as_deref().unwrap();
+
+    let batch = tokio::time::timeout(
+        Duration::from_millis(100),
+        agent.fetch_remote_blobs(remote, vec![digest.clone()], None),
+    )
+    .await
+    .expect("an exhausted budget should stop a blob batch immediately");
+    assert!(batch.is_empty());
+
+    let individual = tokio::time::timeout(
+        Duration::from_millis(100),
+        agent.fetch_remote_blob(remote, &digest),
+    )
+    .await
+    .expect("an exhausted budget should fail before waiting for a transfer permit");
+
+    assert!(individual.is_err());
+}
+
+#[tokio::test]
 async fn merges_overlapping_runs_into_one_task_manifest() {
     let directory = tempfile::tempdir().unwrap();
     let cache = directory.path().join("cache");

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -15,7 +15,8 @@ const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_HTTP_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 const DEFAULT_HTTP_RETRIES: i64 = 3;
 const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
-const DEFAULT_REMOTE_MAX_DOWNLOAD_BYTES: u64 = 256 * MIB;
+const DEFAULT_REMOTE_MAX_DOWNLOAD_BYTES: u64 = GIB;
+const DEFAULT_REMOTE_MAX_DOWNLOAD_TIME: Duration = Duration::from_secs(60);
 /// How long a managed target directory may sit unused before collection.
 const DEFAULT_TARGET_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
@@ -226,10 +227,12 @@ struct RawRemote {
         choices("read-write", "read-only", "write-only")
     )]
     mode: String,
-    /// Most remote artifact data one build may download. Once exhausted, remaining
-    /// actions compile normally instead of letting a slow cache dominate the build.
-    #[usage(env = "MBX_REMOTE_MAX_DOWNLOAD_SIZE", default = "256MiB")]
+    /// Most remote artifact data one build may download.
+    #[usage(env = "MBX_REMOTE_MAX_DOWNLOAD_SIZE", default = "1GiB")]
     max_download_size: String,
+    /// Most active wall time one build may spend downloading remote artifacts.
+    #[usage(env = "MBX_REMOTE_MAX_DOWNLOAD_TIME", default = "1m", ty = "duration")]
+    max_download_time: String,
     /// S3 endpoint for a store that is not AWS, such as MinIO or R2.
     #[usage(env = "MBX_REMOTE_S3_ENDPOINT", ty = "url")]
     s3_endpoint: Option<String>,
@@ -448,6 +451,7 @@ pub struct RemoteSettings {
     pub oidc_audience: Option<String>,
     pub mode: RemoteCacheMode,
     pub max_download_bytes: u64,
+    pub max_download_time: Duration,
     pub s3_endpoint: Option<String>,
     pub s3_region: Option<String>,
     pub s3_force_path_style: Option<bool>,
@@ -464,6 +468,7 @@ impl Default for RemoteSettings {
             oidc_audience: None,
             mode: RemoteCacheMode::default(),
             max_download_bytes: DEFAULT_REMOTE_MAX_DOWNLOAD_BYTES,
+            max_download_time: DEFAULT_REMOTE_MAX_DOWNLOAD_TIME,
             s3_endpoint: None,
             s3_region: None,
             s3_force_path_style: None,
@@ -807,6 +812,8 @@ impl Config {
                 mode,
                 max_download_bytes: parse_byte_size(&raw.remote.max_download_size)
                     .wrap_err("invalid remote.max_download_size")?,
+                max_download_time: parse_duration(&raw.remote.max_download_time)
+                    .wrap_err("invalid remote.max_download_time")?,
                 s3_endpoint: raw.remote.s3_endpoint,
                 s3_region: raw.remote.s3_region,
                 s3_force_path_style: raw.remote.s3_force_path_style,
@@ -1083,6 +1090,7 @@ mod tests {
             namespace = "file"
             mode = "read-only"
             max_download_size = "512MiB"
+            max_download_time = "45s"
             s3_conditional_writes = "required"
             [http]
             timeout = "5s"
@@ -1102,6 +1110,7 @@ mod tests {
                 ("MBX_REMOTE_URL", "https://env.example"),
                 ("MBX_REMOTE_MODE", "write-only"),
                 ("MBX_REMOTE_MAX_DOWNLOAD_SIZE", "128MiB"),
+                ("MBX_REMOTE_MAX_DOWNLOAD_TIME", "15s"),
                 ("MBX_HTTP_TIMEOUT", "250ms"),
                 ("MBX_GC_MAX_SIZE", "2GiB"),
                 ("MBX_TARGET_ROOT", "/from/env/targets"),
@@ -1113,6 +1122,7 @@ mod tests {
         assert_eq!(config.remote.url.unwrap(), "https://env.example");
         assert_eq!(config.remote.mode, RemoteCacheMode::WriteOnly);
         assert_eq!(config.remote.max_download_bytes, 128 * MIB);
+        assert_eq!(config.remote.max_download_time, Duration::from_secs(15));
         assert_eq!(config.http.timeout, Duration::from_millis(250));
         assert_eq!(config.gc.max_bytes, 2 * 1024 * 1024 * 1024);
         // Values absent from the environment still come from the file.
@@ -1142,6 +1152,10 @@ mod tests {
         assert_eq!(
             config.remote.max_download_bytes,
             DEFAULT_REMOTE_MAX_DOWNLOAD_BYTES
+        );
+        assert_eq!(
+            config.remote.max_download_time,
+            DEFAULT_REMOTE_MAX_DOWNLOAD_TIME
         );
         assert!(config.remote.url.is_none());
         assert!(!config.verify);
@@ -1363,6 +1377,7 @@ mod tests {
         assert!(configured(None, &[("MBX_GC_MAX_SIZE", "lots")]).is_err());
         assert!(configured(None, &[("MBX_GC_MAX_TOTAL_SIZE", "lots")]).is_err());
         assert!(configured(None, &[("MBX_REMOTE_MAX_DOWNLOAD_SIZE", "lots")]).is_err());
+        assert!(configured(None, &[("MBX_REMOTE_MAX_DOWNLOAD_TIME", "later")]).is_err());
         assert!(configured(None, &[("MBX_GC_INTERVAL", "later")]).is_err());
         assert!(configured(None, &[("MBX_TARGET_MAX_SIZE", "lots")]).is_err());
         assert!(configured(None, &[("MBX_TARGET_MAX_AGE", "later")]).is_err());

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -15,10 +15,12 @@ const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_HTTP_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 const DEFAULT_HTTP_RETRIES: i64 = 3;
 const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const DEFAULT_REMOTE_MAX_DOWNLOAD_BYTES: u64 = 256 * MIB;
 /// How long a managed target directory may sit unused before collection.
 const DEFAULT_TARGET_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
-const GIB: u64 = 1024 * 1024 * 1024;
+const MIB: u64 = 1024 * 1024;
+const GIB: u64 = 1024 * MIB;
 
 /// The largest the action-store budget nobody configured will grow to.
 const MAX_STORE_BUDGET: u64 = 500 * GIB;
@@ -224,6 +226,10 @@ struct RawRemote {
         choices("read-write", "read-only", "write-only")
     )]
     mode: String,
+    /// Most remote artifact data one build may download. Once exhausted, remaining
+    /// actions compile normally instead of letting a slow cache dominate the build.
+    #[usage(env = "MBX_REMOTE_MAX_DOWNLOAD_SIZE", default = "256MiB")]
+    max_download_size: String,
     /// S3 endpoint for a store that is not AWS, such as MinIO or R2.
     #[usage(env = "MBX_REMOTE_S3_ENDPOINT", ty = "url")]
     s3_endpoint: Option<String>,
@@ -268,7 +274,7 @@ struct RawGc {
     /// Sweep after a build when collection is due.
     #[usage(env = "MBX_GC_AUTO", default = true)]
     auto: bool,
-    /// Action-store and per-session remote-download budget.
+    /// Action-store budget.
     #[usage(
         env = "MBX_GC_MAX_SIZE",
         default_note = "5% of the cache disk, from 5GiB to 500GiB"
@@ -433,7 +439,7 @@ impl std::str::FromStr for SchedulerPriority {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RemoteSettings {
     pub url: Option<String>,
     pub namespace: Option<String>,
@@ -441,10 +447,29 @@ pub struct RemoteSettings {
     pub token_file: Option<PathBuf>,
     pub oidc_audience: Option<String>,
     pub mode: RemoteCacheMode,
+    pub max_download_bytes: u64,
     pub s3_endpoint: Option<String>,
     pub s3_region: Option<String>,
     pub s3_force_path_style: Option<bool>,
     pub s3_conditional_writes: S3ConditionalWrites,
+}
+
+impl Default for RemoteSettings {
+    fn default() -> Self {
+        Self {
+            url: None,
+            namespace: None,
+            token: None,
+            token_file: None,
+            oidc_audience: None,
+            mode: RemoteCacheMode::default(),
+            max_download_bytes: DEFAULT_REMOTE_MAX_DOWNLOAD_BYTES,
+            s3_endpoint: None,
+            s3_region: None,
+            s3_force_path_style: None,
+            s3_conditional_writes: S3ConditionalWrites::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -780,6 +805,8 @@ impl Config {
                 token_file: raw.remote.token_file,
                 oidc_audience: raw.remote.oidc_audience,
                 mode,
+                max_download_bytes: parse_byte_size(&raw.remote.max_download_size)
+                    .wrap_err("invalid remote.max_download_size")?,
                 s3_endpoint: raw.remote.s3_endpoint,
                 s3_region: raw.remote.s3_region,
                 s3_force_path_style: raw.remote.s3_force_path_style,
@@ -1055,6 +1082,7 @@ mod tests {
             url = "https://file.example"
             namespace = "file"
             mode = "read-only"
+            max_download_size = "512MiB"
             s3_conditional_writes = "required"
             [http]
             timeout = "5s"
@@ -1073,6 +1101,7 @@ mod tests {
                 ("MBX_CACHE_DIR", "/from/env"),
                 ("MBX_REMOTE_URL", "https://env.example"),
                 ("MBX_REMOTE_MODE", "write-only"),
+                ("MBX_REMOTE_MAX_DOWNLOAD_SIZE", "128MiB"),
                 ("MBX_HTTP_TIMEOUT", "250ms"),
                 ("MBX_GC_MAX_SIZE", "2GiB"),
                 ("MBX_TARGET_ROOT", "/from/env/targets"),
@@ -1083,6 +1112,7 @@ mod tests {
         assert_eq!(config.cache_dir, PathBuf::from("/from/env"));
         assert_eq!(config.remote.url.unwrap(), "https://env.example");
         assert_eq!(config.remote.mode, RemoteCacheMode::WriteOnly);
+        assert_eq!(config.remote.max_download_bytes, 128 * MIB);
         assert_eq!(config.http.timeout, Duration::from_millis(250));
         assert_eq!(config.gc.max_bytes, 2 * 1024 * 1024 * 1024);
         // Values absent from the environment still come from the file.
@@ -1109,6 +1139,10 @@ mod tests {
         assert_eq!(config.http.download_timeout, DEFAULT_HTTP_DOWNLOAD_TIMEOUT);
         assert_eq!(config.http.retries, DEFAULT_HTTP_RETRIES);
         assert_eq!(config.remote.mode, RemoteCacheMode::ReadWrite);
+        assert_eq!(
+            config.remote.max_download_bytes,
+            DEFAULT_REMOTE_MAX_DOWNLOAD_BYTES
+        );
         assert!(config.remote.url.is_none());
         assert!(!config.verify);
         assert!(!config.incremental);
@@ -1328,6 +1362,7 @@ mod tests {
         assert!(configured(None, &[("MBX_HTTP_RETRIES", "many")]).is_err());
         assert!(configured(None, &[("MBX_GC_MAX_SIZE", "lots")]).is_err());
         assert!(configured(None, &[("MBX_GC_MAX_TOTAL_SIZE", "lots")]).is_err());
+        assert!(configured(None, &[("MBX_REMOTE_MAX_DOWNLOAD_SIZE", "lots")]).is_err());
         assert!(configured(None, &[("MBX_GC_INTERVAL", "later")]).is_err());
         assert!(configured(None, &[("MBX_TARGET_MAX_SIZE", "lots")]).is_err());
         assert!(configured(None, &[("MBX_TARGET_MAX_AGE", "later")]).is_err());
@@ -1361,6 +1396,21 @@ mod tests {
         ] {
             let config = configured(None, &[("MBX_GC_MAX_SIZE", value)]).unwrap();
             assert_eq!(config.gc.max_bytes, expected, "{value} should parse");
+        }
+    }
+
+    #[test]
+    fn reads_a_remote_download_budget_in_either_unit_convention() {
+        for (value, expected) in [
+            ("256MiB", 256 * MIB),
+            ("256MB", 256_000_000),
+            ("1048576", MIB),
+        ] {
+            let config = configured(None, &[("MBX_REMOTE_MAX_DOWNLOAD_SIZE", value)]).unwrap();
+            assert_eq!(
+                config.remote.max_download_bytes, expected,
+                "{value} should parse"
+            );
         }
     }
 

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -145,11 +145,12 @@ impl CacheSession {
         std::fs::create_dir(&staging)?;
         let store = config.store_dir();
         let agent = if let Some(remote) = action_remote_cache(config, &store)? {
-            CacheAgent::new_remote_with_download_limit(
+            CacheAgent::new_remote_with_download_limits(
                 store.clone(),
                 VERSION,
                 remote,
                 config.remote.max_download_bytes,
+                config.remote.max_download_time,
             )
         } else {
             CacheAgent::new(store.clone(), VERSION)

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -149,7 +149,7 @@ impl CacheSession {
                 store.clone(),
                 VERSION,
                 remote,
-                config.gc.max_bytes,
+                config.remote.max_download_bytes,
             )
         } else {
             CacheAgent::new(store.clone(), VERSION)

--- a/crates/mbx/src/session/stats.rs
+++ b/crates/mbx/src/session/stats.rs
@@ -52,6 +52,7 @@ pub(super) struct StatsReport {
     remote_manifest_lookup_duration_ns: u64,
     remote_action_lookup_duration_ns: u64,
     remote_blob_transfer_duration_ns: u64,
+    remote_download_budget_exhausted: bool,
     local_cas_write_duration_ns: u64,
     prefetch_duration_ns: u64,
     materialization_duration_ns: u64,
@@ -72,7 +73,7 @@ struct SlowCompilationReport {
 impl From<&AgentStats> for StatsReport {
     fn from(stats: &AgentStats) -> Self {
         Self {
-            version: 4,
+            version: 5,
             session_duration_ns: stats.session_duration_ns,
             lookups: stats.lookups,
             hits: stats.hits,
@@ -131,6 +132,7 @@ impl From<&AgentStats> for StatsReport {
             remote_manifest_lookup_duration_ns: stats.remote_manifest_lookup_duration_ns,
             remote_action_lookup_duration_ns: stats.remote_action_lookup_duration_ns,
             remote_blob_transfer_duration_ns: stats.remote_blob_transfer_duration_ns,
+            remote_download_budget_exhausted: stats.remote_download_budget_exhausted,
             local_cas_write_duration_ns: stats.local_cas_write_duration_ns,
             prefetch_duration_ns: stats.prefetch_duration_ns,
             materialization_duration_ns: stats.materialization_duration_ns,
@@ -180,6 +182,11 @@ pub(crate) fn display_stats(stats: &AgentStats, config: &Config, style: SummaryS
             "mbx[cache]: the remote cache failed {} of its requests; this build ran without what it could not reach, and the warnings above say why",
             stats.remote_failures,
         ));
+    }
+    if stats.remote_download_budget_exhausted {
+        note(
+            "mbx[cache]: the remote download budget was exhausted; remaining actions compiled normally",
+        );
     }
     if stats.unconsulted > 0 {
         // A cold target directory hits this for everything it compiles, and
@@ -324,6 +331,9 @@ pub(super) fn short_summary(stats: &AgentStats) -> String {
     if stats.remote_failures > 0 {
         outcomes.push(format!("{} remote failures", stats.remote_failures));
     }
+    if stats.remote_download_budget_exhausted {
+        outcomes.push("download budget exhausted".to_string());
+    }
     format!(
         "mbx[cache]: {}; {} downloaded, {} uploaded, {} stored locally",
         outcomes.join(", "),
@@ -359,6 +369,7 @@ pub(super) fn should_display_short_stats(stats: &AgentStats) -> bool {
         || unexpected_bypasses(stats) > 0
         || stats.avoided_compiler_duration_ns > 0
         || stats.remote_failures > 0
+        || stats.remote_download_budget_exhausted
 }
 
 /// Explain a session that loaded a full manifest and matched none of it.
@@ -402,6 +413,7 @@ pub(super) fn should_display_stats(stats: &AgentStats) -> bool {
         // A session that reached a remote cache and got nothing but failures has
         // nothing else to report, and is the session most worth reporting.
         || stats.remote_failures > 0
+        || stats.remote_download_budget_exhausted
 }
 
 pub(super) fn write_stats_report(path: &Path, stats: &AgentStats) -> Result<()> {

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -716,6 +716,10 @@ fn short_summary_omits_routine_compiler_probe_bypasses() {
     );
     assert!(!summary.contains("compiler-query"), "{summary}");
     assert!(!summary.contains("standard-input"), "{summary}");
+
+    let exhausted = agent_stats(|stats| stats.remote_download_budget_exhausted = true);
+    let summary = short_summary(&exhausted);
+    assert!(summary.contains("download budget exhausted"), "{summary}");
 }
 
 #[test]
@@ -742,6 +746,7 @@ fn an_off_summary_still_writes_the_versioned_stats_report() {
         stats.remote_blob_requests = 4;
         stats.remote_blob_pack_requests = 2;
         stats.remote_blob_pack_blobs = 100;
+        stats.remote_download_budget_exhausted = true;
         stats.materialization_duration_ns = 9;
         stats.predictions_loaded = 11;
     });
@@ -753,7 +758,7 @@ fn an_off_summary_still_writes_the_versioned_stats_report() {
 
     // Bumped whenever the report grows a field, so a reader can tell from the
     // version alone which ones it may expect.
-    assert_eq!(report["version"], 4);
+    assert_eq!(report["version"], 5);
     assert_eq!(report["predictions_loaded"], 11);
     assert_eq!(report["session_duration_ns"], 42);
     assert_eq!(report["hits"], 2);
@@ -775,6 +780,7 @@ fn an_off_summary_still_writes_the_versioned_stats_report() {
     assert_eq!(report["remote_blob_requests"], 4);
     assert_eq!(report["remote_blob_pack_requests"], 2);
     assert_eq!(report["remote_blob_pack_blobs"], 100);
+    assert_eq!(report["remote_download_budget_exhausted"], true);
     assert_eq!(report["materialization_duration_ns"], 9);
 }
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -142,10 +142,18 @@ Log filter for mbx's own diagnostics, such as `debug` or `mbx=trace`.
 ### `remote.max_download_size`
 
 - **Type:** `string`
-- **Default:** `256MiB`
+- **Default:** `1GiB`
 - **Set with:** `MBX_REMOTE_MAX_DOWNLOAD_SIZE`
 
-Most remote artifact data one build may download. Once exhausted, remaining actions compile normally instead of letting a slow cache dominate the build.
+Most remote artifact data one build may download.
+
+### `remote.max_download_time`
+
+- **Type:** `duration`
+- **Default:** `1m`
+- **Set with:** `MBX_REMOTE_MAX_DOWNLOAD_TIME`
+
+Most active wall time one build may spend downloading remote artifacts.
 
 ### `remote.mode`
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -80,7 +80,7 @@ Minimum interval between automatic sweeps.
 - **Default:** 5% of the cache disk, from 5GiB to 500GiB
 - **Set with:** `MBX_GC_MAX_SIZE`
 
-Action-store and per-session remote-download budget.
+Action-store budget.
 
 ### `gc.max_total_size`
 
@@ -138,6 +138,14 @@ Compile crates that keep missing the cache with changed content incrementally, k
 - **Set with:** `MBX_LOG`
 
 Log filter for mbx's own diagnostics, such as `debug` or `mbx=trace`.
+
+### `remote.max_download_size`
+
+- **Type:** `string`
+- **Default:** `256MiB`
+- **Set with:** `MBX_REMOTE_MAX_DOWNLOAD_SIZE`
+
+Most remote artifact data one build may download. Once exhausted, remaining actions compile normally instead of letting a slow cache dominate the build.
 
 ### `remote.mode`
 

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -22,6 +22,22 @@ mode = "read-write"
 The namespace isolates one project's cache from another. It is required when a
 remote URL is set. To host your own server, see [cache server](/cache-server).
 
+## Bound downloads
+
+Each build downloads at most 256 MiB of remote artifact data by default. Once
+that budget is exhausted, remaining actions compile normally. This keeps a
+large debug build or a slow remote from turning nominal cache hits into a build
+time regression while preserving the actions already restored into the local
+store.
+
+Set `remote.max_download_size` or `MBX_REMOTE_MAX_DOWNLOAD_SIZE` to choose a
+different per-build budget:
+
+```toml
+[remote]
+max_download_size = "512MiB"
+```
+
 ## Configure an S3-compatible bucket
 
 ```toml

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -24,18 +24,22 @@ remote URL is set. To host your own server, see [cache server](/cache-server).
 
 ## Bound downloads
 
-Each build downloads at most 256 MiB of remote artifact data by default. Once
-that budget is exhausted, remaining actions compile normally. This keeps a
-large debug build or a slow remote from turning nominal cache hits into a build
-time regression while preserving the actions already restored into the local
-store.
+Each build downloads at most 1 GiB of remote artifact data and spends at most
+one minute of active wall time transferring it by default. Concurrent transfers
+share the time budget rather than each charging it independently. Once either
+budget is exhausted, remaining actions compile normally. The size ceiling
+bounds runaway volume while the time ceiling keeps a slow remote from turning
+nominal cache hits into a build-time regression. Actions already restored stay
+in the local store.
 
-Set `remote.max_download_size` or `MBX_REMOTE_MAX_DOWNLOAD_SIZE` to choose a
-different per-build budget:
+Set `remote.max_download_size` / `MBX_REMOTE_MAX_DOWNLOAD_SIZE` and
+`remote.max_download_time` / `MBX_REMOTE_MAX_DOWNLOAD_TIME` to choose different
+per-build budgets:
 
 ```toml
 [remote]
-max_download_size = "512MiB"
+max_download_size = "2GiB"
+max_download_time = "2m"
 ```
 
 ## Configure an S3-compatible bucket


### PR DESCRIPTION
## Summary

- give remote artifact downloads separate per-build size and active-transfer-time budgets
- default to 1 GiB and one minute, allowing large fast restores while stopping slow remotes
- compile remaining actions normally once either budget is exhausted
- expose `remote.max_download_size` / `MBX_REMOTE_MAX_DOWNLOAD_SIZE` and `remote.max_download_time` / `MBX_REMOTE_MAX_DOWNLOAD_TIME`
- report budget exhaustion in summaries and the versioned JSON statistics report

## Why

A trusted pitchfork diagnostic build restored 393 actions but downloaded 2.2 GiB and spent about 17 minutes in `cargo build`; the uncached build took roughly 1.5–2 minutes. A byte limit alone is a poor proxy for that regression: 256 MiB at the observed transfer rate would itself take about two minutes, while a fast nearby cache may restore more than 256 MiB profitably.

The two limits address the independent failure modes. The 1 GiB ceiling bounds runaway volume. The one-minute budget measures the union of time during which one or more artifact transfers are active, so concurrent downloads share one wall-clock allowance rather than multiplying it. In-flight transfers are canceled at the deadline. Pull-request jobs remain read-only and compile anything the cache did not restore.

Remote download allowances are independent from the local action-store retention budget (`gc.max_size`).

## Verification

- `cargo test -p mbx --lib` — 344 passed, 1 ignored
- `cargo test -p mbx-cache-core` — 178 passed including protocol and doc tests, 1 ignored
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run render:docs`
- generated-doc check and docs build pass through `mise run ci`

The local Bats suite reaches all 41 tests; three environment/state-sensitive failures are unrelated to this change: the previously documented `explain --last` cache-state failure, a locally installed mise version that no longer accepts the test fixture’s `--postinstall` flag, and a missing `wasm32-unknown-unknown` target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote cache restore behavior and session download limits; misconfiguration could reduce cache hits, but exhaustion degrades to normal compilation rather than failing builds.
> 
> **Overview**
> Adds **separate per-build remote download budgets** for artifact volume and active transfer time, decoupled from local action-store retention (`gc.max_size`).
> 
> The cache agent tracks cumulative bytes and a shared **active wall-clock** allowance while one or more blob/pack downloads run; concurrent transfers share the time budget. When either limit is hit, further remote restores are skipped (including prefetch) and remaining work compiles locally, without blocking on transfer capacity. In-flight downloads can be cut off via `tokio::time::timeout`.
> 
> **Configuration** defaults to **1 GiB** and **1 minute** via `remote.max_download_size` / `MBX_REMOTE_MAX_DOWNLOAD_SIZE` and `remote.max_download_time` / `MBX_REMOTE_MAX_DOWNLOAD_TIME`. Sessions wire these into `CacheAgent::new_remote_with_download_limits` instead of the GC size cap.
> 
> **Observability**: `remote_download_budget_exhausted` in agent stats, session stderr summaries, and stats JSON **version 5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0175b29e91a9869ed92298c4a7c175d989a84522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->