### PR TITLE
perf(cache): adopt prefetched blobs into CAS

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -73,7 +73,7 @@ const MAX_PREFETCH_TRANSFERS: usize = 48;
 /// Packs are individually bounded to keep their staging footprint predictable.
 /// Allowing a few independent streams prevents one large Azure object stream
 /// from serializing an entire workspace restore.
-const MAX_CONCURRENT_BLOB_PACKS: usize = 4;
+const MAX_CONCURRENT_BLOB_PACKS: usize = 8;
 /// Most predicted actions whose complete output closures are downloaded
 /// speculatively for one task.
 ///

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -1,9 +1,9 @@
 use crate::uploads::{ConnectionUploads, UploadQueue, UploadSink};
 use crate::{
-    ActionPrediction, ActionPromiseCompletion, ActionPromiseState, BlobPackLimits, CacheDigest,
-    CacheDirectory, LocalActionCache, LocalCas, MAX_STAGED_BLOB_PACK_BYTES,
-    MAX_STAGED_BLOB_PACK_ITEMS, ManifestPutOutcome, RemoteActionResult, RemoteCacheClient,
-    RemoteCacheMode, RustcMetadata, TaskActionManifest, blob_pack_chunk, canonical_json,
+    ActionPrediction, ActionPromiseCompletion, ActionPromiseState, CacheDigest, CacheDirectory,
+    LocalActionCache, LocalCas, MAX_STAGED_BLOB_PACK_BYTES, ManifestPutOutcome, RemoteActionResult,
+    RemoteCacheClient, RemoteCacheMode, RustcMetadata, TaskActionManifest, blob_pack_chunk,
+    canonical_json,
 };
 use eyre::{Context, Result, bail};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream};
@@ -68,6 +68,12 @@ const MAX_FILE_DIGEST_BATCH: usize = 16 * 1024;
 const MAX_FILE_DIGEST_ENTRIES: usize = 1024 * 1024;
 const MAX_REMOTE_TRANSFERS: usize = 64;
 const MAX_PREFETCH_TRANSFERS: usize = 48;
+/// Most blob packs downloaded at once.
+///
+/// Packs are individually bounded to keep their staging footprint predictable.
+/// Allowing a few independent streams prevents one large Azure object stream
+/// from serializing an entire workspace restore.
+const MAX_CONCURRENT_BLOB_PACKS: usize = 4;
 /// Most predicted actions whose complete output closures are downloaded
 /// speculatively for one task.
 ///

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -538,151 +538,43 @@ impl CacheAgent {
             return verified;
         }
 
+        let pack_limits = match remote.blob_pack_limits().await {
+            Ok(Some(limits)) => Some(limits),
+            Ok(None) => None,
+            Err(error) => {
+                warn!("remote cache blob pack negotiation failed: {error}");
+                None
+            }
+        };
         let mut pack_candidates = missing.clone();
-        while !pack_candidates.is_empty() {
-            let candidates = match blob_pack_chunk(
-                &pack_candidates.keys().cloned().collect::<Vec<_>>(),
-                BlobPackLimits {
-                    max_items: MAX_STAGED_BLOB_PACK_ITEMS,
-                    max_bytes: MAX_STAGED_BLOB_PACK_BYTES,
-                },
-            ) {
-                Ok(candidates) if !candidates.is_empty() => candidates,
-                Ok(_) => break,
-                Err(error) => {
-                    warn!("remote cache blob pack skipped: {error}");
-                    break;
-                }
-            };
-            // A pack and an individual fetch share these per-digest locks. Hold
-            // them through ingestion so overlapping prefetch and foreground
-            // requests cannot download or charge the same object twice.
-            let mut pack_guards = BTreeMap::new();
-            for digest in candidates {
-                let guard = self.write_lock(&digest).lock_owned().await;
-                match self.find_verified_blob(&digest) {
-                    Ok(Some(path)) => {
-                        pack_candidates.remove(&digest);
-                        missing.remove(&digest);
-                        verified.insert(digest, path);
-                    }
-                    Ok(None) => {
-                        pack_guards.insert(digest, guard);
-                    }
+        let mut pack_requests = Vec::new();
+        while let Some(limits) = pack_limits.filter(|_| !pack_candidates.is_empty()) {
+            let candidates =
+                match blob_pack_chunk(&pack_candidates.keys().cloned().collect::<Vec<_>>(), limits)
+                {
+                    Ok(candidates) if !candidates.is_empty() => candidates,
+                    Ok(_) => break,
                     Err(error) => {
-                        warn!(
-                            "local cache blob lookup failed for {}: {error}",
-                            digest.hash
-                        );
-                        pack_guards.insert(digest, guard);
-                    }
-                }
-            }
-            let requested = pack_guards.keys().cloned().collect::<Vec<_>>();
-            if requested.is_empty() {
-                continue;
-            }
-            let requested_bytes = requested
-                .iter()
-                .fold(0_u64, |total, digest| total.saturating_add(digest.size));
-            let pack_reservation = match self
-                .reserve_remote_download_up_to(requested_bytes.min(MAX_STAGED_BLOB_PACK_BYTES))
-            {
-                Ok(reservation) if reservation.bytes() > 0 => reservation,
-                Ok(_) => break,
-                Err(error) => {
-                    warn!("remote cache blob pack skipped: {error}");
-                    break;
-                }
-            };
-            let (pack, transfer_duration_ns) = {
-                let _prefetch_permit = match prefetch_limit {
-                    Some(limit) => match limit.acquire().await {
-                        Ok(permit) => Some(permit),
-                        Err(error) => {
-                            warn!(
-                                "remote cache blob pack could not acquire prefetch limit: {error}"
-                            );
-                            break;
-                        }
-                    },
-                    None => None,
-                };
-                let _transfer_permit = match self.remote_transfers.acquire().await {
-                    Ok(permit) => permit,
-                    Err(error) => {
-                        warn!("remote cache blob pack could not acquire transfer limit: {error}");
+                        warn!("remote cache blob pack skipped: {error}");
                         break;
                     }
                 };
-                let transfer_started = Instant::now();
-                let pack = remote
-                    .get_blob_pack_with_limit(
-                        &requested,
-                        self.remote_staging_dir.as_path(),
-                        pack_reservation.bytes(),
-                    )
-                    .await;
-                (pack, duration_ns(transfer_started))
-            };
-            let pack = match pack {
-                Ok(Some(pack)) => pack,
-                Ok(None) => break,
-                Err(error) => {
-                    atomic_saturating_add(
-                        &self.stats.remote_blob_transfer_duration_ns,
-                        transfer_duration_ns,
-                    );
-                    warn!(
-                        "remote cache blob pack failed; falling back to individual blobs: {error}"
-                    );
-                    break;
-                }
-            };
-            pack_reservation.commit(pack.payload_bytes);
-            atomic_saturating_add(
-                &self.stats.remote_blob_transfer_duration_ns,
-                transfer_duration_ns,
-            );
-            atomic_saturating_add(&self.stats.remote_blob_pack_requests, pack.requests);
-            atomic_saturating_add(&self.stats.remote_blob_pack_blobs, pack.blob_count);
-            atomic_saturating_add(&self.stats.downloaded_bytes, pack.payload_bytes);
-            if pack.requested.is_empty() {
-                // The server's negotiated cap can be smaller than the local
-                // staging cap used to select this locked slice. Fall back for
-                // this slice, but keep packing later candidates that may fit.
-                for digest in &requested {
-                    pack_candidates.remove(digest);
-                }
-                continue;
-            }
-            for digest in &pack.requested {
+            for digest in &candidates {
                 pack_candidates.remove(digest);
             }
-            let mut ingests = stream::iter(pack.blobs.into_iter().map(|(digest, source)| {
-                let digest_for_result = digest.clone();
-                let guard = pack_guards
-                    .remove(&digest)
-                    .expect("requested packed blob has a write lock");
-                async move {
-                    (
-                        digest_for_result,
-                        self.ingest_packed_blob(digest, source, guard).await,
-                    )
-                }
-            }))
-            .buffer_unordered(MAX_PREFETCH_TRANSFERS);
-            while let Some((digest, result)) = ingests.next().await {
-                match result {
-                    Ok(path) => {
-                        missing.remove(&digest);
-                        verified.insert(digest, path);
-                    }
-                    Err(error) => warn!(
-                        "remote cache packed blob ingest failed for {}: {error}",
-                        digest.hash
-                    ),
-                }
+            pack_requests.push(candidates);
+        }
+
+        let mut packs = stream::iter(pack_requests)
+            .map(|requested| async move {
+                self.fetch_remote_blob_pack(remote, requested, prefetch_limit)
+                    .await
+            })
+            .buffer_unordered(MAX_CONCURRENT_BLOB_PACKS);
+        while let Some(blobs) = packs.next().await {
+            for (digest, path) in blobs {
+                missing.remove(&digest);
+                verified.insert(digest, path);
             }
         }
 
@@ -704,6 +596,119 @@ impl CacheAgent {
                 }
                 Err(error) => warn!(
                     "remote cache blob prefetch failed for {}: {error}",
+                    digest.hash
+                ),
+            }
+        }
+        verified
+    }
+
+    async fn fetch_remote_blob_pack(
+        &self,
+        remote: &RemoteCacheClient,
+        candidates: Vec<CacheDigest>,
+        prefetch_limit: Option<&tokio::sync::Semaphore>,
+    ) -> Vec<(CacheDigest, PathBuf)> {
+        // A pack and an individual fetch share these per-digest locks. Acquire
+        // them only after this pack enters the bounded active set, then hold
+        // them through ingestion so a foreground request may win against a
+        // queued pack but cannot duplicate an active download.
+        let mut guards = BTreeMap::new();
+        for digest in candidates {
+            let guard = self.write_lock(&digest).lock_owned().await;
+            match self.find_verified_blob(&digest) {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    guards.insert(digest, guard);
+                }
+                Err(error) => {
+                    warn!(
+                        "local cache blob lookup failed for {}: {error}",
+                        digest.hash
+                    );
+                    guards.insert(digest, guard);
+                }
+            }
+        }
+        let requested = guards.keys().cloned().collect::<Vec<_>>();
+        if requested.is_empty() {
+            return Vec::new();
+        }
+        let requested_bytes = requested
+            .iter()
+            .fold(0_u64, |total, digest| total.saturating_add(digest.size));
+        let reservation = match self
+            .reserve_remote_download_up_to(requested_bytes.min(MAX_STAGED_BLOB_PACK_BYTES))
+        {
+            Ok(reservation) if reservation.bytes() > 0 => reservation,
+            Ok(_) => return Vec::new(),
+            Err(error) => {
+                warn!("remote cache blob pack skipped: {error}");
+                return Vec::new();
+            }
+        };
+        let _prefetch_permit = match prefetch_limit {
+            Some(limit) => match limit.acquire().await {
+                Ok(permit) => Some(permit),
+                Err(error) => {
+                    warn!("remote cache blob pack could not acquire prefetch limit: {error}");
+                    return Vec::new();
+                }
+            },
+            None => None,
+        };
+        let _transfer_permit = match self.remote_transfers.acquire().await {
+            Ok(permit) => permit,
+            Err(error) => {
+                warn!("remote cache blob pack could not acquire transfer limit: {error}");
+                return Vec::new();
+            }
+        };
+        let transfer_started = Instant::now();
+        let pack = remote
+            .get_blob_pack_with_limit(
+                &requested,
+                self.remote_staging_dir.as_path(),
+                reservation.bytes(),
+            )
+            .await;
+        let transfer_duration_ns = duration_ns(transfer_started);
+        atomic_saturating_add(
+            &self.stats.remote_blob_transfer_duration_ns,
+            transfer_duration_ns,
+        );
+        let pack = match pack {
+            Ok(Some(pack)) => pack,
+            Ok(None) => return Vec::new(),
+            Err(error) => {
+                warn!("remote cache blob pack failed; falling back to individual blobs: {error}");
+                return Vec::new();
+            }
+        };
+        reservation.commit(pack.payload_bytes);
+        atomic_saturating_add(&self.stats.remote_blob_pack_requests, pack.requests);
+        atomic_saturating_add(&self.stats.remote_blob_pack_blobs, pack.blob_count);
+        atomic_saturating_add(&self.stats.downloaded_bytes, pack.payload_bytes);
+
+        let mut ingests = stream::iter(pack.blobs.into_iter().map(|(digest, source)| {
+            let digest_for_result = digest.clone();
+            let guard = guards
+                .remove(&digest)
+                .expect("requested packed blob has a write lock");
+            async move {
+                (
+                    digest_for_result,
+                    self.ingest_packed_blob(digest, source, guard).await,
+                )
+            }
+        }))
+        .buffer_unordered(MAX_PREFETCH_TRANSFERS);
+        let mut verified = Vec::new();
+        while let Some((digest, result)) = ingests.next().await {
+            match result {
+                Ok(path) => verified.push((digest, path)),
+                Err(error) => warn!(
+                    "remote cache packed blob ingest failed for {}: {error}",
                     digest.hash
                 ),
             }

--- a/crates/mbx-cache-core/src/agent/prefetch.rs
+++ b/crates/mbx-cache-core/src/agent/prefetch.rs
@@ -729,7 +729,7 @@ impl CacheAgent {
                 return Ok::<_, eyre::Report>((path, false, 0));
             }
             let cas_started = Instant::now();
-            let path = agent.cas.store_verified_file(&digest, &source)?;
+            let path = agent.cas.adopt_verified_file(&digest, &source)?;
             let cas_duration_ns = duration_ns(cas_started);
             agent.remember_verified_blob(&digest, &path);
             Ok((path, true, cas_duration_ns))

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -1760,6 +1760,34 @@ async fn foreground_blob_batches_use_blob_packs() {
 }
 
 #[tokio::test]
+async fn downloads_independent_blob_packs_concurrently() {
+    let directory = tempfile::tempdir().unwrap();
+    let entries = BTreeMap::from([
+        (CacheDigest::blake3(b"first pack"), b"first pack".to_vec()),
+        (CacheDigest::blake3(b"second pack"), b"second pack".to_vec()),
+    ]);
+    let (base_url, maximum_in_flight, server) =
+        delayed_pack_server(entries.clone(), Duration::from_millis(50)).await;
+    let agent = remote_agent_url(
+        base_url,
+        directory.path().join("reader"),
+        RemoteCacheMode::ReadOnly,
+    );
+    let remote = agent.remote.as_deref().unwrap();
+
+    let verified = agent
+        .fetch_remote_blobs(remote, entries.keys().cloned().collect(), None)
+        .await;
+    server.await.unwrap();
+
+    assert_eq!(verified.len(), entries.len());
+    for (digest, bytes) in entries {
+        assert_eq!(fs::read(&verified[&digest]).unwrap(), bytes);
+    }
+    assert!(maximum_in_flight.load(Ordering::Relaxed) > 1);
+}
+
+#[tokio::test]
 async fn pack_and_individual_fetches_share_a_digest_lock() {
     let directory = tempfile::tempdir().unwrap();
     let mut server = mockito::Server::new_async().await;
@@ -3347,6 +3375,120 @@ async fn delayed_blob_server(
     });
     (
         format!("http://{address}").parse().unwrap(),
+        observed_maximum,
+        server,
+    )
+}
+
+async fn delayed_pack_server(
+    entries: BTreeMap<CacheDigest, Vec<u8>>,
+    latency: Duration,
+) -> (
+    url::Url,
+    Arc<std::sync::atomic::AtomicUsize>,
+    tokio::task::JoinHandle<()>,
+) {
+    use std::sync::atomic::AtomicUsize;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let entries = Arc::new(entries);
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let maximum_in_flight = Arc::new(AtomicUsize::new(0));
+    let observed_maximum = maximum_in_flight.clone();
+    let server = tokio::spawn(async move {
+        let mut requests = tokio::task::JoinSet::new();
+        for _ in 0..3 {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let entries = entries.clone();
+            let in_flight = in_flight.clone();
+            let maximum_in_flight = maximum_in_flight.clone();
+            requests.spawn(async move {
+                let mut request = Vec::new();
+                let (header_end, content_length) = loop {
+                    let mut chunk = [0; 1024];
+                    let size = socket.read(&mut chunk).await.unwrap();
+                    assert!(size > 0, "client closed before sending request headers");
+                    request.extend_from_slice(&chunk[..size]);
+                    let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") else {
+                        continue;
+                    };
+                    let header_end = header_end + 4;
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().unwrap())
+                        })
+                        .unwrap_or(0);
+                    break (header_end, content_length);
+                };
+                while request.len() < header_end + content_length {
+                    let mut chunk = [0; 1024];
+                    let size = socket.read(&mut chunk).await.unwrap();
+                    assert!(size > 0, "client closed before sending request body");
+                    request.extend_from_slice(&chunk[..size]);
+                }
+                let first_line = String::from_utf8_lossy(&request[..header_end])
+                    .lines()
+                    .next()
+                    .unwrap()
+                    .to_owned();
+                let path = first_line.split_whitespace().nth(1).unwrap();
+                if path == "/v1/capabilities" {
+                    let body = serde_json::json!({
+                        "protocol":{"major":1},
+                        "features":{"blob_packs":true},
+                        "limits":{"max_batch_items":1,"max_pack_bytes":1048576}
+                    })
+                    .to_string();
+                    socket
+                        .write_all(
+                            format!(
+                                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                                body.len()
+                            )
+                            .as_bytes(),
+                        )
+                        .await
+                        .unwrap();
+                    return;
+                }
+                assert_eq!(path, "/v1/blobs:pack");
+                let body: serde_json::Value =
+                    serde_json::from_slice(&request[header_end..header_end + content_length])
+                        .unwrap();
+                let digest: CacheDigest =
+                    serde_json::from_value(body["digests"][0].clone()).unwrap();
+                let bytes = entries.get(&digest).unwrap();
+                let body = blob_pack_body(&[(digest, bytes.as_slice())]);
+                let active = in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+                maximum_in_flight.fetch_max(active, Ordering::Relaxed);
+                tokio::time::sleep(latency).await;
+                socket
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\ncontent-type: {}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                            crate::BLOB_PACK_MEDIA_TYPE,
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                socket.write_all(&body).await.unwrap();
+                in_flight.fetch_sub(1, Ordering::Relaxed);
+            });
+        }
+        while let Some(result) = requests.join_next().await {
+            result.unwrap();
+        }
+    });
+    (
+        url::Url::parse(&format!("http://{address}/")).unwrap(),
         observed_maximum,
         server,
     )

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -351,6 +351,14 @@ impl RemoteCacheClient {
         }
     }
 
+    /// How many blobs, and how many payload bytes, one downloaded pack may carry.
+    pub(crate) async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
+        match &self.backend {
+            Backend::Http(client) => client.blob_pack_limits().await,
+            Backend::S3(_) => Ok(None),
+        }
+    }
+
     /// Fetch and validate an action-result record, returning `None` on a miss.
     pub async fn get_action_result(
         &self,

--- a/crates/mbx-cache-core/src/local.rs
+++ b/crates/mbx-cache-core/src/local.rs
@@ -79,6 +79,38 @@ impl LocalCas {
         self.store_file_inner(digest, source, false)
     }
 
+    /// Move an already-verified temporary file into the CAS when possible.
+    ///
+    /// Remote downloads are staged beneath the cache root, so the usual path
+    /// is an atomic same-filesystem rename. If a caller supplies a path on a
+    /// different filesystem, fall back to the copy-based store operation.
+    pub(crate) fn adopt_verified_file(
+        &self,
+        digest: &CacheDigest,
+        source: &Path,
+    ) -> Result<PathBuf> {
+        if fs::metadata(source)?.len() != digest.size {
+            bail!("staged blob size does not match the declared CAS digest");
+        }
+        let destination = self.path_for(digest)?;
+        match self.find(digest) {
+            Ok(Some(existing)) => return Ok(existing),
+            // Preserve the established repair path for a poisoned destination;
+            // replacing it portably needs the copy-based temporary file flow.
+            Err(_) => return self.store_file_inner(digest, source, false),
+            Ok(None) => {}
+        }
+        fs::create_dir_all(destination.parent().expect("CAS path has a parent"))?;
+        make_owner_writable(source)?;
+        match fs::rename(source, &destination) {
+            Ok(()) => Ok(destination),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => self
+                .find(digest)?
+                .ok_or_else(|| eyre::eyre!("concurrent CAS write did not publish a valid blob")),
+            Err(_) => self.store_file_inner(digest, source, false),
+        }
+    }
+
     fn store_file_inner(
         &self,
         digest: &CacheDigest,
@@ -304,6 +336,23 @@ mod tests {
 
         assert_eq!(fs::read(stored).unwrap(), b"cached object");
         assert!(cas.find(&digest).unwrap().is_some());
+    }
+
+    #[test]
+    fn adopts_verified_files_without_leaving_the_staging_copy() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path().join("cache"));
+        let staging = directory.path().join("remote");
+        fs::create_dir(&staging).unwrap();
+        let source = staging.join("blob");
+        fs::write(&source, b"cached object").unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+
+        let stored = cas.adopt_verified_file(&digest, &source).unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(fs::read(&stored).unwrap(), b"cached object");
+        assert_eq!(cas.find(&digest).unwrap(), Some(stored));
     }
 
     #[test]

--- a/crates/mbx-cache-core/src/remote_http.rs
+++ b/crates/mbx-cache-core/src/remote_http.rs
@@ -356,7 +356,7 @@ impl HttpRemoteCache {
         }
     }
 
-    async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
+    pub(crate) async fn blob_pack_limits(&self) -> Result<Option<BlobPackLimits>> {
         Ok(self.negotiated_capabilities().await?.blob_packs)
     }
 


### PR DESCRIPTION
## Summary

- atomically rename already-verified remote staging files into the local CAS when both are on the same filesystem
- retain the existing copy path as a cross-filesystem and corrupt-destination fallback
- use adoption for verified blob-pack entries and cover the move behavior with a focused test

## Motivation

The eight-way hk Windows benchmark spent 320.51s of cumulative worker time copying 964 MiB of already-verified pack payload from the cache's remote staging directory into the CAS. Both paths are beneath the same cache root, so a rename can publish each blob without copying its contents a second time.

This is stacked on #323 because that PR provides the benchmarked concurrent pack path.

## Validation

- `cargo test -p mbx-cache-core local::tests::adopts_verified_files_without_leaving_the_staging_copy`
- `cargo clippy -p mbx-cache-core --all-features --all-targets -- -D warnings`

## AI disclosure

This change was implemented with AI assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CAS publish semantics for high-volume prefetch ingestion; fallbacks preserve prior behavior, but rename vs copy changes failure and concurrency edge cases around blob publication.
> 
> **Overview**
> **Packed remote blob ingest** now publishes into the local CAS with `adopt_verified_file` instead of copying through `store_verified_file`, so verified staging files under the cache root can be moved with a same-filesystem `rename` instead of re-reading and writing the payload.
> 
> `LocalCas` gains **`adopt_verified_file`**: it checks declared size, returns an existing valid blob, and on success renames the staging file into the CAS path (staging is removed). **Poisoned destinations**, **cross-filesystem paths**, **rename races** (`AlreadyExists`), and other rename failures still use the existing copy-based `store_file_inner` path.
> 
> A unit test asserts adoption removes the staging file and leaves the blob at the CAS location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51428e62d9d02e1cd48557406c661550c3c99ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->