### PR TITLE
fix: verify compiler inputs across clock domains

### DIFF
--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -380,9 +380,35 @@ impl CcDiscoveredInputs {
     /// being mistaken for the contents that produced the object; `verify`
     /// closes the remaining race after hashing.
     pub fn verify_not_modified_since(&self, started_at: SystemTime) -> Result<(), CcBypassReason> {
+        self.verify_not_modified_since_with_identities(started_at, &BTreeMap::new())
+    }
+
+    /// Reject inputs that changed from identities captured before the driver
+    /// ran, falling back to the wall-clock barrier for discovered headers.
+    pub fn verify_not_modified_since_with_identities(
+        &self,
+        started_at: SystemTime,
+        before: &BTreeMap<PathBuf, FileIdentity>,
+    ) -> Result<(), CcBypassReason> {
         for input in self.files() {
-            let modified = std::fs::metadata(&input.path)
-                .and_then(|metadata| metadata.modified())
+            let metadata =
+                std::fs::metadata(&input.path).map_err(|error| CcBypassReason::InputRead {
+                    path: input.path.clone(),
+                    message: error.to_string(),
+                })?;
+            let identity = FileIdentity::describe(&input.path, &metadata);
+            if let Some(previous) = before.get(&input.path)
+                && previous.changed.is_some()
+            {
+                if identity.as_ref() == Some(previous) {
+                    continue;
+                }
+                return Err(CcBypassReason::InputModifiedDuringCompilation(
+                    input.path.clone(),
+                ));
+            }
+            let modified = metadata
+                .modified()
                 .map_err(|error| CcBypassReason::InputRead {
                     path: input.path.clone(),
                     message: error.to_string(),

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -276,7 +276,9 @@ fn discovery_rejects_inputs_modified_during_compilation() {
 fn precompile_identity_does_not_depend_on_the_host_clock() {
     let directory = tempfile::tempdir().expect("tempdir");
     let root = directory.path();
-    let source = write(root, "a.c", "int a(void) { return 0; }\n");
+    write(root, "a.c", "int a(void) { return 0; }\n");
+    std::fs::create_dir(root.join("nested")).expect("nested directory");
+    let source = root.join("nested/../a.c");
     let discovered = CcDiscoveredInputs::collect(
         root,
         BTreeSet::from([source.clone()]),

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -271,6 +271,39 @@ fn discovery_rejects_inputs_modified_during_compilation() {
     assert_eq!(discovered.verify().unwrap_err().kind(), "input-changed");
 }
 
+#[cfg(unix)]
+#[test]
+fn precompile_identity_does_not_depend_on_the_host_clock() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let root = directory.path();
+    let source = write(root, "a.c", "int a(void) { return 0; }\n");
+    let discovered = CcDiscoveredInputs::collect(
+        root,
+        BTreeSet::from([source.clone()]),
+        BTreeSet::new(),
+        &NoFileDigestCache,
+    )
+    .expect("discovery");
+    let identity = FileIdentity::describe(&source, &std::fs::metadata(&source).unwrap()).unwrap();
+    let before = BTreeMap::from([(source.clone(), identity)]);
+
+    discovered
+        .verify_not_modified_since_with_identities(SystemTime::UNIX_EPOCH, &before)
+        .expect("an unchanged identity is independent of clock offset");
+
+    std::fs::write(&source, "int a(void) { return 1; }\n").expect("rewrite");
+    assert_eq!(
+        discovered
+            .verify_not_modified_since_with_identities(
+                SystemTime::now() + std::time::Duration::from_secs(60),
+                &before,
+            )
+            .unwrap_err()
+            .kind(),
+        "input-modified-during-compilation"
+    );
+}
+
 #[test]
 fn discovery_requires_an_absolute_working_directory() {
     assert_eq!(

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -754,7 +754,7 @@ mod tests {
     fn precompile_identity_does_not_depend_on_the_host_clock() {
         let directory = tempfile::tempdir().unwrap();
         let source = directory.path().join("lib.rs");
-        std::fs::write(&source, "pub fn library() {}\n").unwrap();
+        std::fs::write(&source, "pub fn library() {0}\n").unwrap();
         let invocation = RustcInvocation::parse(&[
             "--crate-name=widget".into(),
             "--crate-type=lib".into(),
@@ -777,7 +777,7 @@ mod tests {
             .unwrap();
 
         // Conversely, a filesystem clock far behind must not conceal a write.
-        std::fs::write(&source, "pub fn library() { }\n").unwrap();
+        std::fs::write(&source, "pub fn library() {1}\n").unwrap();
         assert_eq!(
             discovered.verify_not_modified_since_with_identities(
                 SystemTime::now() + std::time::Duration::from_secs(60),

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -234,9 +234,40 @@ impl DiscoveredInputs {
     /// the contents that produced the artifact. `verify` closes the remaining
     /// race after hashing.
     pub fn verify_not_modified_since(&self, started_at: SystemTime) -> Result<(), BypassReason> {
+        self.verify_not_modified_since_with_identities(started_at, &BTreeMap::new())
+    }
+
+    /// Reject inputs that changed from identities captured before rustc ran,
+    /// falling back to the wall-clock barrier for inputs only dep-info named.
+    ///
+    /// Exact identity comparison does not order a client timestamp against a
+    /// filesystem timestamp, so it remains valid when an NFS server and the
+    /// compiler host use different clocks. Only identities carrying a change
+    /// token qualify: without one a same-length rewrite can restore its mtime.
+    pub fn verify_not_modified_since_with_identities(
+        &self,
+        started_at: SystemTime,
+        before: &BTreeMap<PathBuf, FileIdentity>,
+    ) -> Result<(), BypassReason> {
         for input in &self.inputs {
-            let modified = std::fs::metadata(&input.path)
-                .and_then(|metadata| metadata.modified())
+            let metadata =
+                std::fs::metadata(&input.path).map_err(|error| BypassReason::InputRead {
+                    path: input.path.clone(),
+                    message: error.to_string(),
+                })?;
+            let identity = FileIdentity::describe(&input.path, &metadata);
+            if let Some(previous) = before.get(&input.path)
+                && previous.changed.is_some()
+            {
+                if identity.as_ref() == Some(previous) {
+                    continue;
+                }
+                return Err(BypassReason::InputModifiedDuringCompilation(
+                    input.path.clone(),
+                ));
+            }
+            let modified = metadata
+                .modified()
                 .map_err(|error| BypassReason::InputRead {
                     path: input.path.clone(),
                     message: error.to_string(),
@@ -714,6 +745,44 @@ mod tests {
 
         assert_eq!(
             discovered.verify_not_modified_since(modified),
+            Err(BypassReason::InputModifiedDuringCompilation(source))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn precompile_identity_does_not_depend_on_the_host_clock() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("lib.rs");
+        std::fs::write(&source, "pub fn library() {}\n").unwrap();
+        let invocation = RustcInvocation::parse(&[
+            "--crate-name=widget".into(),
+            "--crate-type=lib".into(),
+            "--emit=dep-info,metadata".into(),
+            source.clone().into_os_string(),
+        ])
+        .unwrap();
+        let dep_info = RustcDepInfo::parse(&format!("output: {}\n", source.display())).unwrap();
+        let discovered = invocation
+            .discover_inputs(&dep_info, directory.path())
+            .unwrap();
+        let identity =
+            FileIdentity::describe(&source, &std::fs::metadata(&source).unwrap()).unwrap();
+        let before = BTreeMap::from([(source.clone(), identity)]);
+
+        // Every ordinary mtime is after the epoch. The unchanged identity is
+        // nevertheless enough proof when the filesystem clock is far ahead.
+        discovered
+            .verify_not_modified_since_with_identities(SystemTime::UNIX_EPOCH, &before)
+            .unwrap();
+
+        // Conversely, a filesystem clock far behind must not conceal a write.
+        std::fs::write(&source, "pub fn library() { }\n").unwrap();
+        assert_eq!(
+            discovered.verify_not_modified_since_with_identities(
+                SystemTime::now() + std::time::Duration::from_secs(60),
+                &before,
+            ),
             Err(BypassReason::InputModifiedDuringCompilation(source))
         );
     }

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -500,13 +500,16 @@ impl RustcInvocation {
         &self.source
     }
 
-    /// Files named directly by the invocation that rustc must read.
+    /// Absolute files named directly by the invocation that rustc must read.
     ///
     /// This includes the source, explicit extern artifacts, and custom target
     /// specifications. Callers can snapshot these before rustc starts even
     /// though the complete input set is only known from dep-info afterwards.
-    pub fn required_inputs(&self) -> &[PathBuf] {
-        &self.required_inputs
+    pub fn required_inputs_in(&self, working_dir: &Path) -> Vec<PathBuf> {
+        self.required_inputs
+            .iter()
+            .map(|path| absolute_path(path, working_dir))
+            .collect()
     }
 
     /// Return the explicitly selected compilation target, if any.

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -500,6 +500,15 @@ impl RustcInvocation {
         &self.source
     }
 
+    /// Files named directly by the invocation that rustc must read.
+    ///
+    /// This includes the source, explicit extern artifacts, and custom target
+    /// specifications. Callers can snapshot these before rustc starts even
+    /// though the complete input set is only known from dep-info afterwards.
+    pub fn required_inputs(&self) -> &[PathBuf] {
+        &self.required_inputs
+    }
+
     /// Return the explicitly selected compilation target, if any.
     pub fn target(&self) -> Option<&str> {
         self.target.as_deref()

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -360,7 +360,7 @@ fn publish(
     depfile: &Path,
     output: &Output,
     compilation_started: SystemTime,
-    input_identities: &BTreeMap<PathBuf, FileIdentity>,
+    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
     task: &str,
     invocation_digest: &CacheDigest,
     duration_ns: u64,
@@ -370,6 +370,9 @@ fn publish(
     remote_claim: Option<&str>,
     portable: &Portable,
 ) -> Result<()> {
+    let input_identities = input_identities
+        .as_ref()
+        .map_err(|error| eyre::eyre!(error.to_string()))?;
     let discovered = discover(invocation, context, depfile)?;
     discovered.verify_not_modified_since_with_identities(compilation_started, input_identities)?;
     verify_search_path_unchanged(searchable, before)?;

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -265,6 +265,10 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     // The machine-wide permit is taken after every chance to hit the cache,
     // and the timer starts afterwards: time spent waiting for the machine is
     // not time this compilation cost.
+    let input_identities = crate::util::snapshot_file_identities(
+        &working_dir,
+        invocation.required_inputs().iter().map(PathBuf::as_path),
+    );
     let demand = crate::scheduler::Demand::new(&compilation_name(&invocation), false);
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));
     let started = Instant::now();
@@ -311,6 +315,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         &depfile,
         &output,
         compilation_started,
+        &input_identities,
         &task,
         &invocation_digest,
         duration_ns,
@@ -352,6 +357,7 @@ fn publish(
     depfile: &Path,
     output: &Output,
     compilation_started: SystemTime,
+    input_identities: &BTreeMap<PathBuf, FileIdentity>,
     task: &str,
     invocation_digest: &CacheDigest,
     duration_ns: u64,
@@ -362,7 +368,7 @@ fn publish(
     portable: &Portable,
 ) -> Result<()> {
     let discovered = discover(invocation, context, depfile)?;
-    discovered.verify_not_modified_since(compilation_started)?;
+    discovered.verify_not_modified_since_with_identities(compilation_started, input_identities)?;
     verify_search_path_unchanged(searchable, before)?;
     discovered.verify()?;
     discovered.apply_to(context)?;

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -265,10 +265,13 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     // The machine-wide permit is taken after every chance to hit the cache,
     // and the timer starts afterwards: time spent waiting for the machine is
     // not time this compilation cost.
-    let input_identities = crate::util::snapshot_file_identities(
-        &working_dir,
-        invocation.required_inputs().iter().map(PathBuf::as_path),
-    );
+    let required_inputs = invocation
+        .required_inputs()
+        .iter()
+        .map(|path| absolute(path, &working_dir))
+        .collect::<Vec<_>>();
+    let input_identities =
+        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
     let demand = crate::scheduler::Demand::new(&compilation_name(&invocation), false);
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));
     let started = Instant::now();

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -458,11 +458,12 @@ pub(crate) fn compile(
     if output.status.success() {
         learned.record_compiled();
         let publication: Result<Option<ActionDiagnostic>> = (|| {
+            let input_identities = input_identities
+                .as_ref()
+                .map_err(|error| eyre::eyre!(error.to_string()))?;
             let (candidates, discovered) = action_from_dep_info(&compilation, &outputs.dep_info)?;
-            discovered.verify_not_modified_since_with_identities(
-                compilation_started,
-                &input_identities,
-            )?;
+            discovered
+                .verify_not_modified_since_with_identities(compilation_started, input_identities)?;
             discovered.verify()?;
             if learned_enabled && learned.record.is_none() && source_is_in_workspace(&compilation) {
                 record_learned_baseline(&compilation, &discovered);

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -398,6 +398,10 @@ pub(crate) fn compile(
     // The machine-wide permit is taken after every chance to hit the cache,
     // and before anything expensive starts. The timer starts afterwards: time
     // spent waiting for the machine is not time this compilation cost.
+    let input_identities = crate::util::snapshot_file_identities(
+        &working_dir,
+        invocation.required_inputs().iter().map(PathBuf::as_path),
+    );
     let demand =
         crate::scheduler::Demand::new(invocation.crate_name(), invocation.links_natively());
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));
@@ -456,7 +460,10 @@ pub(crate) fn compile(
         learned.record_compiled();
         let publication: Result<Option<ActionDiagnostic>> = (|| {
             let (candidates, discovered) = action_from_dep_info(&compilation, &outputs.dep_info)?;
-            discovered.verify_not_modified_since(compilation_started)?;
+            discovered.verify_not_modified_since_with_identities(
+                compilation_started,
+                &input_identities,
+            )?;
             discovered.verify()?;
             if learned_enabled && learned.record.is_none() && source_is_in_workspace(&compilation) {
                 record_learned_baseline(&compilation, &discovered);

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -398,10 +398,9 @@ pub(crate) fn compile(
     // The machine-wide permit is taken after every chance to hit the cache,
     // and before anything expensive starts. The timer starts afterwards: time
     // spent waiting for the machine is not time this compilation cost.
-    let input_identities = crate::util::snapshot_file_identities(
-        &working_dir,
-        invocation.required_inputs().iter().map(PathBuf::as_path),
-    );
+    let required_inputs = invocation.required_inputs_in(&working_dir);
+    let input_identities =
+        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
     let demand =
         crate::scheduler::Demand::new(invocation.crate_name(), invocation.links_natively());
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -1,7 +1,52 @@
 use eyre::{Context, Result};
+use mbx_cache_core::FileIdentity;
+use std::collections::BTreeMap;
 use std::io::Write as _;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
+
+/// Capture clock-independent identities for compiler inputs known up front.
+#[cfg(unix)]
+pub(crate) fn snapshot_file_identities<'a>(
+    working_dir: &Path,
+    paths: impl IntoIterator<Item = &'a Path>,
+) -> BTreeMap<PathBuf, FileIdentity> {
+    paths
+        .into_iter()
+        .filter_map(|path| {
+            let path = if path.is_absolute() {
+                normalize_components(path)
+            } else {
+                normalize_components(&working_dir.join(path))
+            };
+            let metadata = std::fs::metadata(&path).ok()?;
+            let identity = FileIdentity::describe(&path, &metadata)?;
+            Some((path, identity))
+        })
+        .collect()
+}
+
+#[cfg(not(unix))]
+pub(crate) fn snapshot_file_identities<'a>(
+    _working_dir: &Path,
+    _paths: impl IntoIterator<Item = &'a Path>,
+) -> BTreeMap<PathBuf, FileIdentity> {
+    BTreeMap::new()
+}
+
+fn normalize_components(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
 
 /// Find the workspace root above `start`.
 ///

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -2,50 +2,29 @@ use eyre::{Context, Result};
 use mbx_cache_core::FileIdentity;
 use std::collections::BTreeMap;
 use std::io::Write as _;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Capture clock-independent identities for compiler inputs known up front.
 #[cfg(unix)]
 pub(crate) fn snapshot_file_identities<'a>(
-    working_dir: &Path,
     paths: impl IntoIterator<Item = &'a Path>,
 ) -> BTreeMap<PathBuf, FileIdentity> {
     paths
         .into_iter()
         .filter_map(|path| {
-            let path = if path.is_absolute() {
-                normalize_components(path)
-            } else {
-                normalize_components(&working_dir.join(path))
-            };
-            let metadata = std::fs::metadata(&path).ok()?;
-            let identity = FileIdentity::describe(&path, &metadata)?;
-            Some((path, identity))
+            let metadata = std::fs::metadata(path).ok()?;
+            let identity = FileIdentity::describe(path, &metadata)?;
+            Some((path.to_path_buf(), identity))
         })
         .collect()
 }
 
 #[cfg(not(unix))]
 pub(crate) fn snapshot_file_identities<'a>(
-    _working_dir: &Path,
     _paths: impl IntoIterator<Item = &'a Path>,
 ) -> BTreeMap<PathBuf, FileIdentity> {
     BTreeMap::new()
-}
-
-fn normalize_components(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            component => normalized.push(component.as_os_str()),
-        }
-    }
-    normalized
 }
 
 /// Find the workspace root above `start`.

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -9,13 +9,29 @@ use std::time::Duration;
 #[cfg(unix)]
 pub(crate) fn snapshot_file_identities<'a>(
     paths: impl IntoIterator<Item = &'a Path>,
-) -> BTreeMap<PathBuf, FileIdentity> {
+) -> std::io::Result<BTreeMap<PathBuf, FileIdentity>> {
     paths
         .into_iter()
-        .filter_map(|path| {
-            let metadata = std::fs::metadata(path).ok()?;
-            let identity = FileIdentity::describe(path, &metadata)?;
-            Some((path.to_path_buf(), identity))
+        .map(|path| {
+            let metadata = std::fs::metadata(path).map_err(|error| {
+                std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "failed to capture compiler input identity for {}: {error}",
+                        path.display()
+                    ),
+                )
+            })?;
+            let identity = FileIdentity::describe(path, &metadata).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    format!(
+                        "filesystem supplied no identity for compiler input {}",
+                        path.display()
+                    ),
+                )
+            })?;
+            Ok((path.to_path_buf(), identity))
         })
         .collect()
 }
@@ -23,8 +39,8 @@ pub(crate) fn snapshot_file_identities<'a>(
 #[cfg(not(unix))]
 pub(crate) fn snapshot_file_identities<'a>(
     _paths: impl IntoIterator<Item = &'a Path>,
-) -> BTreeMap<PathBuf, FileIdentity> {
-    BTreeMap::new()
+) -> std::io::Result<BTreeMap<PathBuf, FileIdentity>> {
+    Ok(BTreeMap::new())
 }
 
 /// Find the workspace root above `start`.
@@ -523,6 +539,19 @@ pub fn random_string(length: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn compiler_input_snapshot_fails_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("missing-input");
+        let error = snapshot_file_identities([missing.as_path()]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to capture compiler input identity")
+        );
+    }
 
     #[test]
     fn cgroup_usage_discounts_the_page_cache() {


### PR DESCRIPTION
## Summary

- snapshot command-line compiler inputs before compilation
- verify unchanged inputs by exact file identity instead of comparing filesystem time with the host clock
- retain the conservative timestamp fallback for inputs discovered only after compilation
- apply the same protection to rustc and C/C++ adapters

This addresses the NFS clock-domain behavior reported in discussion #316. In particular, Rust extern artifacts such as rmeta and rlib files are known before rustc starts and no longer depend on client/server clock alignment.

## Verification

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-compile cache publication guards for compiler inputs; incorrect logic could wrongly cache or bypass, but the design fails closed and keeps the timestamp fallback for late-discovered inputs.
> 
> **Overview**
> Fixes false **input-modified-during-compilation** bypasses when the compiler host clock and the filesystem (e.g. NFS) disagree, by no longer relying on `mtime >= compilation_started` for inputs that were known before the driver ran.
> 
> **Before compile**, the C/C++ and `rustc` shims snapshot **clock-independent `FileIdentity`** for command-line inputs (sources, `--extern` artifacts, custom targets, etc.) via new `snapshot_file_identities` and `RustcInvocation::required_inputs_in`.
> 
> **After compile**, `verify_not_modified_since` delegates to **`verify_not_modified_since_with_identities`**: if a pre-snapshot exists and carries a change token, unchanged identity skips the wall-clock check; any identity drift still fails closed. Inputs only discovered from dep-info/depfile still use the existing timestamp barrier.
> 
> Unix tests assert unchanged files pass even with extreme `started_at` offsets, while real rewrites are still detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd7223e6fda2bbce1869c4b182b6ea6c02d5e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of source and header files modified during compilation by comparing file identities captured before compilation.
  - Prevented filesystem clock differences or inaccurate timestamps from causing unchanged inputs to be incorrectly rejected.
  - Continued using timestamp-based checks for inputs without a pre-compilation identity, preserving existing safeguards.
  - Added validation to reliably report inputs that changed while compilation was in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->