### PR TITLE
fix(ci): restrict performance dispatch to main

### DIFF
--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   measure:
+    if: github.ref == 'refs/heads/main'
     runs-on: [self-hosted, jdx-perf-v1]
     env:
       # Persistent appliance-local store; no remote backend is configured.


### PR DESCRIPTION
## Summary

- restrict manual performance-history dispatches to `main`
- keep the persistent appliance cache reachable only from the trusted main ref

Follow-up to #290. The bind source and UID/GID 1001 ownership are provisioned by `jdx/perf-runner` bootstrap.

## Validation

- `actionlint .github/workflows/measure.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow condition with no application or auth changes; only narrows when CI can touch the perf runner and local cache.
> 
> **Overview**
> Adds a job-level guard on the **performance history** workflow so the `measure` job only runs when the ref is **`main`**.
> 
> That closes a gap where **`workflow_dispatch`** could still trigger benchmarks on other branches. The self-hosted `measure` job mounts a persistent appliance cache (`/var/cache/jdx-perf/mbx`); limiting runs to `main` keeps that trusted path aligned with push-to-main behavior. Downstream **`publish`** still depends on `measure`, so it will not run when the guard skips measurement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe08d322a437d7b84298804b31e4e026ffd108e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Measurement workflows now run only for changes on the main branch.
  * Manual or other workflow events on non-main branches no longer trigger measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->