### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "blake3",
  "eyre",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.15...mbx-cache-cargo-v0.1.16) - 2026-09-03
+
+### Added
+
+- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
+
 ## [0.1.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.14...mbx-cache-cargo-v0.1.15) - 2026-09-02
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.15"
+version = "0.1.16"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.2...mbx-cache-cc-v0.11.3) - 2026-09-03
+
+### Added
+
+- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
+
+### Fixed
+
+- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
+
 ## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.1...mbx-cache-cc-v0.11.2) - 2026-09-02
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.11.2"
+version = "0.11.3"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.2...mbx-cache-core-v0.11.3) - 2026-09-03
+
+### Added
+
+- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
+
+### Other
+
+- *(cache)* complete large remote transfers reliably ([#320](https://github.com/jdx/mr-boxington/pull/320))
+
 ## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.1...mbx-cache-core-v0.11.2) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.11.2"
+version = "0.11.3"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.12" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.13" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.12...mbx-cache-protocol-v0.5.13) - 2026-09-03
+
+### Added
+
+- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
+
 ## [0.5.12](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.11...mbx-cache-protocol-v0.5.12) - 2026-09-02
 
 ### Other

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.12"
+version = "0.5.13"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.2...mbx-cache-rustc-v0.11.3) - 2026-09-03
+
+### Added
+
+- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
+
+### Fixed
+
+- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
+
 ## [0.11.2](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.1...mbx-cache-rustc-v0.11.2) - 2026-09-02
 
 ### Fixed

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.11.2"
+version = "0.11.3"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.14...mbx-cache-store-v0.1.15) - 2026-09-03
+
+### Added
+
+- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
+
 ## [0.1.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.13...mbx-cache-store-v0.1.14) - 2026-09-02
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.14"
+version = "0.1.15"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/jdx/mr-boxington/compare/v1.5.0...v1.6.0) - 2026-09-03
+
+### Added
+
+- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
+
+### Fixed
+
+- preserve caching when Unix listeners are blocked ([#317](https://github.com/jdx/mr-boxington/pull/317))
+- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
+
 ## [1.5.0](https://github.com/jdx/mr-boxington/compare/v1.4.1...v1.5.0) - 2026-09-02
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.5.0"
+version = "1.6.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -26,11 +26,11 @@ flate2 = "1"
 hex = "0.4"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.2", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.15", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.2", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.2", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.14", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.16", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.3", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.3", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.15", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.5.0
+**Version:** 1.6.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.12 -> 0.5.13 (✓ API compatible changes)
* `mbx-cache-core`: 0.11.2 -> 0.11.3 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.15 -> 0.1.16 (✓ API compatible changes)
* `mbx-cache-cc`: 0.11.2 -> 0.11.3 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.11.2 -> 0.11.3 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.14 -> 0.1.15 (✓ API compatible changes)
* `mbx`: 1.5.0 -> 1.6.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.12...mbx-cache-protocol-v0.5.13) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.2...mbx-cache-core-v0.11.3) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))

### Other

- *(cache)* complete large remote transfers reliably ([#320](https://github.com/jdx/mr-boxington/pull/320))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.15...mbx-cache-cargo-v0.1.16) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.2...mbx-cache-cc-v0.11.3) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))

### Fixed

- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.2...mbx-cache-rustc-v0.11.3) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))

### Fixed

- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.14...mbx-cache-store-v0.1.15) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))
</blockquote>

## `mbx`

<blockquote>

## [1.6.0](https://github.com/jdx/mr-boxington/compare/v1.5.0...v1.6.0) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))

### Fixed

- preserve caching when Unix listeners are blocked ([#317](https://github.com/jdx/mr-boxington/pull/317))
- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical release-plz version and changelog updates only; behavioral changes were already merged in referenced PRs.
> 
> **Overview**
> **Release packaging** for **mbx 1.6.0** and aligned workspace crates (`mbx-cache-*` patch/minor bumps, `Cargo.lock` refresh). The diff does not change runtime logic—only versions, changelogs, and the generated CLI docs version string (**1.5.0 → 1.6.0**).
> 
> The published notes bundle prior work: **profile-specific linker management** ([#319]) across the cache stack, **compiler input verification across clock domains** ([#318]) in `mbx-cache-cc` / `mbx-cache-rustc`, **reliable completion of large remote transfers** ([#320]) in `mbx-cache-core`, and **preserving caching when Unix listeners are blocked** ([#317]) in `mbx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a61508cb2fbf029b238457bf8e44f35ce409a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->