### PR TITLE
ci: use shared Namespace volume for local mbx caching

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,7 @@
 self-hosted-runner:
   labels:
     - jdx-perf-v1
-    - namespace-profile-endev-linux-amd64
-    - namespace-profile-endev-linux-arm64
-    - namespace-profile-endev-macos-arm64
-    - namespace-profile-endev-linux-amd64-xlarge
+    - namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    - namespace-profile-endev-linux-arm64;overrides.cache-tag=cache
+    - namespace-profile-endev-macos-arm64;overrides.cache-tag=cache
+    - namespace-profile-endev-linux-amd64-xlarge;overrides.cache-tag=cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           mise run check:links
 
   lint:
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
@@ -53,9 +53,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
           - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
+            runner: namespace-profile-endev-macos-arm64;overrides.cache-tag=cache
           - os: windows-latest
             runner: windows-latest
           # Every Linux binary a release ships is musl, and every job above
@@ -65,10 +65,10 @@ jobs:
           # Both release architectures have a native runner, so a static musl
           # binary needs no emulation to build or run its own test suite.
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
             target: x86_64-unknown-linux-musl
           - os: ubuntu-24.04-arm
-            runner: namespace-profile-endev-linux-arm64
+            runner: namespace-profile-endev-linux-arm64;overrides.cache-tag=cache
             target: aarch64-unknown-linux-musl
     runs-on: ${{ matrix.runner }}
     env:
@@ -136,7 +136,7 @@ jobs:
         run: pwsh e2e-win/run.ps1
 
   compatibility:
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # master
@@ -155,7 +155,7 @@ jobs:
         run: cargo check --locked --workspace --all-targets --no-default-features --features rustls-native-roots
 
   supply-chain:
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
@@ -238,7 +238,7 @@ jobs:
       - supply-chain
       - public-api
       - test
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     timeout-minutes: 1
     # Run on success or upstream failure but skip when the workflow is cancelled
     # — `always()` would override `cancel-in-progress` and waste a runner.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     permissions:
       contents: read
       pages: write
@@ -57,7 +57,7 @@ jobs:
       pages: write
       id-token: write
     needs: build
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   release-plz-release:
     name: Release
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     # Forks should never attempt to publish.
     if: ${{ github.repository_owner == 'jdx' }}
     permissions:
@@ -158,7 +158,7 @@ jobs:
     name: Enhance release notes
     needs: release-plz-release
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     continue-on-error: true
     permissions:
       contents: read
@@ -196,7 +196,7 @@ jobs:
     name: Publish release
     needs: [release-plz-release, upload-assets, enhance-release]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     permissions:
       contents: write
     steps:
@@ -208,7 +208,7 @@ jobs:
 
   release-plz-pr:
     name: Release PR
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     if: ${{ github.repository_owner == 'jdx' }}
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,28 +60,28 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
             bin: mbx
             cross: true
             pgo: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
             bin: mbx
             pgo: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
             bin: mbx
             cross: true
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
-            runner: namespace-profile-endev-linux-arm64
+            runner: namespace-profile-endev-linux-arm64;overrides.cache-tag=cache
             bin: mbx
             pgo: true
           - target: aarch64-apple-darwin
             os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
+            runner: namespace-profile-endev-macos-arm64;overrides.cache-tag=cache
             bin: mbx
             pgo: true
           - target: x86_64-pc-windows-msvc
@@ -315,7 +315,7 @@ jobs:
     # Needs every target: a release carrying only some of its archives is worse
     # than one that arrives late, and the draft stays unpublished either way.
     needs: build
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Keep Mr Boxington as the local build cacher for ordinary trusted Namespace jobs, using the shared Namespace volume selected by `overrides.cache-tag=cache`.

Trusted jobs use the project `mbx` wrapper locally without GitHub-cache or remote-server transport. Untrusted jobs remain on GitHub-hosted runners with the GitHub cache backend.

Privileged release, signing, deployment, and architecture-specific release jobs retain their existing isolated or untagged runner profiles.

Validation: actionlint
