### PR TITLE
fix: stop cache hits from keeping Cargo targets stale

### DIFF
--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -94,7 +94,10 @@ pub(crate) fn install(executable: &Path, binary_action: &CacheDigest) -> Result<
     let temporary = real.with_extension("mbx-real-new");
     let _ = std::fs::remove_file(&temporary);
     std::fs::copy(executable, &temporary).wrap_err("failed to preserve the build script")?;
-    std::fs::File::open(&temporary)?.set_times(std::fs::FileTimes::new().set_modified(modified))?;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&temporary)?
+        .set_times(std::fs::FileTimes::new().set_modified(modified))?;
     let _ = std::fs::remove_file(&real);
     std::fs::rename(&temporary, &real)?;
     std::fs::write(
@@ -105,7 +108,10 @@ pub(crate) fn install(executable: &Path, binary_action: &CacheDigest) -> Result<
     let mbx = std::env::current_exe().wrap_err("failed to locate the mbx shim")?;
     let _ = std::fs::remove_file(executable);
     let installed = std::fs::copy(&mbx, executable).and_then(|_| {
-        std::fs::File::open(executable)?.set_times(std::fs::FileTimes::new().set_modified(modified))
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(executable)?
+            .set_times(std::fs::FileTimes::new().set_modified(modified))
     });
     if let Err(error) = installed {
         let _ = std::fs::rename(&real, executable);

--- a/crates/mbx/src/build_script.rs
+++ b/crates/mbx/src/build_script.rs
@@ -82,10 +82,19 @@ struct Restored {
 
 /// Preserve the real program beside Cargo's expected path and replace it with mbx.
 pub(crate) fn install(executable: &Path, binary_action: &CacheDigest) -> Result<()> {
+    // Cargo decides whether a build-script compilation is fresh partly by
+    // comparing this path's mtime with its dependencies. The path becomes a
+    // shim below, but it still has to look as new as the binary it represents:
+    // copying the mbx executable can otherwise give it mbx's older mtime and
+    // make Cargo compile the build script again on every invocation.
+    let modified = std::fs::metadata(executable)?
+        .modified()
+        .wrap_err("failed to inspect the build-script modification time")?;
     let real = session::build_script_real_path(executable);
     let temporary = real.with_extension("mbx-real-new");
     let _ = std::fs::remove_file(&temporary);
     std::fs::copy(executable, &temporary).wrap_err("failed to preserve the build script")?;
+    std::fs::File::open(&temporary)?.set_times(std::fs::FileTimes::new().set_modified(modified))?;
     let _ = std::fs::remove_file(&real);
     std::fs::rename(&temporary, &real)?;
     std::fs::write(
@@ -95,7 +104,9 @@ pub(crate) fn install(executable: &Path, binary_action: &CacheDigest) -> Result<
 
     let mbx = std::env::current_exe().wrap_err("failed to locate the mbx shim")?;
     let _ = std::fs::remove_file(executable);
-    let installed = std::fs::copy(&mbx, executable).map(|_| ());
+    let installed = std::fs::copy(&mbx, executable).and_then(|_| {
+        std::fs::File::open(executable)?.set_times(std::fs::FileTimes::new().set_modified(modified))
+    });
     if let Err(error) = installed {
         let _ = std::fs::rename(&real, executable);
         return Err(error).wrap_err("failed to install the build-script shim");
@@ -856,6 +867,31 @@ fn restore_symlink(_: &str, _: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn build_script_shim_keeps_the_compiled_binary_mtime() {
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("build-script-build");
+        std::fs::write(&executable, b"compiled build script").unwrap();
+        let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        filetime::set_file_mtime(&executable, filetime::FileTime::from_system_time(modified))
+            .unwrap();
+
+        install(&executable, &CacheDigest::blake3(b"action")).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&executable).unwrap().modified().unwrap(),
+            modified
+        );
+        assert_eq!(
+            std::fs::metadata(session::build_script_real_path(&executable))
+                .unwrap()
+                .modified()
+                .unwrap(),
+            modified
+        );
+    }
 
     #[test]
     fn directives_are_deduplicated_and_both_cargo_spellings_are_accepted() {

--- a/crates/mbx/src/materialize.rs
+++ b/crates/mbx/src/materialize.rs
@@ -151,6 +151,13 @@ pub(crate) fn stage_verified_cached_output(
         );
     }
     apply_file_mode(&temporary, node.mode, node.executable)?;
+    // A cache hit stands in for work Cargo decided was stale. Reflinks and
+    // some copy implementations preserve the CAS blob's older mtime, which
+    // can leave this output older than the dependency that triggered the
+    // invocation and make Cargo repeat it forever. A real compiler would have
+    // produced the file now, so give the restored output the same ordering.
+    std::fs::File::open(&temporary)?
+        .set_times(std::fs::FileTimes::new().set_modified(std::time::SystemTime::now()))?;
     Ok((temporary, materialization))
 }
 

--- a/crates/mbx/src/materialize.rs
+++ b/crates/mbx/src/materialize.rs
@@ -156,7 +156,9 @@ pub(crate) fn stage_verified_cached_output(
     // can leave this output older than the dependency that triggered the
     // invocation and make Cargo repeat it forever. A real compiler would have
     // produced the file now, so give the restored output the same ordering.
-    std::fs::File::open(&temporary)?
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&temporary)?
         .set_times(std::fs::FileTimes::new().set_modified(std::time::SystemTime::now()))?;
     Ok((temporary, materialization))
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1818,7 +1818,9 @@ fn restore_result(
 }
 
 fn mark_output_restored(path: &Path) -> Result<()> {
-    std::fs::File::open(path)?
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
         .set_times(std::fs::FileTimes::new().set_modified(std::time::SystemTime::now()))?;
     Ok(())
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1730,6 +1730,7 @@ fn restore_result(
             if restore_outputs
                 && std::fs::read(&destination).is_ok_and(|existing| existing == bytes)
             {
+                mark_output_restored(&destination)?;
                 restore.reused_output_files = restore.reused_output_files.saturating_add(1);
                 restore.reused_output_bytes = restore
                     .reused_output_bytes
@@ -1753,15 +1754,16 @@ fn restore_result(
             executable: node.executable,
             mode: node.mode,
         });
-        // An output that already holds these bytes is kept, not rewritten.
-        // What the rewrite would change is only the modification time, and
-        // that change is what makes cargo's next freshness pass re-dirty
-        // every dependent of this unit -- a rebuild loop that never settles.
-        // Keeping the file settles it: once nothing rewrites, nothing is
-        // newer than what depends on it, and the next build is a no-op.
+        // Avoid copying bytes that are already here, but still make the output
+        // look freshly produced. Cargo only invoked rustc because this unit
+        // was stale; leaving its old mtime behind lets a newer dependency keep
+        // the same unit stale forever, even though this cache hit rebuilt it
+        // logically. Cargo writes the unit fingerprint after rustc returns, so
+        // touching it here preserves the same ordering as a real compilation.
         if restore_outputs
             && output_already_in_place(&node, &destination, session::file_digest_cache())
         {
+            mark_output_restored(&destination)?;
             restore.reused_output_files = restore.reused_output_files.saturating_add(1);
             restore.reused_output_bytes =
                 restore.reused_output_bytes.saturating_add(node.digest.size);
@@ -1815,14 +1817,19 @@ fn restore_result(
     }))
 }
 
+fn mark_output_restored(path: &Path) -> Result<()> {
+    std::fs::File::open(path)?
+        .set_times(std::fs::FileTimes::new().set_modified(std::time::SystemTime::now()))?;
+    Ok(())
+}
+
 /// Whether the destination already holds exactly the bytes this hit would
 /// place there.
 ///
 /// The session ledger answers without a read when it can; otherwise the file
 /// is read once and hashed, which costs what the copy it replaces would have
-/// cost and buys an unchanged modification time. A ledger entry whose digest
-/// disagrees is a content difference already proven, so it refuses without
-/// reading either.
+/// cost. A ledger entry whose digest disagrees is a content difference already
+/// proven, so it refuses without reading either.
 pub(crate) fn output_already_in_place(
     node: &CacheFileNode,
     destination: &Path,

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1407,7 +1407,41 @@ fn build_script_shim_does_not_redirty_its_compilation() {
                 .then_some(path)
         })
         .expect("the build dependency should have an rlib");
-    filetime::set_file_mtime(&helper, filetime::FileTime::now()).unwrap();
+    let build_script = project
+        .path()
+        .join("target/debug/build")
+        .read_dir()
+        .unwrap()
+        .find_map(|entry| {
+            let directory = entry.ok()?.path();
+            directory.read_dir().ok()?.find_map(|entry| {
+                let path = entry.ok()?.path();
+                let name = path.file_name()?.to_str()?;
+                (path.is_file()
+                    && name.starts_with("build_script_build-")
+                    && !name.ends_with(".d")
+                    && !name.ends_with(".pdb"))
+                .then_some(path)
+            })
+        })
+        .expect("the compiled build script should exist");
+
+    let build_script_mtime = build_script.metadata().unwrap().modified().unwrap();
+    filetime::set_file_mtime(
+        &helper,
+        filetime::FileTime::from_system_time(
+            build_script_mtime + std::time::Duration::from_secs(4),
+        ),
+    )
+    .unwrap();
+    assert!(
+        helper.metadata().unwrap().modified().unwrap() > build_script_mtime,
+        "the fixture dependency must be newer than the compiled build script"
+    );
+    let helper_mtime = helper.metadata().unwrap().modified().unwrap();
+    while std::time::SystemTime::now() <= helper_mtime {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
     let repaired = build(
         project.path(),
         store.path(),

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1343,6 +1343,98 @@ fn write_execution_cached_project(directory: &Path, declares_inputs: bool) {
     assert!(status.success());
 }
 
+/// Write a build script with a Rust build-dependency. Cargo compares the
+/// build-script executable's mtime with that dependency when checking whether
+/// the compilation is fresh.
+fn write_build_dependent_script_project(directory: &Path) {
+    std::fs::create_dir_all(directory.join("src")).unwrap();
+    std::fs::create_dir_all(directory.join("helper/src")).unwrap();
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        "[package]\nname = \"build-dependent-script\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[build-dependencies]\nhelper = { path = \"helper\" }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("helper/Cargo.toml"),
+        "[package]\nname = \"helper\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("helper/src/lib.rs"),
+        "pub fn emit() { println!(\"cargo:rerun-if-changed=build.rs\"); }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("build.rs"),
+        "fn main() { helper::emit(); }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("src/lib.rs"),
+        "pub fn value() -> u32 { 1 }\n",
+    )
+    .unwrap();
+    let status = Command::new(cargo())
+        .current_dir(directory)
+        .args(["generate-lockfile", "--offline"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn build_script_shim_does_not_redirty_its_compilation() {
+    let store = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    write_build_dependent_script_project(project.path());
+
+    build(
+        project.path(),
+        store.path(),
+        &reports.path().join("first.json"),
+    );
+    let helper = project
+        .path()
+        .join("target/debug/deps")
+        .read_dir()
+        .unwrap()
+        .find_map(|entry| {
+            let path = entry.ok()?.path();
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("libhelper-") && name.ends_with(".rlib"))
+                .then_some(path)
+        })
+        .expect("the build dependency should have an rlib");
+    filetime::set_file_mtime(&helper, filetime::FileTime::now()).unwrap();
+    let repaired = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("repaired.json"),
+    );
+    assert!(
+        count(&repaired, "hits") > 0,
+        "the newer dependency should make Cargo invoke cached work: {repaired}"
+    );
+
+    let noop = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("noop.json"),
+    );
+    assert_eq!(
+        count(&noop, "hits"),
+        0,
+        "Cargo should not invoke the compiler or build script again: {noop}"
+    );
+    assert_eq!(
+        count(&noop, "misses"),
+        0,
+        "Cargo should consider every target fresh: {noop}"
+    );
+}
+
 /// Write a fixture that relies on Cargo's implicit package-wide build-script
 /// input. Its execution log lives outside the package so observing a run does
 /// not itself invalidate that input.


### PR DESCRIPTION
Cargo can invoke rustc because an input is newer than an existing output. On a cache hit, mbx reused those output bytes without advancing their mtimes; reflinks could also inherit the older CAS timestamp. Cargo therefore saw the same stale relationship on the next build and repeated work across the dependency graph.

Build-script shims had a related problem: replacing the compiled binary with the mbx executable gave Cargo the mbx binary timestamp rather than the compiled output timestamp.

This change makes restored outputs look newly produced and preserves the compiled binary timestamp on its build-script shim. The regression test uses a build dependency, forces the same stale ordering, and verifies that one repair build is followed by a true no-op.

Local validation:
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- mise trunk no-op after repair: 0.69s, 0 cache hits/misses (previously 8.79s and 296 hits)
- mise edit loop after the initial full root rebuild: 12.0s, 11.1s, with no unchanged Rust dependencies rescheduled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem timestamps on every cache restore path in rustc/materialize/build-script install; wrong mtime logic could cause unnecessary rebuilds or mask real staleness, but scope is limited to mbx’s restore/shim code with targeted tests.
> 
> **Overview**
> **Fixes rebuild loops** where mbx cache hits left Cargo thinking targets were still stale because output files kept old modification times (including from CAS reflinks/copies).
> 
> On **rustc cache restore**, reused or in-place matching bytes now get their mtime bumped to “now” via `mark_output_restored`, so outputs look as fresh as a real compile after Cargo already decided the unit was stale. **Materialized** cache outputs get the same treatment when staged from the store.
> 
> For **build-script shims**, `install` now **preserves** the compiled build-script binary’s mtime on both the saved real binary and the mbx executable at Cargo’s expected path, so swapping in the shim does not make the build-script artifact look older than its build-dependencies.
> 
> Adds a unit test for shim mtime preservation and an integration test where a newer build-dependency forces one cached repair build, then a fully fresh no-op build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff071266828c3193813a61b6550dddfee42103c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build caching so restored outputs are recognized as freshly produced.
  * Prevented unchanged build scripts from triggering unnecessary recompilation.
  * Preserved file timestamps during build-script installation and cache restoration.
* **Tests**
  * Added coverage confirming unchanged projects remain fully up to date after cached build work is reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->