### PR TITLE
feat: supply persisted digests to jdxld

### DIFF
--- a/crates/mbx/src/jdxld.rs
+++ b/crates/mbx/src/jdxld.rs
@@ -20,6 +20,7 @@ impl Worker {
     pub(crate) async fn start(
         session_dir: &Path,
         state_root: &Path,
+        agent_socket: &str,
         configured: Option<&Path>,
     ) -> Result<Option<Self>> {
         let Some(configured) = configured else {
@@ -38,11 +39,14 @@ impl Worker {
         let socket_path = session_dir.join("jdxld.sock");
         let socket = socket_path.to_string_lossy().into_owned();
         let executable_string = executable.to_string_lossy().into_owned();
+        let helper = std::env::current_exe().wrap_err("failed to locate the mbx executable")?;
         let child = Command::new(&executable)
             .arg("--mbx-worker")
             .arg(&socket_path)
             .arg(std::process::id().to_string())
             .arg(state_root)
+            .env("MBX_JDXLD_DIGEST_HELPER", helper)
+            .env(crate::session::SOCKET_ENV, agent_socket)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .spawn()

--- a/crates/mbx/src/jdxld_digest_helper.rs
+++ b/crates/mbx/src/jdxld_digest_helper.rs
@@ -1,0 +1,147 @@
+//! Internal bridge from jdxld's input paths to the session file-digest ledger.
+
+use eyre::{Context, Result, bail};
+use mbx_cache_core::{
+    CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, RecordedFileDigest,
+};
+use std::ffi::OsString;
+use std::io::{Read, Write};
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+pub const ARG: &str = "__jdxld_digests_v1";
+const MAGIC: &[u8; 8] = b"JDXLDG01";
+
+pub fn run() -> ExitCode {
+    match resolve_request(&mut std::io::stdin().lock(), &mut std::io::stdout().lock()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("mbx: jdxld digest helper failed: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn resolve_request(input: &mut impl Read, output: &mut impl Write) -> Result<()> {
+    let paths = read_request(input)?;
+    let digests = resolve(&paths, crate::session::file_digest_cache())?;
+    write_response(output, &digests)
+}
+
+fn resolve(paths: &[PathBuf], cache: &dyn FileDigestCache) -> Result<Vec<[u8; 32]>> {
+    let identities = paths
+        .iter()
+        .map(|path| {
+            let metadata = std::fs::metadata(path)
+                .wrap_err_with(|| format!("failed to inspect `{}`", path.display()))?;
+            FileIdentity::describe(path, &metadata)
+                .ok_or_else(|| eyre::eyre!("failed to identify `{}`", path.display()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let found = cache.find(FileDigestScope::Content, &identities);
+    let mut recorded = Vec::new();
+    let mut digests = Vec::with_capacity(paths.len());
+    for ((path, identity), found) in paths.iter().zip(&identities).zip(found) {
+        let digest = match found.filter(|digest| usable_digest(digest, identity.len)) {
+            Some(digest) => digest,
+            None => {
+                let digest = CacheDigest::blake3_file(path)
+                    .wrap_err_with(|| format!("failed to hash `{}`", path.display()))?;
+                if !identity.still_describes()? {
+                    bail!("linker input changed while hashing `{}`", path.display());
+                }
+                recorded.push(RecordedFileDigest {
+                    file: identity.clone(),
+                    digest: digest.clone(),
+                });
+                digest
+            }
+        };
+        digests.push(decode_blake3(&digest)?);
+    }
+    cache.record(FileDigestScope::Content, recorded);
+    Ok(digests)
+}
+
+fn usable_digest(digest: &CacheDigest, expected_size: u64) -> bool {
+    digest.algorithm == "blake3"
+        && digest.size == expected_size
+        && digest.hash.len() == 64
+        && digest.hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn decode_blake3(digest: &CacheDigest) -> Result<[u8; 32]> {
+    if !usable_digest(digest, digest.size) {
+        bail!("file-digest ledger returned an invalid BLAKE3 digest");
+    }
+    let mut bytes = [0; 32];
+    for (destination, pair) in bytes.iter_mut().zip(digest.hash.as_bytes().chunks_exact(2)) {
+        let text = std::str::from_utf8(pair)?;
+        *destination = u8::from_str_radix(text, 16)?;
+    }
+    Ok(bytes)
+}
+
+fn read_request(input: &mut impl Read) -> Result<Vec<PathBuf>> {
+    let mut magic = [0; 8];
+    input.read_exact(&mut magic)?;
+    if &magic != MAGIC {
+        bail!("invalid jdxld digest request");
+    }
+    let count = read_u32(input)? as usize;
+    let mut paths = Vec::with_capacity(count);
+    for _ in 0..count {
+        let length = read_u32(input)? as usize;
+        let mut bytes = vec![0; length];
+        input.read_exact(&mut bytes)?;
+        paths.push(PathBuf::from(OsString::from_vec(bytes)));
+    }
+    let mut trailing = [0];
+    if input.read(&mut trailing)? != 0 {
+        bail!("jdxld digest request contains trailing data");
+    }
+    Ok(paths)
+}
+
+fn write_response(output: &mut impl Write, digests: &[[u8; 32]]) -> Result<()> {
+    output.write_all(MAGIC)?;
+    write_u32(
+        output,
+        digests.len().try_into().context("too many digests")?,
+    )?;
+    for digest in digests {
+        output.write_all(digest)?;
+    }
+    output.flush()?;
+    Ok(())
+}
+
+fn read_u32(input: &mut impl Read) -> Result<u32> {
+    let mut bytes = [0; 4];
+    input.read_exact(&mut bytes)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn write_u32(output: &mut impl Write, value: u32) -> Result<()> {
+    output.write_all(&value.to_le_bytes())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mbx_cache_core::NoFileDigestCache;
+
+    #[test]
+    fn hashes_a_ledger_miss() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("input.o");
+        std::fs::write(&path, b"linker input").unwrap();
+        let digest = resolve(&[path], &NoFileDigestCache).unwrap().pop().unwrap();
+        assert_eq!(
+            digest,
+            decode_blake3(&CacheDigest::blake3(b"linker input")).unwrap()
+        );
+    }
+}

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -51,6 +51,9 @@ mod cc;
 mod digest_ledger;
 mod incremental;
 mod jdxld;
+#[cfg(unix)]
+#[doc(hidden)]
+pub mod jdxld_digest_helper;
 mod linker;
 mod materialize;
 mod rustc;

--- a/crates/mbx/src/main.rs
+++ b/crates/mbx/src/main.rs
@@ -1,6 +1,12 @@
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    #[cfg(unix)]
+    if std::env::args_os().nth(1).as_deref()
+        == Some(std::ffi::OsStr::new(mbx::jdxld_digest_helper::ARG))
+    {
+        return mbx::jdxld_digest_helper::run();
+    }
     if mbx::session::is_build_script_shim() {
         return mbx::session::run_build_script_shim();
     }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -180,6 +180,7 @@ impl CacheSession {
         let jdxld = crate::jdxld::Worker::start(
             session_dir,
             &config.cache_dir.join("incremental/jdxld"),
+            &socket,
             config.jdxld.as_deref(),
         )
         .await?;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,11 +214,13 @@ soon as the command finishes. The worker does not linger on a timeout.
 
 The current prototype reuses unchanged input mappings within a command and
 writes advisory link manifests under `incremental/jdxld` in mbx's cache
-directory. A later Cargo command can load the prior manifest and identify
-changed inputs, but jdxld still performs resolution, layout, relocation, and
-output in full. The captured warm-worker benchmark reduced link-only time by
-about 12%; the on-disk manifest does not save time yet. These links currently
-bypass mbx's native-link output cache because that cache does not yet model an
+directory. Linker inputs are content-addressed through mbx's persistent
+file-digest ledger, so later commands can reuse known digests without rereading
+unchanged files and can recognize rustc temporary inputs after their paths
+change. jdxld still performs resolution, layout, relocation, and output in
+full. The captured warm-worker benchmark reduced link-only time by about 12%;
+the on-disk manifest does not save time yet. These links currently bypass
+mbx's native-link output cache because that cache does not yet model an
 overridden Clang linker.
 
 ## Learned incremental reuse


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New subprocess IPC and ledger integration on the linker input path; incorrect digests could affect jdxld manifest reuse, though hashing guards and verify bypass limit exposure.
> 
> **Overview**
> **jdxld** can now resolve linker input paths through mbx’s **persistent file-digest ledger** instead of always re-reading files on disk.
> 
> When a session starts the jdxld worker, mbx passes **`MBX_JDXLD_DIGEST_HELPER`** (path to the running `mbx` binary) and **`MBX_SOCKET`** (the cache agent) into the worker environment. jdxld is expected to spawn that helper for digest batches.
> 
> A new Unix-only entry mode, **`__jdxld_digests_v1`**, speaks a small stdin/stdout binary protocol (`JDXLDG01`): it looks up **content-scoped** identities in the session ledger, hashes misses with BLAKE3 (with a **changed-while-hashing** guard), records new entries, and returns raw 32-byte digests. Verification mode still bypasses the ledger via the existing shim behavior.
> 
> `Worker::start` now takes the agent socket from `CacheSession`; docs for **jdxld session linking** describe ledger-backed content addressing and rustc temp-path reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdbf00aa5eeab8c54b8a003ca3a1df66cb54f598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->