### PR TITLE
perf: keep hot-edit bookkeeping off the build's critical path

### DIFF
--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -243,6 +243,9 @@ fn queue_prefetch_directory(
     true
 }
 
+/// See [`CacheAgent::with_task_loader`].
+pub type TaskLoader = dyn for<'a> Fn(&'a CacheAgent, &'a str) -> BoxFuture<'a, ()> + Send + Sync;
+
 /// Shared state for an agent hosted by the process that owns a build session.
 ///
 /// Transport listeners deliberately live in the embedder so the session
@@ -259,6 +262,9 @@ pub struct CacheAgent {
     stats: Arc<AtomicAgentStats>,
     observer: Option<Arc<dyn AgentEventObserver>>,
     observer_emission: Arc<Mutex<()>>,
+    /// Loads a task the first time a request names it, so a connection that
+    /// only reports a bypass never waits for a manifest it will not read.
+    task_loader: Option<Arc<TaskLoader>>,
     executable_identities: Arc<Mutex<BTreeMap<ExecutableIdentityKey, Vec<u8>>>>,
     manifest_dir: Arc<PathBuf>,
     task_actions: Arc<Mutex<BTreeMap<String, TaskActionState>>>,
@@ -512,6 +518,7 @@ impl CacheAgent {
             stats,
             observer: None,
             observer_emission: Arc::new(Mutex::new(())),
+            task_loader: None,
             executable_identities: Arc::new(Mutex::new(BTreeMap::new())),
             manifest_dir: Arc::new(task_manifest_dir(&cache_dir)),
             task_actions: Arc::new(Mutex::new(BTreeMap::new())),
@@ -537,6 +544,29 @@ impl CacheAgent {
     pub fn with_observer(mut self, observer: Arc<dyn AgentEventObserver>) -> Self {
         self.observer = Some(observer);
         self
+    }
+
+    /// Load tasks on demand.
+    ///
+    /// The loader is called with the agent and the task's identity before the
+    /// first request that names a task this agent has not begun, and is
+    /// expected to begin it; a second call for the same task must be a no-op.
+    /// Requests that name no task never wait on it.
+    pub fn with_task_loader(mut self, loader: Arc<TaskLoader>) -> Self {
+        self.task_loader = Some(loader);
+        self
+    }
+
+    /// Make sure `task` has been begun before a request reads or records
+    /// under it.
+    async fn ensure_task_loaded(&self, task: &str) {
+        let Some(loader) = &self.task_loader else {
+            return;
+        };
+        if self.task_actions.lock().unwrap().contains_key(task) {
+            return;
+        }
+        loader(self, task).await;
     }
 
     fn emit(&self, event: impl FnOnce() -> AgentEvent) {
@@ -657,19 +687,23 @@ impl CacheAgent {
         // manifest lookup; the authoritative snapshot is loaded again below
         // before it is merged, so another process can still update it while
         // this request is in flight.
-        let early_predictions = {
+        let early_manifest = {
             let _write_guard = self.manifest_write_lock.lock().unwrap();
             let _file_guard = self.lock_task_manifest(task)?;
             self.load_task_manifest(task)?
-                .map(|manifest| manifest.predictions)
-                .unwrap_or_default()
         };
-        let early_actions: BTreeSet<_> = early_predictions
+        let early_actions: BTreeSet<_> = early_manifest
             .iter()
+            .flat_map(|manifest| manifest.predictions.iter())
             .map(|prediction| prediction.action.clone())
             .collect();
         if eager_prefetch {
-            self.spawn_prefetch_predictions(early_predictions);
+            self.spawn_prefetch_predictions(
+                early_manifest
+                    .as_ref()
+                    .map(|manifest| manifest.predictions.clone())
+                    .unwrap_or_default(),
+            );
         }
         let (remote_manifest, mut remote_etag) = if self.remote_mode.reads() {
             match self.get_remote_task_manifest(task).await {
@@ -689,7 +723,10 @@ impl CacheAgent {
         } else {
             (None, None)
         };
-        let manifest = {
+        // Without a remote there is nothing to reconcile: the manifest just
+        // read is the whole truth, and writing it back byte for byte would
+        // serialize every prediction for nothing.
+        let manifest = if self.remote.is_some() && self.remote_mode.reads() {
             let _write_guard = self.manifest_write_lock.lock().unwrap();
             let _file_guard = self.lock_task_manifest(task)?;
             let local_manifest = self.load_task_manifest(task)?;
@@ -708,6 +745,8 @@ impl CacheAgent {
                 self.persist_task_manifest(manifest)?;
             }
             manifest
+        } else {
+            early_manifest
         };
         let mut state = if let Some(manifest) = manifest {
             TaskActionState {
@@ -816,16 +855,27 @@ impl CacheAgent {
     /// mistake that cumulative manifest for the work the run completed.
     pub async fn commit_task_actions(&self, run: &str) -> Result<Vec<ActionPrediction>> {
         validate_task_identity(run)?;
-        let state = self
-            .task_actions
-            .lock()
-            .unwrap()
-            .get(run)
-            .cloned()
-            .ok_or_else(|| eyre::eyre!("task action manifest baseline was not loaded"))?;
-        if !state.baseline_loaded {
-            bail!("task action manifest baseline was not loaded");
-        }
+        let state = {
+            let mut runs = self.task_actions.lock().unwrap();
+            let state = runs
+                .get(run)
+                .ok_or_else(|| eyre::eyre!("task action manifest baseline was not loaded"))?;
+            if !state.baseline_loaded {
+                bail!("task action manifest baseline was not loaded");
+            }
+            // A run that predicted nothing new leaves the manifest as it found
+            // it. Rewriting it would serialize every inherited prediction to
+            // say so, and a remote that is only read has nothing to learn
+            // either. Decided before the baseline is cloned: the baseline is
+            // every prediction the manifest holds.
+            if state.pending_predictions.is_empty()
+                && (self.remote.is_none() || !self.remote_mode.writes())
+            {
+                runs.remove(run);
+                return Ok(Vec::new());
+            }
+            state.clone()
+        };
         let task = state.manifest;
         validate_task_identity(&task)?;
         let completed = state
@@ -1170,6 +1220,13 @@ impl CacheAgent {
         request: AgentRequest,
         connection: &mut ConnectionUploads,
     ) -> AgentResponse {
+        match &request {
+            AgentRequest::FindActionPrediction { task, .. }
+            | AgentRequest::RecordActionPrediction { task, .. } => {
+                self.ensure_task_loaded(task).await;
+            }
+            _ => {}
+        }
         let result = match request {
             AgentRequest::BeginTask { task } => self
                 .begin_task(&task)
@@ -1778,7 +1835,20 @@ impl CacheAgent {
     /// a stale seed costs a hash and nothing else. Entries this session has
     /// already recorded are kept over seeded ones. Returns how many were taken.
     pub fn seed_file_digests(&self, entries: Vec<(FileDigestScope, RecordedFileDigest)>) -> usize {
+        self.seed_file_digests_with(|| entries)
+    }
+
+    /// Seed the ledger from entries produced under its lock.
+    ///
+    /// A lookup that arrives while `load` is still reading waits for it rather
+    /// than missing, so a caller can start the read in the background and let
+    /// whatever else the build is doing overlap it.
+    pub fn seed_file_digests_with(
+        &self,
+        load: impl FnOnce() -> Vec<(FileDigestScope, RecordedFileDigest)>,
+    ) -> usize {
         let mut ledger = self.file_digests.lock().unwrap();
+        let entries = load();
         let mut seeded = 0;
         for (scope, entry) in entries {
             if ledger.len() >= MAX_FILE_DIGEST_ENTRIES {

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -770,7 +770,9 @@ pub fn record_checkout(
     };
     let mut contents = serde_json::to_vec(&record)?;
     contents.push(b'\n');
-    write_atomic(
+    // Refreshed by every build and read back only as a last-used stamp, so a
+    // power cut costs one build's worth of recency, not a wait on the disk.
+    write_advisory(
         &checkout_record_path(store, identity, workspace_root),
         &contents,
     )
@@ -1515,6 +1517,27 @@ fn tree_bytes(root: &Path) -> u64 {
 #[cfg(test)]
 #[path = "store_tests.rs"]
 mod tests;
+
+/// [`write_atomic`] without the sync: for records every build rewrites and
+/// that a torn or missing file only makes one build older.
+fn write_advisory(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| eyre::eyre!("path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".mbx-")
+        .tempfile_in(parent)?;
+    use std::io::Write as _;
+    temporary.write_all(contents)?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .wrap_err_with(|| format!("failed atomic write: {}", path.display()))?;
+    Ok(())
+}
 
 fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
     let parent = path

--- a/crates/mbx/src/digest_ledger.rs
+++ b/crates/mbx/src/digest_ledger.rs
@@ -27,6 +27,14 @@ const LEDGER_VERSION: u8 = 1;
 /// graph name, and a bound on a checkout that keeps renaming its outputs.
 const MAX_PERSISTED_ENTRIES: usize = 256 * 1024;
 
+/// Above this many entries, a save checks each one's file still exists and
+/// drops the ones whose file is gone. Below it the check is skipped: it costs
+/// a stat per entry on every build, and an entry for a vanished file is only
+/// dead weight, never a wrong answer, since the identity it answers under
+/// can no longer match anything. A checkout that keeps renaming its outputs
+/// therefore grows to this size once, is swept back down, and repeats.
+const SWEEP_ABOVE_ENTRIES: usize = 64 * 1024;
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Ledger {
@@ -67,6 +75,23 @@ pub(crate) fn path(state_dir: &Path) -> PathBuf {
     state_dir.join(LEDGER_FILE)
 }
 
+/// What the ledger file looked like at one moment: enough to tell whether
+/// another session has written it since.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Stamp {
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+}
+
+/// The ledger file's current stamp, or nothing where there is no file.
+pub(crate) fn stamp(state_dir: &Path) -> Option<Stamp> {
+    let metadata = std::fs::metadata(path(state_dir)).ok()?;
+    Some(Stamp {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
 /// The entries an earlier session left in `state_dir`, or nothing.
 ///
 /// A ledger this version cannot read is no ledger: the cost is rehashing what
@@ -96,25 +121,50 @@ pub(crate) fn load(state_dir: &Path) -> Vec<(FileDigestScope, RecordedFileDigest
 pub(crate) fn save(
     state_dir: &Path,
     entries: Vec<(FileDigestScope, RecordedFileDigest)>,
+    loaded: Option<Stamp>,
+) -> Result<usize> {
+    save_sweeping_above(state_dir, entries, loaded, SWEEP_ABOVE_ENTRIES)
+}
+
+fn save_sweeping_above(
+    state_dir: &Path,
+    entries: Vec<(FileDigestScope, RecordedFileDigest)>,
+    loaded: Option<Stamp>,
+    sweep_above: usize,
 ) -> Result<usize> {
     let path = path(state_dir);
-    let mut merged: BTreeMap<(FileDigestScope, PathBuf), RecordedFileDigest> = read(&path)
-        .map(|ledger| {
-            ledger
-                .entries
-                .into_iter()
-                .map(LedgerEntry::into_record)
-                .map(|(scope, record)| ((scope, record.file.path.clone()), record))
-                .collect()
-        })
-        .unwrap_or_default();
-    for (scope, record) in entries {
-        merged.insert((scope, record.file.path.clone()), record);
-    }
+    // A session that seeded itself from this file, and finds it as it left
+    // it, already holds everything in it: the merge is for the session that
+    // was not alone.
+    let unchanged = loaded.is_some() && loaded == stamp(state_dir);
+    let merged: Vec<(FileDigestScope, RecordedFileDigest)> = if unchanged {
+        // The agent's ledger is already keyed by scope and path, so there is
+        // nothing to merge and no map to build.
+        entries
+    } else {
+        let mut merged: BTreeMap<(FileDigestScope, PathBuf), RecordedFileDigest> = read(&path)
+            .map(|ledger| {
+                ledger
+                    .entries
+                    .into_iter()
+                    .map(LedgerEntry::into_record)
+                    .map(|(scope, record)| ((scope, record.file.path.clone()), record))
+                    .collect()
+            })
+            .unwrap_or_default();
+        for (scope, record) in entries {
+            merged.insert((scope, record.file.path.clone()), record);
+        }
+        merged
+            .into_iter()
+            .map(|((scope, _), record)| (scope, record))
+            .collect()
+    };
+    let sweep = merged.len() > sweep_above;
     let mut entries = merged
         .into_iter()
-        .filter(|(_, record)| record.file.path.is_file())
-        .map(|((scope, _), record)| LedgerEntry::new(scope, record))
+        .filter(|(_, record)| !sweep || record.file.path.is_file())
+        .map(|(scope, record)| LedgerEntry::new(scope, record))
         .collect::<Vec<_>>();
     if entries.len() > MAX_PERSISTED_ENTRIES {
         // Nothing here says which entries matter more, so the newest write is
@@ -127,7 +177,8 @@ pub(crate) fn save(
         version: LEDGER_VERSION,
         entries,
     };
-    crate::util::write_atomic(&path, &serde_json::to_vec(&ledger)?)
+    let bytes = serde_json::to_vec(&ledger)?;
+    crate::util::write_advisory(&path, &bytes)
         .wrap_err_with(|| format!("failed to write the file-digest ledger {}", path.display()))?;
     Ok(count)
 }
@@ -165,7 +216,10 @@ mod tests {
         ];
         std::fs::remove_file(&gone).unwrap();
 
-        assert_eq!(save(state.path(), entries.clone()).unwrap(), 1);
+        assert_eq!(
+            save_sweeping_above(state.path(), entries.clone(), None, 0).unwrap(),
+            1
+        );
         assert_eq!(load(state.path()), vec![entries[0].clone()]);
     }
 
@@ -187,12 +241,18 @@ mod tests {
                 (FileDigestScope::Content, record(&theirs)),
                 (FileDigestScope::Content, stale_shared),
             ],
+            None,
         )
         .unwrap();
 
         let ours = record(&shared);
         assert_eq!(
-            save(state.path(), vec![(FileDigestScope::Content, ours.clone())]).unwrap(),
+            save(
+                state.path(),
+                vec![(FileDigestScope::Content, ours.clone())],
+                None
+            )
+            .unwrap(),
             2
         );
         let loaded = load(state.path());

--- a/crates/mbx/src/incremental.rs
+++ b/crates/mbx/src/incremental.rs
@@ -38,7 +38,7 @@ pub(crate) fn touch(root: &Path, workspace_root: &Path) -> Result<PathBuf> {
         workspace_root: workspace_root.to_path_buf(),
         updated_secs: now_secs(),
     };
-    crate::util::write_atomic(&directory.join(RECORD_FILE), &serde_json::to_vec(&record)?)?;
+    crate::util::write_advisory(&directory.join(RECORD_FILE), &serde_json::to_vec(&record)?)?;
     Ok(directory)
 }
 

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -490,53 +490,75 @@ pub(crate) fn compile(
     }
     if output.status.success() {
         learned.record_compiled();
-        let publication: Result<Option<ActionDiagnostic>> = (|| {
-            let input_identities = input_identities
-                .as_ref()
-                .map_err(|error| eyre::eyre!(error.to_string()))?;
-            let (candidates, discovered) = action_from_dep_info(&compilation, &outputs.dep_info)?;
-            discovered
-                .verify_not_modified_since_with_identities(compilation_started, input_identities)?;
-            discovered.verify()?;
-            if learned_enabled && learned.record.is_none() && source_is_in_workspace(&compilation) {
-                record_learned_baseline(&compilation, &discovered);
-            }
-            // An incremental artifact carries state from this checkout's edit
-            // history, so it is recorded as what the unit currently contains --
-            // which is how the next build notices the churn ended -- but never
-            // published for another checkout to restore. The literal key is
-            // enough for that, and it skips reading the outputs back.
-            let action = if learned.engaged() {
-                &candidates.literal
-            } else {
-                publish_result(
-                    &candidates,
-                    &portable,
-                    &outputs,
-                    &output,
-                    &portable.mappings,
-                )?
-            };
-            install_build_script_shim(&invocation, &outputs, &action.digest);
-            // The flight prediction is only left behind a *published* result:
-            // an incremental artifact was withheld from the store, so a
-            // waiter restoring through its key could only miss.
-            record_prediction(
-                &compilation,
-                &action.digest,
-                &discovered,
-                &timing,
-                flight
+        // An incremental artifact is never published, and what it compiled
+        // was fingerprinted before the compiler ran, so nothing has to be
+        // read back for it: rebuilding the action would hash every input
+        // again for a key nothing looks up. Two exceptions. A build script's
+        // execution shim is installed under that key. And the manifest has to
+        // keep naming the inputs the compiler just recorded, because a wiped
+        // target rebuilds the churn comparison from the manifest: an edit
+        // that adds or drops an input, an `include_str!` say, has to reach
+        // it or settled sources would read as another edit.
+        let reads_back = !learned.engaged()
+            || outputs
+                .build_script_executable(invocation.crate_name())
+                .is_some()
+            || !manifest_predicts_current_inputs(&compilation, &outputs);
+        if reads_back {
+            let publication: Result<Option<ActionDiagnostic>> = (|| {
+                let input_identities = input_identities
                     .as_ref()
-                    .filter(|_| !learned.engaged())
-                    .map(|flight| &flight.flight),
-                remote_claim.as_deref().filter(|_| !learned.engaged()),
-            );
-            Ok(compilation_action_diagnostic(&compilation, action).ok())
-        })();
-        match publication {
-            Ok(diagnostic) => current_diagnostic = diagnostic,
-            Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
+                    .map_err(|error| eyre::eyre!(error.to_string()))?;
+                let (candidates, discovered) =
+                    action_from_dep_info(&compilation, &outputs.dep_info)?;
+                discovered.verify_not_modified_since_with_identities(
+                    compilation_started,
+                    input_identities,
+                )?;
+                discovered.verify()?;
+                if learned_enabled
+                    && learned.record.is_none()
+                    && source_is_in_workspace(&compilation)
+                {
+                    record_learned_baseline(&compilation, &discovered);
+                }
+                // An incremental artifact carries state from this checkout's edit
+                // history, so it is recorded as what the unit currently contains --
+                // which is how the next build notices the churn ended -- but never
+                // published for another checkout to restore. The literal key is
+                // enough for that, and it skips reading the outputs back.
+                let action = if learned.engaged() {
+                    &candidates.literal
+                } else {
+                    publish_result(
+                        &candidates,
+                        &portable,
+                        &outputs,
+                        &output,
+                        &portable.mappings,
+                    )?
+                };
+                install_build_script_shim(&invocation, &outputs, &action.digest);
+                // The flight prediction is only left behind a *published* result:
+                // an incremental artifact was withheld from the store, so a
+                // waiter restoring through its key could only miss.
+                record_prediction(
+                    &compilation,
+                    &action.digest,
+                    &discovered,
+                    &timing,
+                    flight
+                        .as_ref()
+                        .filter(|_| !learned.engaged())
+                        .map(|flight| &flight.flight),
+                    remote_claim.as_deref().filter(|_| !learned.engaged()),
+                );
+                Ok(compilation_action_diagnostic(&compilation, action).ok())
+            })();
+            match publication {
+                Ok(diagnostic) => current_diagnostic = diagnostic,
+                Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
+            }
         }
     }
     session::record_compiler_invocation_with_diagnostic(
@@ -887,6 +909,48 @@ fn reuse_hot_workspace_plan(
     }
 }
 
+/// Whether the manifest's prediction for this unit names the inputs its
+/// dep-info now records.
+///
+/// The payload is paths and environment names, never digests, so the common
+/// edit, the one that changes a file's contents and nothing else, leaves it
+/// current. Only an edit that changed which files the crate reads makes the
+/// caller record a fresh one, and it pays the full read-back for that.
+fn manifest_predicts_current_inputs(compilation: &Compilation<'_>, outputs: &RustcOutputs) -> bool {
+    let current = (|| -> Result<bool> {
+        let context = base_action_context(
+            compilation.rustc,
+            compilation.working_dir,
+            compilation.portable,
+        )?;
+        let invocation_digest = compilation.invocation.invocation_digest(&context)?;
+        let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
+            task: prediction_task(&invocation_digest),
+            invocation: invocation_digest.clone(),
+        }])?;
+        let Some(AgentResponse::ActionPrediction {
+            prediction: Some(prediction),
+        }) = responses.into_iter().next()
+        else {
+            return Ok(false);
+        };
+        if prediction.adapter != "rustc" || prediction.invocation != invocation_digest {
+            return Ok(false);
+        }
+        let recorded: RustcInputPrediction = serde_json::from_str(&prediction.payload)?;
+        let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
+        let discovered = compilation.invocation.discover_inputs_with_mappings(
+            &dep_info,
+            compilation.working_dir,
+            &compilation.portable.mappings,
+            session::file_digest_cache(),
+        )?;
+        let now = compilation.invocation.prediction(&context, &discovered)?;
+        Ok(now.inputs == recorded.inputs && now.environment == recorded.environment)
+    })();
+    current.unwrap_or(false)
+}
+
 /// Whether the crate root belongs to the checkout Cargo is building.
 fn source_is_in_workspace(compilation: &Compilation<'_>) -> bool {
     let Some(root) = std::env::var_os(session::WORKSPACE_ROOT_ENV).map(PathBuf::from) else {
@@ -1050,7 +1114,7 @@ fn write_churn_state(path: &Path, sources: &CacheDigest, streak: u32) -> Result<
         sources: sources.key(),
         streak,
     };
-    crate::util::write_atomic(path, &serde_json::to_vec(&state)?)
+    crate::util::write_advisory(path, &serde_json::to_vec(&state)?)
         .wrap_err("failed to record what this crate last compiled")
 }
 

--- a/crates/mbx/src/savings.rs
+++ b/crates/mbx/src/savings.rs
@@ -15,7 +15,7 @@
 //! message, so every failure here is logged and forgotten rather than raised.
 
 use crate::config::SavingsStyle;
-use crate::util::{format_duration, write_atomic};
+use crate::util::{format_duration, write_advisory};
 use bytesize::ByteSize;
 use eyre::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -130,7 +130,7 @@ pub(crate) fn record(store: &Path, delta: &Delta) -> Result<Tally> {
 
     let mut contents = serde_json::to_vec_pretty(&tally)?;
     contents.push(b'\n');
-    write_atomic(&path, &contents)?;
+    write_advisory(&path, &contents)?;
     Ok(tally)
 }
 

--- a/crates/mbx/src/scheduler.rs
+++ b/crates/mbx/src/scheduler.rs
@@ -889,7 +889,8 @@ impl Pool {
         }
         let mut contents = serde_json::to_vec(&ledger)?;
         contents.push(b'\n');
-        crate::util::write_atomic(&path, &contents)
+        // A heuristic every link refreshes: a lost write costs one sample.
+        crate::util::write_advisory(&path, &contents)
     }
 }
 

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -113,6 +113,9 @@ pub struct CacheSession {
     /// The checkout's private state directory once `begin` has claimed it,
     /// where the file-digest ledger is saved when the session finishes.
     ledger_dir: Mutex<Option<PathBuf>>,
+    /// What the ledger file looked like when this session read it, so a
+    /// session that was alone in the checkout can write without merging.
+    ledger_stamp: Arc<Mutex<Option<crate::digest_ledger::Stamp>>>,
     started: Instant,
     shutdown: Mutex<Option<oneshot::Sender<()>>>,
     server: Mutex<Option<JoinHandle<Result<()>>>>,
@@ -123,6 +126,8 @@ pub struct CacheSession {
 pub(super) struct SessionTask {
     identity: std::sync::OnceLock<String>,
     initialized: tokio::sync::OnceCell<bool>,
+    /// Whether any shim connected, which is what makes a run worth committing.
+    connected: std::sync::atomic::AtomicBool,
 }
 
 impl CacheSession {
@@ -153,6 +158,11 @@ impl CacheSession {
         let staging = session_dir.join("staging");
         std::fs::create_dir(&staging)?;
         let store = config.store_dir();
+        let task = Arc::new(SessionTask {
+            identity: std::sync::OnceLock::new(),
+            initialized: tokio::sync::OnceCell::new(),
+            connected: std::sync::atomic::AtomicBool::new(false),
+        });
         let agent = if let Some(remote) = action_remote_cache(config, &store)? {
             CacheAgent::new_remote_with_download_limit(
                 store.clone(),
@@ -171,11 +181,22 @@ impl CacheSession {
             Some(events) => agent.with_observer(Arc::new(events.clone())),
             None => agent,
         };
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let task = Arc::new(SessionTask {
-            identity: std::sync::OnceLock::new(),
-            initialized: tokio::sync::OnceCell::new(),
+        // A shim that needs the build's predictions is the one that waits for
+        // the manifest; the probes cargo runs first only report bypasses.
+        let agent = agent.with_task_loader({
+            let task = Arc::clone(&task);
+            Arc::new(move |agent: &CacheAgent, identity: &str| {
+                let task = Arc::clone(&task);
+                let identity = identity.to_string();
+                Box::pin(async move {
+                    if task.identity.get().is_some_and(|known| *known == identity) {
+                        server::initialize_task(agent, &task).await;
+                    }
+                })
+                    as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>>
+            })
         });
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (socket, server) =
             spawn_server(session_dir, agent.clone(), Arc::clone(&task), shutdown_rx).await?;
         Ok(Self {
@@ -194,6 +215,7 @@ impl CacheSession {
             store,
             incremental_root: config.cache_dir.join("incremental"),
             ledger_dir: Mutex::new(None),
+            ledger_stamp: Arc::new(Mutex::new(None)),
             started: Instant::now(),
             shutdown: Mutex::new(Some(shutdown_tx)),
             server: Mutex::new(Some(server)),
@@ -230,6 +252,17 @@ impl CacheSession {
             warn!("this checkout was not recorded as a cache root: {error}");
         }
         let _ = self.task.identity.set(identity.clone());
+        // Read now, in the background, rather than when the first shim
+        // connects: cargo spends its own startup planning the build, and that
+        // is time the manifest can be parsed in instead of stalling the first
+        // compilation on it.
+        {
+            let agent = self.agent.clone();
+            let task = Arc::clone(&self.task);
+            tokio::spawn(async move {
+                server::initialize_task(&agent, &task).await;
+            });
+        }
         let action_run = Some(ActionRun {
             run: identity.clone(),
             receipt: build_receipt_run(&identity),
@@ -267,13 +300,20 @@ impl CacheSession {
                     INCREMENTAL_ROOT_ENV.into(),
                     root.to_string_lossy().into_owned(),
                 );
-                // Seeded before any shim can ask: the first compilation of the
-                // crate being edited is the one that would otherwise read every
-                // unchanged dependency again.
-                let seeded = self
-                    .agent
-                    .seed_file_digests(crate::digest_ledger::load(&root));
-                debug!("file-digest ledger seeded with {seeded} entries");
+                // Seeded under the ledger's own lock on a blocking thread, so
+                // cargo's startup overlaps the read, and a shim that asks
+                // before it is done waits for the answer instead of hashing
+                // every unchanged dependency again.
+                let agent = self.agent.clone();
+                let ledger_root = root.clone();
+                let stamp = Arc::clone(&self.ledger_stamp);
+                tokio::task::spawn_blocking(move || {
+                    let seeded = agent.seed_file_digests_with(|| {
+                        *stamp.lock().unwrap() = crate::digest_ledger::stamp(&ledger_root);
+                        crate::digest_ledger::load(&ledger_root)
+                    });
+                    debug!("file-digest ledger seeded with {seeded} entries");
+                });
                 *self.ledger_dir.lock().unwrap() = Some(root);
             }
             Err(error) => warn!("incremental state was not recorded: {error:#}"),
@@ -517,7 +557,8 @@ impl CacheSession {
         // session in this checkout starts from everything this one hashed.
         // Best-effort like the ledger itself.
         if let Some(ledger_dir) = self.ledger_dir.lock().unwrap().take() {
-            match crate::digest_ledger::save(&ledger_dir, self.agent.file_digests()) {
+            let stamp = self.ledger_stamp.lock().unwrap().take();
+            match crate::digest_ledger::save(&ledger_dir, self.agent.file_digests(), stamp) {
                 Ok(count) => debug!("file-digest ledger saved with {count} entries"),
                 Err(error) => warn!("the file-digest ledger was not saved: {error:#}"),
             }
@@ -702,14 +743,20 @@ pub struct ActionRun {
 
 impl ActionRun {
     pub async fn commit(self) -> Result<()> {
-        if self
-            .initialized
-            .as_ref()
-            .is_some_and(|task| task.initialized.get() != Some(&true))
-        {
+        if self.initialized.as_ref().is_some_and(|task| {
+            !task.connected.load(std::sync::atomic::Ordering::Relaxed)
+                || task.initialized.get() != Some(&true)
+        }) {
             return Ok(());
         }
         let predictions = self.agent.commit_task_actions(&self.run).await?;
+        // A build that predicted nothing new has nothing to export that the
+        // receipt before it did not already name, so that receipt stands. A
+        // grouped export still gets its receipt: the group is the record of
+        // which runs took part.
+        if predictions.is_empty() && self.export_group.is_none() {
+            return Ok(());
+        }
         crate::store::record_build_receipt(
             &self.store,
             &self.receipt,

--- a/crates/mbx/src/session/server.rs
+++ b/crates/mbx/src/session/server.rs
@@ -147,7 +147,7 @@ pub(super) async fn spawn_server(
                     let agent = agent.clone();
                     let task = Arc::clone(&task);
                     connections.spawn(async move {
-                        initialize_task(&agent, &task).await;
+                        task.connected.store(true, std::sync::atomic::Ordering::Relaxed);
                         if let Err(error) = agent.handle_connection(stream).await {
                             debug!("cache agent connection failed: {error}");
                         }
@@ -213,7 +213,7 @@ fn spawn_fifo_server(
                                 let result = (|| {
                                     let (reader, writer) = accept_fifo_client(&connection_path)?;
                                     runtime.block_on(async {
-                                        initialize_task(&agent, &task).await;
+                                        task.connected.store(true, std::sync::atomic::Ordering::Relaxed);
                                         let stream = tokio::io::join(
                                             BlockingFifoReader(reader),
                                             BlockingFifoWriter(writer),
@@ -468,6 +468,7 @@ mod tests {
         let task = Arc::new(super::super::SessionTask {
             identity: std::sync::OnceLock::new(),
             initialized: tokio::sync::OnceCell::new(),
+            connected: std::sync::atomic::AtomicBool::new(false),
         });
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (endpoint, server) =
@@ -508,6 +509,7 @@ mod tests {
         let task = Arc::new(super::super::SessionTask {
             identity: std::sync::OnceLock::new(),
             initialized: tokio::sync::OnceCell::new(),
+            connected: std::sync::atomic::AtomicBool::new(false),
         });
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (endpoint, server) =
@@ -579,7 +581,7 @@ pub(super) async fn spawn_server(
                     let agent = agent.clone();
                     let task = Arc::clone(&task);
                     connections.spawn(async move {
-                        initialize_task(&agent, &task).await;
+                        task.connected.store(true, std::sync::atomic::Ordering::Relaxed);
                         if let Err(error) = agent.handle_connection(pipe).await {
                             debug!("cache agent connection failed: {error}");
                         }
@@ -599,7 +601,7 @@ pub(super) async fn spawn_server(
     Ok((endpoint, server))
 }
 
-async fn initialize_task(agent: &CacheAgent, task: &super::SessionTask) {
+pub(super) async fn initialize_task(agent: &CacheAgent, task: &super::SessionTask) {
     let Some(identity) = task.identity.get() else {
         return;
     };

--- a/crates/mbx/src/target.rs
+++ b/crates/mbx/src/target.rs
@@ -851,7 +851,7 @@ fn record_view(root: &Path, workspace_root: &Path) -> Result<()> {
     };
     let mut contents = serde_json::to_vec(&record)?;
     contents.push(b'\n');
-    crate::util::write_atomic(&view_record_path(root, workspace_root), &contents)
+    crate::util::write_advisory(&view_record_path(root, workspace_root), &contents)
 }
 
 fn read_record_state(path: &Path) -> Result<Option<Vec<u8>>> {
@@ -864,7 +864,7 @@ fn read_record_state(path: &Path) -> Result<Option<Vec<u8>>> {
 
 fn restore_record_state(path: &Path, previous: Option<Vec<u8>>) -> Result<()> {
     if let Some(contents) = previous {
-        return crate::util::write_atomic(path, &contents);
+        return crate::util::write_advisory(path, &contents);
     }
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -112,6 +112,32 @@ pub fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// Replace `path` atomically without waiting for the bytes to reach disk.
+///
+/// For records a build rewrites every time it runs and reads back only as a
+/// shortcut: a checkout's last-used stamp, a crate's churn record, the
+/// file-digest ledger. Losing the newest one to a power cut costs the next
+/// build a rehash or a record one build older, and every reader here treats
+/// a torn file as no file. `sync_all` is what makes [`write_atomic`] cost a
+/// disk round trip per call, and a build pays for several of these.
+pub fn write_advisory(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| eyre::eyre!("path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".mbx-")
+        .tempfile_in(parent)?;
+    temporary.write_all(contents)?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .wrap_err_with(|| format!("failed atomic write: {}", path.display()))?;
+    Ok(())
+}
+
 /// Format a duration for humans, widening precision as the duration grows.
 pub fn format_duration(duration: Duration) -> String {
     if duration < Duration::from_millis(1) {

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -1953,6 +1953,11 @@ fn a_failed_build_records_the_compilations_it_completed() {
         .env("MBX_GC_AUTO", "0")
         .env_remove("CARGO_TARGET_DIR")
         .env_remove("CARGO_INCREMENTAL")
+        // A test run that is itself under mbx would otherwise hand its
+        // wrapper down, and the build under test would defer to it and
+        // record nothing.
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .output()
         .expect("mbx should run");
 


### PR DESCRIPTION
## What

On a hot edit of a workspace crate that mbx compiles with its own incremental state, the shim added about a second per build on mise, none of it in rustc. This trims the bookkeeping that scaled with the size of the checkout's records:

- An incremental unit no longer rebuilds its action after compiling. It is never published, and what it compiled was fingerprinted before the compiler ran, so re-hashing every input recorded a prediction nothing looks up. Two exceptions keep the old path: a build script, whose execution shim is installed under that key, and a unit whose dep-info now names different inputs than the manifest predicts. A wiped target rebuilds the churn comparison from the manifest, so an edit that adds or drops an `include_str!` has to reach it, or settled sources would read as another edit (this is what `editing_one_crate_takes_its_dependents_private_too` caught).
- The task manifest is read once when a task begins instead of twice with a rewrite in between, and a run that predicted nothing new leaves it as it found it instead of serializing every inherited prediction. On mise the manifest is 24 MB.
- The manifest loads in the background as soon as the session begins, and only a request that reads or records a prediction waits for it (`CacheAgent::with_task_loader`). Cargo's compiler probes used to stall on that parse at every connection.
- The file-digest ledger is seeded under its own lock on a blocking thread, overlapping cargo's startup, and a session that finds the file as it left it writes without re-reading and merging it. The stat sweep for vanished files runs only above 64k entries.
- Records every build rewrites and only reads back as a shortcut (checkout stamp, churn record, scheduler memory ledger, savings tally, ledger) are written without fsync. A power cut costs one build's worth of recency.
- A build that completed nothing new does not overwrite the checkout's last receipt with an empty one; grouped exports still get theirs.

## Measurements

Profiled on a hot edit of the mise binary (bin-crate edit, 442 source files, 24 MB manifest, 26k-entry ledger). Per build, before and after:

| Work | before | after |
|---|---|---|
| post-compile action rebuild for the incremental unit | 240ms | ~35ms input-set check |
| task manifest at first shim connection | 200ms stall | 65ms in background |
| task manifest rewrite at commit | 200ms | 2ms |
| ledger load and seed | 90ms | background |
| ledger save | 130ms | 20ms |
| fsync'd record writes | 6 × 9ms | 0 |
| root probe, wrapper pre-compile, misc | ~100ms | ~100ms |

rustc itself is unaffected: the command lines differ from raw cargo only in paths, hashes, and the incremental directory, and sampled rustc lifetimes matched. mbx's session time minus compiler time is now about 1s including cargo's own startup, the same as raw cargo's.

## Reviewer notes

- `RemoteCacheMode` defaults to `ReadWrite` with no remote configured, so the local-only paths test `remote.is_none()`, not the mode.
- `a_failed_build_records_the_compilations_it_completed` only passed before because a test run nested inside an outer mbx session handed its `RUSTC_WRAPPER` down, the inner build deferred to it and recorded nothing, and an empty manifest was still written. The test now scrubs the inherited wrapper and exercises a real build.
- Rebased on #326. Verified with clippy and the full workspace test suite under plain cargo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches incremental prediction/manifest correctness and ledger persistence semantics; mitigations are explicit (input-set check, stamp-based merge skip, idempotent task loader) but regressions would show up as wrong cache hits or stale manifests rather than build failures.
> 
> **Overview**
> This PR cuts **session overhead on repeated edits** by deferring or skipping work that used to run on every compile and commit, without changing rustc itself.
> 
> **Incremental compiles** skip the full post-compile action rebuild (re-hashing inputs and recording predictions nothing looks up) unless a build-script shim is needed or **`manifest_predicts_current_inputs`** finds the manifest’s input set out of date vs current dep-info—so churn detection still sees `include_str!`-style graph changes after a wiped target.
> 
> **Task manifests**: `CacheAgent::with_task_loader` loads the manifest on the first prediction read/record; the session **starts that load in the background** at `begin` instead of on every shim connect. Local-only agents **skip a second read/merge/persist** at begin and **skip rewriting the manifest on commit** when there are no new pending predictions (and no remote writes).
> 
> **File-digest ledger**: seeding uses **`seed_file_digests_with`** on a blocking thread so cargo startup overlaps disk I/O; saves take an optional **stamp** to skip re-read/merge when the file is unchanged, and **existence sweeps** run only above 64k entries. **`write_advisory`** (atomic rename, no `fsync`) replaces `write_atomic` for frequently rewritten bookkeeping (checkout stamps, churn, ledger, savings, scheduler samples).
> 
> **Session commit** tracks shim **connection** and skips empty build receipts when nothing new was predicted (grouped exports unchanged). Integration test scrubs inherited **`RUSTC_WRAPPER`** so nested mbx runs don’t mask recording behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db47964d864fdb2a79423c83053f8ed754d79f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->