### PR TITLE
chore(ci): update performance runner image

### DIFF
--- a/.github/workflows/measure.yml
+++ b/.github/workflows/measure.yml
@@ -14,7 +14,7 @@ env:
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
   MISE_DISABLE_TOOLS: rust
   RUSTUP_TOOLCHAIN: 1.97.1
-  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1-img5263c143
 
 jobs:
   measure:
@@ -25,7 +25,7 @@ jobs:
       MBX_CACHE_DIR: /var/cache/mbx
       MBX_REMOTE_URL: ""
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
+      image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68
       options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
     timeout-minutes: 30
     permissions:
@@ -45,8 +45,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@34a523e'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
+            echo 'environment-revision: perf-runner@fd66d9b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -16,7 +16,7 @@ env:
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
   MISE_DISABLE_TOOLS: rust
   RUSTUP_TOOLCHAIN: 1.97.1
-  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1-img5263c143
 
 jobs:
   authorize:
@@ -66,7 +66,7 @@ jobs:
       MBX_CACHE_DIR: /var/cache/mbx
       MBX_REMOTE_URL: ""
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
+      image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68
       # Anonymous by design; perf-runner#10 prunes it after this container stops.
       options: --cpuset-cpus 0-7 --mount type=volume,dst=/var/cache/mbx
     timeout-minutes: 40
@@ -93,8 +93,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@34a523e'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
+            echo 'environment-revision: perf-runner@fd66d9b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68'
             uname -a
             lscpu
             mise --version


### PR DESCRIPTION
## Summary

- pin performance workflows to the verified perf-runner image containing GitHub CLI
- report perf-runner revision fd66d9b in job summaries
- start a fresh TAK_RUNNER series for the rebuilt measurement environment

Image: `ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68`

## Validation

- `actionlint`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*