### PR TITLE
perf(ci): use precompiled kache release

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -111,8 +111,21 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       # Pinned: the comparison is only fair while both caches are the versions
       # the published numbers name.
-      - name: Install kache
-        run: cargo install kache --locked --version 0.16.0
+      - name: Install released kache
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          archive=kache-x86_64-unknown-linux-musl.tar.gz
+          install_dir="$RUNNER_TEMP/kache-release"
+          mkdir -p "$install_dir"
+          gh release download v0.16.0 \
+            --repo kunobi-ninja/kache \
+            --pattern "$archive" \
+            --pattern "$archive.sha256" \
+            --dir "$install_dir"
+          (cd "$install_dir" && sha256sum --check --strict "$archive.sha256")
+          tar -xzf "$install_dir/$archive" -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
       - name: Install released mbx
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -109,23 +109,6 @@ jobs:
             valgrind --version
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-      # Pinned: the comparison is only fair while both caches are the versions
-      # the published numbers name.
-      - name: Install released kache
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          archive=kache-x86_64-unknown-linux-musl.tar.gz
-          install_dir="$RUNNER_TEMP/kache-release"
-          mkdir -p "$install_dir"
-          gh release download v0.16.0 \
-            --repo kunobi-ninja/kache \
-            --pattern "$archive" \
-            --pattern "$archive.sha256" \
-            --dir "$install_dir"
-          (cd "$install_dir" && sha256sum --check --strict "$archive.sha256")
-          tar -xzf "$install_dir/$archive" -C "$install_dir"
-          echo "$install_dir" >> "$GITHUB_PATH"
       - name: Install released mbx
         env:
           GH_TOKEN: ${{ github.token }}
@@ -147,8 +130,9 @@ jobs:
       - name: Refresh benchmarks
         env:
           MBX_BENCH_ALTERNATE_TOOLCHAIN: 1.96.0
+          MISE_LOCKED: "1"
         run: |
-          python3 benchmarks/real_world.py \
+          mise x -- python3 benchmarks/real_world.py \
             --mbx "$MBX_BENCH_BINARY" \
             --scenarios cold,warm,commit,worktree,toolchain,contention \
             --output target/benchmarks \

--- a/mise.lock
+++ b/mise.lock
@@ -127,6 +127,48 @@ url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-pc-windows
 url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992910"
 provenance = "github-attestations"
 
+[[tools."github:kunobi-ninja/kache"]]
+version = "0.16.0"
+backend = "github:kunobi-ninja/kache"
+specifiers = ["0.16.0"]
+
+[tools."github:kunobi-ninja/kache"."platforms.linux-arm64"]
+checksum = "sha256:6eabb67867022eecdbfffe43c16e75b5c5b561983742bda3c900a4cb4c50e4a7"
+url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655675"
+provenance = "github-attestations"
+
+[tools."github:kunobi-ninja/kache"."platforms.linux-arm64-musl"]
+checksum = "sha256:6eabb67867022eecdbfffe43c16e75b5c5b561983742bda3c900a4cb4c50e4a7"
+url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655675"
+provenance = "github-attestations"
+
+[tools."github:kunobi-ninja/kache"."platforms.linux-x64"]
+checksum = "sha256:caee657c662379475af2a0a7611ad32a6d053822036c1ec191bb8fd1c826d54b"
+url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655714"
+provenance = "github-attestations"
+
+[tools."github:kunobi-ninja/kache"."platforms.linux-x64-musl"]
+checksum = "sha256:caee657c662379475af2a0a7611ad32a6d053822036c1ec191bb8fd1c826d54b"
+url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655714"
+provenance = "github-attestations"
+
+[tools."github:kunobi-ninja/kache"."platforms.macos-arm64"]
+checksum = "sha256:6ad80d3bbb33d7db1715d5a919edbdf755dc19ca22fa83797c659147f1f9e229"
+url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655624"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools."github:kunobi-ninja/kache"."platforms.windows-x64"]
+checksum = "sha256:b4b53a54926e5cdc8c084562fdf215780306c9d5dc7eeaff9e4eb70c0b47fe2a"
+url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655706"
+provenance = "github-attestations"
+
 [[tools.lychee]]
 version = "0.24.2"
 backend = "aqua:lycheeverse/lychee"

--- a/mise.toml
+++ b/mise.toml
@@ -163,6 +163,7 @@ run = "tak run --record"
 # Perf jobs build the current source with the latest released mbx so the
 # appliance cache is usable without bootstrapping from the branch under test.
 mr-boxington = "1.4.1"
+"github:kunobi-ninja/kache" = { version = "0.16.0", lazy = true, lazy_bins = ["kache"] }
 "github:jdx/tak" = "0.0.9"
 aube = "latest"
 communique = "latest"


### PR DESCRIPTION
## Summary

- declare `github:kunobi-ninja/kache@0.16.0` as a lazy mise tool for benchmark refreshes
- let mise select the precompiled platform artifact and verify its locked checksum and GitHub attestation
- install kache only when the benchmark first invokes it, never through Cargo

The currently running refresh keeps its existing default-branch workflow; this applies to refreshes after merge.

## Validation

- `mise x -- kache --version` → `kache 0.16.0`
- `actionlint .github/workflows/bench-refresh.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the scheduled bench-refresh CI job and mise tool pinning; benchmark numbers may shift slightly if the prebuilt kache differs from a local compile, but there is no production or auth impact.
> 
> **Overview**
> **Benchmark refresh** no longer runs `cargo install kache` on the perf runner. **kache 0.16.0** is declared as a lazy mise tool in `mise.toml`, with platform checksums added to `mise.lock`, so CI gets the published binary through mise instead of compiling from source.
> 
> The **Refresh benchmarks** step now runs `mise x -- python3 benchmarks/real_world.py` with **`MISE_LOCKED=1`**, so the harness sees a locked tool environment (including `kache` on `PATH` when the scenarios need it) while still using the separately downloaded release `mbx` binary via `--mbx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c1d186cce23ce6afd083dc8462115b6c95adc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->