### PR TITLE
fix(ci): install kache for benchmark refresh

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -94,6 +94,18 @@ jobs:
           cache: false
         env:
           MISE_LOCKED: "1"
+      # The comparison should track kache itself, not the version that happened
+      # to be current when mise.lock was last updated. Install the newest stable
+      # release explicitly, then keep its real path for builds that run outside
+      # this repository (where a mise shim cannot resolve this configuration).
+      - name: Install latest benchmark comparator
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
+          MISE_LOCKED: "0"
+        run: |
+          mise install github:kunobi-ninja/kache@latest
+          echo "KACHE_INSTALL_DIR=$(mise where github:kunobi-ninja/kache@latest)" \
+            >> "$GITHUB_ENV"
       - name: Runner metadata
         run: |
           {
@@ -132,7 +144,8 @@ jobs:
           MBX_BENCH_ALTERNATE_TOOLCHAIN: 1.96.0
           MISE_LOCKED: "1"
         run: |
-          mise x -- python3 benchmarks/real_world.py \
+          PATH="$KACHE_INSTALL_DIR:$PATH" \
+            python3 benchmarks/real_world.py \
             --mbx "$MBX_BENCH_BINARY" \
             --scenarios cold,warm,commit,worktree,toolchain,contention \
             --output target/benchmarks \

--- a/mise.lock
+++ b/mise.lock
@@ -7,9 +7,6 @@ version = "2.2.4"
 backend = "aqua:jdx/aube"
 specifiers = ["latest"]
 
-[tools.aube.options]
-"vars.lazy" = "true"
-
 [tools.aube."platforms.linux-arm64"]
 checksum = "sha256:ded66b083215124d196d918ce44506791c2153552f8f307786e07d9bb3f9221e"
 url = "https://github.com/jdx/aube/releases/download/v2.2.4/aube-v2.2.4-aarch64-unknown-linux-gnu.tar.gz"
@@ -123,48 +120,6 @@ provenance_verified = true
 checksum = "sha256:a15f62ea6fa0051f8ae01fca58da26c550ae95fd9d7eccaa167ca53d6f2262b3"
 url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992910"
-provenance = "github-attestations"
-
-[[tools."github:kunobi-ninja/kache"]]
-version = "0.16.0"
-backend = "github:kunobi-ninja/kache"
-specifiers = ["0.16.0"]
-
-[tools."github:kunobi-ninja/kache"."platforms.linux-arm64"]
-checksum = "sha256:6eabb67867022eecdbfffe43c16e75b5c5b561983742bda3c900a4cb4c50e4a7"
-url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655675"
-provenance = "github-attestations"
-
-[tools."github:kunobi-ninja/kache"."platforms.linux-arm64-musl"]
-checksum = "sha256:6eabb67867022eecdbfffe43c16e75b5c5b561983742bda3c900a4cb4c50e4a7"
-url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655675"
-provenance = "github-attestations"
-
-[tools."github:kunobi-ninja/kache"."platforms.linux-x64"]
-checksum = "sha256:caee657c662379475af2a0a7611ad32a6d053822036c1ec191bb8fd1c826d54b"
-url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655714"
-provenance = "github-attestations"
-
-[tools."github:kunobi-ninja/kache"."platforms.linux-x64-musl"]
-checksum = "sha256:caee657c662379475af2a0a7611ad32a6d053822036c1ec191bb8fd1c826d54b"
-url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655714"
-provenance = "github-attestations"
-
-[tools."github:kunobi-ninja/kache"."platforms.macos-arm64"]
-checksum = "sha256:6ad80d3bbb33d7db1715d5a919edbdf755dc19ca22fa83797c659147f1f9e229"
-url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655624"
-provenance = "github-attestations"
-provenance_verified = true
-
-[tools."github:kunobi-ninja/kache"."platforms.windows-x64"]
-checksum = "sha256:b4b53a54926e5cdc8c084562fdf215780306c9d5dc7eeaff9e4eb70c0b47fe2a"
-url = "https://github.com/kunobi-ninja/kache/releases/download/v0.16.0/kache-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/kunobi-ninja/kache/releases/assets/529655706"
 provenance = "github-attestations"
 
 [[tools.lychee]]

--- a/mise.toml
+++ b/mise.toml
@@ -163,7 +163,6 @@ run = "tak run --record"
 # Perf jobs build the current source with the latest released mbx so the
 # appliance cache is usable without bootstrapping from the branch under test.
 mr-boxington = "1.4.1"
-"github:kunobi-ninja/kache" = { version = "0.16.0", lazy = true, lazy_bins = ["kache"] }
 "github:jdx/tak" = "0.0.9"
 aube = { version = "latest", lazy = true, lazy_bins = ["aube"] }
 communique = "latest"


### PR DESCRIPTION
## Summary

- remove kache from mise.toml and mise.lock so project tooling does not pin or manage the comparator
- explicitly resolve and install the newest stable kache release on every benchmark refresh
- invoke the real installed binary from benchmark subject checkouts instead of a repository-dependent mise shim
- keep all non-comparator benchmark tooling locked

## Why

The latest bench-refresh run failed in the cold kache cell. The benchmark resolved kache to a mise shim, then Cargo invoked that shim from the cloned benchmark subject. Outside this repository the shim could not resolve the kache tool configuration and exited before rustc started.

The workflow now treats kache as benchmark input: it installs github:kunobi-ninja/kache@latest with locked mode disabled only for that standalone comparator resolution. This both avoids the shim and automatically follows new stable kache releases.

## Validation

- ran the standalone install and path-resolution flow with the same mise 2026.9.1 version used by the performance runner and an empty MISE_DATA_DIR
- verified kache is absent from mise.toml and mise.lock
- verified the resolved version equals mise latest github:kunobi-ninja/kache
- verified the installed binary runs from an unrelated temporary working directory
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only benchmark workflow and lockfile cleanup; no runtime product or auth changes, with modest risk from floating @latest kache on scheduled benchmarks.
> 
> **Overview**
> Fixes **bench-refresh** failures where the cold **kache** scenario resolved a mise shim that could not run from cloned benchmark subject trees.
> 
> **kache** is removed from `mise.toml` and `mise.lock` so the repo no longer pins the benchmark comparator. The workflow adds a step that installs `github:kunobi-ninja/kache@latest` (with `MISE_LOCKED` off only for that install), records `KACHE_INSTALL_DIR`, and runs `real_world.py` with that directory on `PATH` instead of `mise x`. Comparator version now tracks the newest stable kache release each refresh; other mise tooling stays locked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ebd71b14c3f8b6a1d06d1851af767f5dbb34940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->