### PR TITLE
docs: clarify incremental cache tradeoff

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,9 +204,9 @@ mbx speeds up repeated edits without relying on `CARGO_INCREMENTAL`. It keeps
 incremental state for crates you are actively changing while leaving everything
 else reusable across branches and worktrees.
 
-Most users should leave `MBX_INCREMENTAL` unset. Turning it on makes the whole
-workspace incremental, producing checkout-specific artifacts that are less
-useful to the shared cache.
+You probably do not want to turn it on. When policy allows, it makes local
+workspace crates use Cargo's incremental mode. Those checkout-specific builds
+bypass the shared cache and can make crates above them miss it too.
 :::
 
 `MBX_INCREMENTAL=1` stops mbx from forcing `CARGO_INCREMENTAL=0` locally. This


### PR DESCRIPTION
Follow-up to #296, assuming #300 lands.

Clarifies that `MBX_INCREMENTAL=1` applies to local workspace crates when policy allows, and explains plainly why most users should leave it unset: Cargo incremental builds bypass the shared cache and can cause downstream misses.

Checks:
- `mise run check:docs`
- `mise run check:links`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or configuration behavior changes.
> 
> **Overview**
> Updates the **Incremental builds** tip in `docs/configuration.md` so it matches the intended `MBX_INCREMENTAL` behavior and cache impact.
> 
> The old text said turning incremental on makes the **whole workspace** incremental and only that artifacts are less useful to the shared cache. The new text says you usually should not enable it, that—**when policy allows**—it applies Cargo incremental to **local workspace crates**, and that those checkout-specific builds **bypass the shared cache** and can cause **upstream crates to miss** the cache too.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c636ef4571c720473fbb715d3802575373e178e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->