### PR TITLE
feat(cc): write the caller's dependency list instead of bypassing it

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -257,16 +257,107 @@ fn preprocess_and_assembly_modes_bypass_as_non_object_output() {
     }
 }
 
+/// `-M` and `-MM` stop after preprocessing, `-MG` changes what a missing
+/// header means, and a list modifier with no `-MD` or `-MMD` to modify is not
+/// a shape any build produces: all of those still bypass.
 #[test]
-fn caller_dependency_flags_bypass_before_injection() {
-    for flag in ["-MD", "-MMD", "-MP", "-M", "-MM"] {
-        let arguments = argv(&[flag, "-c", "-o", "a.o", "a.c"]);
+fn dependency_flags_that_are_not_a_compile_with_a_list_bypass() {
+    for arguments in [
+        vec!["-M", "-c", "-o", "a.o", "a.c"],
+        vec!["-MM", "-c", "-o", "a.o", "a.c"],
+        vec!["-MD", "-MG", "-c", "-o", "a.o", "a.c"],
+        vec!["-MP", "-c", "-o", "a.o", "a.c"],
+        vec!["-MF", "a.d", "-c", "-o", "a.o", "a.c"],
+        vec!["-MT", "a.o", "-c", "-o", "a.o", "a.c"],
+    ] {
         assert_eq!(
-            CcInvocation::parse(&arguments).unwrap_err().kind(),
+            CcInvocation::parse(&argv(&arguments)).unwrap_err().kind(),
             "caller-dependency-flags",
-            "{flag} should bypass"
+            "{arguments:?} should bypass"
         );
     }
+}
+
+/// A caller asking for a dependency list beside the object -- OpenSSL's
+/// makefiles, CMake -- gets one from the shim. The flags shape that list and
+/// nothing else, so they are neither key material nor passed to the driver,
+/// which honors only one `-MF` and owes the shim its own.
+#[test]
+fn caller_dependency_lists_are_taken_from_the_flags_and_kept_out_of_the_key() {
+    let plain = CcInvocation::parse(&argv(&["-O2", "-c", "-o", "out/a.o", "a.c"])).unwrap();
+    assert_eq!(plain.caller_depfile(), None);
+
+    let arguments = argv(&[
+        "-O2",
+        "-MMD",
+        "-MF",
+        "out/a.o.d",
+        "-MT",
+        "a.o",
+        "-MQ",
+        "$(OBJ)",
+        "-MP",
+        "-c",
+        "-o",
+        "out/a.o",
+        "a.c",
+    ]);
+    let listed = CcInvocation::parse(&arguments).unwrap();
+    let caller = listed.caller_depfile().expect("a list was asked for");
+    assert_eq!(caller.path, PathBuf::from("out/a.o.d"));
+    assert_eq!(
+        caller.targets,
+        vec![
+            DepfileTarget {
+                name: "a.o".into(),
+                quoted: false
+            },
+            DepfileTarget {
+                name: "$(OBJ)".into(),
+                quoted: true
+            },
+        ]
+    );
+    assert!(caller.user_headers_only);
+    assert!(caller.phony_targets);
+    assert_eq!(
+        listed.arguments, plain.arguments,
+        "the list flags are not key material"
+    );
+    assert_eq!(
+        listed.compiler_arguments(&arguments),
+        argv(&["-O2", "-c", "-o", "out/a.o", "a.c"]),
+        "the driver runs without the list flags"
+    );
+
+    // `-MD` alone: the driver would write `<object>.d` naming the object.
+    let defaulted = CcInvocation::parse(&argv(&["-MD", "-c", "-o", "out/a.o", "a.c"])).unwrap();
+    let caller = defaulted.caller_depfile().unwrap();
+    assert_eq!(caller.path, PathBuf::from("out/a.d"));
+    assert_eq!(
+        caller.targets,
+        vec![DepfileTarget {
+            name: "out/a.o".into(),
+            quoted: true
+        }]
+    );
+    assert!(!caller.user_headers_only);
+    assert!(!caller.phony_targets);
+
+    // Attached spellings, as CMake writes them.
+    let attached = CcInvocation::parse(&argv(&[
+        "-MMD",
+        "-MFout/b.d",
+        "-MTb.o",
+        "-c",
+        "-o",
+        "b.o",
+        "a.c",
+    ]))
+    .unwrap();
+    let caller = attached.caller_depfile().unwrap();
+    assert_eq!(caller.path, PathBuf::from("out/b.d"));
+    assert_eq!(caller.targets[0].name, "b.o");
 }
 
 #[test]
@@ -1014,5 +1105,34 @@ fn isa_and_codegen_switches_are_admitted_key_material() {
             .unwrap_err()
             .kind(),
         "local-cpu-target"
+    );
+}
+
+/// `-o` is often relative to the compiler's working directory -- OpenSSL's
+/// makefiles name every object that way -- and a path handed to the cache
+/// agent has to mean the same file from the agent's own directory.
+#[test]
+fn the_object_is_addressed_absolutely_from_the_working_directory() {
+    let relative = CcInvocation::parse(&argv(&[
+        "-c",
+        "-o",
+        "ssl/./lib/../ssl_lib.o",
+        "ssl/ssl_lib.c",
+    ]))
+    .unwrap();
+    assert_eq!(
+        relative.output_in(Path::new("/build/openssl")),
+        PathBuf::from("/build/openssl/ssl/ssl_lib.o")
+    );
+    assert_eq!(
+        relative.output(),
+        Path::new("ssl/./lib/../ssl_lib.o"),
+        "the spelling the key sees is the caller's"
+    );
+
+    let absolute = CcInvocation::parse(&argv(&["-c", "-o", "/out/a.o", "a.c"])).unwrap();
+    assert_eq!(
+        absolute.output_in(Path::new("/elsewhere")),
+        PathBuf::from("/out/a.o")
     );
 }

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -104,6 +104,63 @@ impl CcDepfile {
 
 const RULE_SEPARATOR: &str = ": ";
 
+impl CcDepfile {
+    /// Render the dependency list a caller asked for, the way the driver
+    /// writes one: the rule's targets, then every prerequisite on its own
+    /// continued line, then, for `-MP`, an empty rule per header so make does
+    /// not fail when one is deleted. `source` is the file that was compiled
+    /// and gets no phony rule, exactly as the driver leaves it out.
+    ///
+    /// Escapes are the ones `parse` reads back: a space, a `#`, and a `$` in
+    /// a path. A quoted target gets the same treatment; a literal one is
+    /// written as given, which is what `-MT` promises.
+    pub fn render(
+        targets: &[crate::DepfileTarget],
+        files: &[PathBuf],
+        source: &Path,
+        phony_targets: bool,
+    ) -> String {
+        let mut rendered = String::new();
+        for (index, target) in targets.iter().enumerate() {
+            if index > 0 {
+                rendered.push(' ');
+            }
+            if target.quoted {
+                rendered.push_str(&escape_make_word(&target.name));
+            } else {
+                rendered.push_str(&target.name);
+            }
+        }
+        rendered.push(':');
+        for file in files {
+            rendered.push_str(" \\\n ");
+            rendered.push_str(&escape_make_word(&file.to_string_lossy()));
+        }
+        rendered.push('\n');
+        if phony_targets {
+            for file in files.iter().filter(|file| file.as_path() != source) {
+                rendered.push_str(&escape_make_word(&file.to_string_lossy()));
+                rendered.push_str(":\n");
+            }
+        }
+        rendered
+    }
+}
+
+/// Quote a word for make the way the driver does in a dependency list.
+fn escape_make_word(word: &str) -> String {
+    let mut escaped = String::with_capacity(word.len());
+    for character in word.chars() {
+        match character {
+            ' ' => escaped.push_str("\\ "),
+            '#' => escaped.push_str("\\#"),
+            '$' => escaped.push_str("$$"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
 /// Join physical lines the compiler wrapped with a trailing backslash.
 fn join_continuations(contents: &str) -> Result<String, CcBypassReason> {
     let mut joined = String::with_capacity(contents.len());

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -522,3 +522,37 @@ fn verification_trusts_an_unchanged_identity_and_rereads_a_changed_one() {
     std::fs::write(&header, "int b(void);\n").expect("rewrite");
     assert_eq!(discovered.verify().unwrap_err().kind(), "input-changed");
 }
+
+/// The list the shim writes for a caller reads back through the same parser,
+/// escapes exactly what the parser unescapes, quotes only the targets that
+/// asked for it, and gives every header but the source a phony rule when `-MP`
+/// asked.
+#[test]
+fn a_rendered_caller_depfile_reads_back_and_quotes_like_the_driver() {
+    let files = vec![
+        PathBuf::from("/src/a.c"),
+        PathBuf::from("/src/my dir/a.h"),
+        PathBuf::from("/src/#odd$/b.h"),
+    ];
+    let targets = [
+        crate::DepfileTarget {
+            name: "$(OBJ)".into(),
+            quoted: false,
+        },
+        crate::DepfileTarget {
+            name: "out/a b.o".into(),
+            quoted: true,
+        },
+    ];
+
+    let rendered = CcDepfile::render(&targets, &files, Path::new("/src/a.c"), true);
+
+    assert_eq!(
+        rendered,
+        "$(OBJ) out/a\\ b.o: \\\n /src/a.c \\\n /src/my\\ dir/a.h \\\n /src/\\#odd$$/b.h\n/src/my\\ dir/a.h:\n/src/\\#odd$$/b.h:\n"
+    );
+    assert_eq!(CcDepfile::parse(&rendered).unwrap().files, files);
+
+    let plain = CcDepfile::render(&targets[1..], &files[..1], Path::new("/src/a.c"), false);
+    assert_eq!(plain, "out/a\\ b.o: \\\n /src/a.c\n");
+}

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -737,9 +737,76 @@ pub struct CcInvocation {
     required_inputs: Vec<PathBuf>,
     language: CcLanguage,
     sysroot: Option<PathBuf>,
+    caller_depfile: Option<CallerDepfile>,
+    /// Positions in the parsed command line of the dependency-list flags the
+    /// caller passed, which the shim leaves out when it runs the driver.
+    dependency_argument_indices: Vec<usize>,
+}
+
+/// A dependency list the caller asked the driver to write beside the object.
+///
+/// Build systems driving the compiler through a build script -- OpenSSL's
+/// makefiles under `openssl-src`, CMake under many `-sys` crates -- ask for one
+/// with `-MD` or `-MMD` so their own rebuild logic has something to read. The
+/// flags do not change the object, so they are not key material, and the file
+/// names paths on this machine, so it is never stored. The shim writes it
+/// itself from the dependency list it already collects, whether the object
+/// was compiled or restored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CallerDepfile {
+    /// Where the list goes: `-MF`, or the object's path with a `.d` extension.
+    pub path: PathBuf,
+    /// The rule's targets, from `-MT` and `-MQ`, or the object as `-o` named it.
+    pub targets: Vec<DepfileTarget>,
+    /// Whether system headers are left out, as `-MMD` does.
+    pub user_headers_only: bool,
+    /// Whether every header also gets an empty rule of its own, as `-MP` does.
+    pub phony_targets: bool,
+}
+
+/// One target of a caller's dependency rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DepfileTarget {
+    /// The target text as the caller gave it.
+    pub name: String,
+    /// Whether characters special to make are quoted on output, as `-MQ`
+    /// asks; `-MT` writes the name literally.
+    pub quoted: bool,
 }
 
 impl CcInvocation {
+    /// The object's path made absolute against the compiler's working
+    /// directory, for reading and storing it. `-o` is often relative --
+    /// OpenSSL's makefiles name every object that way -- and a path handed to
+    /// the cache agent has to mean the same file from the agent's own
+    /// directory. Key material still normalizes the spelling as given.
+    pub fn output_in(&self, working_dir: &Path) -> PathBuf {
+        if self.output.is_absolute() {
+            normalize_components(&self.output)
+        } else {
+            normalize_components(&working_dir.join(&self.output))
+        }
+    }
+
+    /// The dependency list the caller asked for, if any.
+    pub fn caller_depfile(&self) -> Option<&CallerDepfile> {
+        self.caller_depfile.as_ref()
+    }
+
+    /// The command line to run the driver with: `arguments` as parsed, less
+    /// the caller's dependency-list flags. The shim asks the driver for its
+    /// own list, the driver honors only one `-MF`, and the caller's list is
+    /// written by the shim afterwards.
+    pub fn compiler_arguments(&self, arguments: &[OsString]) -> Vec<OsString> {
+        arguments
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !self.dependency_argument_indices.contains(index))
+            .map(|(_, argument)| argument.clone())
+            .collect()
+    }
+
     /// Parse a driver command line, admitting only modeled single-object
     /// compiles.
     pub fn parse(arguments: &[OsString]) -> Result<Self, CcBypassReason> {
@@ -1212,6 +1279,21 @@ struct Parser<'a> {
     sysroot: Option<PathBuf>,
     explicit_language: Option<CcLanguage>,
     compiling: bool,
+    dependency: DependencyRequest,
+}
+
+/// What the caller's `-M` flags asked for, gathered while parsing.
+#[derive(Debug, Default)]
+struct DependencyRequest {
+    /// `Some(false)` for `-MD`, `Some(true)` for `-MMD`.
+    user_headers_only: Option<bool>,
+    file: Option<PathBuf>,
+    targets: Vec<DepfileTarget>,
+    phony_targets: bool,
+    /// The last `-MF`, `-MT`, `-MQ`, or `-MP` seen, for the bypass a request
+    /// without `-MD` or `-MMD` reports.
+    modifier: Option<String>,
+    indices: Vec<usize>,
 }
 
 impl<'a> Parser<'a> {
@@ -1227,6 +1309,7 @@ impl<'a> Parser<'a> {
             sysroot: None,
             explicit_language: None,
             compiling: false,
+            dependency: DependencyRequest::default(),
         }
     }
 
@@ -1254,6 +1337,31 @@ impl<'a> Parser<'a> {
         let output = self.output.clone().ok_or(CcBypassReason::MissingOutput)?;
         let language = self.language(&source)?;
         self.required_inputs.push(source.clone());
+        let caller_depfile = match self.dependency.user_headers_only {
+            Some(user_headers_only) => Some(CallerDepfile {
+                path: self
+                    .dependency
+                    .file
+                    .unwrap_or_else(|| output.with_extension("d")),
+                targets: if self.dependency.targets.is_empty() {
+                    vec![DepfileTarget {
+                        name: output.to_string_lossy().into_owned(),
+                        quoted: true,
+                    }]
+                } else {
+                    self.dependency.targets
+                },
+                user_headers_only,
+                phony_targets: self.dependency.phony_targets,
+            }),
+            // `-MF` or `-MT` without `-MD` or `-MMD` writes nothing, but it is
+            // not a shape the cc crate or a makefile produces, so it is not
+            // one to guess at.
+            None => match self.dependency.modifier {
+                Some(modifier) => return Err(CcBypassReason::CallerDependencyFlags(modifier)),
+                None => None,
+            },
+        };
         Ok(CcInvocation {
             arguments: self.parsed,
             source,
@@ -1262,7 +1370,45 @@ impl<'a> Parser<'a> {
             required_inputs: self.required_inputs,
             language,
             sysroot: self.sysroot,
+            caller_depfile,
+            dependency_argument_indices: self.dependency.indices,
         })
+    }
+
+    /// A `-M` flag: the caller wants a dependency list beside the object.
+    ///
+    /// `-MD` and `-MMD` compile as well as listing, so they are taken, with
+    /// the `-MF`, `-MT`, `-MQ`, and `-MP` that shape the list. None of them
+    /// enters the key: the object is the same with or without them. `-M` and
+    /// `-MM` stop after preprocessing, and `-MG` changes what a missing header
+    /// means, so those still bypass.
+    fn parse_dependency_flag(&mut self, value: &str, option: &str) -> Result<(), CcBypassReason> {
+        let start = self.index - 1;
+        match option {
+            "D" => self.dependency.user_headers_only = Some(false),
+            "MD" => self.dependency.user_headers_only = Some(true),
+            "P" => {
+                self.dependency.phony_targets = true;
+                self.dependency.modifier = Some(value.into());
+            }
+            _ if option.starts_with('F') => {
+                let file = self.take_value("-MF", Some(&option[1..]))?;
+                self.dependency.file = Some(PathBuf::from(file));
+                self.dependency.modifier = Some("-MF".into());
+            }
+            _ if option.starts_with('T') || option.starts_with('Q') => {
+                let flag = &value[..3];
+                let name = self.take_value(flag, Some(&option[1..]))?;
+                self.dependency.targets.push(DepfileTarget {
+                    name,
+                    quoted: option.starts_with('Q'),
+                });
+                self.dependency.modifier = Some(flag.into());
+            }
+            _ => return Err(CcBypassReason::CallerDependencyFlags(value.into())),
+        }
+        self.dependency.indices.extend(start..self.index);
+        Ok(())
     }
 
     fn language(&self, source: &Path) -> Result<CcLanguage, CcBypassReason> {
@@ -1331,8 +1477,8 @@ impl<'a> Parser<'a> {
         if matches!(value, "-E" | "-S") {
             return Err(CcBypassReason::NonObjectOutput(value.into()));
         }
-        if value.starts_with("-M") {
-            return Err(CcBypassReason::CallerDependencyFlags(value.into()));
+        if let Some(option) = value.strip_prefix("-M") {
+            return self.parse_dependency_flag(value, option);
         }
         if value.starts_with("-save-temps") {
             return Err(CcBypassReason::SaveTemps(value.into()));
@@ -1624,6 +1770,8 @@ impl<'a> MsvcParser<'a> {
             required_inputs: self.required_inputs,
             language,
             sysroot: None,
+            caller_depfile: None,
+            dependency_argument_indices: Vec::new(),
         })
     }
 

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -52,6 +52,10 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let arguments = portable.applied_to(arguments);
     let arguments = arguments.as_ref();
     let invocation = CcInvocation::parse_for(arguments, identity.family)?;
+    // The driver honors one `-MF`, and the shim's own dependency list is the
+    // one it needs; the caller's is written by the shim once the files this
+    // compilation read are known.
+    let compiler_arguments = invocation.compiler_arguments(arguments);
     let environment = environment_inputs_for(
         |name| std::env::var(name).ok(),
         invocation.sysroot(),
@@ -104,6 +108,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
             &discovered,
             !verify,
             &context.path_mappings,
+            &context.working_dir,
         ) {
             Ok(restored) => restored,
             Err(error) => {
@@ -113,6 +118,10 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         };
         if let Some(cached) = restored {
             if !verify {
+                write_caller_depfile(
+                    &invocation,
+                    discovered.files().map(|input| input.path.as_path()),
+                );
                 record_prediction(
                     &task,
                     &invocation_digest,
@@ -161,7 +170,11 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
             &mut looked_up,
             None,
         ) {
-            Ok(Some((action, cached))) => {
+            Ok(Some((action, cached, discovered))) => {
+                write_caller_depfile(
+                    &invocation,
+                    discovered.files().map(|input| input.path.as_path()),
+                );
                 replay_bytes(&cached.stdout, &cached.stderr)?;
                 record_action_hit(&action, cached.restore, &compilation_name(&invocation));
                 return Ok(ExitCode::SUCCESS);
@@ -200,13 +213,17 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
                         &mut looked_up,
                         Some(&prediction.action),
                     ) {
-                        Ok(Some((action, cached))) => {
+                        Ok(Some((action, cached, discovered))) => {
                             // Mirror the successful fleet handoff locally:
                             // the remote promise is ephemeral, while this
                             // record survives for the next local flight.
                             if let Some(flight) = &flight {
                                 flight.leave(&prediction.payload);
                             }
+                            write_caller_depfile(
+                                &invocation,
+                                discovered.files().map(|input| input.path.as_path()),
+                            );
                             replay_bytes(&cached.stdout, &cached.stderr)?;
                             record_action_hit(
                                 &action,
@@ -253,7 +270,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let started = Instant::now();
     let compilation_started = SystemTime::now();
     let mut command = Command::new(compiler);
-    command.args(arguments);
+    command.args(&compiler_arguments);
     command.args(invocation.dependency_arguments_for(&depfile, context.compiler.family));
     let output = command
         .output()
@@ -287,7 +304,6 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     if !output.status.success() {
         return Ok(exit_code(output.status));
     }
-
     // A failure to publish must not fail a compilation that already succeeded.
     if let Err(error) = publish(
         &invocation,
@@ -308,6 +324,21 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         session::report_shim_warning(&format!("cc result was not published: {error:#}"));
         #[cfg(not(debug_assertions))]
         let _ = error;
+    }
+    // Owed whether or not the object was published: the build that asked for
+    // the list reads it next. Written after publication, because the list
+    // may land in a directory the compilation searched for headers, and a
+    // file appearing there between the two manifest snapshots would read as
+    // a header that appeared mid-compile.
+    if invocation.caller_depfile().is_some() {
+        match mbx_cache_cc::CcDepfile::read_for(&depfile, context.compiler.family) {
+            Ok(listed) => {
+                write_caller_depfile(&invocation, listed.files.iter().map(PathBuf::as_path))
+            }
+            Err(error) => session::report_shim_warning(&format!(
+                "the caller's dependency list was not written: {error}"
+            )),
+        }
     }
     Ok(exit_code(output.status))
 }
@@ -339,11 +370,15 @@ fn publish(
     // its headers. Publishing one that names the directory anyway would make
     // that claim false for every checkout that restored it, so a compilation
     // whose output kept the value is left uncached rather than shared wrong.
-    if !portable.outputs_are_clean(invocation.output()) {
-        return Err(CcBypassReason::UnportableOutput(invocation.output().to_path_buf()).into());
+    // Addressed absolutely from here on: `-o` may be relative to the compiler's
+    // working directory, and the cache agent that stores the object does not
+    // share it. OpenSSL's makefiles compile every object that way.
+    let object = invocation.output_in(&context.working_dir);
+    if !portable.outputs_are_clean(&object) {
+        return Err(CcBypassReason::UnportableOutput(object).into());
     }
     let action = invocation.action(context.clone())?;
-    publish_result(&action, invocation, output, &context.path_mappings)?;
+    publish_result(&action, &object, output, &context.path_mappings)?;
     let prediction = invocation.prediction(context, duration_ns)?;
     record_prediction(
         task,
@@ -371,7 +406,7 @@ fn restore_flight_prediction(
     invocation_digest: &CacheDigest,
     looked_up: &mut bool,
     recorded_action: Option<&CacheDigest>,
-) -> Result<Option<(CacheDigest, CachedCompilation)>> {
+) -> Result<Option<(CacheDigest, CachedCompilation, CcDiscoveredInputs)>> {
     let prediction: CcInputPrediction = serde_json::from_str(payload)?;
     let discovered = prediction.discover(
         &context.working_dir,
@@ -391,6 +426,7 @@ fn restore_flight_prediction(
         &discovered,
         true,
         &context.path_mappings,
+        &context.working_dir,
     )?;
     let Some(cached) = restored else {
         return Ok(None);
@@ -403,7 +439,46 @@ fn restore_flight_prediction(
         None,
         None,
     );
-    Ok(Some((action.digest, cached)))
+    Ok(Some((action.digest, cached, discovered)))
+}
+
+/// Write the dependency list the caller asked the driver for, from the files
+/// this compilation is known to have read.
+///
+/// Best-effort: the object is already in place, and a build whose list is
+/// missing rebuilds that object at worst. For `-MMD` the system headers are
+/// left out the way the driver would leave them out; a header the shim cannot
+/// tell is a system one stays in, which only makes the list more cautious.
+fn write_caller_depfile<'a>(invocation: &CcInvocation, files: impl Iterator<Item = &'a Path>) {
+    let Some(caller) = invocation.caller_depfile() else {
+        return;
+    };
+    let files = files
+        .filter(|path| !caller.user_headers_only || !mbx_cache_cc::is_system_path(path))
+        .map(Path::to_path_buf)
+        .collect::<Vec<_>>();
+    let rendered = mbx_cache_cc::CcDepfile::render(
+        &caller.targets,
+        &files,
+        invocation.source(),
+        caller.phony_targets,
+    );
+    let written = (|| {
+        if let Some(parent) = caller
+            .path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&caller.path, rendered)
+    })();
+    if let Err(error) = written {
+        session::report_shim_warning(&format!(
+            "the caller's dependency list {} was not written: {error}",
+            caller.path.display()
+        ));
+    }
 }
 
 /// The environment values whose absolute paths a compilation is made
@@ -880,10 +955,25 @@ fn record_prediction(
         adapter: ADAPTER.into(),
         payload,
     };
-    let _ = session::request_agent(&[AgentRequest::RecordActionPrediction {
+    // Best-effort like the rest of publication, but not silent in a debug
+    // build: a prediction that is never recorded is a compilation that is
+    // never looked up again, with nothing in the summary to say why.
+    let recorded = session::request_agent(&[AgentRequest::RecordActionPrediction {
         task: task.to_string(),
         prediction: wire_prediction.clone(),
     }]);
+    #[cfg(debug_assertions)]
+    match recorded.map(|responses| responses.into_iter().next()) {
+        Ok(Some(AgentResponse::ActionPredictionRecorded)) => {}
+        Ok(other) => session::report_shim_warning(&format!(
+            "cc prediction was not recorded: unexpected agent response {other:?}"
+        )),
+        Err(error) => {
+            session::report_shim_warning(&format!("cc prediction was not recorded: {error:#}"))
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = recorded;
     if let Some(claim) = remote_claim {
         let _ = session::request_agent(&[AgentRequest::CompleteActionPromise {
             claim: claim.to_string(),
@@ -917,6 +1007,7 @@ fn restore_result(
     discovered: &CcDiscoveredInputs,
     restore_outputs: bool,
     mappings: &[PathMapping],
+    working_dir: &Path,
 ) -> Result<Option<CachedCompilation>> {
     let text_mappings = rustc_path_mappings(mappings);
     let responses = session::request_agent(&[AgentRequest::FindActionResult {
@@ -958,7 +1049,7 @@ fn restore_result(
     let directory: CacheDirectory =
         read_canonical_blob(&roots[2], &output_root_digest, "output directory")?;
     let node = validated_object(directory, invocation)?;
-    let destination = invocation.output().to_path_buf();
+    let destination = invocation.output_in(working_dir);
 
     let blobs = find_blobs(&[
         metadata.stdout.clone(),
@@ -1076,12 +1167,11 @@ fn validated_object(directory: CacheDirectory, invocation: &CcInvocation) -> Res
 
 fn publish_result(
     action: &CcAction,
-    invocation: &CcInvocation,
+    object: &Path,
     output: &Output,
     mappings: &[PathMapping],
 ) -> Result<()> {
     let text_mappings = rustc_path_mappings(mappings);
-    let object = invocation.output();
     let metadata = std::fs::metadata(object)
         .wrap_err_with(|| format!("failed to inspect cc output {}", object.display()))?;
     if !metadata.is_file() {

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -41,7 +41,11 @@ Unlike rustc, a C compile leaves no dependency record behind for a later build
 to read, and publishing one would add a file the uncached build never produced.
 So the shim asks for its own dependency list, keeps it private, and keys the
 compilation on the files that list names. A cold compilation therefore has no
-key to look up yet; it is stored after compiling and warms the next build. The
+key to look up yet; it is stored after compiling and warms the next build.
+A build that asks the compiler for its own list, as OpenSSL's makefiles and
+CMake do with `-MD` or `-MMD`, gets one from the shim instead, written from the
+same files whether the object was compiled or restored; the flags shape that
+list and nothing else, so they are not part of the key. The
 directories the compile searched also contribute a manifest of the names in
 them that could answer an `#include`, so a header appearing where it would
 *shadow* one that was read changes the key even though every file that was read

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -189,3 +189,65 @@ EOF
   run grep -E '"hits"[[:space:]]*:[[:space:]]*2' "$warm_report"
   assert_success
 }
+
+@test "a build script's own dependency list is written on a compile and on a restore" {
+  # OpenSSL's makefiles and CMake ask the driver for a dependency list with
+  # `-MMD -MF`, which used to bypass every such object. The list is not key
+  # material and names this machine's paths, so the shim writes it itself,
+  # from the files the compilation read, whether the object was compiled or
+  # restored into a fresh target.
+  cat >"$PROJECT/build.rs" <<'RS'
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let compiler = env::var("HOST_CC")
+        .or_else(|_| env::var("CC"))
+        .unwrap_or_else(|_| "cc".into());
+    let status = Command::new(&compiler)
+        .arg("-O2")
+        .arg("-Iinclude")
+        .arg("-MMD")
+        .arg("-MF")
+        .arg(out.join("hello.d"))
+        .arg("-MT")
+        .arg("hello.o")
+        .arg("-c")
+        .arg("-o")
+        .arg(out.join("hello.o"))
+        .arg("src/hello.c")
+        .status()
+        .expect("the C compiler should run");
+    assert!(status.success());
+    let list = std::fs::read_to_string(out.join("hello.d")).expect("the dependency list");
+    assert!(list.starts_with("hello.o:"), "unexpected list: {list}");
+    assert!(list.contains("include/hello.h"), "unexpected list: {list}");
+}
+RS
+  local first_target="$BATS_TEST_TMPDIR/first-target"
+  local second_target="$BATS_TEST_TMPDIR/second-target"
+  local warm_report="$BATS_TEST_TMPDIR/warm.json"
+
+  run env CARGO_TARGET_DIR="$first_target" \
+    "$MBX_BIN" build --offline --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  local compiled
+  compiled="$(object_in "$first_target")"
+  [ -n "$compiled" ]
+
+  run env CARGO_TARGET_DIR="$second_target" MBX_STATS_REPORT="$warm_report" \
+    "$MBX_BIN" build --offline --manifest-path "$PROJECT/Cargo.toml"
+  assert_success
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*3' "$warm_report"
+  assert_success
+  local restored
+  restored="$(object_in "$second_target")"
+  [ -n "$restored" ]
+  run cmp "$compiled" "$restored"
+  assert_success
+  # The build script's own assertions ran against a restored object, so the
+  # list was written on the restore too; this makes that explicit.
+  run find "$second_target" -name hello.d -type f
+  assert_success
+  assert_output --partial hello.d
+}


### PR DESCRIPTION
## Summary

- Any C compile passing `-MD`/`-MMD` bypassed as `cc-caller-dependency-flags`. OpenSSL's makefiles (via `openssl-src`) and CMake do this for every object; in jdx/fnox that was 1102 objects recompiled on every fresh target, about 40s of a warm build. jdx/mise and jdx/aube each have 34.
- The flags shape the dependency list and nothing else, so they are not key material, and the list names host paths, so it is never stored. The parser now takes `-MD`, `-MMD`, `-MF`, `-MT`, `-MQ`, `-MP` into a `CallerDepfile`; the shim runs the driver without them (it honors one `-MF`, and the shim needs its own) and writes the caller's list from the files the compilation read, on a compile and on a restore alike. `-MMD` leaves system headers out; `-MP` gets phony rules. `-M`, `-MM`, `-MG` still bypass.
- Admitting these exposed a latent bug: the object path was handed to the agent as spelled by the caller, and OpenSSL's make spells it relative to a build directory the agent does not share, so every publish failed with a bare "No such file or directory". `CcInvocation::output_in` resolves it against the compiler's working directory for storing and restoring; key material is unchanged.
- Debug builds now warn when a cc prediction record is refused by the agent, which was silent and is what made the bug above hard to see.
- Docs: how-it-works notes the caller list.

## Measurements

jdx/fnox, `cargo build`, fresh target from a warm store (release build of mbx):

| | before | after |
|---|---|---|
| hits | 1003 | 1766 |
| `cc-caller-dependency-flags` bypasses | 1102 | 0 |
| wall time | 43.7s | 35.4s |

The remaining OpenSSL misses are its in-tree build generating `.c` files under `-I.` while other compiles run, which moves the include-directory manifests between builds. That is a separate limit worth its own change (manifests could be narrowed to names that could shadow this compilation's own inputs).

## Test plan

- [x] Parser tests: flags parsed into `CallerDepfile` with `-MD` defaults (`<object>.d`, object as target), attached spellings, key unchanged, driver arguments stripped; `-M`/`-MM`/`-MG` and lone modifiers bypass
- [x] Renderer round-trips through the existing parser, quotes `-MQ` targets only, emits phony rules
- [x] `output_in` resolves relative and absolute objects
- [x] New bats test: a build script passing `-MMD -MF -MT` gets its list on the cold compile and on the restore into a second target
- [x] `mise run lint`, `mise run test:cargo`, `test/cc_*.bats`
- [x] fnox builds and `fnox --version` runs from the restored build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cc shim admission, object path resolution for cache storage, and dependency file output on both compile and restore; correctness of cache hits and makefile rebuild graphs depends on the new depfile rendering matching driver behavior.
> 
> **Overview**
> **Compiles that pass `-MD` or `-MMD` are now cacheable** instead of bypassing as `caller-dependency-flags`. OpenSSL-style and CMake build scripts that asked the driver for a `.d` beside each object used to force a full recompile on every fresh target.
> 
> The parser records those flags in a **`CallerDepfile`** (path, `-MT`/`‑MQ` targets, `-MMD` / `-MP` behavior) but **does not put them in the action key** and **does not pass them to the real compiler**—the shim still injects its own private dependency capture. After a compile or a **cache restore**, the shim **writes the caller’s dependency file** from the files the compilation actually read, via new **`CcDepfile::render`** (make quoting and `-MP` phony rules). `-M`, `-MM`, `-MG`, and lone `-MF`/`‑MT` without `-MD`/`‑MMD` still bypass.
> 
> A related fix: **`CcInvocation::output_in`** resolves relative `-o` paths against the compiler working directory so publish/restore use paths the cache agent can open (OpenSSL’s relative object names had been failing publication).
> 
> Debug builds now **warn** when cc action predictions fail to record with the agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6032aa4df49bfbc54fcbbef301c447318617ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->