### PR TITLE
bench: measure mise edit loops

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,6 +22,17 @@ are temporary and are not retained. CI uploads the correctness measurements
 and a `tak history` snapshot as artifacts; trusted main-branch runs publish the
 shared performance series to `refs/notes/tak`.
 
+`edit_loop.py` measures the other important build shape: repeated source edits
+in a pinned mise checkout while keeping the Cargo target and incremental state.
+It seeds an unedited build, discards the first edited build that teaches mbx to
+enable rustc incremental compilation for the workspace crate, and reports 30
+subsequent edits. Raw Cargo runs with its normal incremental compilation; mbx
+starts with `CARGO_INCREMENTAL=0`, so its results specifically exercise the
+learned per-checkout policy. The report separates wall, mbx session, and summed
+compiler-process time so Cargo orchestration is not mistaken for rustc work.
+The subject and latest stable Rust release are pinned in the driver so results
+do not silently change with the machine running it.
+
 `real_world.py` measures somebody else's project instead of this one. It
 clones a pinned checkout of [jdx/hk](https://github.com/jdx/hk) and runs the
 same `cargo build --locked` under raw cargo, mbx, and kache across the

--- a/benchmarks/edit_loop.py
+++ b/benchmarks/edit_loop.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Measure repeated source edits in a pinned mise checkout.
+
+This is deliberately separate from real_world.py. That benchmark recreates
+targets to model CI cache restores; this one preserves the target and mbx's
+learned rustc incremental state to model a developer's edit/build loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+MISE_URL = "https://github.com/jdx/mise.git"
+MISE_COMMIT = "8fe6385de7f73908ab5a6c9789f477a322eda3a5"
+RUST_TOOLCHAIN = "1.98.0"
+FIXTURE = Path("src/duration.rs")
+BEFORE = "pub(crate) const HOURLY: Duration = Duration::from_secs(60 * 60);"
+EDIT_PREFIX = "pub(crate) const HOURLY: Duration = Duration::from_secs(60 * 60 + "
+
+
+def percentile(samples: list[int], fraction: float) -> int:
+    """Return a nearest-rank percentile without interpolating measurements."""
+    if not samples:
+        raise ValueError("cannot summarize zero samples")
+    ordered = sorted(samples)
+    rank = max(1, int(len(ordered) * fraction + 0.999999999))
+    return ordered[rank - 1]
+
+
+def set_edit(checkout: Path, value: int) -> None:
+    path = checkout / FIXTURE
+    source = path.read_text(encoding="utf-8")
+    candidates = [
+        line
+        for line in source.splitlines()
+        if line == BEFORE or line.startswith(EDIT_PREFIX)
+    ]
+    if len(candidates) != 1:
+        raise RuntimeError(f"edit fixture changed upstream: {path}")
+    old = candidates[0]
+    new = f"{EDIT_PREFIX}{value});"
+    path.write_text(source.replace(old, new), encoding="utf-8")
+
+
+def compiler_duration(stats: dict[str, object]) -> int:
+    compiler = stats.get("compiler", {})
+    if not isinstance(compiler, dict):
+        raise RuntimeError("invalid mbx statistics: compiler is not an object")
+    total = 0
+    for outcome in compiler.values():
+        if isinstance(outcome, dict):
+            duration = outcome.get("duration_ns", 0)
+            if isinstance(duration, int):
+                total += duration
+    return total
+
+
+def clone_subject(destination: Path, local_checkout: Path | None) -> None:
+    source = str(local_checkout) if local_checkout else MISE_URL
+    command = ["git", "clone", "--quiet"]
+    if local_checkout:
+        command.append("--shared")
+    command.extend([source, str(destination)])
+    subprocess.run(command, check=True)
+    subprocess.run(
+        ["git", "checkout", "--quiet", "--detach", MISE_COMMIT],
+        cwd=destination,
+        check=True,
+    )
+
+
+def environment(tool: str, work: Path, report: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("RUSTC_WRAPPER", None)
+    env.pop("RUSTC_WORKSPACE_WRAPPER", None)
+    env.update(
+        {
+            "CARGO_TARGET_DIR": str(work / "target"),
+            "RUSTUP_TOOLCHAIN": RUST_TOOLCHAIN,
+            # Raw Cargo gets its normal incremental path. mbx starts from Cargo's
+            # non-incremental shape so the measurement specifically exercises
+            # mbx's per-checkout learned incremental policy.
+            "CARGO_INCREMENTAL": "1" if tool == "cargo" else "0",
+        }
+    )
+    if tool == "mbx":
+        env["MBX_CACHE_DIR"] = str(work / "mbx-cache")
+        env["MBX_STATS_REPORT"] = str(report)
+    return env
+
+
+def run_build(
+    tool: str,
+    executable: Path,
+    checkout: Path,
+    work: Path,
+    output: Path,
+    phase: str,
+) -> dict[str, object]:
+    report = output / f"{tool}-{phase}-stats.json"
+    env = environment(tool, work, report)
+    started = time.perf_counter_ns()
+    completed = subprocess.run(
+        [str(executable), "build", "--locked"],
+        cwd=checkout,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    wall_duration_ns = time.perf_counter_ns() - started
+    (output / f"{tool}-{phase}.stdout.log").write_text(
+        completed.stdout, encoding="utf-8"
+    )
+    (output / f"{tool}-{phase}.stderr.log").write_text(
+        completed.stderr, encoding="utf-8"
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"{tool} {phase} failed; see benchmark logs")
+
+    result: dict[str, object] = {"wall_duration_ns": wall_duration_ns}
+    if tool == "mbx":
+        stats = json.loads(report.read_text(encoding="utf-8"))
+        result["session_duration_ns"] = stats["session_duration_ns"]
+        result["compiler_duration_ns"] = compiler_duration(stats)
+        result["compiler"] = stats["compiler"]
+        result["hits"] = stats["hits"]
+        result["misses"] = stats["misses"]
+    return result
+
+
+def summarize(samples: list[dict[str, object]], key: str) -> dict[str, int]:
+    values = [sample[key] for sample in samples if isinstance(sample.get(key), int)]
+    assert all(isinstance(value, int) for value in values)
+    integer_values = [int(value) for value in values]
+    return {
+        "min_ns": min(integer_values),
+        "p50_ns": int(statistics.median(integer_values)),
+        "p95_ns": percentile(integer_values, 0.95),
+        "max_ns": max(integer_values),
+    }
+
+
+def measure_tool(
+    tool: str,
+    executable: Path,
+    source_checkout: Path | None,
+    root: Path,
+    output: Path,
+    iterations: int,
+) -> dict[str, object]:
+    checkout = root / f"mise-{tool}"
+    work = root / f"work-{tool}"
+    work.mkdir()
+    clone_subject(checkout, source_checkout)
+
+    print(f"{tool}: seeding target", flush=True)
+    run_build(tool, executable, checkout, work, output, "seed")
+    set_edit(checkout, 1)
+    print(f"{tool}: warming first edited build", flush=True)
+    run_build(tool, executable, checkout, work, output, "warmup")
+
+    samples = []
+    for index in range(1, iterations + 1):
+        # Never repeat source content: an mbx artifact hit would skip rustc and
+        # measure undo/redo caching rather than an ordinary new edit.
+        set_edit(checkout, index + 1)
+        phase = f"edit-{index:02d}"
+        sample = run_build(tool, executable, checkout, work, output, phase)
+        if tool == "mbx":
+            compiler = sample.get("compiler")
+            incremental = compiler.get("incremental") if isinstance(compiler, dict) else None
+            if not isinstance(incremental, dict) or incremental.get("invocations") != 1:
+                raise RuntimeError(
+                    f"{phase} did not run exactly one incremental mise compilation"
+                )
+        samples.append(sample)
+        print(f"{tool}: {phase} {sample['wall_duration_ns'] / 1e9:.3f}s", flush=True)
+
+    summaries = {"wall": summarize(samples, "wall_duration_ns")}
+    if tool == "mbx":
+        summaries["session"] = summarize(samples, "session_duration_ns")
+        summaries["compiler"] = summarize(samples, "compiler_duration_ns")
+    return {"tool": tool, "summary": summaries, "samples": samples}
+
+
+def markdown(result: dict[str, object]) -> str:
+    lines = [
+        "# mise edit-loop benchmark",
+        "",
+        f"Pinned mise commit: `{MISE_COMMIT}`",
+        f"Rust toolchain: `{RUST_TOOLCHAIN}`",
+        "",
+        "| tool | wall p50 | wall p95 | compiler p50 | compiler p95 |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for entry in result["results"]:  # type: ignore[index]
+        summary = entry["summary"]
+        wall = summary["wall"]
+        compiler = summary.get("compiler")
+        compiler_p50 = f"{compiler['p50_ns'] / 1e9:.3f}s" if compiler else "—"
+        compiler_p95 = f"{compiler['p95_ns'] / 1e9:.3f}s" if compiler else "—"
+        lines.append(
+            f"| {entry['tool']} | {wall['p50_ns'] / 1e9:.3f}s | "
+            f"{wall['p95_ns'] / 1e9:.3f}s | {compiler_p50} | {compiler_p95} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mbx", type=Path, required=True)
+    parser.add_argument("--checkout", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--iterations", type=int, default=30)
+    parser.add_argument("--tools", default="cargo,mbx")
+    args = parser.parse_args()
+    if args.iterations < 1:
+        parser.error("--iterations must be positive")
+
+    tools = [tool.strip() for tool in args.tools.split(",") if tool.strip()]
+    unknown = set(tools) - {"cargo", "mbx"}
+    if unknown:
+        parser.error(f"unknown tools: {', '.join(sorted(unknown))}")
+
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    executables = {
+        "cargo": Path(shutil.which("cargo") or "cargo"),
+        "mbx": args.mbx.resolve(),
+    }
+    source_checkout = args.checkout.resolve() if args.checkout else None
+    if source_checkout and not source_checkout.exists():
+        parser.error(f"checkout does not exist: {source_checkout}")
+
+    # Keep mise's multi-gigabyte targets on the caller-selected filesystem.
+    with tempfile.TemporaryDirectory(
+        prefix="edit-loop-", dir=output.parent
+    ) as temporary:
+        root = Path(temporary)
+        results = [
+            measure_tool(
+                tool,
+                executables[tool],
+                source_checkout,
+                root,
+                output,
+                args.iterations,
+            )
+            for tool in tools
+        ]
+
+    result: dict[str, object] = {
+        "version": 1,
+        "subject": {"name": "mise", "commit": MISE_COMMIT},
+        "platform": platform.platform(),
+        "rustc": subprocess.check_output(
+            ["rustup", "run", RUST_TOOLCHAIN, "rustc", "-V"], text=True
+        ).strip(),
+        "iterations": args.iterations,
+        "results": results,
+    }
+    (output / "edit-loop.json").write_text(
+        json.dumps(result, indent=2) + "\n", encoding="utf-8"
+    )
+    (output / "edit-loop.md").write_text(markdown(result), encoding="utf-8")
+    print(markdown(result), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/edit_loop_tests.py
+++ b/benchmarks/edit_loop_tests.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import edit_loop
+
+
+class EditLoopTests(unittest.TestCase):
+    def test_environment_pins_benchmark_toolchain(self) -> None:
+        env = edit_loop.environment("cargo", Path("work"), Path("report"))
+        self.assertEqual(env["RUSTUP_TOOLCHAIN"], edit_loop.RUST_TOOLCHAIN)
+
+    def test_percentile_uses_nearest_rank(self) -> None:
+        self.assertEqual(edit_loop.percentile(list(range(1, 21)), 0.95), 19)
+        self.assertEqual(edit_loop.percentile([3], 0.95), 3)
+
+    def test_set_edit_uses_unique_values(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            checkout = Path(temporary)
+            fixture = checkout / edit_loop.FIXTURE
+            fixture.parent.mkdir(parents=True)
+            fixture.write_text(edit_loop.BEFORE + "\n", encoding="utf-8")
+            edit_loop.set_edit(checkout, 1)
+            self.assertEqual(
+                fixture.read_text(encoding="utf-8"), edit_loop.EDIT_PREFIX + "1);\n"
+            )
+            edit_loop.set_edit(checkout, 2)
+            self.assertEqual(
+                fixture.read_text(encoding="utf-8"), edit_loop.EDIT_PREFIX + "2);\n"
+            )
+
+    def test_compiler_duration_sums_outcomes(self) -> None:
+        stats = {
+            "compiler": {
+                "incremental": {"invocations": 1, "duration_ns": 10},
+                "bypass": {"invocations": 2, "duration_ns": 5},
+            }
+        }
+        self.assertEqual(edit_loop.compiler_duration(stats), 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mise.toml
+++ b/mise.toml
@@ -141,6 +141,15 @@ python3 benchmarks/real_world.py \
   --output target/benchmarks
 """
 
+[tasks."bench:edit-loop"]
+description = "Measure repeated source edits in a pinned mise checkout"
+depends = ["perf:prepare"]
+run = """
+python3 benchmarks/edit_loop.py \
+  --mbx target/release/mbx \
+  --output target/benchmarks/edit-loop
+"""
+
 # What CI runs. Adds the scenarios that need a second checkout or a second
 # toolchain, and rewrites the results file the documentation site reads.
 [tasks."bench:refresh"]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and documentation only; no changes to mbx runtime, caching, or CI gates.
> 
> **Overview**
> Adds a **developer edit/build loop** benchmark alongside the CI-oriented `real_world` harness. **`edit_loop.py`** clones a pinned **mise** commit, keeps a shared Cargo target, seeds an unedited build, warms one edited build (so mbx can learn incremental policy), then times **30 unique source edits** comparing **cargo** vs **mbx**.
> 
> mbx runs with **`CARGO_INCREMENTAL=0`** while cargo uses normal incremental compilation, so the numbers stress mbx’s per-checkout learned policy rather than Cargo’s default. mbx runs also record **wall**, **session**, and **summed compiler** time and assert each measured edit triggers exactly one incremental mise compilation.
> 
> **`benchmarks/README.md`** documents the workflow; **`mise run bench:edit-loop`** runs it via **`perf:prepare`**. **`edit_loop_tests.py`** covers toolchain pinning, percentile math, fixture edits, and compiler-duration aggregation. Results land in **`edit-loop.json`** / **`edit-loop.md`** under the chosen output directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9378e1396c35d5165b8b25e6921a8aa9d35bcc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->