### PR TITLE
perf: skip cache lookup for hot workspace edits

### DIFF
--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -181,7 +181,6 @@ pub(crate) fn compile(
     let mut verification = None;
     let mut action_lookup_attempted = false;
     let mut current_diagnostic = None;
-    let mut learned = LearnedPlan::default();
     // Probed once, before anything that would swallow the answer: a host whose
     // linker cannot be described bypasses here, where the reason is recorded,
     // rather than deep inside key construction where it becomes a warning
@@ -193,7 +192,9 @@ pub(crate) fn compile(
         portable: &portable,
         linker: linker_for(&invocation)?,
     };
-    if outputs.dep_info.is_file()
+    let mut learned = reuse_hot_workspace_plan(&compilation, &outputs, learned_enabled);
+    if !learned.engaged()
+        && outputs.dep_info.is_file()
         && let Ok((candidates, discovered)) =
             action_from_current_dep_info(&compilation, &outputs.dep_info)
     {
@@ -250,7 +251,7 @@ pub(crate) fn compile(
         }
     }
     let mut prediction_missing = false;
-    if !action_lookup_attempted {
+    if !learned.engaged() && !action_lookup_attempted {
         match restore_predicted_result(
             &compilation,
             &outputs,
@@ -285,7 +286,7 @@ pub(crate) fn compile(
     // waking from that wait, or finding the prediction a finished flight left
     // behind, is one more chance to restore instead of compile. Never in
     // verify mode, whose whole point is running the compiler.
-    let flight = if verify {
+    let flight = if verify || learned.engaged() {
         None
     } else {
         join_flight(&compilation)
@@ -766,6 +767,65 @@ fn plan_learned_reuse(
         Ok(plan) => plan,
         Err(error) => {
             eprintln!("mbx[warning]: churn was not tracked for this crate: {error:#}");
+            LearnedPlan::default()
+        }
+    }
+}
+
+/// Re-enter a workspace unit's established private state without rebuilding a
+/// shared action key first.
+///
+/// An intact dep-info file supplies the source fingerprint without constructing
+/// a shared action. A missing target, settled source, or changed environment
+/// deliberately takes the slower path so it can restore or republish.
+fn reuse_hot_workspace_plan(
+    compilation: &Compilation<'_>,
+    outputs: &RustcOutputs,
+    enabled: bool,
+) -> LearnedPlan {
+    if !enabled || !outputs.dep_info.is_file() || !source_is_in_workspace(compilation) {
+        return LearnedPlan::default();
+    }
+    let planned = (|| {
+        let context = base_action_context(
+            compilation.rustc,
+            compilation.working_dir,
+            compilation.portable,
+        )?;
+        let unit = compilation.invocation.invocation_digest(&context)?;
+        let Some(state_path) = churn_state_path(&unit) else {
+            return Result::<LearnedPlan>::Ok(LearnedPlan::default());
+        };
+        let Some(recorded) = read_churn_state(&state_path) else {
+            return Ok(LearnedPlan::default());
+        };
+        let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
+        verify_environment(&dep_info.environment)?;
+        let discovered = compilation.invocation.discover_inputs_with_mappings(
+            &dep_info,
+            compilation.working_dir,
+            &compilation.portable.mappings,
+            session::file_digest_cache(),
+        )?;
+        let sources = compilation.invocation.source_fingerprint(&discovered);
+        if recorded.streak < WORKSPACE_HOT_STREAK_THRESHOLD || recorded.sources == sources.key() {
+            return Ok(LearnedPlan::default());
+        }
+        Ok(LearnedPlan {
+            hot: true,
+            streak: recorded
+                .streak
+                .saturating_add(1)
+                .min(WORKSPACE_HOT_STREAK_THRESHOLD),
+            directory: None,
+            record: Some((state_path, sources)),
+        }
+        .resolved(&unit, compilation.invocation.crate_name()))
+    })();
+    match planned {
+        Ok(plan) => plan,
+        Err(error) => {
+            eprintln!("mbx[warning]: incremental state was not reused: {error:#}");
             LearnedPlan::default()
         }
     }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1047,6 +1047,11 @@ fn editing_one_crate_leaves_its_dependents_publishing() {
         stats["stored_bytes"].as_u64().unwrap_or(0) > 0,
         "the crate above it never changed, so it should still publish: {stats}"
     );
+    assert_eq!(
+        stats["lookups"].as_u64(),
+        Some(1),
+        "the hot edited crate should skip lookup while its dependent still publishes: {stats}"
+    );
 }
 
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,9 +227,11 @@ misses with changed sources. The build reports those compilations as
 The trigger is the crate's own sources, not its cache key. A rebuilt dependency
 changes the keys of everything above it, and those crates keep compiling and
 publishing normally. So does a miss on unchanged sources, such as a wiped
-`target/` or a first build in a new checkout. The record and state are private
-to each checkout and live under `incremental/` in mbx's cache directory, so
-`cargo clean` does not discard the next edit's speedup. Normal garbage
+`target/` or a first build in a new checkout. Once a crate is known to be hot,
+later edits go straight to its private incremental state instead of rebuilding
+and looking up a shared action the edit cannot hit. The record and state are
+private to each checkout and live under `incremental/` in mbx's cache directory,
+so `cargo clean` does not discard the next edit's speedup. Normal garbage
 collection removes state for deleted or expired checkouts.
 
 Each crate's state is discarded, with a warning naming the crate, once it


### PR DESCRIPTION
## Summary

- recognize an already-hot workspace crate from its churn record and current dep-info before constructing a shared action
- send second and later source edits straight to the crate's private incremental directory
- preserve the existing behavior for settled sources, missing targets, environment changes, and dependent crates

## Why

A changed source in a known-hot workspace crate cannot hit the shared action cache: its content is new and its useful state is private to the checkout. The old path still constructed and looked up that action, joined build-flight coordination, then selected the same private incremental directory.

The fast path verifies the recorded environment and fingerprints the current dep-info sources first. It falls back to the normal restore/publish path unless the crate is still hot and its own sources changed.

In the dependent-crate edit-loop fixture, a later edit now performs one shared lookup instead of two: the edited crate skips lookup while its dependent remains cacheable and continues to publish. On the full mise benchmark, wall time remains dominated by the final GNU ld link (roughly 14–17 seconds), so this PR intentionally removes deterministic mbx overhead without changing linker selection or requiring `MBX_INCREMENTAL=1`.

## Validation

- `cargo test -p mbx --lib` (348 passed, 1 ignored)
- `cargo test -p mbx --test build` (55 passed)
- `cargo clippy -p mbx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the rustc compile orchestration fast path (cache lookup, predictions, flights) for workspace edit loops; behavior is gated and falls back on failure, but mistakes could skip valid restores or add coordination gaps.
> 
> **Overview**
> **Hot workspace crates** can now re-enter **private learned incremental** state **before** mbx builds a shared action key or consults the cache.
> 
> At compile start, `reuse_hot_workspace_plan` reads the checkout churn record and current **dep-info** (environment + source fingerprint). When learned incremental is on, the crate is in-workspace, and it is still hot with **changed own sources**, mbx sets a `LearnedPlan` immediately and **skips** dep-info restore, prediction restore, and **build-flight** coordination—the same paths that cannot succeed for an edit that will miss the shared store anyway.
> 
> Unsettled sources, missing incremental state, environment drift, or errors still fall through to the existing restore/publish flow. A dependent-crate edit-loop test now expects **one** shared lookup (dependent only), and configuration docs note that later hot edits go straight to private incremental state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d7f83f92bca3ef165e3fdca6c6e904d95ab4037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved incremental rebuilds for previously built (“hot”) crates by reusing local build state directly, reducing unnecessary cache lookups and speeding up source-edit workflows.
  - Unchanged dependent crates continue to publish normally after an upstream crate is edited.

- **Documentation**
  - Clarified how learned incremental reuse works, including its checkout-private storage and persistence after `cargo clean`.

- **Tests**
  - Added coverage confirming that hot crate edits avoid redundant cache lookups while dependent crates remain publishable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->