### PR TITLE
perf(cache): complete large remote transfers reliably

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -74,10 +74,11 @@ const MAX_PREFETCH_TRANSFERS: usize = 48;
 /// Manifests deliberately retain predictions across compatible builds, so a
 /// large workspace can describe far more actions than the next invocation
 /// will request. Keep the most expensive recorded actions warm and let
-/// foreground lookups fetch the long tail on demand. A 256-action ceiling also
-/// bounds speculative output transfer: real Cargo manifests commonly contain
-/// predictions for build-script work made unnecessary by an earlier cache hit.
-const MAX_PREFETCH_ACTIONS: usize = 256;
+/// foreground lookups fetch only unusually large tails on demand. The remote
+/// download-byte budget remains the primary bound on speculative transfer. A
+/// 1,024-action ceiling covers the measured large-workspace manifests while
+/// retaining a guard against pathological manifests and stale prediction sets.
+const MAX_PREFETCH_ACTIONS: usize = 1024;
 // Resolve speculative actions progressively so the most valuable predictions
 // become usable first and cancellation at the end of a build abandons a small
 // tail instead of one workspace-sized transfer wave. Action-result lookup is

--- a/crates/mbx-cache-core/src/core_tests.rs
+++ b/crates/mbx-cache-core/src/core_tests.rs
@@ -84,6 +84,34 @@ fn action_result_keys_require_blake3() {
 }
 
 #[tokio::test]
+async fn action_upload_is_idempotent_when_result_already_exists() {
+    let mut server = mockito::Server::new_async().await;
+    let action = CacheDigest::blake3(b"existing action");
+    let endpoint = format!("/v1/action-results/blake3/{}/{}", action.hash, action.size);
+    let upload = server
+        .mock("PUT", endpoint.as_str())
+        .match_header("if-none-match", "*")
+        .with_status(409)
+        .with_body(r#"{"error":"an immutable action result already exists"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let result = RemoteActionResult {
+        action,
+        metadata: None,
+        output_root: None,
+        version: 1,
+    };
+
+    test_client(&server)
+        .put_action_result(&result)
+        .await
+        .unwrap();
+
+    upload.assert_async().await;
+}
+
+#[tokio::test]
 async fn action_upload_errors_include_a_bounded_server_response() {
     let mut server = mockito::Server::new_async().await;
     let action = CacheDigest::blake3(b"rejected action");
@@ -737,6 +765,34 @@ async fn rejects_oversized_capabilities() {
         error.contains("over the") || error.contains("exceeded the"),
         "unexpected error: {error}"
     );
+}
+
+#[tokio::test]
+async fn caps_streaming_upload_packs_below_the_download_limit() {
+    let mut server = mockito::Server::new_async().await;
+    server
+        .mock("GET", format!("/v{PROTOCOL_VERSION}/capabilities").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":{"blob_packs":true,"blob_pack_uploads":true},
+                "limits":{"max_batch_items":10000,"max_pack_bytes":5368709120_u64}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let client = test_client(&server);
+
+    let downloads = client.blob_pack_limits().await.unwrap().unwrap();
+    let uploads = client.blob_pack_upload_limits().await.unwrap().unwrap();
+
+    assert_eq!(downloads.max_bytes, MAX_STAGED_BLOB_PACK_BYTES);
+    assert_eq!(uploads.max_bytes, MAX_UPLOAD_BLOB_PACK_BYTES);
+    assert_eq!(uploads.max_items, MAX_STAGED_BLOB_PACK_ITEMS);
 }
 
 #[tokio::test]

--- a/crates/mbx-cache-core/src/remote_http.rs
+++ b/crates/mbx-cache-core/src/remote_http.rs
@@ -125,6 +125,16 @@ pub(crate) struct BlobPackLimits {
     pub(crate) max_bytes: u64,
 }
 
+/// Largest blob pack sent in one streaming upload.
+///
+/// Downloads can make progress while the response body arrives, but an upload
+/// receives no response progress until the server has consumed its request.
+/// Keep one pack comfortably inside the ordinary HTTP inactivity timeout even
+/// when a server advertises a multi-gigabyte protocol limit. The upload queue
+/// sends independent packs concurrently, so smaller packs also avoid making a
+/// single timeout replay hundreds of megabytes.
+const MAX_UPLOAD_BLOB_PACK_BYTES: u64 = 64 * 1024 * 1024;
+
 /// What one capabilities exchange settled, cached for the session.
 ///
 /// `Default` is also the answer for a server with no capabilities endpoint:
@@ -412,7 +422,11 @@ impl HttpRemoteCache {
             }))
         };
         let blob_packs = pack_limits(capabilities.features.blob_packs)?;
-        let blob_pack_uploads = pack_limits(capabilities.features.blob_pack_uploads)?;
+        let blob_pack_uploads =
+            pack_limits(capabilities.features.blob_pack_uploads)?.map(|limits| BlobPackLimits {
+                max_bytes: limits.max_bytes.min(MAX_UPLOAD_BLOB_PACK_BYTES),
+                ..limits
+            });
         let action_batches = if capabilities.features.action_batch {
             let max_items = usize::try_from(capabilities.limits.max_batch_items)
                 .ok()
@@ -754,7 +768,10 @@ impl HttpRemoteCache {
                 .body(body.clone())
                 .send()
                 .await?;
-            if response.status() != StatusCode::PRECONDITION_FAILED {
+            if !matches!(
+                response.status(),
+                StatusCode::PRECONDITION_FAILED | StatusCode::CONFLICT
+            ) {
                 error_for_status_with_body(response).await?;
             }
             Ok(())


### PR DESCRIPTION
## Summary

- raise speculative action prefetch coverage from 256 to 1,024 actions so measured large workspaces can restore their full predicted build graph in the background
- cap streaming upload packs at 64 MiB while retaining 256 MiB download packs, avoiding 30-second upload inactivity timeouts and expensive large-request retries
- treat an immutable HTTP action-result conflict as an already-published result, matching existing S3/HTTP precondition behavior so it remains eligible for task manifests

## Evidence

The protected-main hk benchmark exposed all three limits: every platform stopped at exactly 256 prefetched actions, Linux twice timed out uploading large packs, and its final action upload returned an immutable-result 409 and was omitted from the manifest.

A local production-cache A/B on hk confirmed prefetch coverage rises from 256/473 to 473/473. Wall time was 38.74s before and 38.07s after on this machine; the GitHub-hosted benchmark remains the meaningful end-to-end measurement after release.

## Verification

- `cargo fmt --all --check`
- `cargo test --workspace` (all tests pass)
- production read-only hk build with an empty local cache (473 actions prefetched, no remote failures)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote upload sizing, prefetch volume, and action-result error handling on the critical cache publication path; behavior is covered by new tests but affects production CI throughput and manifest completeness.
> 
> **Overview**
> Improves **remote cache reliability** for large workspaces by raising speculative prefetch coverage and tightening upload behavior.
> 
> **Prefetch:** `MAX_PREFETCH_ACTIONS` goes from **256 → 1,024**, so background warming can cover full predicted action graphs on measured large manifests while the download-byte budget still bounds transfer size.
> 
> **Blob pack uploads:** Negotiated upload pack size is now capped at **64 MiB** (`MAX_UPLOAD_BLOB_PACK_BYTES`) even when the server advertises multi-gigabyte limits—downloads keep the existing staged pack ceiling. Smaller streaming uploads avoid HTTP inactivity timeouts and costly retries on huge single requests.
> 
> **Action result PUTs:** HTTP **409 Conflict** (immutable result already exists) is treated like **412 Precondition Failed**—upload succeeds idempotently so background publication and **`wait_for_actions`** do not drop actions from remote task manifests when the server already holds the result.
> 
> Tests cover idempotent action upload on 409 and that upload pack limits stay below download limits when capabilities advertise large `max_pack_bytes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c23d7f58795774f09ae2a61ba2066eb223d6bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->