### PR TITLE
docs: recommend learned incremental default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,6 +199,15 @@ suppress the summary for that invocation.
 
 ## Incremental builds
 
+::: tip Start with the default
+You do not need `MBX_INCREMENTAL=1` to make edited crates compile
+incrementally. mbx already gives a changing crate private incremental state
+while keeping the rest of the build in the shared cache.
+
+Turn it on when one checkout's edit loop matters more than cache reuse across
+branches and worktrees.
+:::
+
 `MBX_INCREMENTAL=1` stops mbx from forcing `CARGO_INCREMENTAL=0` locally. This
 can help an edit/rebuild loop, but an incremental workspace artifact changes
 the inputs of crates above it and reduces reuse across worktrees. CI always

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,13 +199,14 @@ suppress the summary for that invocation.
 
 ## Incremental builds
 
-::: tip Start with the default
-You do not need `MBX_INCREMENTAL=1` to make edited crates compile
-incrementally. mbx already gives a changing crate private incremental state
-while keeping the rest of the build in the shared cache.
+::: tip Smart incremental is already on
+mbx speeds up repeated edits without relying on `CARGO_INCREMENTAL`. It keeps
+incremental state for crates you are actively changing while leaving everything
+else reusable across branches and worktrees.
 
-Turn it on when one checkout's edit loop matters more than cache reuse across
-branches and worktrees.
+Most users should leave `MBX_INCREMENTAL` unset. Turning it on makes the whole
+workspace incremental, producing checkout-specific artifacts that are less
+useful to the shared cache.
 :::
 
 `MBX_INCREMENTAL=1` stops mbx from forcing `CARGO_INCREMENTAL=0` locally. This


### PR DESCRIPTION
## Summary

- recommend leaving `MBX_INCREMENTAL` unset for normal development
- explain that learned incremental reuse keeps the edited crate fast without making the whole workspace checkout-local
- reserve full Cargo incremental mode for workloads where that tradeoff is intentional

This guidance assumes the cache-hit freshness fix in #300.

## Testing

- `mise run check:docs`
- `mise run check:links`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b923d716070a65b2d1a64294ecd4bee39eaa4f79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining smart incremental builds, when to enable `MBX_INCREMENTAL`, and how incremental behavior affects workspace artifacts and shared-cache reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->