### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.17...mbx-cache-cargo-v0.1.18) - 2026-09-04
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.17](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.16...mbx-cache-cargo-v0.1.17) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.17"
+version = "0.1.18"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.4...mbx-cache-cc-v0.11.5) - 2026-09-04
+
+### Fixed
+
+- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
+
 ## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.2...mbx-cache-cc-v0.11.3) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.11.4"
+version = "0.11.5"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.4...mbx-cache-core-v0.11.5) - 2026-09-04
+
+### Fixed
+
+- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
+
 ## [0.11.4](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.3...mbx-cache-core-v0.11.4) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.11.4"
+version = "0.11.5"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.4...mbx-cache-rustc-v0.11.5) - 2026-09-04
+
+### Fixed
+
+- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
+
 ## [0.11.3](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.2...mbx-cache-rustc-v0.11.3) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.11.4"
+version = "0.11.5"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.16...mbx-cache-store-v0.1.17) - 2026-09-04
+
+### Added
+
+- *(cache)* restore Cargo workspace state from exports ([#337](https://github.com/jdx/mr-boxington/pull/337))
+
 ## [0.1.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.15...mbx-cache-store-v0.1.16) - 2026-09-03
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.16"
+version = "0.1.17"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/jdx/mr-boxington/compare/v1.7.0...v1.8.0) - 2026-09-04
+
+### Added
+
+- *(cache)* restore Cargo workspace state from exports ([#337](https://github.com/jdx/mr-boxington/pull/337))
+
+### Fixed
+
+- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
+
 ## [1.7.0](https://github.com/jdx/mr-boxington/compare/v1.6.0...v1.7.0) - 2026-09-03
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.7.0"
+version = "1.8.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -26,11 +26,11 @@ flate2 = "1"
 hex = "0.4"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.4", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.17", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.4", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.4", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.16", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.18", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.5", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.5", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.17", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.7.0
+**Version:** 1.8.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.11.4 -> 0.11.5 (✓ API compatible changes)
* `mbx-cache-cc`: 0.11.4 -> 0.11.5 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.11.4 -> 0.11.5 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `mbx`: 1.7.0 -> 1.8.0 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.17 -> 0.1.18

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.4...mbx-cache-core-v0.11.5) - 2026-09-04

### Fixed

- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.4...mbx-cache-cc-v0.11.5) - 2026-09-04

### Fixed

- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.4...mbx-cache-rustc-v0.11.5) - 2026-09-04

### Fixed

- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.17](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.16...mbx-cache-store-v0.1.17) - 2026-09-04

### Added

- *(cache)* restore Cargo workspace state from exports ([#337](https://github.com/jdx/mr-boxington/pull/337))
</blockquote>

## `mbx`

<blockquote>

## [1.8.0](https://github.com/jdx/mr-boxington/compare/v1.7.0...v1.8.0) - 2026-09-04

### Added

- *(cache)* restore Cargo workspace state from exports ([#337](https://github.com/jdx/mr-boxington/pull/337))

### Fixed

- verify NFS compiler inputs by content ([#338](https://github.com/jdx/mr-boxington/pull/338))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.18](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.17...mbx-cache-cargo-v0.1.18) - 2026-09-04

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version numbers, lockfile entries, changelogs, and generated CLI version text change; behavioral fixes ship via already-merged commits tagged in the release notes.
> 
> **Overview**
> **Release-only PR** (release-plz): bumps crate versions, refreshes `Cargo.lock`, and records **1.8.0** / patch releases in changelogs and CLI docs—no application source changes in this diff.
> 
> The **mbx 1.8.0** release notes bundled here are **restore Cargo workspace state from cache exports** ([#337](https://github.com/jdx/mr-boxington/pull/337)) and **verify compiler inputs by content on NFS** ([#338](https://github.com/jdx/mr-boxington/pull/338)), reflected across `mbx`, `mbx-cache-store`, `mbx-cache-core`, `mbx-cache-cc`, `mbx-cache-rustc`, and a dependency-only bump for `mbx-cache-cargo` **0.1.18**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb667de032235158584c41740955fc3486684ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->