### PR TITLE
perf(cache): gate prefetch on matching adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,12 @@ jobs:
 
   compatibility:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    env:
+      RUSTUP_TOOLCHAIN: "1.91"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # master
-        with:
-          toolchain: "1.91"
+      - name: Install the minimum supported Rust toolchain
+        run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 env:
   CARGO_INCREMENTAL: "0"
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
-  MISE_DISABLE_TOOLS: rust
+  MISE_DISABLE_TOOLS: rust,aube
   RUSTUP_TOOLCHAIN: 1.97.1
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1-img5263c143
 

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 env:
   CARGO_INCREMENTAL: "0"
   # Rust 1.97.1 is part of the digest-pinned benchmark image.
-  MISE_DISABLE_TOOLS: rust,aube
+  MISE_DISABLE_TOOLS: rust
   RUSTUP_TOOLCHAIN: 1.97.1
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mr-boxington-rust1.97.1-img5263c143
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,9 +116,11 @@ jobs:
           git show "$WORKFLOW_SHA:benchmarks/train-pgo.bash" > "$automation_dir/train-pgo.bash"
           chmod +x "$automation_dir"/*.bash
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install Rust target
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: rustup target add "$TARGET"
 
       - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2
         if: matrix.cross

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -371,6 +371,7 @@ struct TaskActionState {
     remote_etag: Option<String>,
 }
 
+/// Match an invocation and, on an adapter's first match, select its prefetch wave.
 fn activate_prediction_adapter(
     state: &mut TaskActionState,
     invocation: &CacheDigest,

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -367,7 +367,29 @@ struct TaskActionState {
     baseline_loaded: bool,
     predictions: BTreeMap<CacheDigest, ActionPrediction>,
     pending_predictions: BTreeMap<CacheDigest, ActionPrediction>,
+    prefetched_adapters: BTreeSet<String>,
     remote_etag: Option<String>,
+}
+
+fn activate_prediction_adapter(
+    state: &mut TaskActionState,
+    invocation: &CacheDigest,
+) -> (Option<ActionPrediction>, Option<Vec<ActionPrediction>>) {
+    let prediction = state.predictions.get(invocation).cloned();
+    let prefetch = prediction.as_ref().and_then(|prediction| {
+        if !state.prefetched_adapters.insert(prediction.adapter.clone()) {
+            return None;
+        }
+        Some(
+            state
+                .predictions
+                .values()
+                .filter(|candidate| candidate.adapter == prediction.adapter)
+                .cloned()
+                .collect(),
+        )
+    });
+    (prediction, prefetch)
 }
 
 struct PrefetchedAction {
@@ -584,7 +606,15 @@ impl CacheAgent {
 
     /// Load the last committed action manifest for a task into this session.
     pub async fn begin_task(&self, task: &str) -> Result<String> {
-        self.begin_task_with_remote_errors(task, false, None).await
+        self.begin_task_with_remote_errors(task, false, None, true)
+            .await
+    }
+
+    /// Load a task but defer each adapter's speculative downloads until its
+    /// first prediction matches the current build.
+    pub async fn begin_task_on_prediction(&self, task: &str) -> Result<String> {
+        self.begin_task_with_remote_errors(task, false, None, false)
+            .await
     }
 
     /// Load a task using its identity as the run key.
@@ -593,14 +623,16 @@ impl CacheAgent {
     /// this work until its first client connects while putting the identity in
     /// the client's environment ahead of time.
     pub async fn begin_session_task(&self, task: &str) -> Result<()> {
-        self.begin_task_with_remote_errors(task, false, Some(task.to_string()))
+        self.begin_task_with_remote_errors(task, false, Some(task.to_string()), false)
             .await?;
         Ok(())
     }
 
     /// Load a task and finish its prefetch, surfacing remote lookup failures.
     pub async fn prefetch_task(&self, task: &str) -> Result<String> {
-        let run = self.begin_task_with_remote_errors(task, true, None).await?;
+        let run = self
+            .begin_task_with_remote_errors(task, true, None, true)
+            .await?;
         self.wait_for_prefetches().await;
         Ok(run)
     }
@@ -610,6 +642,7 @@ impl CacheAgent {
         task: &str,
         strict: bool,
         run: Option<String>,
+        eager_prefetch: bool,
     ) -> Result<String> {
         validate_task_identity(task)?;
         // The local manifest is already enough to start useful work. Do not
@@ -628,7 +661,9 @@ impl CacheAgent {
             .iter()
             .map(|prediction| prediction.action.clone())
             .collect();
-        self.spawn_prefetch_predictions(early_predictions);
+        if eager_prefetch {
+            self.spawn_prefetch_predictions(early_predictions);
+        }
         let (remote_manifest, mut remote_etag) = if self.remote_mode.reads() {
             match self.get_remote_task_manifest(task).await {
                 Ok(Some((manifest, etag))) => (Some(manifest), Some(etag)),
@@ -667,7 +702,7 @@ impl CacheAgent {
             }
             manifest
         };
-        let state = if let Some(manifest) = manifest {
+        let mut state = if let Some(manifest) = manifest {
             TaskActionState {
                 manifest: task.to_string(),
                 baseline_loaded: true,
@@ -677,6 +712,7 @@ impl CacheAgent {
                     .map(|prediction| (prediction.invocation.clone(), prediction))
                     .collect(),
                 pending_predictions: BTreeMap::new(),
+                prefetched_adapters: BTreeSet::new(),
                 remote_etag,
             }
         } else {
@@ -699,6 +735,14 @@ impl CacheAgent {
             state.predictions.len().try_into().unwrap_or(u64::MAX),
             Ordering::Relaxed,
         );
+        if eager_prefetch {
+            state.prefetched_adapters.extend(
+                state
+                    .predictions
+                    .values()
+                    .map(|prediction| prediction.adapter.clone()),
+            );
+        }
         // The early local wave already owns these actions. Only launch a
         // second wave for predictions learned from the remote or from a local
         // writer that committed while its lookup was in flight.
@@ -709,7 +753,9 @@ impl CacheAgent {
             .cloned()
             .collect();
         self.task_actions.lock().unwrap().insert(run.clone(), state);
-        self.spawn_prefetch_predictions(predictions);
+        if eager_prefetch {
+            self.spawn_prefetch_predictions(predictions);
+        }
         Ok(run)
     }
 
@@ -1762,13 +1808,16 @@ impl CacheAgent {
     ) -> Result<AgentResponse> {
         validate_task_identity(task)?;
         invocation.validate()?;
-        let prediction = self
-            .task_actions
-            .lock()
-            .unwrap()
-            .get(task)
-            .and_then(|state| state.predictions.get(invocation))
-            .cloned();
+        let (prediction, prefetch) = {
+            let mut tasks = self.task_actions.lock().unwrap();
+            let Some(state) = tasks.get_mut(task) else {
+                return Ok(AgentResponse::ActionPrediction { prediction: None });
+            };
+            activate_prediction_adapter(state, invocation)
+        };
+        if let Some(prefetch) = prefetch {
+            self.spawn_prefetch_predictions(prefetch);
+        }
         Ok(AgentResponse::ActionPrediction { prediction })
     }
 

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -760,6 +760,58 @@ async fn begin_task_reports_how_many_predictions_were_loaded() {
     assert_eq!(reader.stats().predictions_loaded, 2);
 }
 
+#[test]
+fn a_matching_prediction_activates_only_its_adapter_once() {
+    let rustc_first = ActionPrediction {
+        invocation: CacheDigest::blake3(b"first rustc invocation"),
+        action: CacheDigest::blake3(b"first rustc action"),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let rustc_second = ActionPrediction {
+        invocation: CacheDigest::blake3(b"second rustc invocation"),
+        action: CacheDigest::blake3(b"second rustc action"),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let cc = ActionPrediction {
+        invocation: CacheDigest::blake3(b"cc invocation"),
+        action: CacheDigest::blake3(b"cc action"),
+        adapter: "cc".into(),
+        payload: "{}".into(),
+    };
+    let mut state = TaskActionState::default();
+    for prediction in [&rustc_first, &rustc_second, &cc] {
+        state
+            .predictions
+            .insert(prediction.invocation.clone(), prediction.clone());
+    }
+
+    let (prediction, prefetch) =
+        activate_prediction_adapter(&mut state, &CacheDigest::blake3(b"stale invocation"));
+    assert_eq!(prediction, None);
+    assert_eq!(prefetch, None);
+    assert!(state.prefetched_adapters.is_empty());
+
+    let (prediction, prefetch) = activate_prediction_adapter(&mut state, &rustc_first.invocation);
+    assert_eq!(prediction, Some(rustc_first.clone()));
+    let prefetch = prefetch.unwrap();
+    assert_eq!(prefetch.len(), 2);
+    assert!(
+        prefetch
+            .iter()
+            .all(|prediction| prediction.adapter == "rustc")
+    );
+
+    let (prediction, prefetch) = activate_prediction_adapter(&mut state, &rustc_second.invocation);
+    assert_eq!(prediction, Some(rustc_second));
+    assert_eq!(prefetch, None, "one adapter starts only one prefetch wave");
+
+    let (prediction, prefetch) = activate_prediction_adapter(&mut state, &cc.invocation);
+    assert_eq!(prediction, Some(cc.clone()));
+    assert_eq!(prefetch, Some(vec![cc]));
+}
+
 #[tokio::test]
 async fn commit_receipt_contains_this_runs_predictions_not_its_baseline() {
     let directory = tempfile::tempdir().unwrap();
@@ -2702,6 +2754,106 @@ async fn prefetch_skips_remote_negotiation_when_every_action_is_local() {
 
     assert!(agent.prefetch_action_batches(&actions).await.unwrap());
     assert_eq!(agent.stats().remote_action_lookups, 0);
+}
+
+#[tokio::test]
+async fn deferred_prefetch_waits_for_a_matching_adapter() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let task = "5".repeat(64);
+    let rustc = ActionPrediction {
+        invocation: CacheDigest::blake3(b"matching rustc invocation"),
+        action: CacheDigest::blake3(b"matching rustc action"),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let cc = ActionPrediction {
+        invocation: CacheDigest::blake3(b"unmatched cc invocation"),
+        action: CacheDigest::blake3(b"unmatched cc action"),
+        adapter: "cc".into(),
+        payload: "{}".into(),
+    };
+    let manifest_bytes = canonical_json(&TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.clone(),
+        predictions: vec![rustc.clone(), cc],
+    })
+    .unwrap();
+    let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+    let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+    let manifest = server
+        .mock("GET", action_manifest_path(&selector).as_str())
+        .with_status(200)
+        .with_header("etag", &format!("\"{manifest_etag}\""))
+        .with_body(manifest_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+    let capabilities = server
+        .mock("GET", "/v1/capabilities")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "protocol":{"major":1},
+                "features":{"action_batch":true},
+                "limits":{"max_batch_items":100,"max_pack_bytes":1048576}
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let batch = server
+        .mock("POST", "/v1/action-results:batch")
+        .match_body(mockito::Matcher::Json(serde_json::json!({
+            "digests": [rustc.action.clone()]
+        })))
+        .with_status(200)
+        .with_header("content-type", ACTION_RESULT_BATCH_MEDIA_TYPE)
+        .with_body(serde_json::json!({ "results": [] }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let agent = remote_agent(
+        &server,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+
+    let run = agent.begin_task_on_prediction(&task).await.unwrap();
+    agent.wait_for_prefetches().await;
+    assert_eq!(agent.stats().prefetch_runs, 0);
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::FindActionPrediction {
+                task: run.clone(),
+                invocation: CacheDigest::blake3(b"stale invocation"),
+            })
+            .await,
+        AgentResponse::ActionPrediction { prediction: None }
+    ));
+    agent.wait_for_prefetches().await;
+    assert_eq!(agent.stats().prefetch_runs, 0);
+
+    assert!(matches!(
+        agent
+            .respond(AgentRequest::FindActionPrediction {
+                task: run,
+                invocation: rustc.invocation.clone(),
+            })
+            .await,
+        AgentResponse::ActionPrediction {
+            prediction: Some(found)
+        } if found == rustc
+    ));
+    agent.wait_for_prefetches().await;
+
+    manifest.assert_async().await;
+    capabilities.assert_async().await;
+    batch.assert_async().await;
+    assert_eq!(agent.stats().prefetch_runs, 1);
+    assert_eq!(agent.stats().remote_action_lookups, 1);
 }
 
 #[tokio::test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -435,25 +435,26 @@ impl CacheSession {
         {
             warn!("this checkout was not recorded as a cache root: {error}");
         }
-        let (protocol_build, action_run) = match self.agent.begin_task(&identity).await {
-            Ok(run) => (
-                run.clone(),
-                Some(ActionRun {
-                    receipt: run.clone(),
-                    run,
-                    identity: identity.clone(),
-                    workspace_root: project_root.to_path_buf(),
-                    export_group: std::env::var(CACHE_EXPORT_GROUP_ENV).ok(),
-                    store: self.store.clone(),
-                    agent: self.agent.clone(),
-                    initialized: None,
-                }),
-            ),
-            Err(error) => {
-                warn!("build action manifest was not loaded: {error}");
-                (identity, None)
-            }
-        };
+        let (protocol_build, action_run) =
+            match self.agent.begin_task_on_prediction(&identity).await {
+                Ok(run) => (
+                    run.clone(),
+                    Some(ActionRun {
+                        receipt: run.clone(),
+                        run,
+                        identity: identity.clone(),
+                        workspace_root: project_root.to_path_buf(),
+                        export_group: std::env::var(CACHE_EXPORT_GROUP_ENV).ok(),
+                        store: self.store.clone(),
+                        agent: self.agent.clone(),
+                        initialized: None,
+                    }),
+                ),
+                Err(error) => {
+                    warn!("build action manifest was not loaded: {error}");
+                    (identity, None)
+                }
+            };
         environment.insert(
             WORKSPACE_ROOT_ENV.into(),
             project_root.to_string_lossy().into_owned(),

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -14,9 +14,6 @@ importers:
       vitepress-plugin-tabs:
         specifier: ^0.9.1
         version: 0.9.1(vitepress@1.6.4)(vue@3.5.41)
-      vue:
-        specifier: ^3.5.0
-        version: 3.5.41
 
 packages:
 

--- a/mise.lock
+++ b/mise.lock
@@ -3,45 +3,42 @@
 lockfile_version = 1
 
 [[tools.aube]]
-version = "2.0.1"
+version = "2.2.4"
 backend = "aqua:jdx/aube"
 specifiers = ["latest"]
 
+[tools.aube.options]
+"vars.lazy" = "true"
+
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:167bf3749f1eac646b0096e6113e29ac154294c8fe5f8ff5ce3a440b3f73dfe2"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525718579"
-provenance = "github-attestations"
+checksum = "sha256:ded66b083215124d196d918ce44506791c2153552f8f307786e07d9bb3f9221e"
+url = "https://github.com/jdx/aube/releases/download/v2.2.4/aube-v2.2.4-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/538160671"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:720514470b025d3aee2eae25a5cbc354c22875e24f546146ad9a73ac95dc5443"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525682625"
-provenance = "github-attestations"
+checksum = "sha256:07ad5c91d0c7ebb8e9092883ce4910284dc3c909d3aa3ef3c0041c8d25facb7b"
+url = "https://github.com/jdx/aube/releases/download/v2.2.4/aube-v2.2.4-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/538133294"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:320696667be8d64c04f559d730cea84a953e0d553d7fdb2d1dd6830e5266623d"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525694267"
-provenance = "github-attestations"
+checksum = "sha256:20b8fda0f9f471500ee64814880bd84c1bc402ee7f6dece39bfae25cc93aa1d8"
+url = "https://github.com/jdx/aube/releases/download/v2.2.4/aube-v2.2.4-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/538149375"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:530ecdf99cc52fa6e603f7a69ed82ba82667a51143d9a8294cfe2755295db82e"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525697493"
-provenance = "github-attestations"
+checksum = "sha256:ff864b3348d8aad6a1b50fe47e2234d53527797e80f190533c0456ef6255d6e4"
+url = "https://github.com/jdx/aube/releases/download/v2.2.4/aube-v2.2.4-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/538157265"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:61eb75b7fc5e83c7a09666673c7a6310169cb49e44db3d923a27207e7b461371"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525744752"
-provenance = "github-attestations"
+checksum = "sha256:aa3f6e8e319c8d9c92393e797cd5576229eacc0740e8cf2b34d4c65bb1e61708"
+url = "https://github.com/jdx/aube/releases/download/v2.2.4/aube-v2.2.4-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/538155490"
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:5383e428dc7ab02853bb37ceec1a5d72894b6455471c8d02ce9d84ed82430ab6"
-url = "https://github.com/jdx/aube/releases/download/v2.0.1/aube-v2.0.1-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/525700617"
-provenance = "github-attestations"
+checksum = "sha256:b6ace0276285c6a0e0f0f2850f45bdcc4e51e1cc11fa005457c6fb83998a6d23"
+url = "https://github.com/jdx/aube/releases/download/v2.2.4/aube-v2.2.4-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/538150861"
 
 [[tools.communique]]
 version = "1.3.2"
@@ -78,6 +75,7 @@ checksum = "sha256:c5eca847e9d1b4c8c8cb5633ffbbbf8e8659b86cf3e43083c0f6304db5137
 url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525622989"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.communique."platforms.windows-x64"]
 checksum = "sha256:82dad4450baf31869005287fa87c74b3513d2d16aae6996bfb3cd9cd40dcfffc"

--- a/mise.toml
+++ b/mise.toml
@@ -165,7 +165,7 @@ run = "tak run --record"
 mr-boxington = "1.4.1"
 "github:kunobi-ninja/kache" = { version = "0.16.0", lazy = true, lazy_bins = ["kache"] }
 "github:jdx/tak" = "0.0.9"
-aube = "latest"
+aube = { version = "latest", lazy = true, lazy_bins = ["aube"] }
 communique = "latest"
 lychee = "0.24.2"
 node = "24"


### PR DESCRIPTION
## Summary

- defer speculative downloads during normal cache sessions until an invocation matches the manifest
- activate predictions one adapter at a time and only once per adapter
- keep explicit `mbx cache prefetch` eager

## Why

A runner image/toolchain change can leave an old manifest with no usable invocations. Eager prefetch still downloaded the entire workspace cache before the build discovered that none of those predictions applied. Gating each adapter on its first matching invocation avoids that stale-manifest download while retaining read-ahead for the rest of an adapter once it proves relevant.

## Verification

- `cargo test -p mbx-cache-core`
- `cargo test -p mbx`
- `cargo clippy -p mbx-cache-core -p mbx --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cache-agent prefetch timing and remote I/O for every standalone build; behavior shifts are covered by new tests but could affect cache hit latency or bandwidth in edge cases.
> 
> **Overview**
> **Defers remote speculative downloads** until a build actually matches a predicted invocation, instead of prefetching the whole manifest at task start. Normal sessions use `begin_task_on_prediction`; explicit prefetch and `begin_task` / `prefetch_task` stay eager.
> 
> When `FindActionPrediction` hits an invocation, **`activate_prediction_adapter`** returns that prediction and, on the adapter’s **first** match, kicks off one prefetch wave for **all** predictions sharing that adapter (`prefetched_adapters` prevents repeats). Standalone `mbx` sessions now call `begin_task_on_prediction`, so stale manifests (e.g. after runner/toolchain changes) should not pull unrelated remote cache up front.
> 
> CI replaces `dtolnay/rust-toolchain` with direct `rustup` steps (MSRV 1.91 on compatibility; matrix targets on release). Dev tooling bumps **aube** to 2.2.4 with lazy install and trims a redundant **vue** devDependency from the docs lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b41528e6ce77d6b5838e218b0d1c54746907f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adapter-aware prefetching for remote action predictions.
  * Added deferred prefetching, beginning only when a matching adapter prediction is found.
  * Prevented repeated prefetching for the same adapter.

* **Bug Fixes**
  * Standalone builds now use prediction-based task initialization for more targeted action lookup.

* **Chores**
  * Updated Rust toolchain setup for compatibility and release workflows.
  * Refined development tool installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->