### PR TITLE
perf(ci): reuse appliance-local mbx cache

### DIFF
--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -11,8 +11,6 @@ concurrency:
   cancel-in-progress: false
 env:
   CARGO_INCREMENTAL: "0"
-  # Persistent appliance-local store; no remote backend is configured.
-  MBX_CACHE_DIR: /var/cache/mbx
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
   MISE_DISABLE_TOOLS: rust
   RUSTUP_TOOLCHAIN: 1.97.1
@@ -21,6 +19,9 @@ env:
 jobs:
   measure:
     runs-on: [self-hosted, jdx-perf-v1]
+    env:
+      # Persistent appliance-local store; no remote backend is configured.
+      MBX_CACHE_DIR: /var/cache/mbx
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -11,6 +11,8 @@ concurrency:
   cancel-in-progress: false
 env:
   CARGO_INCREMENTAL: "0"
+  # Persistent appliance-local store; no remote backend is configured.
+  MBX_CACHE_DIR: /var/cache/mbx
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
   MISE_DISABLE_TOOLS: rust
   RUSTUP_TOOLCHAIN: 1.97.1
@@ -21,7 +23,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
-      options: --cpuset-cpus 0-7
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
     timeout-minutes: 30
     permissions:
       contents: read
@@ -45,6 +47,8 @@ jobs:
             uname -a
             lscpu
             mise --version
+            mbx --version
+            mbx cache dir
             rustc --version
             cargo --version
             valgrind --version

--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       # Persistent appliance-local store; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
+      MBX_REMOTE_URL: ""
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -67,6 +67,7 @@ jobs:
       MBX_REMOTE_URL: ""
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
+      # Anonymous by design; perf-runner#10 prunes it after this container stops.
       options: --cpuset-cpus 0-7 --mount type=volume,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -64,9 +64,10 @@ jobs:
     env:
       # Persistent appliance-local store; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
+      MBX_REMOTE_URL: ""
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
-      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx-pr,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:
       contents: read

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -13,6 +13,8 @@ concurrency:
   cancel-in-progress: true
 env:
   CARGO_INCREMENTAL: "0"
+  # Persistent appliance-local store; no remote backend is configured.
+  MBX_CACHE_DIR: /var/cache/mbx
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
   MISE_DISABLE_TOOLS: rust
   RUSTUP_TOOLCHAIN: 1.97.1
@@ -63,7 +65,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
-      options: --cpuset-cpus 0-7
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:
       contents: read
@@ -91,6 +93,8 @@ jobs:
             uname -a
             lscpu
             mise --version
+            mbx --version
+            mbx cache dir
             rustc --version
             cargo --version
             valgrind --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -13,8 +13,6 @@ concurrency:
   cancel-in-progress: true
 env:
   CARGO_INCREMENTAL: "0"
-  # Persistent appliance-local store; no remote backend is configured.
-  MBX_CACHE_DIR: /var/cache/mbx
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
   MISE_DISABLE_TOOLS: rust
   RUSTUP_TOOLCHAIN: 1.97.1
@@ -63,6 +61,9 @@ jobs:
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: [self-hosted, jdx-perf-v1]
+    env:
+      # Persistent appliance-local store; no remote backend is configured.
+      MBX_CACHE_DIR: /var/cache/mbx
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -62,12 +62,12 @@ jobs:
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: [self-hosted, jdx-perf-v1]
     env:
-      # Persistent appliance-local store; no remote backend is configured.
+      # Job-local appliance volume; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
       MBX_REMOTE_URL: ""
     container:
       image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
-      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx-pr,dst=/var/cache/mbx
+      options: --cpuset-cpus 0-7 --mount type=volume,dst=/var/cache/mbx
     timeout-minutes: 40
     permissions:
       contents: read
@@ -75,6 +75,8 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Initialize isolated build cache
+        run: sudo chown "$(id -u):$(id -g)" "$MBX_CACHE_DIR"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.authorize.outputs.head_sha }}

--- a/mise.lock
+++ b/mise.lock
@@ -162,6 +162,48 @@ checksum = "sha256:32975d1493ee1a975d6bb41e4fb56fe419cb442ded628bb772ba2e614acfa
 url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409959491"
 
+[[tools.mr-boxington]]
+version = "1.4.1"
+backend = "github:jdx/mr-boxington"
+specifiers = ["1.4.1"]
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:7ca1deeb64ad22bd5ddc9f45c749c78d3eb32608562c363727de3f0c595df0f0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505948"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:3113dfce87c8ee6d3485f7eb99f87ae130b9b9f2c73224720edf2cef7279b5d1"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505946"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:57f1cac111d9972ad675aa80cbedf4c86b3423dfb11091383175db0f6341847e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505945"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
+provenance = "github-attestations"
+
 [[tools.node]]
 version = "24.19.0"
 backend = "core:node"

--- a/mise.toml
+++ b/mise.toml
@@ -117,7 +117,7 @@ run = "lychee --offline --include-fragments --root-dir \"$PWD/docs/.vitepress/di
 
 [tasks."perf:prepare"]
 description = "Build the fixed benchmark subject"
-run = "cargo build --release --locked -p mbx"
+run = "mbx build --release --locked -p mbx"
 
 [tasks."build:pgo"]
 description = "Build a profile-guided mbx release binary"
@@ -160,6 +160,9 @@ depends = ["perf:prepare"]
 run = "tak run --record"
 
 [tools]
+# Perf jobs build the current source with the latest released mbx so the
+# appliance cache is usable without bootstrapping from the branch under test.
+mr-boxington = "1.4.1"
 "github:jdx/tak" = "0.0.9"
 aube = "latest"
 communique = "latest"


### PR DESCRIPTION
## Summary

- build performance-test source once with the released `mbx`
- persist trusted-main build outputs on `jdx-perf-01`; use a fresh appliance-local volume for each PR comparison
- discard each PR volume after cleanup so code under test cannot affect a later job
- explicitly disable remote mbx backends and report the mbx version and cache directory

Depends on jdx/perf-runner#10. Benchmark-refresh jobs remain release-artifact-only and do not use this source-build cache. Tak remains on its deliberate GitHub-hosted built-in Rust build.

## Validation

- `actionlint` on changed workflows
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes perf measurement infrastructure and cache isolation on self-hosted runners; misconfiguration could skew instruction-count comparisons or leak cache between PRs, but scope is limited to CI perf jobs with remote backends explicitly disabled.
> 
> **Overview**
> **Perf CI now builds benchmark subjects with pinned released `mbx` (1.4.1) instead of plain `cargo build`, so jobs can reuse a local compile cache without bootstrapping from the branch under test.**
> 
> On **main** (`measure.yml`), the perf container gets a **host bind mount** at `/var/cache/mbx` plus `MBX_CACHE_DIR` / empty `MBX_REMOTE_URL` so builds stay on-appliance with no remote cache backend. **PR perf** (`perf-pr.yml`) uses an **anonymous Docker volume** at the same path (isolated per run, pruned after the container stops), with an initial `chown` on the cache dir so the job user can write. Both workflows log **`mbx --version`** and **`mbx cache dir`** in runner metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2450170cceeaefa22027acbf334083981e251ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved benchmark runs by using a persistent local cache, reducing repeated setup work and improving measurement consistency.
  * Isolated cache storage between performance jobs to prevent cross-run interference.

* **Chores**
  * Updated performance preparation to use the latest released MBX tooling when building benchmark subjects.
  * Performance metadata now includes the MBX version and cache location for improved run traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->