### PR TITLE
fix: scale the stale-manifest note to what was predicted

### DIFF
--- a/crates/mbx/src/session/stats.rs
+++ b/crates/mbx/src/session/stats.rs
@@ -368,8 +368,19 @@ pub(super) fn should_display_short_stats(stats: &AgentStats) -> bool {
 /// CI runner image updating its preinstalled toolchain is the common way --
 /// that reading sends people hunting for restore failures. The distinction is
 /// observable: predictions were loaded, and not one lookup was ever made.
+///
+/// Only when what compiled is a real share of what was predicted, though. The
+/// manifest is shared by every Cargo command in a workspace, so the first
+/// `cargo test --no-run` after `cargo build` compiles a couple of test
+/// harnesses the manifest has never seen and looks nothing up, while a
+/// toolchain change recompiles everything the manifest predicted. A handful
+/// of new units against hundreds of predictions is the former.
 pub(super) fn stale_manifest_note(stats: &AgentStats) -> Option<String> {
-    (stats.unconsulted > 0 && stats.lookups == 0 && stats.predictions_loaded > 0).then(|| {
+    (stats.unconsulted > 0
+        && stats.lookups == 0
+        && stats.predictions_loaded > 0
+        && stats.unconsulted.saturating_mul(2) >= stats.predictions_loaded)
+        .then(|| {
         format!(
             "mbx[cache]: a manifest predicting {} compilations was loaded, but none matched this build; the compiler or its flags changed since they were recorded (a toolchain update does this)",
             stats.predictions_loaded,

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -664,6 +664,15 @@ fn a_loaded_manifest_that_matched_nothing_is_called_out() {
         stats.predictions_loaded = 257;
     });
     assert_eq!(stale_manifest_note(&live), None);
+
+    // The first `cargo test --no-run` after `cargo build`: the shared manifest
+    // predicts the whole build, and the two test harnesses it has never seen
+    // are all that compiles. Nothing about the toolchain changed.
+    let new_shape = agent_stats(|stats| {
+        stats.unconsulted = 2;
+        stats.predictions_loaded = 816;
+    });
+    assert_eq!(stale_manifest_note(&new_shape), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `stale_manifest_note` fires whenever predictions were loaded and no lookup happened. Running `cargo test --no-run` right after `cargo build` in jdx/hk and jdx/tak printed "a manifest predicting 816 compilations was loaded, but none matched this build; the compiler or its flags changed since they were recorded (a toolchain update does this)" for a build that compiled two never-seen test harnesses. The manifest is shared across Cargo commands, so that is the normal first run of a new command shape, not a toolchain change.
- Require the unconsulted count to be at least half of the loaded predictions before blaming the compiler. A toolchain change recompiles everything predicted and still qualifies; a handful of new units against hundreds of predictions does not.

## Test plan

- [x] Existing test extended with the `test --no-run` shape (2 unconsulted, 816 predicted, 0 lookups) expecting no note
- [x] `mise run lint`, `mise run test:cargo` (mbx lib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing cache summary text only; heuristic change with no auth, storage, or compilation behavior.
> 
> **Overview**
> **Tightens when the cache summary warns about a “stale” prediction manifest** so normal follow-on Cargo commands don’t look like a toolchain break.
> 
> `stale_manifest_note` used to appear whenever predictions were loaded, zero lookups happened, and some units were unconsulted. After `cargo build`, the first `cargo test --no-run` shares that manifest but only compiles a few new test harnesses—so users saw a message blaming compiler/toolchain changes (e.g. “816 compilations predicted, none matched”) even though nothing about the toolchain changed.
> 
> The note now requires **unconsulted ≥ half of `predictions_loaded`** (`unconsulted * 2 >= predictions_loaded`) before emitting that explanation. Full recompiles after a real toolchain change still qualify; a handful of new units against hundreds of predictions no longer trigger it.
> 
> Tests add the `test --no-run` shape (2 unconsulted, 816 predicted, 0 lookups) and expect no stale-manifest note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f87fbf24cafcc1abeab4d98425edc191c05d9d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->