### PR TITLE
feat(cc): cache preprocessed assembly

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -84,6 +84,10 @@ fn bypass_kinds_are_stable_and_field_independent() {
             "embedded-timestamp-macro",
         ),
         (
+            CcBypassReason::AssemblerInputDirective("/w/a.S".into()),
+            "assembler-input-directive",
+        ),
+        (
             CcBypassReason::MalformedDepfile("no rule".into()),
             "malformed-depfile",
         ),
@@ -1171,4 +1175,23 @@ fn preprocessed_assembly_is_admitted_and_plain_assembly_is_not() {
             "unsupported-language"
         );
     }
+}
+
+#[test]
+fn assembler_input_directives_bypass_only_preprocessed_assembly() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = directory.path().join("a.S");
+    std::fs::write(&source, ".include \"constants.inc\"\n").unwrap();
+    let assembly = CcInvocation::parse(&argv(&["-c", "-o", "a.o", "a.S"])).unwrap();
+    assert_eq!(
+        assembly
+            .validate_discovered_inputs([source.as_path()])
+            .unwrap_err()
+            .kind(),
+        "assembler-input-directive"
+    );
+
+    let c = CcInvocation::parse(&argv(&["-c", "-o", "a.o", "a.c"])).unwrap();
+    c.validate_discovered_inputs([source.as_path()])
+        .expect("assembler syntax in C text is irrelevant");
 }

--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -429,8 +429,8 @@ fn plain_warning_flags_stay_admitted_key_material() {
 }
 
 #[test]
-fn assembly_and_objective_c_sources_bypass_as_unsupported_languages() {
-    for source in ["a.S", "a.s", "a.m", "a.mm", "a.C", "a.rs"] {
+fn plain_assembly_and_objective_c_sources_bypass_as_unsupported_languages() {
+    for source in ["a.s", "a.m", "a.mm", "a.C", "a.rs"] {
         let arguments = argv(&["-c", "-o", "a.o", source]);
         assert_eq!(
             CcInvocation::parse(&arguments).unwrap_err().kind(),
@@ -1135,4 +1135,40 @@ fn the_object_is_addressed_absolutely_from_the_working_directory() {
         absolute.output_in(Path::new("/elsewhere")),
         PathBuf::from("/out/a.o")
     );
+}
+
+/// Preprocessed assembly compiles like C: the preprocessor reports the
+/// includes it read, and the assembler is already part of the identity. Plain
+/// assembly is not preprocessed, reports nothing, and stays out.
+#[test]
+fn preprocessed_assembly_is_admitted_and_plain_assembly_is_not() {
+    let by_extension = CcInvocation::parse(&argv(&["-c", "-o", "a.o", "curve25519.S"])).unwrap();
+    assert_eq!(by_extension.language(), CcLanguage::C);
+
+    let explicit = CcInvocation::parse(&argv(&[
+        "-x",
+        "assembler-with-cpp",
+        "-c",
+        "-o",
+        "a.o",
+        "a.S",
+    ]))
+    .unwrap();
+    assert_eq!(explicit.language(), CcLanguage::C);
+    assert!(
+        explicit
+            .arguments
+            .contains(&Argument::Plain("-xassembler-with-cpp".into())),
+        "the explicit language enters the key"
+    );
+
+    for arguments in [
+        vec!["-c", "-o", "a.o", "a.s"],
+        vec!["-x", "assembler", "-c", "-o", "a.o", "a.S"],
+    ] {
+        assert_eq!(
+            CcInvocation::parse(&argv(&arguments)).unwrap_err().kind(),
+            "unsupported-language"
+        );
+    }
 }

--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -1181,15 +1181,18 @@ fn preprocessed_assembly_is_admitted_and_plain_assembly_is_not() {
 fn assembler_input_directives_bypass_only_preprocessed_assembly() {
     let directory = tempfile::tempdir().unwrap();
     let source = directory.path().join("a.S");
-    std::fs::write(&source, ".include \"constants.inc\"\n").unwrap();
     let assembly = CcInvocation::parse(&argv(&["-c", "-o", "a.o", "a.S"])).unwrap();
-    assert_eq!(
-        assembly
-            .validate_discovered_inputs([source.as_path()])
-            .unwrap_err()
-            .kind(),
-        "assembler-input-directive"
-    );
+    for directive in [".include", ".INCBIN", ".SInclude"] {
+        std::fs::write(&source, format!("{directive} \"constants.inc\"\n")).unwrap();
+        assert_eq!(
+            assembly
+                .validate_discovered_inputs([source.as_path()])
+                .unwrap_err()
+                .kind(),
+            "assembler-input-directive",
+            "{directive} must bypass"
+        );
+    }
 
     let c = CcInvocation::parse(&argv(&["-c", "-o", "a.o", "a.c"])).unwrap();
     c.validate_discovered_inputs([source.as_path()])

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -18,6 +18,10 @@ pub const INCLUDE_MANIFEST_PREFIX: &str = "@include-manifest:";
 /// Macros whose expansion is not a function of the compilation's inputs.
 const TIMESTAMP_MACROS: &[&[u8]] = &[b"__DATE__", b"__TIME__", b"__TIMESTAMP__"];
 
+/// Directives whose operands are consumed by the assembler, after the
+/// compiler has finished producing its dependency list.
+const ASSEMBLER_INPUT_DIRECTIVES: &[&[u8]] = &[b".include", b".incbin"];
+
 const SCAN_CHUNK_BYTES: usize = 64 * 1024;
 
 /// A parsed GNU-style dependency list.
@@ -540,7 +544,7 @@ pub fn manifest_snapshot(
 /// adapter's explicit precompiled-header bypass cannot see.
 const INCLUDABLE_EXTENSIONS: &[&str] = &[
     "c", "c++", "cc", "cpp", "cxx", "def", "gch", "h", "h++", "hh", "hpp", "hxx", "inc", "inl",
-    "ipp", "pch", "tcc",
+    "ipp", "pch", "s", "tcc",
 ];
 
 /// Whether a file name could be what an `#include` directive names.
@@ -656,6 +660,51 @@ fn contains_timestamp_macro(path: &Path) -> Result<bool, CcBypassReason> {
             return Ok(true);
         }
         // Keep the tail so a token split across two reads is still found.
+        let keep = window.len().saturating_sub(longest.saturating_sub(1));
+        window.drain(..keep);
+    }
+}
+
+/// Whether a preprocessor input can make the assembler read another file.
+///
+/// Searching for the directive text, including in comments and inactive
+/// conditional branches, deliberately accepts false positives. Missing a real
+/// directive would publish an object whose complete inputs are absent from the
+/// key; bypassing an otherwise cacheable object is the safe outcome instead.
+pub(crate) fn contains_assembler_input_directive(path: &Path) -> Result<bool, CcBypassReason> {
+    contains_any(path, ASSEMBLER_INPUT_DIRECTIVES)
+}
+
+fn contains_any(path: &Path, needles: &[&[u8]]) -> Result<bool, CcBypassReason> {
+    let file = std::fs::File::open(path).map_err(|error| CcBypassReason::InputRead {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    })?;
+    let longest = needles
+        .iter()
+        .map(|needle| needle.len())
+        .max()
+        .unwrap_or_default();
+    let mut reader = std::io::BufReader::new(file);
+    let mut window = Vec::with_capacity(SCAN_CHUNK_BYTES + longest);
+    let mut chunk = vec![0_u8; SCAN_CHUNK_BYTES];
+    loop {
+        let read = reader
+            .read(&mut chunk)
+            .map_err(|error| CcBypassReason::InputRead {
+                path: path.to_path_buf(),
+                message: error.to_string(),
+            })?;
+        if read == 0 {
+            return Ok(false);
+        }
+        window.extend_from_slice(&chunk[..read]);
+        if needles
+            .iter()
+            .any(|needle| contains_subslice(&window, needle))
+        {
+            return Ok(true);
+        }
         let keep = window.len().saturating_sub(longest.saturating_sub(1));
         window.drain(..keep);
     }

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -20,7 +20,7 @@ const TIMESTAMP_MACROS: &[&[u8]] = &[b"__DATE__", b"__TIME__", b"__TIMESTAMP__"]
 
 /// Directives whose operands are consumed by the assembler, after the
 /// compiler has finished producing its dependency list.
-const ASSEMBLER_INPUT_DIRECTIVES: &[&[u8]] = &[b".include", b".incbin"];
+const ASSEMBLER_INPUT_DIRECTIVES: &[&[u8]] = &[b".include", b".incbin", b".sinclude"];
 
 const SCAN_CHUNK_BYTES: usize = 64 * 1024;
 
@@ -701,13 +701,25 @@ fn contains_any(path: &Path, needles: &[&[u8]]) -> Result<bool, CcBypassReason> 
         window.extend_from_slice(&chunk[..read]);
         if needles
             .iter()
-            .any(|needle| contains_subslice(&window, needle))
+            .any(|needle| contains_subslice_ascii_case_insensitive(&window, needle))
         {
             return Ok(true);
         }
         let keep = window.len().saturating_sub(longest.saturating_sub(1));
         window.drain(..keep);
     }
+}
+
+fn contains_subslice_ascii_case_insensitive(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|window| {
+        window
+            .iter()
+            .zip(needle)
+            .all(|(left, right)| left.eq_ignore_ascii_case(right))
+    })
 }
 
 fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -211,6 +211,19 @@ fn include_directory_manifests_change_the_key_when_a_shadowing_header_appears() 
 }
 
 #[test]
+fn assembly_names_contribute_to_include_manifests() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let include = directory.path().join("include");
+    std::fs::create_dir_all(&include).expect("create include dir");
+    let directories = BTreeSet::from([include.clone()]);
+    let before = manifest_snapshot(&directories).expect("initial manifest");
+
+    write(&include, "constants.S", ".equ constant, 1\n");
+    let after = manifest_snapshot(&directories).expect("updated manifest");
+    assert_ne!(before, after);
+}
+
+#[test]
 fn a_missing_include_directory_has_an_empty_manifest_rather_than_an_error() {
     let directory = tempfile::tempdir().expect("tempdir");
     let root = directory.path();

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -431,6 +431,10 @@ pub enum CcBypassReason {
     /// of its inputs.
     #[error("input expands a timestamp macro: {0}")]
     EmbeddedTimestampMacro(PathBuf),
+    /// Preprocessed assembly names an input that compiler dependency output
+    /// does not report.
+    #[error("preprocessed assembly uses an assembler input directive in {0}")]
+    AssemblerInputDirective(PathBuf),
     /// The injected depfile could not be parsed exactly.
     #[error("could not model the compiler depfile: {0}")]
     MalformedDepfile(String),
@@ -670,6 +674,8 @@ struct CcActionDescriptor {
     version: u8,
     kind: &'static str,
     adapter_version: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    assembly_input_model: Option<u8>,
     compiler: CcCompilerDescriptor,
     arguments: Vec<String>,
     environment: BTreeMap<String, Option<String>>,
@@ -681,6 +687,8 @@ struct CcInvocationDescriptor {
     version: u8,
     kind: &'static str,
     adapter_version: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    assembly_input_model: Option<u8>,
     compiler: CcCompilerDescriptor,
     arguments: Vec<String>,
     required_inputs: Vec<String>,
@@ -736,6 +744,7 @@ pub struct CcInvocation {
     include_dirs: Vec<PathBuf>,
     required_inputs: Vec<PathBuf>,
     language: CcLanguage,
+    preprocessed_assembly: bool,
     sysroot: Option<PathBuf>,
     caller_depfile: Option<CallerDepfile>,
     /// Positions in the parsed command line of the dependency-list flags the
@@ -853,6 +862,27 @@ impl CcInvocation {
     /// Language the driver compiles.
     pub fn language(&self) -> CcLanguage {
         self.language
+    }
+
+    /// Reject assembler-time file directives that the preprocessor's
+    /// dependency list cannot name.
+    ///
+    /// This is a no-op for C and C++ inputs. For preprocessed assembly, every
+    /// file reported by dependency discovery is scanned conservatively before
+    /// an object can be published.
+    pub fn validate_discovered_inputs<'a>(
+        &self,
+        paths: impl IntoIterator<Item = &'a Path>,
+    ) -> Result<(), CcBypassReason> {
+        if !self.preprocessed_assembly {
+            return Ok(());
+        }
+        for path in paths {
+            if depfile::contains_assembler_input_directive(path)? {
+                return Err(CcBypassReason::AssemblerInputDirective(path.to_path_buf()));
+            }
+        }
+        Ok(())
     }
 
     /// Sysroot named on the command line, if any.
@@ -1139,6 +1169,7 @@ impl<'a> ActionBuilder<'a> {
             version: ACTION_SCHEMA_VERSION,
             kind: "cc",
             adapter_version: ADAPTER_VERSION,
+            assembly_input_model: invocation.assembly_input_model,
             compiler: invocation.compiler,
             arguments: invocation.arguments,
             environment: self.context.environment.clone(),
@@ -1170,6 +1201,9 @@ impl<'a> ActionBuilder<'a> {
             version: ACTION_SCHEMA_VERSION,
             kind: "cc",
             adapter_version: ADAPTER_VERSION,
+            // Version the assembly-only safety model independently so adding
+            // support does not invalidate every existing C and C++ entry.
+            assembly_input_model: self.invocation.preprocessed_assembly.then_some(1),
             compiler: self.compiler_descriptor(),
             arguments,
             required_inputs,
@@ -1278,6 +1312,7 @@ struct Parser<'a> {
     required_inputs: Vec<PathBuf>,
     sysroot: Option<PathBuf>,
     explicit_language: Option<CcLanguage>,
+    preprocessed_assembly: bool,
     compiling: bool,
     dependency: DependencyRequest,
 }
@@ -1308,6 +1343,7 @@ impl<'a> Parser<'a> {
             required_inputs: Vec::new(),
             sysroot: None,
             explicit_language: None,
+            preprocessed_assembly: false,
             compiling: false,
             dependency: DependencyRequest::default(),
         }
@@ -1336,6 +1372,9 @@ impl<'a> Parser<'a> {
         let source = self.source.clone().ok_or(CcBypassReason::MissingInput)?;
         let output = self.output.clone().ok_or(CcBypassReason::MissingOutput)?;
         let language = self.language(&source)?;
+        let preprocessed_assembly = self.preprocessed_assembly
+            || (self.explicit_language.is_none()
+                && source.extension().and_then(|value| value.to_str()) == Some("S"));
         self.required_inputs.push(source.clone());
         let caller_depfile = match self.dependency.user_headers_only {
             Some(user_headers_only) => Some(CallerDepfile {
@@ -1369,6 +1408,7 @@ impl<'a> Parser<'a> {
             include_dirs: self.include_dirs,
             required_inputs: self.required_inputs,
             language,
+            preprocessed_assembly,
             sysroot: self.sysroot,
             caller_depfile,
             dependency_argument_indices: self.dependency.indices,
@@ -1621,7 +1661,11 @@ impl<'a> Parser<'a> {
         if let Some(rest) = value.strip_prefix("-x") {
             let language = self.take_value("-x", Some(rest))?;
             self.explicit_language = Some(match language.as_str() {
-                "c" | "assembler-with-cpp" => CcLanguage::C,
+                "c" => CcLanguage::C,
+                "assembler-with-cpp" => {
+                    self.preprocessed_assembly = true;
+                    CcLanguage::C
+                }
                 "c++" => CcLanguage::Cxx,
                 other => return Err(CcBypassReason::UnsupportedLanguage(other.into())),
             });
@@ -1774,6 +1818,7 @@ impl<'a> MsvcParser<'a> {
             include_dirs: self.include_dirs,
             required_inputs: self.required_inputs,
             language,
+            preprocessed_assembly: false,
             sysroot: None,
             caller_depfile: None,
             dependency_argument_indices: Vec::new(),

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -1420,7 +1420,12 @@ impl<'a> Parser<'a> {
             .and_then(|extension| extension.to_str())
             .unwrap_or_default();
         match extension {
-            "c" => Ok(CcLanguage::C),
+            // Preprocessed assembly goes through the C driver: the preprocessor
+            // resolves its includes, which is what dependency discovery reads,
+            // and the assembler that then produces the object is already part
+            // of a GCC identity. Plain `.s` is not preprocessed and reports no
+            // dependencies, so it stays out.
+            "c" | "S" => Ok(CcLanguage::C),
             "cc" | "cpp" | "cxx" | "c++" => Ok(CcLanguage::Cxx),
             _ => Err(CcBypassReason::UnsupportedLanguage(
                 source.display().to_string(),
@@ -1461,7 +1466,7 @@ impl<'a> Parser<'a> {
                 .extension()
                 .and_then(|extension| extension.to_str())
                 .unwrap_or_default();
-            if !matches!(extension, "c" | "cc" | "cpp" | "cxx" | "c++") {
+            if !matches!(extension, "c" | "S" | "cc" | "cpp" | "cxx" | "c++") {
                 return Err(CcBypassReason::UnsupportedLanguage(value.into()));
             }
         }
@@ -1616,7 +1621,7 @@ impl<'a> Parser<'a> {
         if let Some(rest) = value.strip_prefix("-x") {
             let language = self.take_value("-x", Some(rest))?;
             self.explicit_language = Some(match language.as_str() {
-                "c" => CcLanguage::C,
+                "c" | "assembler-with-cpp" => CcLanguage::C,
                 "c++" => CcLanguage::Cxx,
                 other => return Err(CcBypassReason::UnsupportedLanguage(other.into())),
             });

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -596,6 +596,7 @@ fn discover(
     {
         files.insert(absolute(&path, &context.working_dir));
     }
+    invocation.validate_discovered_inputs(files.iter().map(PathBuf::as_path))?;
     Ok(CcDiscoveredInputs::collect(
         &context.working_dir,
         files.clone(),

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -143,7 +143,10 @@ build the object with the wrong compiler. A value that is a command, such as
 `ccache gcc`, is left alone for the same reason.
 
 Only a plain single-source object compile through a gcc-, clang-, or MSVC-style
-driver is admitted. Linking, preprocessing, assembly, Objective-C, precompiled
+driver is admitted, with preprocessed assembly (`.S`, or `-x
+assembler-with-cpp`) counting as C: its includes are what dependency discovery
+reads, and the assembler is part of a GCC identity. Linking, preprocessing,
+assembly that skips the preprocessor (`.s`), Objective-C, precompiled
 headers, coverage instrumentation, compiler plugins, options forwarded to a
 sub-tool with `-Wp,`/`-Wl,`/`-Xclang`, unmodeled `-Wa,` assembler options, and
 response files all bypass, as does any flag the adapter does not model. Known

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -149,8 +149,8 @@ reads, and the assembler is part of a GCC identity. Linking, preprocessing,
 assembly that skips the preprocessor (`.s`), Objective-C, precompiled
 headers, coverage instrumentation, compiler plugins, options forwarded to a
 sub-tool with `-Wp,`/`-Wl,`/`-Xclang`, unmodeled `-Wa,` assembler options, and
-assembler-time `.include`/`.incbin` inputs, and response files all bypass, as
-does any flag the adapter does not model. Known
+assembler-time `.include`/`.sinclude`/`.incbin` inputs, and response files all
+bypass, as does any flag the adapter does not model. Known
 assembler options that add no inputs, such as `-Wa,--noexecstack`, are keyed
 and admitted. MSVC compiler PDBs, modules, and other extra outputs also bypass.
 A source or header that expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__`

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -149,7 +149,8 @@ reads, and the assembler is part of a GCC identity. Linking, preprocessing,
 assembly that skips the preprocessor (`.s`), Objective-C, precompiled
 headers, coverage instrumentation, compiler plugins, options forwarded to a
 sub-tool with `-Wp,`/`-Wl,`/`-Xclang`, unmodeled `-Wa,` assembler options, and
-response files all bypass, as does any flag the adapter does not model. Known
+assembler-time `.include`/`.incbin` inputs, and response files all bypass, as
+does any flag the adapter does not model. Known
 assembler options that add no inputs, such as `-Wa,--noexecstack`, are keyed
 and admitted. MSVC compiler PDBs, modules, and other extra outputs also bypass.
 A source or header that expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__`


### PR DESCRIPTION
## Summary

- Every `.S` source compiled by a build script bypassed as `cc-unsupported-language`. aws-lc-sys has 111 of them, so every workspace behind rustls with aws-lc-rs (hk, communique, pklr, fnox, aube in the jdx set) recompiled them on each fresh target.
- Preprocessed assembly goes through the C driver's preprocessor, which reports the includes it read exactly as for C, and the assembler that produces the object is already part of a GCC identity (`uses_external_assembler`). Treat `.S` and `-x assembler-with-cpp` as C. Plain `.s` and `-x assembler` are not preprocessed, report no dependencies, and keep bypassing.
- `docs/limits.md` updated.

## Measurements

jdx/hk, `cargo build`, fresh cache dir:

| | before | after |
|---|---|---|
| fresh-target warm build hits | 610 | 721 |
| `cc-unsupported-language` bypasses | 111 | 0 |

`MBX_VERIFY=1` on a third fresh target: 892 verified, 0 diverged. `hk --version` runs from the restored build.

## Test plan

- [x] New test: `.S` by extension and `-x assembler-with-cpp` parse as C with the explicit language in the key; `.s` and `-x assembler` still bypass
- [x] Existing bypass test narrowed to plain assembly and Objective-C
- [x] `mise run lint`, `mise run test:cargo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache key semantics and input validation for a new source class; conservative directive scanning may bypass some cacheable `.S` builds, but false negatives would be correctness bugs.
> 
> **Overview**
> **Preprocessed assembly** (`.S` sources and `-x assembler-with-cpp`) is now admitted for C/C++ object caching instead of bypassing as unsupported language—matching how the C preprocessor reports includes while the assembler stays in the GCC identity. Plain `.s` and `-x assembler` still bypass.
> 
> For admitted preprocessed assembly, discovered inputs are scanned for assembler-only file directives (`.include`, `.incbin`, `.sinclude`, case-insensitive); hits trigger a new **`assembler-input-directive`** bypass because dependency output does not name those operands. Include-directory manifests also treat `.s` names as shadowable includables.
> 
> Cache descriptors gain optional **`assembly_input_model`** versioning so this safety model does not invalidate existing C/C++ keys. `docs/limits.md` documents the expanded admission and bypass rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e292a121ee52acbbe0a6c7ebdddcd4487701ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->