### PR TITLE
fix: discard outputs when rustc inputs mutate

### DIFF
--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -491,7 +491,7 @@ pub(crate) fn compile(
         }
         return Ok(exit_code(output.status));
     }
-    let mut final_status = exit_code(output.status);
+    let mut compiler_input_invalid = false;
     if output.status.success() {
         let publication: Result<Option<ActionDiagnostic>> = (|| {
             let input_identities = input_identities
@@ -547,7 +547,7 @@ pub(crate) fn compile(
                     );
                 }
                 eprintln!("mbx[error]: compilation result was discarded: {error:#}");
-                final_status = ExitCode::FAILURE;
+                compiler_input_invalid = true;
             }
             Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
         }
@@ -558,7 +558,11 @@ pub(crate) fn compile(
         timing.duration_ns,
         current_diagnostic,
     );
-    Ok(final_status)
+    if compiler_input_invalid {
+        Ok(ExitCode::FAILURE)
+    } else {
+        Ok(exit_code(output.status))
+    }
 }
 
 /// Whether publication failed because the compiler's inputs moved underneath it.

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -482,6 +482,21 @@ pub(crate) fn compile(
             timing.duration_ns,
             current_diagnostic,
         );
+        if output.status.success()
+            && let Err(error) = validate_compiler_inputs(
+                &invocation,
+                &outputs,
+                &working_dir,
+                &portable,
+                compilation_started,
+                &input_identities,
+            )
+        {
+            if discard_modified_compiler_result(&outputs, &error) {
+                return Ok(ExitCode::FAILURE);
+            }
+            eprintln!("mbx[warning]: verification inputs were not validated: {error:#}");
+        }
         let divergence = verification_divergence(&cached, &output);
         record_verification(divergence.is_none(), cached.restore);
         if let Some(divergence) = divergence {
@@ -540,13 +555,7 @@ pub(crate) fn compile(
         })();
         match publication {
             Ok(diagnostic) => current_diagnostic = diagnostic,
-            Err(error) if compiler_input_was_modified(&error) => {
-                if let Err(discard_error) = discard_compiler_outputs(&outputs) {
-                    eprintln!(
-                        "mbx[warning]: some invalid compiler outputs could not be removed: {discard_error:#}"
-                    );
-                }
-                eprintln!("mbx[error]: compilation result was discarded: {error:#}");
+            Err(error) if discard_modified_compiler_result(&outputs, &error) => {
                 compiler_input_invalid = true;
             }
             Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
@@ -575,6 +584,43 @@ fn compiler_input_was_modified(error: &eyre::Report) -> bool {
         error.downcast_ref::<BypassReason>(),
         Some(BypassReason::InputModifiedDuringCompilation(_) | BypassReason::InputChanged(_))
     )
+}
+
+/// Reject and remove a successful compiler result whose inputs changed while it ran.
+fn discard_modified_compiler_result(outputs: &RustcOutputs, error: &eyre::Report) -> bool {
+    if !compiler_input_was_modified(error) {
+        return false;
+    }
+    if let Err(discard_error) = discard_compiler_outputs(outputs) {
+        eprintln!(
+            "mbx[warning]: some invalid compiler outputs could not be removed: {discard_error:#}"
+        );
+    }
+    eprintln!("mbx[error]: compilation result was discarded: {error:#}");
+    true
+}
+
+fn validate_compiler_inputs(
+    invocation: &RustcInvocation,
+    outputs: &RustcOutputs,
+    working_dir: &Path,
+    portable: &Portable,
+    compilation_started: SystemTime,
+    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
+) -> Result<()> {
+    let input_identities = input_identities
+        .as_ref()
+        .map_err(|error| eyre::eyre!(error.to_string()))?;
+    let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
+    let discovered = invocation.discover_inputs_with_mappings(
+        &dep_info,
+        working_dir,
+        &portable.mappings,
+        session::file_digest_cache(),
+    )?;
+    discovered.verify_not_modified_since_with_identities(compilation_started, input_identities)?;
+    discovered.verify()?;
+    Ok(())
 }
 
 /// Remove an invalid compiler result before Cargo can consume or fingerprint it.
@@ -610,6 +656,10 @@ fn compile_execution_only_build_script(
 ) -> Result<ExitCode> {
     let demand = crate::scheduler::Demand::new(invocation.crate_name(), true);
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));
+    let required_inputs = invocation.required_inputs_in(working_dir);
+    let input_identities =
+        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
+    let compilation_started = SystemTime::now();
     let started = Instant::now();
     let output = compiler_command(rustc, wrapper_argument)
         .args(arguments)
@@ -624,6 +674,21 @@ fn compile_execution_only_build_script(
         started.elapsed().as_nanos().try_into().unwrap_or(u64::MAX),
     );
     let _ = replay_output(&output);
+    if output.status.success()
+        && let Err(error) = validate_compiler_inputs(
+            invocation,
+            outputs,
+            working_dir,
+            portable,
+            compilation_started,
+            &input_identities,
+        )
+    {
+        if discard_modified_compiler_result(outputs, &error) {
+            return Ok(ExitCode::FAILURE);
+        }
+        eprintln!("mbx[warning]: build-script inputs were not validated: {error:#}");
+    }
     if output.status.success()
         && let Some(executable) = outputs.build_script_executable(invocation.crate_name())
     {

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -424,12 +424,15 @@ pub(crate) fn compile(
     // The machine-wide permit is taken after every chance to hit the cache,
     // and before anything expensive starts. The timer starts afterwards: time
     // spent waiting for the machine is not time this compilation cost.
-    let required_inputs = invocation.required_inputs_in(&working_dir);
-    let input_identities =
-        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
     let demand =
         crate::scheduler::Demand::new(invocation.crate_name(), invocation.links_natively());
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));
+    // Capture these after admission: an edit while this compile waits for
+    // capacity happened before rustc ran and belongs to the valid compilation
+    // it is about to perform, not to the overlap this snapshot detects.
+    let required_inputs = invocation.required_inputs_in(&working_dir);
+    let input_identities =
+        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
     let compilation_started = SystemTime::now();
     let compiler_timer = Instant::now();
     let mut command = compiler_command(rustc, wrapper_argument);

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -488,8 +488,8 @@ pub(crate) fn compile(
         }
         return Ok(exit_code(output.status));
     }
+    let mut final_status = exit_code(output.status);
     if output.status.success() {
-        learned.record_compiled();
         let publication: Result<Option<ActionDiagnostic>> = (|| {
             let input_identities = input_identities
                 .as_ref()
@@ -498,6 +498,7 @@ pub(crate) fn compile(
             discovered
                 .verify_not_modified_since_with_identities(compilation_started, input_identities)?;
             discovered.verify()?;
+            learned.record_compiled();
             if learned_enabled && learned.record.is_none() && source_is_in_workspace(&compilation) {
                 record_learned_baseline(&compilation, &discovered);
             }
@@ -536,6 +537,15 @@ pub(crate) fn compile(
         })();
         match publication {
             Ok(diagnostic) => current_diagnostic = diagnostic,
+            Err(error) if compiler_input_was_modified(&error) => {
+                if let Err(discard_error) = discard_compiler_outputs(&outputs) {
+                    eprintln!(
+                        "mbx[warning]: some invalid compiler outputs could not be removed: {discard_error:#}"
+                    );
+                }
+                eprintln!("mbx[error]: compilation result was discarded: {error:#}");
+                final_status = ExitCode::FAILURE;
+            }
             Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
         }
     }
@@ -545,7 +555,39 @@ pub(crate) fn compile(
         timing.duration_ns,
         current_diagnostic,
     );
-    Ok(exit_code(output.status))
+    Ok(final_status)
+}
+
+/// Whether publication failed because the compiler's inputs moved underneath it.
+///
+/// Other publication failures only prevent caching: rustc's local result is
+/// still valid and Cargo can use it. These two failures instead mean the
+/// artifact cannot be trusted, regardless of whether it was ever published.
+fn compiler_input_was_modified(error: &eyre::Report) -> bool {
+    matches!(
+        error.downcast_ref::<BypassReason>(),
+        Some(BypassReason::InputModifiedDuringCompilation(_) | BypassReason::InputChanged(_))
+    )
+}
+
+/// Remove an invalid compiler result before Cargo can consume or fingerprint it.
+fn discard_compiler_outputs(outputs: &RustcOutputs) -> Result<()> {
+    let mut failures = Vec::new();
+    for path in outputs
+        .files
+        .iter()
+        .chain(std::iter::once(&outputs.dep_info))
+    {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => failures.push(format!("{}: {error}", path.display())),
+        }
+    }
+    if !failures.is_empty() {
+        bail!("{}", failures.join("; "));
+    }
+    Ok(())
 }
 
 /// Compile a build script whose native link cannot be action-cached, then

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -474,7 +474,6 @@ pub(crate) fn compile(
     } else {
         "unconsulted"
     };
-    let _ = replay_output(&output);
     if let Some(cached) = verification {
         session::record_compiler_invocation_with_diagnostic(
             recorded_outcome,
@@ -492,7 +491,8 @@ pub(crate) fn compile(
                 &input_identities,
             )
         {
-            if discard_modified_compiler_result(&outputs, &error) {
+            if discard_modified_compiler_result(&outputs, &input_identities, &error) {
+                let _ = replay_bytes(&[], &output.stderr);
                 return Ok(ExitCode::FAILURE);
             }
             eprintln!("mbx[warning]: verification inputs were not validated: {error:#}");
@@ -504,6 +504,7 @@ pub(crate) fn compile(
                 "mbx[warning]: shadow verification diverged from cached output: {divergence}"
             );
         }
+        let _ = replay_output(&output);
         return Ok(exit_code(output.status));
     }
     let mut compiler_input_invalid = false;
@@ -592,7 +593,7 @@ pub(crate) fn compile(
             };
         match publication {
             Ok(diagnostic) => current_diagnostic = diagnostic,
-            Err(error) if discard_modified_compiler_result(&outputs, &error) => {
+            Err(error) if discard_modified_compiler_result(&outputs, &input_identities, &error) => {
                 compiler_input_invalid = true;
             }
             Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
@@ -605,8 +606,15 @@ pub(crate) fn compile(
         current_diagnostic,
     );
     if compiler_input_invalid {
+        // Keep rustc's diagnostics, but do not forward stdout notifications
+        // for an artifact that was just rejected. Cargo pipelines dependents
+        // as soon as it observes those notifications.
+        let _ = replay_bytes(&[], &output.stderr);
         Ok(ExitCode::FAILURE)
     } else {
+        // Publication validates the inputs and keeps invalid metadata out of
+        // Cargo's hands. Only advertise rustc's result after that completes.
+        let _ = replay_output(&output);
         Ok(exit_code(output.status))
     }
 }
@@ -614,18 +622,32 @@ pub(crate) fn compile(
 /// Whether publication failed because the compiler's inputs moved underneath it.
 ///
 /// Other publication failures only prevent caching: rustc's local result is
-/// still valid and Cargo can use it. These two failures instead mean the
-/// artifact cannot be trusted, regardless of whether it was ever published.
-fn compiler_input_was_modified(error: &eyre::Report) -> bool {
-    matches!(
-        error.downcast_ref::<BypassReason>(),
-        Some(BypassReason::InputModifiedDuringCompilation(_) | BypassReason::InputChanged(_))
-    )
+/// still valid and Cargo can use it. A content change or an overlap proved by
+/// a pre-compilation file identity instead means the artifact cannot be
+/// trusted. A timestamp-only overlap remains a conservative cache bypass: it
+/// is not reliable enough across skewed filesystem clocks to fail the build.
+fn compiler_input_was_modified(
+    error: &eyre::Report,
+    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
+) -> bool {
+    match error.downcast_ref::<BypassReason>() {
+        Some(BypassReason::InputChanged(_)) => true,
+        Some(BypassReason::InputModifiedDuringCompilation(path)) => input_identities
+            .as_ref()
+            .ok()
+            .and_then(|identities| identities.get(path))
+            .is_some_and(|identity| identity.changed.is_some()),
+        _ => false,
+    }
 }
 
 /// Reject and remove a successful compiler result whose inputs changed while it ran.
-fn discard_modified_compiler_result(outputs: &RustcOutputs, error: &eyre::Report) -> bool {
-    if !compiler_input_was_modified(error) {
+fn discard_modified_compiler_result(
+    outputs: &RustcOutputs,
+    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
+    error: &eyre::Report,
+) -> bool {
+    if !compiler_input_was_modified(error, input_identities) {
         return false;
     }
     if let Err(discard_error) = discard_compiler_outputs(outputs) {
@@ -710,7 +732,6 @@ fn compile_execution_only_build_script(
         Some(invocation.crate_name()),
         started.elapsed().as_nanos().try_into().unwrap_or(u64::MAX),
     );
-    let _ = replay_output(&output);
     if output.status.success()
         && let Err(error) = validate_compiler_inputs(
             invocation,
@@ -721,7 +742,8 @@ fn compile_execution_only_build_script(
             &input_identities,
         )
     {
-        if discard_modified_compiler_result(outputs, &error) {
+        if discard_modified_compiler_result(outputs, &input_identities, &error) {
+            let _ = replay_bytes(&[], &output.stderr);
             return Ok(ExitCode::FAILURE);
         }
         eprintln!("mbx[warning]: build-script inputs were not validated: {error:#}");
@@ -781,6 +803,7 @@ fn compile_execution_only_build_script(
             ));
         }
     }
+    let _ = replay_output(&output);
     Ok(exit_code(output.status))
 }
 

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -614,17 +614,36 @@ fn materialized_outputs_are_independent_from_the_cas() {
 
 #[test]
 fn only_compiler_input_mutations_invalidate_local_outputs() {
-    let changed = eyre::Report::new(BypassReason::InputChanged("src/lib.rs".into()))
-        .wrap_err("publication failed");
+    let path = PathBuf::from("src/lib.rs");
+    let identity = FileIdentity {
+        path: path.clone(),
+        len: 6,
+        modified: SystemTime::UNIX_EPOCH,
+        changed: Some((1, 2)),
+    };
+    let identities = Ok(BTreeMap::from([(path.clone(), identity)]));
+    let changed =
+        eyre::Report::new(BypassReason::InputChanged(path.clone())).wrap_err("publication failed");
+    let overlapping = eyre::Report::new(BypassReason::InputModifiedDuringCompilation(path));
+
+    assert!(compiler_input_was_modified(&changed, &identities));
+    assert!(compiler_input_was_modified(&overlapping, &identities));
+    assert!(!compiler_input_was_modified(
+        &eyre::eyre!("the cache is unavailable"),
+        &identities
+    ));
+}
+
+#[test]
+fn timestamp_only_input_overlap_does_not_invalidate_local_outputs() {
     let overlapping = eyre::Report::new(BypassReason::InputModifiedDuringCompilation(
-        "src/lib.rs".into(),
+        "src/module.rs".into(),
     ));
 
-    assert!(compiler_input_was_modified(&changed));
-    assert!(compiler_input_was_modified(&overlapping));
-    assert!(!compiler_input_was_modified(&eyre::eyre!(
-        "the cache is unavailable"
-    )));
+    assert!(!compiler_input_was_modified(
+        &overlapping,
+        &Ok(BTreeMap::new())
+    ));
 }
 
 #[test]

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -613,6 +613,44 @@ fn materialized_outputs_are_independent_from_the_cas() {
 }
 
 #[test]
+fn only_compiler_input_mutations_invalidate_local_outputs() {
+    let changed = eyre::Report::new(BypassReason::InputChanged("src/lib.rs".into()))
+        .wrap_err("publication failed");
+    let overlapping = eyre::Report::new(BypassReason::InputModifiedDuringCompilation(
+        "src/lib.rs".into(),
+    ));
+
+    assert!(compiler_input_was_modified(&changed));
+    assert!(compiler_input_was_modified(&overlapping));
+    assert!(!compiler_input_was_modified(&eyre::eyre!(
+        "the cache is unavailable"
+    )));
+}
+
+#[test]
+fn discards_every_modeled_compiler_output() {
+    let directory = tempfile::tempdir().unwrap();
+    let metadata = directory.path().join("libfixture.rmeta");
+    let library = directory.path().join("libfixture.rlib");
+    let dep_info = directory.path().join("fixture.d");
+    for path in [&metadata, &library, &dep_info] {
+        std::fs::write(path, b"output").unwrap();
+    }
+    let outputs = RustcOutputs {
+        directory: directory.path().to_path_buf(),
+        files: vec![metadata.clone(), library.clone()],
+        dep_info: dep_info.clone(),
+    };
+
+    discard_compiler_outputs(&outputs).unwrap();
+
+    assert!(!metadata.exists());
+    assert!(!library.exists());
+    assert!(!dep_info.exists());
+    discard_compiler_outputs(&outputs).unwrap();
+}
+
+#[test]
 fn rejects_cached_outputs_with_the_wrong_size() {
     let root = tempfile::tempdir().unwrap();
     let source = root.path().join("cas-blob");

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -4,7 +4,7 @@
 //! dependencies, so nothing here needs the network.
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn write_project(directory: &Path) {
     write_named_project(directory, "fixture");
@@ -205,6 +205,106 @@ fn rustc_workspace_wrapper_is_preserved_without_becoming_the_compiler() {
     assert!(
         stats["bypasses"].get("multiple-inputs").is_none(),
         "the workspace wrapper must not be parsed as rustc: {stats}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_mid_compilation_input_edit_discards_the_result() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    write_dependent_project(project.path());
+
+    // Let rustc produce the old metadata, then hold the wrapper open until the
+    // test edits both the crate and its dependent. This makes the race exact
+    // without depending on how long a real compilation happens to take.
+    let wrapper = project.path().join("delayed-rustc");
+    let compiled = project.path().join("compiler-finished");
+    let release = project.path().join("release-compiler");
+    std::fs::write(
+        &wrapper,
+        "#!/bin/sh\n\"$TEST_REAL_RUSTC\" \"$@\"\nstatus=$?\ncase \" $* \" in\n  *\" --crate-name base \"*)\n    if [ \"$status\" -eq 0 ]; then\n      : > \"$TEST_COMPILER_FINISHED\"\n      while [ ! -e \"$TEST_RELEASE_COMPILER\" ]; do sleep 0.02; done\n    fi\n    ;;\nesac\nexit \"$status\"\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&wrapper, permissions).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mbx"));
+    child
+        .current_dir(project.path())
+        .args(["check", "--offline", "--verbose"])
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_TARGET_VIEWS", "0")
+        .env("MBX_LEARNED_INCREMENTAL", "0")
+        .env("CARGO_INCREMENTAL", "0")
+        .env("RUSTC", &wrapper)
+        .env("TEST_REAL_RUSTC", which::which("rustc").unwrap())
+        .env("TEST_COMPILER_FINISHED", &compiled)
+        .env("TEST_RELEASE_COMPILER", &release)
+        .env_remove("MBX_SOCKET")
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = child.spawn().expect("mbx should run");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !compiled.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "the build exited before the compiler could be released"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(
+        compiled.exists(),
+        "the compiler did not reach the test barrier"
+    );
+
+    std::fs::write(
+        project.path().join("base/src/lib.rs"),
+        "pub fn value() -> u32 { 1 }\npub fn added() -> u32 { 2 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join("above/src/lib.rs"),
+        "pub fn value() -> u32 { base::added() }\n",
+    )
+    .unwrap();
+    std::fs::write(&release, b"").unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "the invalid compilation must fail"
+    );
+    assert!(
+        stderr.contains("compilation result was discarded: compiler input was modified"),
+        "the mutation should be diagnosed: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Checking above"),
+        "Cargo must not compile a dependent against the stale metadata: {stderr}"
+    );
+
+    let deps = project.path().join("target/debug/deps");
+    let stale_outputs = std::fs::read_dir(deps)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| {
+            (name.starts_with("libbase-") && name.ends_with(".rmeta"))
+                || (name.starts_with("base-") && name.ends_with(".d"))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        stale_outputs.is_empty(),
+        "the stale compiler outputs should be removed: {stale_outputs:?}"
     );
 }
 

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -310,6 +310,78 @@ fn a_mid_compilation_input_edit_discards_the_result() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn a_mid_compilation_build_script_edit_discards_the_execution_only_result() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    write_execution_cached_project(project.path(), true);
+
+    let wrapper = project.path().join("delayed-rustc");
+    let compiled = project.path().join("compiler-finished");
+    let release = project.path().join("release-compiler");
+    std::fs::write(
+        &wrapper,
+        "#!/bin/sh\n\"$TEST_REAL_RUSTC\" \"$@\"\nstatus=$?\ncase \" $* \" in\n  *\" --crate-name build_script_build \"*)\n    if [ \"$status\" -eq 0 ]; then\n      : > \"$TEST_COMPILER_FINISHED\"\n      while [ ! -e \"$TEST_RELEASE_COMPILER\" ]; do sleep 0.02; done\n    fi\n    ;;\nesac\nexit \"$status\"\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&wrapper, permissions).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mbx"));
+    child
+        .current_dir(project.path())
+        .args(["build", "--offline", "--verbose"])
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_CACHE_LINKS", "0")
+        .env("MBX_BUILD_SCRIPT_EXECUTION", "1")
+        .env("MBX_TARGET_VIEWS", "0")
+        .env("RUSTC", &wrapper)
+        .env("TEST_REAL_RUSTC", which::which("rustc").unwrap())
+        .env("TEST_COMPILER_FINISHED", &compiled)
+        .env("TEST_RELEASE_COMPILER", &release)
+        .env_remove("MBX_SOCKET")
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = child.spawn().expect("mbx should run");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !compiled.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "the build exited before the build-script compiler could be released"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(
+        compiled.exists(),
+        "the build-script compiler did not reach the test barrier"
+    );
+
+    let build_script = project.path().join("build.rs");
+    let mut source = std::fs::read_to_string(&build_script).unwrap();
+    source.push_str("\n// edited while rustc was running\n");
+    std::fs::write(build_script, source).unwrap();
+    std::fs::write(&release, b"").unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "the invalid build-script compilation must fail"
+    );
+    assert!(
+        stderr.contains("compilation result was discarded: compiler input was modified"),
+        "the build-script mutation should be diagnosed: {stderr}"
+    );
+}
+
 /// Build `project` against `store`, returning the run's statistics.
 fn build(project: &Path, store: &Path, report: &Path) -> serde_json::Value {
     build_with(project, store, report, &[]).0

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -4,7 +4,9 @@
 //! dependencies, so nothing here needs the network.
 
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
+#[cfg(unix)]
+use std::process::Stdio;
 
 fn write_project(directory: &Path) {
     write_named_project(directory, "fixture");


### PR DESCRIPTION
## Summary

- distinguish compiler-input mutation from ordinary cache publication failures
- remove every modeled rustc output and return failure when inputs change during or immediately after compilation
- update learned-incremental state only after compiler inputs have been verified
- cover the race with a deterministic delayed-compiler integration test

This addresses the correctness failure reported in [discussion #325](https://github.com/jdx/mr-boxington/discussions/325): Cargo can no longer compile a dependent against metadata produced before a mid-compilation edit.

## Testing

- `cargo test -p mbx`
- `cargo clippy -p mbx --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core rustc wrapper path (timing of snapshots, output replay, and failure semantics) that Cargo depends on for pipeline ordering; behavior is heavily tested but wrong classification could either fail good builds or briefly expose stale artifacts.
> 
> **Overview**
> Fixes a race where Cargo could build dependents against **metadata from a compilation that started before a mid-build source edit**.
> 
> **Input snapshots** are taken **after** the scheduler admits the compile (not before), so edits while waiting for capacity are treated as part of the upcoming compile rather than as overlap during rustc.
> 
> After a successful rustc run, **publication/validation** runs before **stdout is replayed** to Cargo, so artifact notifications are not emitted for results that will be rejected.
> 
> When validation fails only because **compiler inputs actually changed** (`BypassReason::InputChanged` or overlap proven by pre-compile **content** identity), the wrapper **deletes modeled outputs** (artifacts + dep-info), logs an error, replays stderr only, and returns **failure**. Ordinary cache/publication errors still warn and leave rustc’s local outputs usable. **Timestamp-only** overlap during compile does **not** fail the build.
> 
> **Learned incremental** paths reuse manifest-matched discovered inputs for a lighter verify path; churn recording moves to **after** input checks. **Execution-only build scripts** get the same validation.
> 
> Tests cover classification/cleanup helpers and Unix e2e builds with a **delayed rustc** wrapper that edits sources after compile finishes but before the wrapper returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1c9894bbe53ad69fb8aadaf37b34b30b9d810df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation validity checks to detect source changes made while builds are waiting for capacity.
  * Stale compiler outputs are now removed when compiler inputs change during compilation.
  * Compilation now reports modified inputs as errors instead of returning potentially stale results.
  * Unrelated publication or caching failures continue to produce warnings without deleting outputs.

* **Tests**
  * Added coverage for dependency and dependent-source changes during compilation.
  * Verified cleanup of metadata, library, and dependency-information outputs, including repeated cleanup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->