### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bytesize",
  "demand",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.14...mbx-cache-cargo-v0.1.15) - 2026-09-02
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.13...mbx-cache-cargo-v0.1.14) - 2026-09-02
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.14"
+version = "0.1.15"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.1...mbx-cache-cc-v0.11.2) - 2026-09-02
+
+### Fixed
+
+- *(cc)* admit instruction-set and code-generation switches ([#287](https://github.com/jdx/mr-boxington/pull/287))
+
+### Other
+
+- verify compiler inputs by identity after compiling ([#284](https://github.com/jdx/mr-boxington/pull/284))
+
 ## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.0...mbx-cache-cc-v0.11.1) - 2026-09-02
 
 ### Other

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.11.1"
+version = "0.11.2"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.1...mbx-cache-core-v0.11.2) - 2026-09-02
+
+### Fixed
+
+- *(remote)* bound what a build loses to failed cache reads ([#292](https://github.com/jdx/mr-boxington/pull/292))
+
+### Other
+
+- verify compiler inputs by identity after compiling ([#284](https://github.com/jdx/mr-boxington/pull/284))
+- carry the file-digest ledger across sessions ([#285](https://github.com/jdx/mr-boxington/pull/285))
+
 ## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.0...mbx-cache-core-v0.11.1) - 2026-09-02
 
 ### Other

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.11.1"
+version = "0.11.2"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.1...mbx-cache-rustc-v0.11.2) - 2026-09-02
+
+### Fixed
+
+- cache dependencies of LTO builds ([#286](https://github.com/jdx/mr-boxington/pull/286))
+
+### Other
+
+- verify compiler inputs by identity after compiling ([#284](https://github.com/jdx/mr-boxington/pull/284))
+
 ## [0.11.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.0...mbx-cache-rustc-v0.11.1) - 2026-09-02
 
 ### Other

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.11.1"
+version = "0.11.2"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.13...mbx-cache-store-v0.1.14) - 2026-09-02
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.12...mbx-cache-store-v0.1.13) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.13"
+version = "0.1.14"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2](https://github.com/jdx/mr-boxington/compare/v1.4.1...v1.4.2) - 2026-09-02
+
+### Fixed
+
+- *(remote)* bound what a build loses to failed cache reads ([#292](https://github.com/jdx/mr-boxington/pull/292))
+- keep learned incremental state for large crates ([#282](https://github.com/jdx/mr-boxington/pull/282))
+- *(setup)* preserve native compiler path when disabled ([#281](https://github.com/jdx/mr-boxington/pull/281))
+
+### Other
+
+- carry the file-digest ledger across sessions ([#285](https://github.com/jdx/mr-boxington/pull/285))
+
 ## [1.4.1](https://github.com/jdx/mr-boxington/compare/v1.4.0...v1.4.1) - 2026-09-02
 
 ### Other

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.4.1"
+version = "1.4.2"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.1", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.14", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.1", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.1", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.13", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.15", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.2", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.2", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.14", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.4.1
+**Version:** 1.4.2
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `mbx-cache-cc`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `mbx`: 1.4.1 -> 1.4.2 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.14 -> 0.1.15
* `mbx-cache-store`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.1...mbx-cache-core-v0.11.2) - 2026-09-02

### Fixed

- *(remote)* bound what a build loses to failed cache reads ([#292](https://github.com/jdx/mr-boxington/pull/292))

### Other

- verify compiler inputs by identity after compiling ([#284](https://github.com/jdx/mr-boxington/pull/284))
- carry the file-digest ledger across sessions ([#285](https://github.com/jdx/mr-boxington/pull/285))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.1...mbx-cache-cc-v0.11.2) - 2026-09-02

### Fixed

- *(cc)* admit instruction-set and code-generation switches ([#287](https://github.com/jdx/mr-boxington/pull/287))

### Other

- verify compiler inputs by identity after compiling ([#284](https://github.com/jdx/mr-boxington/pull/284))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.1...mbx-cache-rustc-v0.11.2) - 2026-09-02

### Fixed

- cache dependencies of LTO builds ([#286](https://github.com/jdx/mr-boxington/pull/286))

### Other

- verify compiler inputs by identity after compiling ([#284](https://github.com/jdx/mr-boxington/pull/284))
</blockquote>

## `mbx`

<blockquote>

## [1.4.2](https://github.com/jdx/mr-boxington/compare/v1.4.1...v1.4.2) - 2026-09-02

### Fixed

- *(remote)* bound what a build loses to failed cache reads ([#292](https://github.com/jdx/mr-boxington/pull/292))
- keep learned incremental state for large crates ([#282](https://github.com/jdx/mr-boxington/pull/282))
- *(setup)* preserve native compiler path when disabled ([#281](https://github.com/jdx/mr-boxington/pull/281))

### Other

- carry the file-digest ledger across sessions ([#285](https://github.com/jdx/mr-boxington/pull/285))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.14...mbx-cache-cargo-v0.1.15) - 2026-09-02

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.13...mbx-cache-store-v0.1.14) - 2026-09-02

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The tagged release bundles cache-keying, remote-cache, and incremental-compilation behavior changes from prior merges; this PR is mechanical but what ships affects build correctness and cache hits.
> 
> **Overview**
> **Release-only PR** (release-plz): bumps crate versions, refreshes `Cargo.lock`, records changelog sections, and updates the generated CLI docs version string. No runtime or library logic changes appear in this diff.
> 
> **`mbx` 1.4.2** documents fixes for remote cache read failures (less work discarded), incremental state on large crates, and setup preserving the native compiler path when disabled, plus persisting the file-digest ledger across sessions.
> 
> **`mbx-cache-core` 0.11.2** carries the remote-read bound and digest-ledger work, and post-compile input verification by identity. **`mbx-cache-rustc`**, **`mbx-cache-cc`**, **`mbx-cache-cargo`**, and **`mbx-cache-store`** are bumped mainly to align on **`mbx-cache-core` 0.11.2**; rustc adds LTO dependency caching and cc adds instruction-set / codegen switches in cache keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870965669c202d927527cc5a8fd779e3c1548f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->