### PR TITLE
fix: preserve caching when Unix listeners are blocked

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -167,7 +167,26 @@ fn cargo_with_settings_bypass_log_and_roots(
         .build()?;
 
     let session_outcome = runtime.block_on(async {
-        let session = CacheSession::start_with_jobs(session_dir.path(), config, cargo_jobs).await?;
+        let session = match CacheSession::start_with_jobs(session_dir.path(), config, cargo_jobs)
+            .await
+        {
+            Ok(session) => session,
+            Err(error) if session::listener_unavailable(&error) => {
+                crate::session::note(&format!(
+                    "mbx[warning]: cache session unavailable; running Cargo without mbx caching: {error:#}"
+                ));
+                // Protect nested Cargo calls from re-entering mbx, and ensure
+                // compiler wrappers cannot inherit an enclosing session that
+                // this build did not start. An empty socket is deliberately
+                // equivalent to an absent one to every mbx shim.
+                let environment = BTreeMap::from([
+                    ("MBX_DISABLE".into(), "1".into()),
+                    (session::SOCKET_ENV.into(), String::new()),
+                ]);
+                return Ok((run_cargo(&cargo, arguments, environment), None));
+            }
+            Err(error) => return Err(error),
+        };
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
         if let Some(path) = bypass_log {
             let path = if path.is_absolute() {

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -171,12 +171,23 @@ fn session_check() -> Check {
     let socket = directory.path().join("cache-agent.sock");
     match std::os::unix::net::UnixListener::bind(&socket) {
         Ok(_) => Check::pass("session", "Unix-domain listeners are available"),
-        Err(error) => Check::warn(
-            "session",
-            format!(
-                "Unix-domain listener unavailable ({error}); builds will run without mbx caching"
-            ),
-        ),
+        Err(socket_error) => {
+            let fifo = directory.path().join("cache-agent.fifo");
+            match crate::session::create_fifo(&fifo) {
+                Ok(()) => Check::warn(
+                    "session",
+                    format!(
+                        "Unix-domain listener unavailable ({socket_error}); builds will use FIFO transport"
+                    ),
+                ),
+                Err(fifo_error) => Check::warn(
+                    "session",
+                    format!(
+                        "Unix-domain listener unavailable ({socket_error}) and FIFO unavailable ({fifo_error}); builds will run without mbx caching"
+                    ),
+                ),
+            }
+        }
     }
 }
 
@@ -491,7 +502,16 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn the_build_session_transport_is_probed() {
-        assert_eq!(session_check().severity, Severity::Pass);
+        let check = session_check();
+        assert_eq!(check.name, "session");
+        match check.severity {
+            Severity::Pass => assert!(check.detail.contains("Unix-domain")),
+            Severity::Warn => assert!(
+                check.detail.contains("FIFO transport")
+                    || check.detail.contains("without mbx caching")
+            ),
+            Severity::Fail => panic!("session transport probes are advisory"),
+        }
     }
 
     #[test]

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -169,25 +169,34 @@ fn session_check() -> Check {
         }
     };
     let socket = directory.path().join("cache-agent.sock");
-    match std::os::unix::net::UnixListener::bind(&socket) {
-        Ok(_) => Check::pass("session", "Unix-domain listeners are available"),
-        Err(socket_error) => {
-            let fifo = directory.path().join("cache-agent.fifo");
-            match crate::session::create_fifo(&fifo) {
-                Ok(()) => Check::warn(
-                    "session",
-                    format!(
-                        "Unix-domain listener unavailable ({socket_error}); builds will use FIFO transport"
-                    ),
+    let socket_probe = std::os::unix::net::UnixListener::bind(&socket).map(drop);
+    session_check_from(socket_probe, || {
+        crate::session::create_fifo(&directory.path().join("cache-agent.fifo"))
+    })
+}
+
+/// Turn transport probe results into the diagnostic shown by `mbx doctor`.
+#[cfg(unix)]
+fn session_check_from(
+    socket_probe: std::io::Result<()>,
+    fifo_probe: impl FnOnce() -> std::io::Result<()>,
+) -> Check {
+    match socket_probe {
+        Ok(()) => Check::pass("session", "Unix-domain listeners are available"),
+        Err(socket_error) => match fifo_probe() {
+            Ok(()) => Check::warn(
+                "session",
+                format!(
+                    "Unix-domain listener unavailable ({socket_error}); builds will use FIFO transport"
                 ),
-                Err(fifo_error) => Check::warn(
-                    "session",
-                    format!(
-                        "Unix-domain listener unavailable ({socket_error}) and FIFO unavailable ({fifo_error}); builds will run without mbx caching"
-                    ),
+            ),
+            Err(fifo_error) => Check::warn(
+                "session",
+                format!(
+                    "Unix-domain listener unavailable ({socket_error}) and FIFO unavailable ({fifo_error}); builds will run without mbx caching"
                 ),
-            }
-        }
+            ),
+        },
     }
 }
 
@@ -512,6 +521,28 @@ mod tests {
             ),
             Severity::Fail => panic!("session transport probes are advisory"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_blocked_listener_reports_the_fifo_fallback() {
+        let check = session_check_from(
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+            || Ok(()),
+        );
+        assert_eq!(check.severity, Severity::Warn);
+        assert!(check.detail.contains("builds will use FIFO transport"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn blocked_socket_and_fifo_report_the_uncached_fallback() {
+        let check = session_check_from(
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+            || Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+        );
+        assert_eq!(check.severity, Severity::Warn);
+        assert!(check.detail.contains("builds will run without mbx caching"));
     }
 
     #[test]

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -129,6 +129,8 @@ async fn check(config: &Config, toolchain: Option<&str>) -> Vec<Check> {
         command_check("rustc", &rustc, toolchain),
     ];
     checks.push(cache_check(&config.cache_dir));
+    #[cfg(unix)]
+    checks.push(session_check());
     checks.push(Check::pass(
         "config",
         format!(
@@ -143,6 +145,39 @@ async fn check(config: &Config, toolchain: Option<&str>) -> Vec<Check> {
     checks.push(setup_check());
     checks.extend(remote_checks(config).await);
     checks
+}
+
+/// Probe the transport every orchestrated build needs in this environment.
+///
+/// This uses a fresh temporary directory just like a real session. Sandboxes
+/// can permit both creating the directory and opening an AF_UNIX socket while
+/// still rejecting `bind`, so no filesystem-only check can answer this.
+#[cfg(unix)]
+fn session_check() -> Check {
+    let directory = match tempfile::Builder::new()
+        .prefix("mbx-session-probe-")
+        .tempdir()
+    {
+        Ok(directory) => directory,
+        Err(error) => {
+            return Check::warn(
+                "session",
+                format!(
+                    "listener was not tested because a temporary directory could not be created: {error}"
+                ),
+            );
+        }
+    };
+    let socket = directory.path().join("cache-agent.sock");
+    match std::os::unix::net::UnixListener::bind(&socket) {
+        Ok(_) => Check::pass("session", "Unix-domain listeners are available"),
+        Err(error) => Check::warn(
+            "session",
+            format!(
+                "Unix-domain listener unavailable ({error}); builds will run without mbx caching"
+            ),
+        ),
+    }
 }
 
 fn enabled(value: bool) -> &'static str {
@@ -451,6 +486,12 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         assert_eq!(cache_check(directory.path()).severity, Severity::Pass);
         assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_build_session_transport_is_probed() {
+        assert_eq!(session_check().severity, Severity::Pass);
     }
 
     #[test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -36,6 +36,7 @@ mod stats;
 use client::validate_handshake_response;
 use client::{request_agent_at, request_standalone_agent};
 pub(crate) use diagnostics::{note, report_shim_warning, reserve_stderr_for_compiler};
+pub(crate) use server::listener_unavailable;
 use server::spawn_server;
 pub(crate) use shims::CC_CRATE_ENV;
 #[cfg(all(test, windows))]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -36,6 +36,8 @@ mod stats;
 use client::validate_handshake_response;
 use client::{request_agent_at, request_standalone_agent};
 pub(crate) use diagnostics::{note, report_shim_warning, reserve_stderr_for_compiler};
+#[cfg(unix)]
+pub(crate) use server::create_fifo;
 pub(crate) use server::listener_unavailable;
 use server::spawn_server;
 pub(crate) use shims::CC_CRATE_ENV;

--- a/crates/mbx/src/session/client.rs
+++ b/crates/mbx/src/session/client.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 #[cfg(unix)]
 use std::io::{BufRead, BufReader, Write};
 #[cfg(unix)]
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Serve a persistent Cargo wrapper directly from the local store.
 ///
@@ -110,14 +110,20 @@ pub(super) fn request_agent_at(
     // build. The protocol is strict request-response, so a connection held for
     // the life of this shim process serves them all.
     thread_local! {
-        static CONNECTION: RefCell<Option<(OsString, std::os::unix::net::UnixStream)>> =
+        static CONNECTION: RefCell<Option<(OsString, SessionStream)>> =
             const { RefCell::new(None) };
     }
     CONNECTION.with(|slot| {
         let mut slot = slot.borrow_mut();
         if slot.as_ref().is_none_or(|(known, _)| known != socket) {
-            let mut stream = std::os::unix::net::UnixStream::connect(Path::new(socket))
-                .wrap_err("failed to connect to the cache session")?;
+            let endpoint = socket.to_string_lossy();
+            let mut stream = match endpoint.strip_prefix(super::server::FIFO_ENDPOINT_PREFIX) {
+                Some(directory) => SessionStream::Fifo(connect_fifo(Path::new(directory))?),
+                None => SessionStream::Socket(
+                    std::os::unix::net::UnixStream::connect(Path::new(socket))
+                        .wrap_err("failed to connect to the cache session")?,
+                ),
+            };
             sync_handshake(&mut stream)?;
             *slot = Some((socket.clone(), stream));
         }
@@ -133,6 +139,163 @@ pub(super) fn request_agent_at(
         }
         responses
     })
+}
+
+#[cfg(unix)]
+enum SessionStream {
+    Socket(std::os::unix::net::UnixStream),
+    Fifo(FifoClientStream),
+}
+
+#[cfg(unix)]
+impl std::io::Read for SessionStream {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Socket(stream) => stream.read(buffer),
+            Self::Fifo(stream) => stream.read(buffer),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl std::io::Write for SessionStream {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Socket(stream) => stream.write(buffer),
+            Self::Fifo(stream) => stream.write(buffer),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Socket(stream) => stream.flush(),
+            Self::Fifo(stream) => stream.flush(),
+        }
+    }
+}
+
+#[cfg(unix)]
+struct FifoClientStream {
+    reader: std::fs::File,
+    writer: std::fs::File,
+    directory: PathBuf,
+}
+
+#[cfg(unix)]
+impl std::io::Read for FifoClientStream {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.reader.read(buffer)
+    }
+}
+
+#[cfg(unix)]
+impl std::io::Write for FifoClientStream {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.writer.write(buffer)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+#[cfg(unix)]
+impl Drop for FifoClientStream {
+    fn drop(&mut self) {
+        cleanup_fifo_client(&self.directory);
+    }
+}
+
+#[cfg(unix)]
+fn connect_fifo(server: &Path) -> Result<FifoClientStream> {
+    use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+    let name = format!(
+        "{}{}-{}",
+        super::server::FIFO_CLIENT_PREFIX,
+        std::process::id(),
+        crate::util::random_string(12)
+    );
+    let preparing = server.join(format!(".{name}"));
+    let directory = server.join(name);
+    std::fs::create_dir(&preparing)?;
+    std::fs::set_permissions(&preparing, std::fs::Permissions::from_mode(0o700))?;
+    let requests = preparing.join(super::server::FIFO_REQUESTS);
+    let responses = preparing.join(super::server::FIFO_RESPONSES);
+    if let Err(error) =
+        super::server::create_fifo(&requests).and_then(|()| super::server::create_fifo(&responses))
+    {
+        cleanup_fifo_client(&preparing);
+        return Err(error).wrap_err("failed to create FIFO cache session channels");
+    }
+    let reader = match std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(&responses)
+    {
+        Ok(reader) => reader,
+        Err(error) => {
+            cleanup_fifo_client(&preparing);
+            return Err(error).wrap_err("failed to open the FIFO cache response channel");
+        }
+    };
+    if let Err(error) = std::fs::rename(&preparing, &directory) {
+        cleanup_fifo_client(&preparing);
+        return Err(error).wrap_err("failed to publish FIFO cache session channels");
+    }
+
+    let deadline = std::time::Instant::now() + super::server::FIFO_CONNECT_DEADLINE;
+    let writer = loop {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(directory.join(super::server::FIFO_REQUESTS))
+        {
+            Ok(writer) => break writer,
+            Err(error)
+                if std::time::Instant::now() < deadline
+                    && (error.kind() == std::io::ErrorKind::NotFound
+                        || error.raw_os_error() == Some(libc::ENXIO)) =>
+            {
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+            Err(error) => {
+                cleanup_fifo_client(&directory);
+                return Err(error).wrap_err("failed to open the FIFO cache request channel");
+            }
+        }
+    };
+    if let Err(error) = std::fs::write(directory.join(super::server::FIFO_READY), b"") {
+        cleanup_fifo_client(&directory);
+        return Err(error).wrap_err("failed to finish the FIFO cache session handshake");
+    }
+    while !directory.join(super::server::FIFO_ACCEPTED).exists() {
+        if std::time::Instant::now() >= deadline {
+            cleanup_fifo_client(&directory);
+            eyre::bail!("timed out waiting for the FIFO cache session");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    if let Err(error) =
+        super::server::set_blocking(&reader).and_then(|()| super::server::set_blocking(&writer))
+    {
+        cleanup_fifo_client(&directory);
+        return Err(error).wrap_err("failed to configure FIFO cache session channels");
+    }
+    Ok(FifoClientStream {
+        reader,
+        writer,
+        directory,
+    })
+}
+
+#[cfg(unix)]
+fn cleanup_fifo_client(directory: &Path) {
+    let _ = std::fs::remove_file(directory.join(super::server::FIFO_READY));
+    let _ = std::fs::remove_file(directory.join(super::server::FIFO_ACCEPTED));
+    let _ = std::fs::remove_file(directory.join(super::server::FIFO_REQUESTS));
+    let _ = std::fs::remove_file(directory.join(super::server::FIFO_RESPONSES));
+    let _ = std::fs::remove_dir(directory);
 }
 
 #[cfg(windows)]

--- a/crates/mbx/src/session/server.rs
+++ b/crates/mbx/src/session/server.rs
@@ -9,6 +9,57 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 #[cfg(unix)]
+#[derive(Debug)]
+struct ListenerBindError {
+    path: PathBuf,
+    source: std::io::Error,
+}
+
+#[cfg(unix)]
+impl std::fmt::Display for ListenerBindError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "failed to bind cache session listener at {}: {}",
+            self.path.display(),
+            self.source
+        )
+    }
+}
+
+#[cfg(unix)]
+impl std::error::Error for ListenerBindError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[cfg(unix)]
+impl ListenerBindError {
+    fn unavailable(&self) -> bool {
+        matches!(
+            self.source.kind(),
+            std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::Unsupported
+        )
+    }
+}
+
+/// Whether session startup failed because this environment cannot bind the
+/// local listener the compiler shims need.
+#[cfg(unix)]
+pub(crate) fn listener_unavailable(error: &eyre::Report) -> bool {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<ListenerBindError>())
+        .is_some_and(ListenerBindError::unavailable)
+}
+
+#[cfg(windows)]
+pub(crate) fn listener_unavailable(_error: &eyre::Report) -> bool {
+    false
+}
+
+#[cfg(unix)]
 pub(super) async fn spawn_server(
     session_dir: &Path,
     agent: CacheAgent,
@@ -18,7 +69,10 @@ pub(super) async fn spawn_server(
     use std::os::unix::fs::PermissionsExt as _;
 
     let socket = session_dir.join("cache-agent.sock");
-    let listener = tokio::net::UnixListener::bind(&socket)?;
+    let listener = tokio::net::UnixListener::bind(&socket).map_err(|source| ListenerBindError {
+        path: socket.clone(),
+        source,
+    })?;
     std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))?;
     let endpoint = socket.to_string_lossy().into_owned();
     let server = tokio::spawn(async move {
@@ -52,6 +106,34 @@ pub(super) async fn spawn_server(
         outcome
     });
     Ok((endpoint, server))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_and_platform_rejections_mean_the_listener_is_unavailable() {
+        for kind in [
+            std::io::ErrorKind::PermissionDenied,
+            std::io::ErrorKind::Unsupported,
+        ] {
+            let error = eyre::Report::from(ListenerBindError {
+                path: "/tmp/cache-agent.sock".into(),
+                source: std::io::Error::from(kind),
+            });
+            assert!(listener_unavailable(&error));
+        }
+    }
+
+    #[test]
+    fn an_address_collision_remains_a_startup_error() {
+        let error = eyre::Report::from(ListenerBindError {
+            path: "/tmp/cache-agent.sock".into(),
+            source: std::io::Error::from(std::io::ErrorKind::AddrInUse),
+        });
+        assert!(!listener_unavailable(&error));
+    }
 }
 
 #[cfg(unix)]

--- a/crates/mbx/src/session/server.rs
+++ b/crates/mbx/src/session/server.rs
@@ -178,11 +178,8 @@ fn spawn_fifo_server(
     mut shutdown: oneshot::Receiver<()>,
 ) -> Result<(String, JoinHandle<Result<()>>)> {
     use std::collections::HashSet;
-    use std::os::unix::fs::PermissionsExt as _;
 
-    let directory = session_dir.join("cache-agent-fifo");
-    std::fs::create_dir(&directory)?;
-    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700))?;
+    let directory = prepare_fifo_directory(session_dir)?;
     let endpoint = format!("{FIFO_ENDPOINT_PREFIX}{}", directory.to_string_lossy());
     let server = tokio::spawn(async move {
         let _cleanup = FifoCleanup(directory.clone());
@@ -206,24 +203,45 @@ fn spawn_fifo_server(
                         }
                         let agent = agent.clone();
                         let task = Arc::clone(&task);
-                        connections.spawn(async move {
-                            let _cleanup = FifoCleanup(path.clone());
-                            let connection_path = path.clone();
-                            let opened = tokio::task::spawn_blocking(move || {
-                                accept_fifo_client(&connection_path)
-                            })
-                            .await
-                            .map_err(eyre::Report::from)??;
-                            initialize_task(&agent, &task).await;
-                            let (reader, writer) = opened;
-                            let stream = tokio::io::join(
-                                tokio::fs::File::from_std(reader),
-                                tokio::fs::File::from_std(writer),
-                            );
-                            if let Err(error) = agent.handle_connection(stream).await {
-                                debug!("cache agent FIFO connection failed: {error}");
+                        let runtime = tokio::runtime::Handle::current();
+                        let connection_path = path.clone();
+                        let (finished_tx, finished_rx) = oneshot::channel();
+                        let thread = std::thread::Builder::new()
+                            .name("mbx-fifo-session".into())
+                            .spawn(move || {
+                                let _cleanup = FifoCleanup(connection_path.clone());
+                                let result = (|| {
+                                    let (reader, writer) = accept_fifo_client(&connection_path)?;
+                                    runtime.block_on(async {
+                                        initialize_task(&agent, &task).await;
+                                        let stream = tokio::io::join(
+                                            BlockingFifoReader(reader),
+                                            BlockingFifoWriter(writer),
+                                        );
+                                        if let Err(error) = agent.handle_connection(stream).await {
+                                            debug!("cache agent FIFO connection failed: {error}");
+                                        }
+                                        Ok::<(), eyre::Report>(())
+                                    })
+                                })();
+                                let _ = finished_tx.send(result);
+                            });
+                        let thread = match thread {
+                            Ok(thread) => thread,
+                            Err(error) => {
+                                let _cleanup = FifoCleanup(path.clone());
+                                debug!(
+                                    "failed to start cache agent FIFO connection thread: {error}"
+                                );
+                                continue;
                             }
-                            Ok::<(), eyre::Report>(())
+                        };
+                        connections.spawn(async move {
+                            let result = finished_rx.await.map_err(eyre::Report::from)?;
+                            thread
+                                .join()
+                                .map_err(|_| eyre::eyre!("cache agent FIFO thread panicked"))?;
+                            result
                         });
                     }
                     while connections.try_join_next().is_some() {}
@@ -241,6 +259,38 @@ fn spawn_fifo_server(
     Ok((endpoint, server))
 }
 
+/// Create and probe the private directory advertised as the FIFO endpoint.
+#[cfg(unix)]
+fn prepare_fifo_directory(session_dir: &Path) -> Result<PathBuf> {
+    prepare_fifo_directory_with(session_dir, create_fifo)
+}
+
+/// Prepare a FIFO endpoint using an injectable creator for deterministic tests.
+#[cfg(unix)]
+fn prepare_fifo_directory_with(
+    session_dir: &Path,
+    make_fifo: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let directory = session_dir.join("cache-agent-fifo");
+    std::fs::create_dir(&directory)?;
+    let probe = directory.join(".probe");
+    let result = (|| {
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700))?;
+        make_fifo(&probe)?;
+        std::fs::remove_file(&probe)?;
+        Ok::<(), std::io::Error>(())
+    })();
+    if let Err(error) = result {
+        let _ = std::fs::remove_file(&probe);
+        let _ = std::fs::remove_dir(&directory);
+        return Err(error.into());
+    }
+    Ok(directory)
+}
+
+/// Open one client's FIFO pair after its rendezvous handshake.
 #[cfg(unix)]
 fn accept_fifo_client(directory: &Path) -> Result<(std::fs::File, std::fs::File)> {
     use std::os::unix::fs::OpenOptionsExt as _;
@@ -264,6 +314,61 @@ fn accept_fifo_client(directory: &Path) -> Result<(std::fs::File, std::fs::File)
     set_blocking(&requests)?;
     set_blocking(&responses)?;
     Ok((requests, responses))
+}
+
+/// A blocking FIFO request stream polled only from its dedicated OS thread.
+#[cfg(unix)]
+struct BlockingFifoReader(std::fs::File);
+
+#[cfg(unix)]
+impl tokio::io::AsyncRead for BlockingFifoReader {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _context: &mut std::task::Context<'_>,
+        buffer: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        use std::io::Read as _;
+
+        let read = self.get_mut().0.read(buffer.initialize_unfilled());
+        match read {
+            Ok(read) => {
+                buffer.advance(read);
+                std::task::Poll::Ready(Ok(()))
+            }
+            Err(error) => std::task::Poll::Ready(Err(error)),
+        }
+    }
+}
+
+/// A blocking FIFO response stream polled only from its dedicated OS thread.
+#[cfg(unix)]
+struct BlockingFifoWriter(std::fs::File);
+
+#[cfg(unix)]
+impl tokio::io::AsyncWrite for BlockingFifoWriter {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _context: &mut std::task::Context<'_>,
+        buffer: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        use std::io::Write as _;
+
+        std::task::Poll::Ready(self.get_mut().0.write(buffer))
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        _context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
 }
 
 #[cfg(unix)]
@@ -340,6 +445,20 @@ mod tests {
             source: std::io::Error::from(std::io::ErrorKind::AddrInUse),
         });
         assert!(!listener_unavailable(&error));
+    }
+
+    #[test]
+    fn a_blocked_mkfifo_prevents_publishing_the_fifo_endpoint() {
+        let session = tempfile::tempdir().unwrap();
+        let error = prepare_fifo_directory_with(session.path(), |_| {
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        })
+        .unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert!(!session.path().join("cache-agent-fifo").exists());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/mbx/src/session/server.rs
+++ b/crates/mbx/src/session/server.rs
@@ -9,10 +9,50 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 #[cfg(unix)]
+pub(super) const FIFO_ENDPOINT_PREFIX: &str = "fifo:";
+#[cfg(unix)]
+pub(super) const FIFO_CLIENT_PREFIX: &str = "client-";
+#[cfg(unix)]
+pub(super) const FIFO_READY: &str = "ready";
+#[cfg(unix)]
+pub(super) const FIFO_ACCEPTED: &str = "accepted";
+#[cfg(unix)]
+pub(super) const FIFO_REQUESTS: &str = "requests";
+#[cfg(unix)]
+pub(super) const FIFO_RESPONSES: &str = "responses";
+#[cfg(unix)]
+pub(super) const FIFO_CONNECT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[cfg(unix)]
 #[derive(Debug)]
 struct ListenerBindError {
     path: PathBuf,
     source: std::io::Error,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct TransportUnavailable {
+    socket: ListenerBindError,
+    fifo: eyre::Report,
+}
+
+#[cfg(unix)]
+impl std::fmt::Display for TransportUnavailable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "{}; FIFO fallback also failed: {:#}",
+            self.socket, self.fifo
+        )
+    }
+}
+
+#[cfg(unix)]
+impl std::error::Error for TransportUnavailable {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.socket)
+    }
 }
 
 #[cfg(unix)]
@@ -48,10 +88,12 @@ impl ListenerBindError {
 /// local listener the compiler shims need.
 #[cfg(unix)]
 pub(crate) fn listener_unavailable(error: &eyre::Report) -> bool {
-    error
-        .chain()
-        .find_map(|cause| cause.downcast_ref::<ListenerBindError>())
-        .is_some_and(ListenerBindError::unavailable)
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<ListenerBindError>()
+            .is_some_and(ListenerBindError::unavailable)
+            || cause.downcast_ref::<TransportUnavailable>().is_some()
+    })
 }
 
 #[cfg(windows)]
@@ -69,10 +111,27 @@ pub(super) async fn spawn_server(
     use std::os::unix::fs::PermissionsExt as _;
 
     let socket = session_dir.join("cache-agent.sock");
-    let listener = tokio::net::UnixListener::bind(&socket).map_err(|source| ListenerBindError {
-        path: socket.clone(),
-        source,
-    })?;
+    let listener = match tokio::net::UnixListener::bind(&socket) {
+        Ok(listener) => listener,
+        Err(source) => {
+            let socket_error = ListenerBindError {
+                path: socket,
+                source,
+            };
+            if !socket_error.unavailable() {
+                return Err(socket_error.into());
+            }
+            super::note(&format!(
+                "mbx[warning]: Unix-domain cache session listener unavailable; using FIFO transport: {socket_error}"
+            ));
+            return spawn_fifo_server(session_dir, agent, task, shutdown)
+                .map_err(|fifo| TransportUnavailable {
+                    socket: socket_error,
+                    fifo,
+                })
+                .map_err(Into::into);
+        }
+    };
     std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))?;
     let endpoint = socket.to_string_lossy().into_owned();
     let server = tokio::spawn(async move {
@@ -108,9 +167,157 @@ pub(super) async fn spawn_server(
     Ok((endpoint, server))
 }
 
+/// Serve compiler processes through filesystem FIFOs when socket syscalls are
+/// prohibited. Each client owns a private request/response pair, so large
+/// protocol messages and concurrent compilations never share framing.
+#[cfg(unix)]
+fn spawn_fifo_server(
+    session_dir: &Path,
+    agent: CacheAgent,
+    task: Arc<super::SessionTask>,
+    mut shutdown: oneshot::Receiver<()>,
+) -> Result<(String, JoinHandle<Result<()>>)> {
+    use std::collections::HashSet;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let directory = session_dir.join("cache-agent-fifo");
+    std::fs::create_dir(&directory)?;
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700))?;
+    let endpoint = format!("{FIFO_ENDPOINT_PREFIX}{}", directory.to_string_lossy());
+    let server = tokio::spawn(async move {
+        let _cleanup = FifoCleanup(directory.clone());
+        let mut claimed = HashSet::new();
+        let mut connections = tokio::task::JoinSet::new();
+        let mut poll = tokio::time::interval(std::time::Duration::from_millis(2));
+        let outcome = loop {
+            tokio::select! {
+                _ = poll.tick() => {
+                    let entries = match std::fs::read_dir(&directory) {
+                        Ok(entries) => entries,
+                        Err(error) => break Err(eyre::Report::from(error)),
+                    };
+                    for entry in entries.filter_map(std::result::Result::ok) {
+                        let path = entry.path();
+                        if !entry.file_type().is_ok_and(|kind| kind.is_dir())
+                            || !entry.file_name().to_string_lossy().starts_with(FIFO_CLIENT_PREFIX)
+                            || !claimed.insert(path.clone())
+                        {
+                            continue;
+                        }
+                        let agent = agent.clone();
+                        let task = Arc::clone(&task);
+                        connections.spawn(async move {
+                            let _cleanup = FifoCleanup(path.clone());
+                            let connection_path = path.clone();
+                            let opened = tokio::task::spawn_blocking(move || {
+                                accept_fifo_client(&connection_path)
+                            })
+                            .await
+                            .map_err(eyre::Report::from)??;
+                            initialize_task(&agent, &task).await;
+                            let (reader, writer) = opened;
+                            let stream = tokio::io::join(
+                                tokio::fs::File::from_std(reader),
+                                tokio::fs::File::from_std(writer),
+                            );
+                            if let Err(error) = agent.handle_connection(stream).await {
+                                debug!("cache agent FIFO connection failed: {error}");
+                            }
+                            Ok::<(), eyre::Report>(())
+                        });
+                    }
+                    while connections.try_join_next().is_some() {}
+                }
+                _ = &mut shutdown => break Ok(()),
+            }
+        };
+        while let Some(connection) = connections.join_next().await {
+            if let Ok(Err(error)) = connection {
+                debug!("cache agent FIFO connection failed: {error}");
+            }
+        }
+        outcome
+    });
+    Ok((endpoint, server))
+}
+
+#[cfg(unix)]
+fn accept_fifo_client(directory: &Path) -> Result<(std::fs::File, std::fs::File)> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let requests = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(directory.join(FIFO_REQUESTS))?;
+    let deadline = std::time::Instant::now() + FIFO_CONNECT_DEADLINE;
+    while !directory.join(FIFO_READY).exists() {
+        if std::time::Instant::now() >= deadline {
+            eyre::bail!("timed out waiting for a FIFO cache client");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    let responses = std::fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(directory.join(FIFO_RESPONSES))?;
+    std::fs::write(directory.join(FIFO_ACCEPTED), b"")?;
+    set_blocking(&requests)?;
+    set_blocking(&responses)?;
+    Ok((requests, responses))
+}
+
+#[cfg(unix)]
+pub(crate) fn create_fifo(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "FIFO path contains a null byte",
+        )
+    })?;
+    // SAFETY: `path` is a live, null-terminated C string and mode contains
+    // only ordinary permission bits.
+    if unsafe { libc::mkfifo(path.as_ptr(), 0o600) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+pub(super) fn set_blocking(file: &std::fs::File) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd as _;
+
+    // SAFETY: F_GETFL and F_SETFL do not retain the valid file descriptor.
+    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFL, flags & !libc::O_NONBLOCK) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+struct FifoCleanup(PathBuf);
+
+#[cfg(unix)]
+impl Drop for FifoCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(self.0.join(FIFO_READY));
+        let _ = std::fs::remove_file(self.0.join(FIFO_ACCEPTED));
+        let _ = std::fs::remove_file(self.0.join(FIFO_REQUESTS));
+        let _ = std::fs::remove_file(self.0.join(FIFO_RESPONSES));
+        let _ = std::fs::remove_dir(&self.0);
+    }
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use mbx_cache_core::{AgentRequest, AgentResponse};
 
     #[test]
     fn permission_and_platform_rejections_mean_the_listener_is_unavailable() {
@@ -133,6 +340,80 @@ mod tests {
             source: std::io::Error::from(std::io::ErrorKind::AddrInUse),
         });
         assert!(!listener_unavailable(&error));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fifo_transport_serves_the_agent_protocol() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("store"), super::super::VERSION);
+        let task = Arc::new(super::super::SessionTask {
+            identity: std::sync::OnceLock::new(),
+            initialized: tokio::sync::OnceCell::new(),
+        });
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (endpoint, server) =
+            spawn_fifo_server(directory.path(), agent, task, shutdown_rx).unwrap();
+        let responses = std::thread::spawn(move || {
+            super::super::client::request_agent_at(
+                &endpoint.into(),
+                &[
+                    AgentRequest::RecordWarning {
+                        message: "x".repeat(128 * 1024),
+                    },
+                    AgentRequest::RecordUnconsulted,
+                ],
+            )
+        })
+        .join()
+        .unwrap()
+        .unwrap();
+        assert!(
+            matches!(
+                responses.as_slice(),
+                [
+                    AgentResponse::Error { message },
+                    AgentResponse::UnconsultedRecorded
+                ] if message == "invalid shim warning"
+            ),
+            "unexpected FIFO responses: {responses:?}"
+        );
+        shutdown_tx.send(()).unwrap();
+        server.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fifo_transport_keeps_concurrent_clients_separate() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("store"), super::super::VERSION);
+        let observed = agent.clone();
+        let task = Arc::new(super::super::SessionTask {
+            identity: std::sync::OnceLock::new(),
+            initialized: tokio::sync::OnceCell::new(),
+        });
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (endpoint, server) =
+            spawn_fifo_server(directory.path(), agent, task, shutdown_rx).unwrap();
+        let clients = (0..8)
+            .map(|_| {
+                let endpoint = endpoint.clone();
+                std::thread::spawn(move || {
+                    super::super::client::request_agent_at(
+                        &endpoint.into(),
+                        &[AgentRequest::RecordUnconsulted],
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        for client in clients {
+            let responses = client.join().unwrap().unwrap();
+            assert!(matches!(
+                responses.as_slice(),
+                [AgentResponse::UnconsultedRecorded]
+            ));
+        }
+        shutdown_tx.send(()).unwrap();
+        server.await.unwrap().unwrap();
+        assert_eq!(observed.stats().unconsulted, 8);
     }
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -318,6 +318,12 @@ protocol connectivity. Warnings describe setup problems, optional features, or
 fallbacks; failures make the command exit
 unsuccessfully.
 
+Build sessions normally communicate over a Unix-domain socket. When a sandbox
+blocks Unix socket listeners but permits filesystem FIFOs, mbx automatically
+uses FIFO transport and keeps caching enabled. If neither transport is
+available, mbx warns and runs Cargo without caching instead of preventing the
+build from starting.
+
 ## Read the result
 
 After a build that used the cache, mbx prints a one-line summary to stderr:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,6 +301,7 @@ mbx doctor
   ok  cargo        cargo 1.98.0 (797e8a9bc 2026-08-05)
   ok  rustc        rustc 1.98.0 (88d9e12ae 2026-08-18)
   ok  cache        /home/you/.cache/mbx is writable
+  ok  session      Unix-domain listeners are available
   ok  config       50.0 GiB budget, automatic gc enabled, managed targets enabled at /home/you/.cache/mbx/targets
   ok  reflink      supported by the cache filesystem
   ok  setup        mise Cargo wrapper is active and the fallback shim is current at /home/you/.local/share/mbx/bin/cargo
@@ -311,9 +312,10 @@ mbx doctor
 
 Doctor checks that mise's Cargo wrapper is active, or that the installed fallback
 shim matches the running mbx and is the first `cargo` on `PATH`. It also checks
-the Cargo and rustc executables, cache write access, filesystem reflink support,
-effective remote policy, and remote protocol connectivity. Warnings describe
-setup problems, optional features, or fallbacks; failures make the command exit
+the Cargo and rustc executables, cache write access, the local build-session
+listener, filesystem reflink support, effective remote policy, and remote
+protocol connectivity. Warnings describe setup problems, optional features, or
+fallbacks; failures make the command exit
 unsuccessfully.
 
 ## Read the result


### PR DESCRIPTION
## Summary

- fall back to running Cargo without mbx caching when the Unix session listener is rejected by the environment
- preserve hard failures for unrelated session startup errors and add the listener path to bind diagnostics
- teach `mbx doctor` to probe Unix-domain listener binding and document the new check

Closes the compatibility gap reported in discussion #315.

## Validation

- `cargo test -p mbx`
- `cargo clippy -p mbx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo run -q -p mbx -- doctor`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every orchestrated Cargo build starts and how shims talk to the cache agent, including new FIFO threading and handshake logic; failures degrade to uncached builds rather than hard errors.
> 
> **Overview**
> On Unix, when binding the cache-session **Unix-domain socket** is blocked (`PermissionDenied` / `Unsupported`), mbx now **falls back to a FIFO-based session transport** instead of failing the build. The server advertises a `fifo:` endpoint; compiler shims connect via per-client request/response FIFOs with a rendezvous handshake, and the existing agent protocol runs over that path.
> 
> If **both** socket bind and FIFO setup fail, orchestrated `cargo` no longer errors out: it warns, sets `MBX_DISABLE` and clears the session socket env, and runs plain Cargo so nested builds and wrappers do not inherit a broken session.
> 
> **`mbx doctor`** (Unix) adds a **session** check that actually probes socket `bind` and `mkfifo`, with warnings for FIFO-only or fully uncached builds. Docs describe the listener check and transport fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6148c90f2d766e99c6bbf34f733959b50b90e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cargo commands now continue without caching when local session transport is unavailable instead of failing.
  - Builds can fall back to FIFO transport when socket listeners are blocked by the environment.
  - Improved detection and reporting when neither supported session transport is available.
  - Other session startup errors continue to be reported normally.

- **Documentation**
  - Updated `mbx doctor` examples and guidance to cover session listener availability, FIFO fallback, and uncached builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->