### PR TITLE
feat: persist jdxld link manifests

### DIFF
--- a/crates/mbx/src/jdxld.rs
+++ b/crates/mbx/src/jdxld.rs
@@ -19,6 +19,7 @@ impl Worker {
     /// Start the configured worker, or leave jdxld disabled when no path was set.
     pub(crate) async fn start(
         session_dir: &Path,
+        state_root: &Path,
         configured: Option<&Path>,
     ) -> Result<Option<Self>> {
         let Some(configured) = configured else {
@@ -41,6 +42,7 @@ impl Worker {
             .arg("--mbx-worker")
             .arg(&socket_path)
             .arg(std::process::id().to_string())
+            .arg(state_root)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .spawn()

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -177,7 +177,12 @@ impl CacheSession {
         });
         let (socket, server) =
             spawn_server(session_dir, agent.clone(), Arc::clone(&task), shutdown_rx).await?;
-        let jdxld = crate::jdxld::Worker::start(session_dir, config.jdxld.as_deref()).await?;
+        let jdxld = crate::jdxld::Worker::start(
+            session_dir,
+            &config.cache_dir.join("incremental/jdxld"),
+            config.jdxld.as_deref(),
+        )
+        .await?;
         Ok(Self {
             socket,
             rustc_shim: shim,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,12 +212,14 @@ into jdxld's experimental mr-boxington worker protocol. mbx starts one worker
 for the Cargo command, routes native links to its Unix socket, and stops it as
 soon as the command finishes. The worker does not linger on a timeout.
 
-The current prototype reuses unchanged input mappings while still performing
-resolution, layout, relocation, and output on every link. In the captured mbx
-benchmark this reduced link-only time by about 13%; it is infrastructure for
-deeper incremental linking, not yet a persistent cross-command link cache.
-These links currently bypass mbx's native-link output cache because that cache
-does not yet model an overridden Clang linker.
+The current prototype reuses unchanged input mappings within a command and
+writes advisory link manifests under `incremental/jdxld` in mbx's cache
+directory. A later Cargo command can load the prior manifest and identify
+changed inputs, but jdxld still performs resolution, layout, relocation, and
+output in full. The captured warm-worker benchmark reduced link-only time by
+about 12%; the on-disk manifest does not save time yet. These links currently
+bypass mbx's native-link output cache because that cache does not yet model an
+overridden Clang linker.
 
 ## Learned incremental reuse
 


### PR DESCRIPTION
## Summary

- give each session-scoped jdxld worker the same disk-state root under the mbx cache directory
- preserve state across separate Cargo commands without keeping a process alive
- document that manifests are advisory and full linking still runs

Consumes jdx/jdxld#6.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mbx jdxld_is_added_only_to_native_links`
- `cargo clippy --workspace --all-targets -- -D warnings`
- two separate `mbx build` commands updated one jdxld state directory, produced a runnable binary, and left no worker alive

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>