### PR TITLE
fix: preserve incremental builds with jdxld

### DIFF
--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -119,8 +119,8 @@ pub(crate) struct RawConfig {
     /// Let local workspace members compile incrementally.
     #[usage(env = "MBX_INCREMENTAL", default = false)]
     incremental: bool,
-    /// On Linux, use this jdxld binary for native Rust links and keep its worker alive for the
-    /// build session.
+    /// On Linux, use this jdxld binary for learned incremental native Rust links and keep its
+    /// worker alive for the build session.
     #[usage(env = "MBX_JDXLD")]
     jdxld: Option<PathBuf>,
     /// Compile crates that keep missing the cache with changed content

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -403,7 +403,14 @@ pub(crate) fn compile(
     let compilation_started = SystemTime::now();
     let compiler_timer = Instant::now();
     let mut command = compiler_command(rustc, wrapper_argument);
-    command.args(&arguments).current_dir(&working_dir);
+    let jdxld = std::env::var_os(session::JDXLD_BIN_ENV).filter(|path| !path.is_empty());
+    let compiler_arguments = compiler_arguments(&arguments, &learned, jdxld.as_deref());
+    // jdxld is checkout-local acceleration, like rustc incremental state. Add
+    // it only after a miss has selected that mode: the parser must see the
+    // original invocation so a jdxld path cannot contaminate shared action
+    // keys, and a normal cacheable miss must never publish jdxld output under
+    // the default linker's identity. Incremental outputs are withheld below.
+    command.args(&compiler_arguments).current_dir(&working_dir);
     if let Some(directory) = learned.directory.as_deref() {
         // Appended here rather than to the parsed argument vector: the parser
         // treats incremental state as uncacheable and would bypass the whole
@@ -505,6 +512,20 @@ pub(crate) fn compile(
         current_diagnostic,
     );
     Ok(exit_code(output.status))
+}
+
+fn compiler_arguments(
+    arguments: &[OsString],
+    learned: &LearnedPlan,
+    jdxld: Option<&OsStr>,
+) -> Vec<OsString> {
+    let mut arguments = arguments.to_vec();
+    if learned.engaged()
+        && let Some(jdxld) = jdxld
+    {
+        session::use_jdxld_for_native_link(&mut arguments, jdxld);
+    }
+    arguments
 }
 
 /// Compile a build script whose native link cannot be action-cached, then

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -1047,3 +1047,28 @@ fn incremental_state_is_discarded_only_past_its_budget() {
     );
     assert!(fresh.is_dir());
 }
+#[test]
+fn jdxld_is_added_only_after_learned_incremental_engages() {
+    let arguments = vec![
+        "--crate-type=bin".into(),
+        "--emit=link".into(),
+        "src/main.rs".into(),
+    ];
+    let cold = LearnedPlan::default();
+    assert_eq!(
+        compiler_arguments(&arguments, &cold, Some(OsStr::new("/opt/jdxld"))),
+        arguments
+    );
+
+    let hot = LearnedPlan {
+        hot: true,
+        directory: Some(PathBuf::from("incremental")),
+        ..LearnedPlan::default()
+    };
+    let configured = compiler_arguments(&arguments, &hot, Some(OsStr::new("/opt/jdxld")));
+    assert_eq!(&configured[3], "-Clinker=clang");
+    assert_eq!(
+        configured.last().unwrap(),
+        "-Clink-arg=--ld-path=/opt/jdxld"
+    );
+}

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1247,10 +1247,7 @@ pub fn run_rustc_shim() -> ExitCode {
         eprintln!("mbx[error]: the rustc shim expected the rustc executable as its first argument");
         return ExitCode::from(1);
     };
-    let mut arguments = arguments.collect::<Vec<_>>();
-    if let Some(jdxld) = std::env::var_os(JDXLD_BIN_ENV).filter(|path| !path.is_empty()) {
-        use_jdxld_for_native_link(&mut arguments, &jdxld);
-    }
+    let arguments = arguments.collect::<Vec<_>>();
     let is_workspace_wrapper = std::env::var_os(PREVIOUS_RUSTC_WORKSPACE_WRAPPER_ENV)
         .is_some_and(|wrapper| wrapper == rustc);
     let (wrapper_argument, compiler_arguments) = workspace_wrapper_arguments(&rustc, &arguments);
@@ -1277,7 +1274,7 @@ pub fn run_rustc_shim() -> ExitCode {
 }
 
 /// Pin native links to the worker's executable without changing metadata-only calls.
-fn use_jdxld_for_native_link(arguments: &mut Vec<OsString>, jdxld: &OsStr) {
+pub(crate) fn use_jdxld_for_native_link(arguments: &mut Vec<OsString>, jdxld: &OsStr) {
     if links_natively(arguments)
         && !has_explicit_target(arguments)
         && crate_name_argument(arguments).as_deref() != Some("build_script_build")

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -136,7 +136,7 @@ Let local workspace members compile incrementally.
 - **Optional:** true
 - **Set with:** `MBX_JDXLD`
 
-On Linux, use this jdxld binary for native Rust links and keep its worker alive for the build session.
+On Linux, use this jdxld binary for learned incremental native Rust links and keep its worker alive for the build session.
 
 ### `learned_incremental`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,10 +207,11 @@ disables it because a fresh runner has no incremental state to reuse.
 
 ## jdxld session linking
 
-On Linux, `jdxld = "/path/to/jdxld"` (or `MBX_JDXLD`) opts native Rust links
-into jdxld's experimental mr-boxington worker protocol. mbx starts one worker
-for the Cargo command, routes native links to its Unix socket, and stops it as
-soon as the command finishes. The worker does not linger on a timeout.
+On Linux, `jdxld = "/path/to/jdxld"` (or `MBX_JDXLD`) opts learned incremental
+native Rust links into jdxld's experimental mr-boxington worker protocol. mbx
+starts one worker for the Cargo command, routes native links to its Unix socket,
+and stops it as soon as the command finishes. The worker does not linger on a
+timeout.
 
 The current prototype reuses unchanged input mappings within a command and
 writes advisory link manifests under `incremental/jdxld` in mbx's cache


### PR DESCRIPTION
Routes jdxld only after a cache miss has selected learned Rust incremental mode. This keeps the original invocation parseable and prevents jdxld output from being published under the default linker's cache identity.

Before this fix, MBX_JDXLD injected unmodeled linker flags before parsing, so mbx transparently bypassed learned incremental compilation.

Measured on unique mise source edits with Rust 1.98.0: release jdxld compiler time was 9.75s, 9.66s, and 9.57s; an interleaved default-linker control was 10.80s. Full mbx session time fell from 12.75s to 11.57-11.78s.

Validation: cargo +1.98.0 test --workspace --locked; real mise edits each reported exactly one incremental compiler invocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how native link invocations are mutated, which affects cache keys, learned incremental, and linker choice; scope is limited to the jdxld + learned-incremental interaction with a targeted test.
> 
> **Overview**
> **Defers `MBX_JDXLD` linker wiring** so it no longer runs at rustc-shim entry on every invocation. jdxld flags (`-Clinker=clang` / `--ld-path`) are added only when a cache miss has engaged **learned incremental** mode, via new `compiler_arguments()` in the real compile path.
> 
> That keeps the invocation the cache parser sees **unchanged** (jdxld paths cannot alter shared action keys) and stops default-linker misses from publishing outputs under the wrong linker identity. Transparent rustc bypasses and cache hits are unaffected.
> 
> Docs and config comments now describe jdxld as acceleration for **learned incremental** native links, not all native links. A unit test asserts cold `LearnedPlan` leaves arguments untouched and a hot plan with an incremental directory gets the jdxld link args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db62dd422dfcaf5276c44401cb1e703eb1f550bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->