### PR TITLE
fix(remote): bound what a build loses to failed cache reads

### DIFF
--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -453,6 +453,80 @@ async fn disables_blob_packs_when_the_advertised_endpoint_is_unavailable() {
 }
 
 #[tokio::test]
+async fn stops_reading_once_failed_reads_exhaust_the_stall_budget() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"unreachable blob");
+    // `expect(1)` is the assertion: the second read must not reach the server.
+    // Without a stall budget every object pays the download deadline again, so
+    // an unhealthy remote can outlast the build it is meant to accelerate.
+    let request = server
+        .mock(
+            "GET",
+            format!("/v1/blobs/blake3/{}/{}", digest.hash, digest.size).as_str(),
+        )
+        .with_status(503)
+        .expect(1)
+        .create_async()
+        .await;
+    let client = test_client_with_stall_budget(
+        &server,
+        Duration::from_millis(50),
+        0,
+        Duration::from_nanos(1),
+    );
+    let staging = tempfile::tempdir().unwrap();
+
+    let _ = client
+        .get_blob_file(&digest, staging.path())
+        .await
+        .expect_err("the first read fails against a 503");
+
+    let error = client
+        .get_blob_file(&digest, staging.path())
+        .await
+        .expect_err("the second read is abandoned rather than attempted");
+    assert!(
+        error.to_string().contains("reads were abandoned"),
+        "{error}"
+    );
+    // Packs degrade to "unsupported", which callers already treat as a miss.
+    assert!(
+        client
+            .get_blob_pack(&[digest], staging.path())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    request.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_zero_stall_budget_keeps_reading() {
+    let mut server = mockito::Server::new_async().await;
+    let digest = CacheDigest::blake3(b"still tried");
+    let request = server
+        .mock(
+            "GET",
+            format!("/v1/blobs/blake3/{}/{}", digest.hash, digest.size).as_str(),
+        )
+        .with_status(503)
+        .expect(2)
+        .create_async()
+        .await;
+    let client = test_client_with(&server, Duration::from_millis(50), 0);
+    let staging = tempfile::tempdir().unwrap();
+
+    for _ in 0..2 {
+        let _ = client
+            .get_blob_file(&digest, staging.path())
+            .await
+            .expect_err("every read fails against a 503");
+    }
+
+    request.assert_async().await;
+}
+
+#[tokio::test]
 async fn rejects_truncated_blob_pack_frames() {
     let mut server = mockito::Server::new_async().await;
     let contents = b"complete blob";
@@ -882,7 +956,18 @@ fn test_client_with(
     download_timeout: Duration,
     retries: i64,
 ) -> HttpRemoteCache {
-    HttpRemoteCache::new(RemoteCacheConfig {
+    // Zero leaves the stall budget out of the way: these tests provoke read
+    // failures deliberately and must keep reading afterwards.
+    test_client_with_stall_budget(server, download_timeout, retries, Duration::ZERO)
+}
+
+fn test_client_with_stall_budget(
+    server: &mockito::ServerGuard,
+    download_timeout: Duration,
+    retries: i64,
+    read_stall_budget: Duration,
+) -> HttpRemoteCache {
+    let mut client = HttpRemoteCache::new(RemoteCacheConfig {
         base_url: server.url().parse().unwrap(),
         namespace: "test".into(),
         token: Some("test-token".into()),
@@ -893,7 +978,9 @@ fn test_client_with(
         download_timeout,
         retries,
     })
-    .unwrap()
+    .unwrap();
+    client.set_read_stall_budget(read_stall_budget);
+    client
 }
 
 async fn mock_blob_pack_capabilities(server: &mut mockito::ServerGuard) {

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -276,6 +276,23 @@ impl RemoteCacheClient {
         })
     }
 
+    /// Bound the wall clock this session may lose to reads that fail.
+    ///
+    /// `download_timeout` bounds one logical download; this bounds their sum.
+    /// Without it an unhealthy server charges every object that deadline again,
+    /// so a build can spend longer failing to read the cache than it would have
+    /// spent compiling. Reads are best effort, so exhausting this budget stops
+    /// them for the rest of the session rather than failing the build.
+    ///
+    /// `Duration::ZERO` keeps reading however long the remote takes to fail.
+    /// Has no effect on an S3 backend, which has no such deadline to repeat.
+    pub fn with_read_stall_budget(mut self, budget: Duration) -> Self {
+        if let Backend::Http(client) = &mut self.backend {
+            client.set_read_stall_budget(budget);
+        }
+        self
+    }
+
     /// Construct a client backed directly by an S3-compatible object store.
     ///
     /// The store answers the same lookups a cache server does, without the

--- a/crates/mbx-cache-core/src/remote_http.rs
+++ b/crates/mbx-cache-core/src/remote_http.rs
@@ -32,8 +32,8 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use url::{Host, Url};
 
@@ -170,6 +170,17 @@ pub(crate) struct HttpRemoteCache {
     blob_pack_uploads_disabled: AtomicBool,
     action_batches_disabled: AtomicBool,
     action_promises_disabled: AtomicBool,
+    /// Wall clock this session may lose to reads that fail before it stops
+    /// asking, and the total lost so far.
+    ///
+    /// `download_timeout` bounds one logical download. It cannot bound what a
+    /// session pays for an unhealthy server, because every object is charged
+    /// that deadline again. Reads are best effort — a miss costs a local
+    /// compile — so once the losses add up past the budget the session stops
+    /// reading and builds instead.
+    read_stall_budget: Duration,
+    read_stall_nanos: AtomicU64,
+    reads_abandoned: AtomicBool,
 }
 
 impl HttpRemoteCache {
@@ -202,7 +213,48 @@ impl HttpRemoteCache {
             blob_pack_uploads_disabled: AtomicBool::new(false),
             action_batches_disabled: AtomicBool::new(false),
             action_promises_disabled: AtomicBool::new(false),
+            read_stall_budget: Duration::ZERO,
+            read_stall_nanos: AtomicU64::new(0),
+            reads_abandoned: AtomicBool::new(false),
         })
+    }
+
+    /// Set the budget from [`RemoteCacheClient::with_read_stall_budget`].
+    pub(crate) fn set_read_stall_budget(&mut self, budget: Duration) {
+        self.read_stall_budget = budget;
+    }
+
+    /// Whether this session has given up on reading from the remote.
+    fn reads_abandoned(&self) -> bool {
+        self.reads_abandoned.load(Ordering::Relaxed)
+    }
+
+    /// Charge a failed read against the session's stall budget.
+    ///
+    /// Only failures are charged: a slow read that returns an object paid for
+    /// itself, while a slow read that returns nothing is pure loss. Crossing
+    /// the budget abandons reads for the rest of the session and says so once.
+    fn charge_read_stall(&self, elapsed: Duration) {
+        // A zero budget means the operator asked to keep reading no matter how
+        // long the remote takes to fail.
+        if self.read_stall_budget.is_zero() {
+            return;
+        }
+        let nanos = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+        let total = self
+            .read_stall_nanos
+            .fetch_add(nanos, Ordering::Relaxed)
+            .saturating_add(nanos);
+        if Duration::from_nanos(total) < self.read_stall_budget {
+            return;
+        }
+        if !self.reads_abandoned.swap(true, Ordering::Relaxed) {
+            warn!(
+                "remote cache reads gave up after losing {:?} to failed reads, over the {:?} budget; building locally for the rest of this session",
+                Duration::from_nanos(total),
+                self.read_stall_budget
+            );
+        }
     }
 
     pub(crate) async fn check_connection(&self) -> Result<()> {
@@ -476,7 +528,10 @@ impl HttpRemoteCache {
         staging_dir: &Path,
         max_bytes: u64,
     ) -> Result<Option<RemoteBlobPack>> {
-        if digests.is_empty() || self.blob_packs_disabled.load(Ordering::Relaxed) {
+        if digests.is_empty()
+            || self.blob_packs_disabled.load(Ordering::Relaxed)
+            || self.reads_abandoned()
+        {
             return Ok(None);
         }
         let Some(mut limits) = self.blob_pack_limits().await? else {
@@ -557,13 +612,19 @@ impl HttpRemoteCache {
         // Deliberately outside `retry_async`: `download_timeout` is a deadline
         // for the whole download, not a per-attempt bound. A stalled attempt is
         // already caught by the client's connect and read timeouts.
-        tokio::time::timeout(download_timeout, download)
+        let started_at = Instant::now();
+        let result = tokio::time::timeout(download_timeout, download)
             .await
             .map_err(|_| {
                 eyre!(
                     "remote cache blob pack download for {url} exceeded its {download_timeout:?} budget across all attempts"
                 )
-            })?
+            })
+            .and_then(|result| result);
+        if result.is_err() {
+            self.charge_read_stall(started_at.elapsed());
+        }
+        result
     }
 
     pub(crate) async fn get_action_result(
@@ -806,6 +867,9 @@ impl HttpRemoteCache {
         staging_dir: &Path,
     ) -> Result<tempfile::NamedTempFile> {
         digest.validate()?;
+        if self.reads_abandoned() {
+            bail!("remote cache reads were abandoned for this session");
+        }
         if digest.size > MAX_REMOTE_BLOB_BYTES {
             bail!(
                 "remote cache blob declared {} bytes, over the {} byte limit",
@@ -845,13 +909,19 @@ impl HttpRemoteCache {
         // Deliberately outside `retry_async`: `download_timeout` is a deadline
         // for the whole download, not a per-attempt bound. A stalled attempt is
         // already caught by the client's connect and read timeouts.
-        tokio::time::timeout(download_timeout, download)
+        let started_at = Instant::now();
+        let result = tokio::time::timeout(download_timeout, download)
             .await
             .map_err(|_| {
                 eyre!(
                     "remote cache blob download for {url} exceeded its {download_timeout:?} budget across all attempts"
                 )
-            })?
+            })
+            .and_then(|result| result);
+        if result.is_err() {
+            self.charge_read_stall(started_at.elapsed());
+        }
+        result
     }
 
     pub(crate) async fn blob_pack_upload_limits(&self) -> Result<Option<BlobPackLimits>> {

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -13,6 +13,7 @@ use usage_config::{EnvLayer, FileLayer, FileScope, Layers};
 
 const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_HTTP_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+const DEFAULT_HTTP_READ_STALL_BUDGET: Duration = Duration::from_secs(90);
 const DEFAULT_HTTP_RETRIES: i64 = 3;
 const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60 * 60);
 /// How long a managed target directory may sit unused before collection.
@@ -299,6 +300,10 @@ struct RawHttp {
     /// Deadline for one blob download, retries and backoff included.
     #[usage(env = "MBX_HTTP_DOWNLOAD_TIMEOUT", default = "10m", ty = "duration")]
     download_timeout: String,
+    /// Wall clock a build may lose to failed remote reads before it stops
+    /// reading and just compiles. "0" keeps reading however long it takes.
+    #[usage(env = "MBX_HTTP_READ_STALL_BUDGET", default = "90s", ty = "duration")]
+    read_stall_budget: String,
     /// Request retries.
     #[usage(env = "MBX_HTTP_RETRIES", default = 3)]
     retries: i64,
@@ -459,6 +464,7 @@ pub struct RemoteSettings {
 pub struct HttpSettings {
     pub timeout: Duration,
     pub download_timeout: Duration,
+    pub read_stall_budget: Duration,
     pub retries: i64,
 }
 
@@ -611,6 +617,7 @@ impl Default for HttpSettings {
         Self {
             timeout: DEFAULT_HTTP_TIMEOUT,
             download_timeout: DEFAULT_HTTP_DOWNLOAD_TIMEOUT,
+            read_stall_budget: DEFAULT_HTTP_READ_STALL_BUDGET,
             retries: DEFAULT_HTTP_RETRIES,
         }
     }
@@ -735,6 +742,8 @@ impl Config {
             timeout: parse_duration(&raw.http.timeout).wrap_err("invalid http.timeout")?,
             download_timeout: parse_duration(&raw.http.download_timeout)
                 .wrap_err("invalid http.download_timeout")?,
+            read_stall_budget: parse_duration(&raw.http.read_stall_budget)
+                .wrap_err("invalid http.read_stall_budget")?,
             retries: raw.http.retries,
         };
         let gc = GcSettings {

--- a/crates/mbx/src/remote.rs
+++ b/crates/mbx/src/remote.rs
@@ -68,17 +68,20 @@ pub(crate) fn remote_client_with(
     {
         bail!("remote.s3_* settings apply to an s3:// remote cache URL, but remote.url is {url}");
     }
-    Ok(Some(RemoteCacheClient::new(RemoteCacheConfig {
-        base_url: url,
-        namespace,
-        token: config.remote.token.clone(),
-        token_file: config.remote.token_file.clone(),
-        oidc_audience: config.remote.oidc_audience.clone(),
-        connect_timeout: config.http.timeout,
-        read_timeout: config.http.timeout,
-        download_timeout: config.http.download_timeout,
-        retries: config.http.retries,
-    })?))
+    Ok(Some(
+        RemoteCacheClient::new(RemoteCacheConfig {
+            base_url: url,
+            namespace,
+            token: config.remote.token.clone(),
+            token_file: config.remote.token_file.clone(),
+            oidc_audience: config.remote.oidc_audience.clone(),
+            connect_timeout: config.http.timeout,
+            read_timeout: config.http.timeout,
+            download_timeout: config.http.download_timeout,
+            retries: config.http.retries,
+        })?
+        .with_read_stall_budget(config.http.read_stall_budget),
+    ))
 }
 
 /// The namespace, which isolates one project's cache and is always required.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -98,6 +98,14 @@ Combined action-store and managed-target budget, or "none".
 
 Deadline for one blob download, retries and backoff included.
 
+### `http.read_stall_budget`
+
+- **Type:** `duration`
+- **Default:** `90s`
+- **Set with:** `MBX_HTTP_READ_STALL_BUDGET`
+
+Wall clock a build may lose to failed remote reads before it stops reading and just compiles. "0" keeps reading however long it takes.
+
 ### `http.retries`
 
 - **Type:** `int`

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -249,3 +249,11 @@ can hold a build open. A packed request scales the deadline up with the bytes
 and object count it asks for, since the configured value describes a single
 blob. Raise it if a slow link makes large artifacts run out of time before
 their retries are spent.
+
+That deadline bounds one download, not a build. An unhealthy server charges it
+again for every object, so `MBX_HTTP_READ_STALL_BUDGET` bounds the sum: once a
+session has lost that much wall clock to reads that failed, it stops reading and
+compiles instead. Reads are best effort — a miss costs a local compile, while a
+stall costs the whole job — so this trades a cold build for a bounded one. Only
+failed reads count against it; a slow read that returned an object paid for
+itself. Set it to `0` to keep reading however long the remote takes to fail.


### PR DESCRIPTION
## The problem

`download_timeout` is a deadline for one logical download, retries included. Nothing bounds the *sum* of them, so an unhealthy server charges that deadline again for every object it fails to serve.

The default is 600s, and `blob_pack_download_timeout` scales it by the work a pack declares — up to 4× for a full 256 MiB / 2048-object chunk. So a single pack read can legitimately hold a build open for 10 to 40 minutes, and each subsequent object can do it again.

A remote cache read is best effort: a miss costs a local compile. A stall costs the whole job. Today the second can be far more expensive than the first, which inverts the point of the cache.

## What it looked like

A downstream repository whose CI jobs cap at 10 minutes. The blob-pack endpoint was returning bodies that failed to decode:

```
[WARN] HTTP POST <cache>/v1/blobs:pack attempt 1 failed after 56.59s (transient): error decoding response body
[WARN] HTTP POST <cache>/v1/blobs:pack attempt 2 failed after 123.56s (transient): error decoding response body
##[error]The operation was canceled.
```

Three jobs died at the 10-minute cap without compiling anything. Re-running the same commit against a healthy cache passed in 3–5 minutes.

Everything downstream of the failure behaves as designed — `error decoding response body` is classified transient, retried, and the agent falls back to individual blobs and then to compiling locally. The fallback just arrives long after the build's own budget is gone, and then pays the same deadline per blob against the same sick server.

## The change

Charge failed reads against a session-wide budget, and stop reading once they exhaust it.

- Only **failures** are charged. A slow read that returned an object paid for itself; a slow read that returned nothing is pure loss.
- Crossing the budget flips the session to local builds and says so once, at `warn`.
- Blob packs degrade to "unsupported", which callers already treat as a miss. Individual blob reads fail immediately, which callers already convert to a cache miss (`AgentResponse::Blob { path: None }`).
- `MBX_HTTP_READ_STALL_BUDGET` / `http.read_stall_budget`, default `90s`. `0` keeps the old behavior of reading however long the remote takes to fail.
- The budget arrives through `RemoteCacheClient::with_read_stall_budget` rather than a new `RemoteCacheConfig` field. Adding a field to a struct callers build with a literal trips `constructible_struct_adds_field`, and versions here are release-plz's to bump, not a feature PR's. `cargo semver-checks` reports "no semver update required" as written.

This follows the existing `blob_packs_disabled` / `action_batches_disabled` precedent: when a remote feature proves unusable, stop paying for it for the rest of the session.

## Notes for review

- **The default is the judgment call.** 90s is "ride out a blip, but never lose a CI job." If you'd rather express this as a consecutive-failure count than a time budget, the mechanism swaps out cleanly — I picked wall clock because that is the harm being bounded.
- **`get_blob` (in-memory JSON reads) is deliberately not covered.** It has no `download_timeout`, so it is already bounded by `read_timeout` × retries, which is a much tighter leash. Easy to add if you want reads bounded uniformly.
- `download_timeout` and its scaling are untouched: a single large legitimate download still gets the full runway it does today.

## Verification

- Two new tests in `core_tests.rs`: one asserts the second read never reaches the server once the budget is spent (`expect(1)` on the mock is the assertion), one asserts a `0` budget keeps reading.
- Existing retry tests provoke failures deliberately, so `test_client_with` pins the budget to zero and keeps its current behavior.
- `mise run lint`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass locally.
- `cargo semver-checks --baseline-rev origin/main --package mbx-cache-core --all-features`: 196 checks, all pass.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default remote read behavior (90s cap) and alters how unhealthy HTTP caches interact with builds; failures degrade to local compile rather than long retries.
> 
> **Overview**
> Adds a **session-wide read stall budget** so repeated failed remote cache downloads cannot each spend a full `download_timeout` and stall the whole build.
> 
> The HTTP client accumulates wall time from **failed** blob and blob-pack downloads; successful reads are not charged. When the budget is exhausted, further blob reads fail fast with *reads were abandoned*, blob packs return `None` (treated as unsupported/miss), and a one-time warning is logged. **`RemoteCacheClient::with_read_stall_budget`** configures this without extending `RemoteCacheConfig`; mbx wires **`http.read_stall_budget`** / **`MBX_HTTP_READ_STALL_BUDGET`** (default **90s**, **`0`** disables the cap). S3 is unchanged. Tests cover budget exhaustion vs zero budget; existing failure tests pin stall budget to zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58d5b635a62ca5875a0f76f3d1f116a331cbe3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->