### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.16...mbx-cache-cargo-v0.1.17) - 2026-09-03
+
+### Added
+
+- *(cache)* inherit predictions from earlier lockfiles ([#327](https://github.com/jdx/mr-boxington/pull/327))
+
 ## [0.1.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.15...mbx-cache-cargo-v0.1.16) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.16"
+version = "0.1.17"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.11.3"
+version = "0.11.4"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.3...mbx-cache-core-v0.11.4) - 2026-09-03
+
+### Added
+
+- *(cache)* inherit predictions from earlier lockfiles ([#327](https://github.com/jdx/mr-boxington/pull/327))
+
+### Other
+
+- keep hot-edit bookkeeping off the build's critical path ([#331](https://github.com/jdx/mr-boxington/pull/331))
+- *(cache)* adopt prefetched blobs into CAS ([#324](https://github.com/jdx/mr-boxington/pull/324))
+- *(cache)* download blob packs concurrently ([#323](https://github.com/jdx/mr-boxington/pull/323))
+- *(cache)* gate prefetch on matching adapters ([#321](https://github.com/jdx/mr-boxington/pull/321))
+
 ## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.2...mbx-cache-core-v0.11.3) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.11.3"
+version = "0.11.4"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.11.3"
+version = "0.11.4"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.15...mbx-cache-store-v0.1.16) - 2026-09-03
+
+### Other
+
+- keep hot-edit bookkeeping off the build's critical path ([#331](https://github.com/jdx/mr-boxington/pull/331))
+
 ## [0.1.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.14...mbx-cache-store-v0.1.15) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.15"
+version = "0.1.16"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/jdx/mr-boxington/compare/v1.6.0...v1.7.0) - 2026-09-03
+
+### Added
+
+- *(cache)* inherit predictions from earlier lockfiles ([#327](https://github.com/jdx/mr-boxington/pull/327))
+
+### Other
+
+- use blocking Windows agent I/O ([#333](https://github.com/jdx/mr-boxington/pull/333))
+- keep hot-edit bookkeeping off the build's critical path ([#331](https://github.com/jdx/mr-boxington/pull/331))
+- reuse Windows cache agent connections ([#332](https://github.com/jdx/mr-boxington/pull/332))
+- keep the cone above an edited crate incremental ([#326](https://github.com/jdx/mr-boxington/pull/326))
+- *(cache)* gate prefetch on matching adapters ([#321](https://github.com/jdx/mr-boxington/pull/321))
+
 ## [1.6.0](https://github.com/jdx/mr-boxington/compare/v1.5.0...v1.6.0) - 2026-09-03
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.6.0"
+version = "1.7.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -26,11 +26,11 @@ flate2 = "1"
 hex = "0.4"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.3", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.16", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.3", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.3", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.15", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.17", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.4", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.4", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.16", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.6.0
+**Version:** 1.7.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.11.3 -> 0.11.4 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `mbx-cache-cc`: 0.11.3 -> 0.11.4
* `mbx-cache-rustc`: 0.11.3 -> 0.11.4
* `mbx-cache-store`: 0.1.15 -> 0.1.16 (✓ API compatible changes)
* `mbx`: 1.6.0 -> 1.7.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.11.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.3...mbx-cache-core-v0.11.4) - 2026-09-03

### Added

- *(cache)* inherit predictions from earlier lockfiles ([#327](https://github.com/jdx/mr-boxington/pull/327))

### Other

- keep hot-edit bookkeeping off the build's critical path ([#331](https://github.com/jdx/mr-boxington/pull/331))
- *(cache)* adopt prefetched blobs into CAS ([#324](https://github.com/jdx/mr-boxington/pull/324))
- *(cache)* download blob packs concurrently ([#323](https://github.com/jdx/mr-boxington/pull/323))
- *(cache)* gate prefetch on matching adapters ([#321](https://github.com/jdx/mr-boxington/pull/321))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.17](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.16...mbx-cache-cargo-v0.1.17) - 2026-09-03

### Added

- *(cache)* inherit predictions from earlier lockfiles ([#327](https://github.com/jdx/mr-boxington/pull/327))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.2...mbx-cache-cc-v0.11.3) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))

### Fixed

- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.2...mbx-cache-rustc-v0.11.3) - 2026-09-03

### Added

- manage profile-specific linkers ([#319](https://github.com/jdx/mr-boxington/pull/319))

### Fixed

- verify compiler inputs across clock domains ([#318](https://github.com/jdx/mr-boxington/pull/318))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.15...mbx-cache-store-v0.1.16) - 2026-09-03

### Other

- keep hot-edit bookkeeping off the build's critical path ([#331](https://github.com/jdx/mr-boxington/pull/331))
</blockquote>

## `mbx`

<blockquote>

## [1.7.0](https://github.com/jdx/mr-boxington/compare/v1.6.0...v1.7.0) - 2026-09-03

### Added

- *(cache)* inherit predictions from earlier lockfiles ([#327](https://github.com/jdx/mr-boxington/pull/327))

### Other

- use blocking Windows agent I/O ([#333](https://github.com/jdx/mr-boxington/pull/333))
- keep hot-edit bookkeeping off the build's critical path ([#331](https://github.com/jdx/mr-boxington/pull/331))
- reuse Windows cache agent connections ([#332](https://github.com/jdx/mr-boxington/pull/332))
- keep the cone above an edited crate incremental ([#326](https://github.com/jdx/mr-boxington/pull/326))
- *(cache)* gate prefetch on matching adapters ([#321](https://github.com/jdx/mr-boxington/pull/321))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is versioning, lockfile, changelog, and docs metadata only; behavioral risk depends on code already merged outside this PR.
> 
> **Overview**
> **Release-only PR** (release-plz): bumps crate versions, refreshes `Cargo.lock`, finalizes changelogs, and sets the documented CLI version to **1.7.0**. No application or library source changes appear in the diff.
> 
> Published versions move to `mbx` **1.7.0**, `mbx-cache-core` **0.11.4**, `mbx-cache-cargo` **0.1.17**, `mbx-cache-cc` / `mbx-cache-rustc` **0.11.4**, and `mbx-cache-store` **0.1.16**, with workspace `Cargo.toml` path dependency pins updated to match.
> 
> The new changelog sections ship user-facing behavior that landed in prior PRs, notably **inheriting cache predictions from earlier lockfiles** (#327). `mbx-cache-core` also documents prefetch/CAS improvements (#321–#324), hot-edit bookkeeping off the critical path (#331), incremental cone behavior (#326), and Windows agent I/O/connection reuse (#332–#333).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dee4d962f462de7bf3632e5d4c213d641f4f27f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->