### PR TITLE
perf: keep the cone above an edited crate incremental

### DIFF
--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -40,12 +40,16 @@ struct CompileTiming {
 /// guessing wrong is one uncached compilation the unit was going to pay anyway.
 const HOT_STREAK_THRESHOLD: u32 = 3;
 
-/// A workspace unit is hot on its first edit. Its dependent cone still uses
-/// the ordinary cache because churn is measured from each unit's own sources.
+/// A workspace unit is hot on its first edit. Churn is measured from each
+/// unit's own sources, so a dependent is only dragged along when it links
+/// the private artifact the hot unit produced; see [`links_private_artifact`].
 const WORKSPACE_HOT_STREAK_THRESHOLD: u32 = 1;
 
 /// Schema version of the per-checkout churn record.
 const CHURN_STATE_VERSION: u8 = 1;
+
+/// Schema version of a private-artifact marker.
+const PRIVATE_ARTIFACT_VERSION: u8 = 1;
 
 /// What a churning unit gets: its own incremental state, and no publication.
 #[derive(Clone, Debug, Default)]
@@ -108,6 +112,21 @@ struct ChurnState {
     sources: String,
     /// Consecutive compilations whose sources had changed.
     streak: u32,
+}
+
+/// An output this checkout last compiled with private incremental state.
+///
+/// Kept beside the churn records, keyed by the output's path, so the crates
+/// that link it can tell a private artifact from a published one without
+/// knowing which unit produced it. Written before the compiler runs rather
+/// than after: Cargo starts a dependent as soon as this unit's metadata
+/// exists, while the compiler is still running here.
+#[derive(Debug, Serialize, Deserialize)]
+struct PrivateArtifact {
+    /// Version of this marker's schema.
+    version: u8,
+    /// Absolute path of the artifact, as the compiler was told to write it.
+    path: PathBuf,
 }
 
 #[derive(Serialize)]
@@ -174,6 +193,13 @@ pub(crate) fn compile(
         );
     }
 
+    // Whatever this compilation ends up doing -- restoring, publishing, or
+    // keeping private state -- the outputs it is about to write are no longer
+    // the private artifacts an earlier compilation marked them as. A hot
+    // compilation marks them again below, before the compiler starts.
+    if let Some(root) = incremental_root() {
+        forget_private_artifacts(&root, &outputs);
+    }
     let verify = session::verify_requested();
     // A shadow compilation compares its result against a cached one, which an
     // incremental artifact would never match, so the two modes are exclusive.
@@ -415,6 +441,13 @@ pub(crate) fn compile(
         let mut flag = OsString::from("-Cincremental=");
         flag.push(directory);
         command.arg(flag);
+        // Before the compiler starts, so that a dependent Cargo pipelines
+        // behind this unit's metadata already finds the marker in place.
+        if let Some(root) = incremental_root()
+            && let Err(error) = record_private_artifacts(&root, &outputs)
+        {
+            eprintln!("mbx[warning]: private artifacts were not recorded: {error:#}");
+        }
     }
     let output = command.output().wrap_err("failed to execute rustc")?;
     // Released before the outputs are read back and published: hashing and
@@ -629,14 +662,16 @@ fn install_build_script_shim(
 /// The comparison is against this crate's own sources, not against its action
 /// key: a key also hashes the artifacts the crate links against, so a rebuilt
 /// dependency changes it without anybody having touched this crate. Watching
-/// the key would drag the whole cone above an edited crate into compiling
-/// incrementally and withholding its results, which is the sharing loss this
-/// is meant to avoid.
+/// the key would send the whole cone above any rebuilt crate hot, including
+/// the cone above a dependency that was rebuilt normally and published, whose
+/// dependents can publish results other checkouts will restore.
 ///
 /// Unchanged sources are therefore never churn, however the compilation got
 /// here. A miss on them means something else lost the result -- a wiped target
 /// directory, a first build in this checkout -- and recompiling normally
-/// republishes it for everyone.
+/// republishes it for everyone. The one exception is decided by the caller:
+/// a crate linking an artifact that was itself kept private, see
+/// [`links_private_artifact`].
 fn learned_plan(
     recorded: Option<&ChurnState>,
     sources: &CacheDigest,
@@ -764,7 +799,9 @@ fn plan_learned_reuse(
             enabled,
             threshold,
         );
+        let hot = plan.hot || (enabled && links_private_artifact(compilation));
         Ok(LearnedPlan {
+            hot,
             record: Some((state_path, sources)),
             ..plan
         }
@@ -784,7 +821,9 @@ fn plan_learned_reuse(
 ///
 /// An intact dep-info file supplies the source fingerprint without constructing
 /// a shared action. A missing target, settled source, or changed environment
-/// deliberately takes the slower path so it can restore or republish.
+/// deliberately takes the slower path so it can restore or republish. Settled
+/// sources above a private artifact are the exception: no shared action can
+/// describe what they link, so the lookup would only ever miss.
 fn reuse_hot_workspace_plan(
     compilation: &Compilation<'_>,
     outputs: &RustcOutputs,
@@ -815,15 +854,25 @@ fn reuse_hot_workspace_plan(
             session::file_digest_cache(),
         )?;
         let sources = compilation.invocation.source_fingerprint(&discovered);
-        if recorded.streak < WORKSPACE_HOT_STREAK_THRESHOLD || recorded.sources == sources.key() {
+        let changed = recorded.sources != sources.key();
+        let edited = changed && recorded.streak >= WORKSPACE_HOT_STREAK_THRESHOLD;
+        if !edited && !links_private_artifact(compilation) {
             return Ok(LearnedPlan::default());
         }
-        Ok(LearnedPlan {
-            hot: true,
-            streak: recorded
+        // The streak keeps counting this unit's own sources, as the slower
+        // path would: a unit riding along on a private artifact with settled
+        // sources records no churn of its own.
+        let streak = if changed {
+            recorded
                 .streak
                 .saturating_add(1)
-                .min(WORKSPACE_HOT_STREAK_THRESHOLD),
+                .min(WORKSPACE_HOT_STREAK_THRESHOLD)
+        } else {
+            0
+        };
+        Ok(LearnedPlan {
+            hot: true,
+            streak,
             directory: None,
             record: Some((state_path, sources)),
         }
@@ -906,6 +955,80 @@ fn incremental_root() -> Option<PathBuf> {
             })
         })
         .map(PathBuf::from)
+}
+
+/// Where the marker for one output path lives, beside the churn records.
+fn private_artifact_path(root: &Path, artifact: &Path) -> Option<PathBuf> {
+    let key = CacheDigest::blake3(artifact.as_os_str().as_encoded_bytes()).key();
+    let shard = key.get(..16)?;
+    Some(root.join("private").join(format!("{shard}.json")))
+}
+
+/// Mark every output of a compilation about to run with private incremental
+/// state, so the crates that link them know not to publish either.
+fn record_private_artifacts(root: &Path, outputs: &RustcOutputs) -> Result<()> {
+    for artifact in &outputs.files {
+        let Some(path) = private_artifact_path(root, artifact) else {
+            continue;
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .wrap_err("failed to create the private artifact directory")?;
+        }
+        let marker = PrivateArtifact {
+            version: PRIVATE_ARTIFACT_VERSION,
+            path: artifact.clone(),
+        };
+        crate::util::write_atomic(&path, &serde_json::to_vec(&marker)?)
+            .wrap_err_with(|| format!("failed to mark {} as private", artifact.display()))?;
+    }
+    Ok(())
+}
+
+/// Withdraw the markers for outputs this compilation is about to replace.
+///
+/// Best effort: a marker that cannot be removed costs the crates above one
+/// publication they could have made, never a wrong result.
+fn forget_private_artifacts(root: &Path, outputs: &RustcOutputs) {
+    for artifact in &outputs.files {
+        if let Some(path) = private_artifact_path(root, artifact)
+            && let Err(error) = std::fs::remove_file(&path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            eprintln!(
+                "mbx[warning]: a private artifact marker was not removed for {}: {error}",
+                artifact.display()
+            );
+        }
+    }
+}
+
+/// Whether this compilation links an artifact another unit kept private.
+///
+/// A private artifact describes one checkout's edit history, so an action
+/// keyed on it can never be restored anywhere else: compiling normally here
+/// would pay for a full compilation and a publication nobody can use. Taking
+/// private state instead costs nothing that was available, and gives the edit
+/// loop above an edited dependency the same reuse the dependency itself gets.
+fn links_private_artifact(compilation: &Compilation<'_>) -> bool {
+    let Some(root) = incremental_root() else {
+        return false;
+    };
+    let inputs = compilation
+        .invocation
+        .required_inputs_in(compilation.working_dir);
+    links_private_artifact_in(&root, &inputs)
+}
+
+fn links_private_artifact_in(root: &Path, inputs: &[PathBuf]) -> bool {
+    inputs.iter().any(|input| {
+        private_artifact_path(root, input)
+            .and_then(|path| std::fs::read(path).ok())
+            .and_then(|bytes| serde_json::from_slice::<PrivateArtifact>(&bytes).ok())
+            .is_some_and(|marker| {
+                marker.version == PRIVATE_ARTIFACT_VERSION && marker.path == *input
+            })
+    })
 }
 
 /// A record this version cannot read is treated as no record: the cost is one

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -129,6 +129,35 @@ fn one_changed_workspace_source_is_hot() {
     assert!(plan.hot);
 }
 
+/// A marker names the artifact it was written for and is withdrawn before the
+/// artifact is replaced, so only what a hot compilation wrote reads as private.
+#[test]
+fn private_artifacts_are_recognized_only_while_marked() {
+    let root = tempfile::tempdir().unwrap();
+    let deps = root.path().join("target/debug/deps");
+    let outputs = RustcOutputs {
+        directory: deps.clone(),
+        files: vec![deps.join("libbase-1.rlib"), deps.join("libbase-1.rmeta")],
+        dep_info: deps.join("base-1.d"),
+    };
+    let links = vec![
+        root.path().join("above/src/lib.rs"),
+        deps.join("libbase-1.rmeta"),
+    ];
+    assert!(!links_private_artifact_in(root.path(), &links));
+
+    record_private_artifacts(root.path(), &outputs).unwrap();
+    assert!(links_private_artifact_in(root.path(), &links));
+    assert!(
+        !links_private_artifact_in(root.path(), &[deps.join("libother-1.rlib")]),
+        "a marker must not vouch for an artifact it was not written for"
+    );
+
+    forget_private_artifacts(root.path(), &outputs);
+    assert!(!links_private_artifact_in(root.path(), &links));
+    forget_private_artifacts(root.path(), &outputs);
+}
+
 /// The record belongs to one checkout, so a sibling worktree that cannot read
 /// it simply starts over rather than inheriting somebody else's edit loop.
 #[test]

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1008,13 +1008,13 @@ fn churn_earns_nothing_in_ci() {
     );
 }
 
-/// A crate's action key hashes the artifacts it links against, so rebuilding a
-/// dependency changes it without anybody having touched the crate. Watching the
-/// key instead of the sources would send the whole cone above an edited crate
-/// hot, and stop all of it publishing -- the sharing loss this feature exists
-/// to avoid.
+/// A crate's action key hashes the artifacts it links against. Once the crate
+/// below it has taken private incremental state, no other checkout can hold
+/// that artifact, so publishing the crate above would pay for a full
+/// compilation and store a result nothing can restore. It takes private state
+/// too, and the whole cone publishes again once the edited crate settles.
 #[test]
-fn editing_one_crate_leaves_its_dependents_publishing() {
+fn editing_one_crate_takes_its_dependents_private_too() {
     let store = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();
     let reports = tempfile::tempdir().unwrap();
@@ -1040,17 +1040,49 @@ fn editing_one_crate_leaves_its_dependents_publishing() {
 
     assert_eq!(
         compiled_incrementally(&stats),
-        1,
-        "only the edited crate should be compiling incrementally: {stats}"
+        2,
+        "the edited crate and the crate linking it should both compile incrementally: {stats}"
     );
-    assert!(
-        stats["stored_bytes"].as_u64().unwrap_or(0) > 0,
-        "the crate above it never changed, so it should still publish: {stats}"
+    assert_eq!(
+        stats["stored_bytes"].as_u64(),
+        Some(0),
+        "a result keyed on a private artifact cannot be restored anywhere, so nothing should publish: {stats}"
     );
     assert_eq!(
         stats["lookups"].as_u64(),
-        Some(1),
-        "the hot edited crate should skip lookup while its dependent still publishes: {stats}"
+        Some(0),
+        "neither crate can hit a shared action, so neither should look one up: {stats}"
+    );
+
+    // Unchanged sources after a wiped target are not churn, above or below:
+    // the edited crate republishes, and the crate above it, now linking a
+    // published artifact, publishes again too.
+    let cleaned = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .arg("clean")
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_GC_AUTO", "0")
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .expect("mbx clean should run");
+    assert!(
+        cleaned.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&cleaned.stderr)
+    );
+    let settled = build(
+        project.path(),
+        store.path(),
+        &reports.path().join("settled.json"),
+    );
+    assert_eq!(
+        compiled_incrementally(&settled),
+        0,
+        "settled sources should compile normally again: {settled}"
+    );
+    assert!(
+        settled["stored_bytes"].as_u64().unwrap_or(0) > 0,
+        "a settled cone should publish again: {settled}"
     );
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,12 +283,16 @@ edit history. A crate outside the workspace switches after three consecutive
 misses with changed sources. The build reports those compilations as
 `incremental` and says how many were held back.
 
-The trigger is the crate's own sources, not its cache key. A rebuilt dependency
-changes the keys of everything above it, and those crates keep compiling and
-publishing normally. So does a miss on unchanged sources, such as a wiped
-`target/` or a first build in a new checkout. Once a crate is known to be hot,
-later edits go straight to its private incremental state instead of rebuilding
-and looking up a shared action the edit cannot hit. The record and state are
+The trigger is the crate's own sources, not its cache key. A miss on unchanged
+sources, such as a wiped `target/` or a first build in a new checkout, compiles
+and publishes normally, and so do the crates above a dependency that was
+rebuilt and published. The crates above a dependency that took private state
+are the exception. Their results would be keyed on an artifact no other
+checkout can hold, so they keep private state too instead of paying for a full
+compilation and a publication nothing can restore. The whole cone publishes
+again once the edited crate settles. Once a crate is known to be hot, later
+edits go straight to its private incremental state instead of rebuilding and
+looking up a shared action the edit cannot hit. The record and state are
 private to each checkout and live under `incremental/` in mbx's cache directory,
 so `cargo clean` does not discard the next edit's speedup. Normal garbage
 collection removes state for deleted or expired checkouts.

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -85,6 +85,10 @@ setup() {
 }
 
 @test "explain --last diagnoses a miss from recorded inputs" {
+  # The edited crate would otherwise take private incremental state on its
+  # first edit and skip the lookup this test wants explained. CI sets CI=1,
+  # which disables that already; locally it has to be said.
+  export MBX_LEARNED_INCREMENTAL=0
   cargo init --lib --vcs none missed-project
   cd missed-project
 


### PR DESCRIPTION
## Problem

Learned incremental engages only for the crate whose own sources changed. Edit a workspace dependency and every crate above it recompiles as an ordinary miss and publishes. That publication is wasted: the crate's action key hashes the artifact it links, that artifact was produced from private incremental state, and no other checkout will ever hold the same bytes. So the crate above pays a full compilation for a result nothing can restore.

Measured on jdx/mise (32 cores, rustc 1.98.0, medians of four edits appending a function to `crates/mise-sigstore/src/lib.rs`, rebuilding the `mise` binary each time):

| | raw cargo | mbx 1.6.0 | this branch |
|---|---|---|---|
| `cargo build` after a dependency edit | 16s | 70s | 14 to 19s compiler time |
| `cargo check` after a dependency edit | 8s | 35s | 8 to 11s compiler time |

The mise crate's own edits were already at parity in 1.6.0 (18s against 16s). This closes the other half of the edit loop.

## Change

A hot compilation writes a marker for each of its outputs under `incremental/<checkout>/private/`, keyed by output path, before the compiler starts. Before, not after, because Cargo pipelines a dependent behind this unit's metadata while the compiler is still running. Every compilation withdraws the markers for its own outputs first, so a marker only ever describes what the last compilation of that unit did.

A crate that links a marked artifact takes private state too, on both the miss path and the fast path that skips the lookup. Its streak still counts its own sources, so an edit to it is recognized the same way as before. Once the edited crate settles, for example after a wiped target on unchanged sources, the whole cone compiles and publishes normally again; the integration test covers that half as well.

The previous test asserting that dependents keep publishing is replaced. Its rationale was sharing loss, but a result keyed on a private artifact was never shareable.

The `explain --last` bats test is pinned to `MBX_LEARNED_INCREMENTAL=0`. It expects an edited workspace crate to record a miss, which learned incremental swallows; CI sets `CI=1`, which disabled that already, so it only failed locally, with the released binary too.

## Verification

- `mise run ci` passes (bats submodules initialized).
- Re-measured mise dependency edits with the patched binary: all three crates above the edit report `incremental`, zero lookups, zero bytes stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit afa65cae8ab142960d92b378353e9052f050b08a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved incremental compilation handling for artifacts specific to individual checkouts.
  * When a crate changes, dependent crates now reuse incremental state appropriately instead of publishing results that cannot be restored.
  * Workspace rebuilds better recognize affected dependencies, while unchanged sources continue to be tracked independently.
  * After cleaning and rebuilding settled sources, the full dependency cone publishes normally again.

* **Documentation**
  * Clarified learned incremental reuse triggers, propagation rules, and behavior after cache loss or dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->