### PR TITLE
chore(ci): update performance runner image

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -78,7 +78,7 @@ jobs:
     # with every other jdx performance job.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
+      image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68
       options: --cpuset-cpus 0-7
     # The full refresh also runs every cache scenario and the toolchain guard.
     timeout-minutes: 180
@@ -99,8 +99,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@34a523e'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
+            echo 'environment-revision: perf-runner@fd66d9b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68'
             uname -a
             lscpu
             mise --version


### PR DESCRIPTION
## Summary

- pin bench-refresh to the newly published performance image containing GitHub CLI
- update runner metadata to perf-runner merge `fd66d9b`

Image build and runtime verification: jdx/perf-runner run 33662575126. Published digest: `sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68`.

After merge, bench-refresh can be dispatched again without the previous `gh: not found` failure.

## Validation

- image build, push, and runtime checks passed, including `gh --version`
- `actionlint .github/workflows/bench-refresh.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only container pin and metadata strings; no application or release logic changes beyond fixing the benchmark refresh environment.
> 
> **Overview**
> Updates the **bench-refresh** job’s digest-pinned `ghcr.io/jdx/perf-runner` container and the matching **Runner metadata** lines (`environment-revision` → `perf-runner@fd66d9b`, new SHA256) so weekly/dispatch benchmark refreshes run on the image that includes **`gh`**.
> 
> That unblocks steps in this workflow that call **`gh release download`** during “Install released mbx,” which previously failed with `gh: not found` on the older image. Other perf workflows (e.g. `measure.yml`, `perf-pr.yml`) are **unchanged** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e32918bf4e5aadf9f62c62aad655e74c633faa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->