### PR TITLE
feat(cache): restore Cargo workspace state from exports

### DIFF
--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -30,7 +30,8 @@ const CHECKOUT_RECORD_VERSION: u8 = 1;
 const BUILD_RECEIPTS_DIR: &str = "build-receipts/v1";
 const BUILD_RECEIPT_VERSION: u8 = 1;
 const EXPORT_MANIFEST: &str = "mbx-cache-export-v1.json";
-const EXPORT_VERSION: u8 = 1;
+const EXPORT_VERSION: u8 = 2;
+const LEGACY_EXPORT_VERSION: u8 = 1;
 
 const SESSION_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 const MAX_SESSIONS: usize = 256;
@@ -111,6 +112,23 @@ pub struct TransferOutcome {
     pub actions: u64,
     pub objects: u64,
     pub bytes: u64,
+    pub attachments: BTreeMap<String, CacheDigest>,
+}
+
+/// Extra CAS roots carried by a cache export for a higher-level transport.
+#[derive(Debug, Default)]
+pub struct ExportAdditions {
+    /// Stable names by which the importer can discover selected objects.
+    pub attachments: BTreeMap<String, CacheDigest>,
+    /// Every object the attachments reach, including the named objects.
+    pub objects: BTreeSet<CacheDigest>,
+}
+
+/// One Cargo workspace and the target directory recorded for its build.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WorkspaceTarget {
+    pub workspace_root: PathBuf,
+    pub target_dir: PathBuf,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -119,6 +137,10 @@ struct ExportManifest {
     version: u8,
     tasks: Vec<TaskActionManifest>,
     actions: Vec<CacheDigest>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    attachments: BTreeMap<String, CacheDigest>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    objects: Vec<CacheDigest>,
 }
 
 /// The exact cache predictions completed by one top-level build command.
@@ -242,11 +264,81 @@ pub fn export_checkout(
                 workspace_root.display()
             )
         })?;
-    export_receipts(store, vec![receipt], archive)
+    export_receipts(store, vec![receipt], archive, ExportAdditions::default())
+}
+
+/// Return the target directory recorded for this checkout's latest build.
+pub fn checkout_workspace_target(
+    store: &Path,
+    workspace_root: &Path,
+) -> Result<Option<WorkspaceTarget>> {
+    let Some(receipt) = read_build_receipt(&latest_receipt_path(store, workspace_root))
+        .filter(|receipt| receipt.workspace_root == workspace_root)
+    else {
+        return Ok(None);
+    };
+    Ok(workspace_target_for_receipt(store, &receipt))
+}
+
+/// Return every Cargo target represented by the pending receipts in a group.
+pub fn group_workspace_targets(store: &Path, group: &str) -> Result<Vec<WorkspaceTarget>> {
+    validate_export_group(group)?;
+    let root = store
+        .join(BUILD_RECEIPTS_DIR)
+        .join("groups")
+        .join(group_key(group));
+    let targets = walk_files(&root)?
+        .into_iter()
+        .filter_map(|entry| read_build_receipt(&entry.path))
+        .filter(|receipt| receipt.group.as_deref() == Some(group))
+        .filter_map(|receipt| workspace_target_for_receipt(store, &receipt))
+        .collect::<BTreeSet<_>>();
+    Ok(targets.into_iter().collect())
+}
+
+fn workspace_target_for_receipt(store: &Path, receipt: &BuildReceipt) -> Option<WorkspaceTarget> {
+    let record = read_checkout_record(&checkout_record_path(
+        store,
+        &receipt.identity,
+        &receipt.workspace_root,
+    ))?;
+    (record.workspace_root == receipt.workspace_root && record.target_dir != record.workspace_root)
+        .then_some(WorkspaceTarget {
+            workspace_root: record.workspace_root,
+            target_dir: record.target_dir,
+        })
+}
+
+/// Export one checkout's closure together with higher-level CAS attachments.
+pub fn export_checkout_with(
+    store: &Path,
+    workspace_root: &Path,
+    archive: &Path,
+    additions: ExportAdditions,
+) -> Result<TransferOutcome> {
+    let receipt = read_build_receipt(&latest_receipt_path(store, workspace_root))
+        .filter(|receipt| receipt.workspace_root == workspace_root)
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "no completed mbx build is recorded for {}",
+                workspace_root.display()
+            )
+        })?;
+    export_receipts(store, vec![receipt], archive, additions)
 }
 
 /// Export the union of every completed build recorded under one CI group.
 pub fn export_group(store: &Path, group: &str, archive: &Path) -> Result<TransferOutcome> {
+    export_group_with(store, group, archive, ExportAdditions::default())
+}
+
+/// Export a grouped closure together with higher-level CAS attachments.
+pub fn export_group_with(
+    store: &Path,
+    group: &str,
+    archive: &Path,
+    additions: ExportAdditions,
+) -> Result<TransferOutcome> {
     validate_export_group(group)?;
     let root = store
         .join(BUILD_RECEIPTS_DIR)
@@ -267,6 +359,7 @@ pub fn export_group(store: &Path, group: &str, archive: &Path) -> Result<Transfe
             .map(|(_, receipt)| receipt.clone())
             .collect(),
         archive,
+        additions,
     )?;
     // A receipt is a pending-export root. Retire only the files this export
     // consumed, and only after its complete archive has been published. A
@@ -283,6 +376,7 @@ fn export_receipts(
     store: &Path,
     mut receipts: Vec<BuildReceipt>,
     archive: &Path,
+    additions: ExportAdditions,
 ) -> Result<TransferOutcome> {
     receipts.sort_by_key(|receipt| receipt.completed_nanos);
     let mut actions = BTreeSet::new();
@@ -307,7 +401,12 @@ fn export_receipts(
         );
     }
     let tasks = tasks.into_values().collect::<Vec<_>>();
-    let (objects, result_paths) = strict_closure(store, &actions)?;
+    validate_export_additions(&additions)?;
+    let (mut objects, result_paths) = strict_closure(store, &actions)?;
+    let cas = LocalCas::new(store);
+    for digest in &additions.objects {
+        require_object(&cas, &mut objects, digest)?;
+    }
     let parent = archive
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -321,9 +420,15 @@ fn export_receipts(
         &mut builder,
         Path::new(EXPORT_MANIFEST),
         &serde_json::to_vec(&ExportManifest {
-            version: EXPORT_VERSION,
+            version: if additions.attachments.is_empty() && additions.objects.is_empty() {
+                LEGACY_EXPORT_VERSION
+            } else {
+                EXPORT_VERSION
+            },
             tasks,
             actions: actions.iter().cloned().collect(),
+            attachments: additions.attachments.clone(),
+            objects: additions.objects.iter().cloned().collect(),
         })?,
     )?;
     for path in objects.iter().chain(result_paths.iter()) {
@@ -340,6 +445,7 @@ fn export_receipts(
         actions: actions.len() as u64,
         objects: objects.len() as u64,
         bytes,
+        attachments: additions.attachments,
     })
 }
 
@@ -376,7 +482,9 @@ pub fn import_archive(store: &Path, archive: &Path) -> Result<TransferOutcome> {
         .iter()
         .map(|task| task.task.as_str())
         .collect::<BTreeSet<_>>();
-    if manifest.version != EXPORT_VERSION
+    if !matches!(manifest.version, LEGACY_EXPORT_VERSION | EXPORT_VERSION)
+        || (manifest.version == LEGACY_EXPORT_VERSION
+            && (!manifest.attachments.is_empty() || !manifest.objects.is_empty()))
         || manifest.tasks.is_empty()
         || actions.len() != manifest.actions.len()
         || task_identities.len() != manifest.tasks.len()
@@ -390,11 +498,30 @@ pub fn import_archive(store: &Path, archive: &Path) -> Result<TransferOutcome> {
                 .iter()
                 .any(|prediction| !actions.contains(&prediction.action))
         })
+        || manifest
+            .attachments
+            .keys()
+            .any(|name| !valid_attachment_name(name))
+        || manifest.attachments.values().any(|digest| {
+            digest.algorithm != "blake3"
+                || digest.validate().is_err()
+                || !manifest.objects.contains(digest)
+        })
+        || manifest.objects.iter().collect::<BTreeSet<_>>().len() != manifest.objects.len()
+        || manifest
+            .objects
+            .iter()
+            .any(|digest| digest.algorithm != "blake3" || digest.validate().is_err())
     {
         eyre::bail!("unsupported or invalid cache export manifest");
     }
-    let (objects, result_paths) = strict_closure(staging.path(), &actions)
+    let (mut objects, result_paths) = strict_closure(staging.path(), &actions)
         .wrap_err("cache export is incomplete or corrupt")?;
+    let staged_cas = LocalCas::new(staging.path());
+    for digest in &manifest.objects {
+        require_object(&staged_cas, &mut objects, digest)
+            .wrap_err("cache export attachment is incomplete or corrupt")?;
+    }
 
     let cas = LocalCas::new(store);
     for path in &objects {
@@ -416,7 +543,35 @@ pub fn import_archive(store: &Path, archive: &Path) -> Result<TransferOutcome> {
         actions: actions.len() as u64,
         objects: objects.len() as u64,
         bytes: std::fs::metadata(archive)?.len(),
+        attachments: manifest.attachments,
     })
+}
+
+fn validate_export_additions(additions: &ExportAdditions) -> Result<()> {
+    if additions
+        .attachments
+        .keys()
+        .any(|name| !valid_attachment_name(name))
+        || additions
+            .attachments
+            .values()
+            .any(|digest| !additions.objects.contains(digest))
+        || additions
+            .objects
+            .iter()
+            .any(|digest| digest.algorithm != "blake3" || digest.validate().is_err())
+    {
+        eyre::bail!("invalid cache export attachment");
+    }
+    Ok(())
+}
+
+fn valid_attachment_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn strict_closure(

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -112,6 +112,13 @@ pub struct TransferOutcome {
     pub actions: u64,
     pub objects: u64,
     pub bytes: u64,
+}
+
+/// A cache import together with named higher-level CAS roots it carried.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ImportOutcome {
+    pub transfer: TransferOutcome,
     pub attachments: BTreeMap<String, CacheDigest>,
 }
 
@@ -445,12 +452,16 @@ fn export_receipts(
         actions: actions.len() as u64,
         objects: objects.len() as u64,
         bytes,
-        attachments: additions.attachments,
     })
 }
 
 /// Validate a cache export in isolation, then publish its objects and actions.
 pub fn import_archive(store: &Path, archive: &Path) -> Result<TransferOutcome> {
+    Ok(import_archive_with_attachments(store, archive)?.transfer)
+}
+
+/// Import a cache archive and return its named higher-level CAS roots.
+pub fn import_archive_with_attachments(store: &Path, archive: &Path) -> Result<ImportOutcome> {
     let staging = tempfile::tempdir()?;
     let file = std::fs::File::open(archive)
         .wrap_err_with(|| format!("failed to open {}", archive.display()))?;
@@ -539,10 +550,12 @@ pub fn import_archive(store: &Path, archive: &Path) -> Result<TransferOutcome> {
     for task in manifest.tasks {
         merge_imported_manifest(store, task)?;
     }
-    Ok(TransferOutcome {
-        actions: actions.len() as u64,
-        objects: objects.len() as u64,
-        bytes: std::fs::metadata(archive)?.len(),
+    Ok(ImportOutcome {
+        transfer: TransferOutcome {
+            actions: actions.len() as u64,
+            objects: objects.len() as u64,
+            bytes: std::fs::metadata(archive)?.len(),
+        },
         attachments: manifest.attachments,
     })
 }

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -348,6 +348,78 @@ fn exports_and_imports_the_last_builds_complete_closure() {
     );
 }
 
+#[test]
+fn exports_and_imports_named_attachment_objects() {
+    let source = tempfile::tempdir().unwrap();
+    let destination = tempfile::tempdir().unwrap();
+    let workspace = source.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let action = store_result(source.path(), "compile action", &[]);
+    record_build(source.path(), &"7".repeat(64), &workspace, &[action]);
+    let attachment = store_object(source.path(), b"Cargo scheduler state");
+    let additions = ExportAdditions {
+        attachments: BTreeMap::from([("cargo-state-v1".into(), attachment.clone())]),
+        objects: BTreeSet::from([attachment.clone()]),
+    };
+    let archive = source.path().join("build.tar");
+
+    let exported = export_checkout_with(source.path(), &workspace, &archive, additions).unwrap();
+    let imported = import_archive(destination.path(), &archive).unwrap();
+
+    assert_eq!(
+        exported.attachments.get("cargo-state-v1"),
+        Some(&attachment)
+    );
+    assert_eq!(
+        imported.attachments.get("cargo-state-v1"),
+        Some(&attachment)
+    );
+    assert!(
+        LocalCas::new(destination.path())
+            .find(&attachment)
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
+fn reports_the_targets_represented_by_a_group() {
+    let store = tempfile::tempdir().unwrap();
+    let first = store.path().join("first");
+    let second = store.path().join("second");
+    std::fs::create_dir_all(&first).unwrap();
+    std::fs::create_dir_all(&second).unwrap();
+    let action = store_result(store.path(), "compile action", &[]);
+    record_build_in_group(
+        store.path(),
+        &"6".repeat(64),
+        &first,
+        std::slice::from_ref(&action),
+        Some("ci-job"),
+    );
+    record_build_in_group(
+        store.path(),
+        &"5".repeat(64),
+        &second,
+        &[action],
+        Some("ci-job"),
+    );
+
+    assert_eq!(
+        group_workspace_targets(store.path(), "ci-job").unwrap(),
+        vec![
+            WorkspaceTarget {
+                workspace_root: first.clone(),
+                target_dir: first.join("target"),
+            },
+            WorkspaceTarget {
+                workspace_root: second.clone(),
+                target_dir: second.join("target"),
+            },
+        ]
+    );
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn imports_sparse_files_emitted_by_the_exporter() {

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -364,12 +364,9 @@ fn exports_and_imports_named_attachment_objects() {
     let archive = source.path().join("build.tar");
 
     let exported = export_checkout_with(source.path(), &workspace, &archive, additions).unwrap();
-    let imported = import_archive(destination.path(), &archive).unwrap();
+    let imported = import_archive_with_attachments(destination.path(), &archive).unwrap();
 
-    assert_eq!(
-        exported.attachments.get("cargo-state-v1"),
-        Some(&attachment)
-    );
+    assert_eq!(exported.actions, 1);
     assert_eq!(
         imported.attachments.get("cargo-state-v1"),
         Some(&attachment)

--- a/crates/mbx/src/cli/cache.rs
+++ b/crates/mbx/src/cli/cache.rs
@@ -1,7 +1,7 @@
 use super::cargo::{absolute, cargo_roots};
 use super::exec::discover_project_root;
 use crate::config::Config;
-use crate::{store, target};
+use crate::{store, target, workspace_state};
 use bytesize::ByteSize;
 use eyre::Result;
 use std::path::{Path, PathBuf};
@@ -105,9 +105,17 @@ pub(super) fn cache_export(config: &Config, archive: &Path, group: Option<&str>)
     let workspace = cargo_roots(&cargo, &[], None)
         .map(|roots| roots.workspace_root)
         .unwrap_or_else(|| discover_project_root(&working_dir));
+    let store_dir = config.store_dir();
+    let targets = match group {
+        Some(group) => store::group_workspace_targets(&store_dir, group)?,
+        None => store::checkout_workspace_target(&store_dir, &workspace)?
+            .into_iter()
+            .collect(),
+    };
+    let additions = workspace_state::capture(&store_dir, &targets)?;
     let outcome = match group {
-        Some(group) => store::export_group(&config.store_dir(), group, archive)?,
-        None => store::export_checkout(&config.store_dir(), &workspace, archive)?,
+        Some(group) => store::export_group_with(&store_dir, group, archive, additions)?,
+        None => store::export_checkout_with(&store_dir, &workspace, archive, additions)?,
     };
     let subject = group.map_or_else(
         || workspace.display().to_string(),
@@ -123,7 +131,26 @@ pub(super) fn cache_export(config: &Config, archive: &Path, group: Option<&str>)
 }
 
 pub(super) fn cache_import(config: &Config, archive: &Path) -> Result<()> {
-    let outcome = store::import_archive(&config.store_dir(), archive)?;
+    let store = config.store_dir();
+    let outcome = store::import_archive(&store, archive)?;
+    let restored = if let Some(attachment) = outcome.attachments.get(workspace_state::ATTACHMENT) {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        if let Some(roots) = cargo_roots(&cargo, &[], None) {
+            workspace_state::restore(
+                config,
+                &store,
+                attachment,
+                &roots.workspace_root,
+                &roots.target_dir,
+                roots.target_dir_requested,
+            )?
+        } else {
+            log::debug!("no Cargo workspace was available for workspace-state restore");
+            None
+        }
+    } else {
+        None
+    };
     println!(
         "imported {} actions and {} objects from {} ({})",
         outcome.actions,
@@ -131,6 +158,13 @@ pub(super) fn cache_import(config: &Config, archive: &Path) -> Result<()> {
         archive.display(),
         ByteSize::b(outcome.bytes).display().iec()
     );
+    if let Some(restored) = restored {
+        println!(
+            "restored Cargo workspace state ({} referenced files, {})",
+            restored.files,
+            ByteSize::b(restored.referenced_bytes).display().iec()
+        );
+    }
     Ok(())
 }
 

--- a/crates/mbx/src/cli/cache.rs
+++ b/crates/mbx/src/cli/cache.rs
@@ -117,7 +117,13 @@ pub(super) fn cache_export(config: &Config, archive: &Path, group: Option<&str>)
             .into_iter()
             .collect(),
     };
-    let additions = workspace_state::capture(&store_dir, &targets)?;
+    let additions = match workspace_state::capture(&store_dir, &targets) {
+        Ok(additions) => additions,
+        Err(error) => {
+            log::warn!("Cargo workspace state was not included in the cache export: {error}");
+            store::ExportAdditions::default()
+        }
+    };
     let outcome = match group {
         Some(group) => store::export_group_with(&store_dir, group, archive, additions)?,
         None => store::export_checkout_with(&store_dir, &workspace, archive, additions)?,
@@ -141,14 +147,20 @@ pub(super) fn cache_import(config: &Config, archive: &Path) -> Result<()> {
     let restored = if let Some(attachment) = imported.attachments.get(workspace_state::ATTACHMENT) {
         let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
         if let Some(roots) = cargo_roots(&cargo, &[], None) {
-            workspace_state::restore(
+            match workspace_state::restore(
                 config,
                 &store,
                 attachment,
                 &roots.workspace_root,
                 &roots.target_dir,
                 roots.target_dir_requested,
-            )?
+            ) {
+                Ok(restored) => restored,
+                Err(error) => {
+                    log::warn!("cache imported without restoring Cargo workspace state: {error}");
+                    None
+                }
+            }
         } else {
             log::debug!("no Cargo workspace was available for workspace-state restore");
             None

--- a/crates/mbx/src/cli/cache.rs
+++ b/crates/mbx/src/cli/cache.rs
@@ -25,9 +25,14 @@ pub(super) enum CacheCommands {
     Largest(LargestArgs),
     /// Verify local objects and action results.
     Verify,
-    /// Export the cache closure of this checkout's last build.
+    /// Export the cache closure of this checkout's last build. The export includes
+    /// Cargo scheduler state for recorded workspaces, with compiler outputs referenced
+    /// from the content-addressed closure instead of duplicated.
     Export(ExportArgs),
-    /// Import a cache export into the local store.
+    /// Import a cache export into the local store. If the export contains Cargo
+    /// workspace state and the command runs from a matching checkout with an absent or
+    /// empty target directory, restore that state as well. A non-empty target
+    /// directory is never replaced.
     Import(ImportArgs),
     /// Remove one workspace's managed target and cache claims.
     Remove(RemoveCacheArgs),
@@ -132,8 +137,8 @@ pub(super) fn cache_export(config: &Config, archive: &Path, group: Option<&str>)
 
 pub(super) fn cache_import(config: &Config, archive: &Path) -> Result<()> {
     let store = config.store_dir();
-    let outcome = store::import_archive(&store, archive)?;
-    let restored = if let Some(attachment) = outcome.attachments.get(workspace_state::ATTACHMENT) {
+    let imported = store::import_archive_with_attachments(&store, archive)?;
+    let restored = if let Some(attachment) = imported.attachments.get(workspace_state::ATTACHMENT) {
         let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
         if let Some(roots) = cargo_roots(&cargo, &[], None) {
             workspace_state::restore(
@@ -151,6 +156,7 @@ pub(super) fn cache_import(config: &Config, archive: &Path) -> Result<()> {
     } else {
         None
     };
+    let outcome = imported.transfer;
     println!(
         "imported {} actions and {} objects from {} ({})",
         outcome.actions,

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -56,3 +56,4 @@ mod materialize;
 mod rustc;
 mod rustdoc;
 mod scheduler;
+mod workspace_state;

--- a/crates/mbx/src/workspace_state.rs
+++ b/crates/mbx/src/workspace_state.rs
@@ -1,0 +1,486 @@
+//! Portable Cargo scheduler state carried beside an exported action closure.
+
+use crate::config::Config;
+use eyre::{Context as _, Result, bail};
+use mbx_cache_core::{CacheDigest, LocalCas};
+use mbx_cache_store::{ExportAdditions, WorkspaceTarget};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{File, FileTimes};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::UNIX_EPOCH;
+
+pub(crate) const ATTACHMENT: &str = "cargo-workspace-state-v1";
+const VERSION: u8 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Bundle {
+    version: u8,
+    workspaces: Vec<WorkspaceState>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkspaceState {
+    workspace_root: PathBuf,
+    signature: CacheDigest,
+    inline_archive: CacheDigest,
+    inline_files: Vec<FileMetadata>,
+    references: Vec<FileReference>,
+    symlinks: Vec<Symlink>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileReference {
+    path: PathBuf,
+    source: FileSource,
+    mode: u32,
+    modified_secs: u64,
+    modified_nanos: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileMetadata {
+    path: PathBuf,
+    mode: u32,
+    modified_secs: u64,
+    modified_nanos: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum FileSource {
+    Cas(CacheDigest),
+    Mbx,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Symlink {
+    path: PathBuf,
+    target: PathBuf,
+    directory: bool,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct RestoreOutcome {
+    pub(crate) files: u64,
+    pub(crate) referenced_bytes: u64,
+}
+
+/// Capture every recorded Cargo target as a manifest plus an inline metadata tar.
+pub(crate) fn capture(store: &Path, targets: &[WorkspaceTarget]) -> Result<ExportAdditions> {
+    let executable = std::env::current_exe()?;
+    let executable_digest = CacheDigest::blake3_file(&executable)?;
+    let cas = LocalCas::new(store);
+    let mut objects = BTreeSet::new();
+    let mut workspaces = Vec::new();
+    for target in targets {
+        if !target.target_dir.is_dir() || !target.workspace_root.is_dir() {
+            continue;
+        }
+        workspaces.push(capture_workspace(
+            &cas,
+            target,
+            &executable_digest,
+            &mut objects,
+        )?);
+    }
+    if workspaces.is_empty() {
+        return Ok(ExportAdditions::default());
+    }
+    let bytes = serde_json::to_vec(&Bundle {
+        version: VERSION,
+        workspaces,
+    })?;
+    let digest = CacheDigest::blake3(&bytes);
+    cas.store_bytes(&digest, &bytes)?;
+    objects.insert(digest.clone());
+    Ok(ExportAdditions {
+        attachments: BTreeMap::from([(ATTACHMENT.to_owned(), digest)]),
+        objects,
+    })
+}
+
+fn capture_workspace(
+    cas: &LocalCas,
+    target: &WorkspaceTarget,
+    executable_digest: &CacheDigest,
+    objects: &mut BTreeSet<CacheDigest>,
+) -> Result<WorkspaceState> {
+    let temporary = tempfile::NamedTempFile::new_in(cas.root())?;
+    let mut archive = tar::Builder::new(temporary.reopen()?);
+    let mut references = Vec::new();
+    let mut inline_files = Vec::new();
+    let mut symlinks = Vec::new();
+    for path in tree_entries(&target.target_dir)? {
+        let relative = path.strip_prefix(&target.target_dir)?.to_path_buf();
+        validate_relative_path(&relative)?;
+        let metadata = std::fs::symlink_metadata(&path)?;
+        let kind = metadata.file_type();
+        if kind.is_dir() {
+            archive.append_dir(&relative, &path)?;
+        } else if kind.is_symlink() {
+            let link = std::fs::read_link(&path)?;
+            validate_link(&relative, &link)?;
+            symlinks.push(Symlink {
+                path: relative,
+                target: link,
+                directory: path.metadata().is_ok_and(|metadata| metadata.is_dir()),
+            });
+        } else if kind.is_file() {
+            let digest = CacheDigest::blake3_file(&path)?;
+            let source = if digest == *executable_digest {
+                Some(FileSource::Mbx)
+            } else if cas.path_for(&digest)?.is_file() {
+                objects.insert(digest.clone());
+                Some(FileSource::Cas(digest))
+            } else {
+                None
+            };
+            if let Some(source) = source {
+                let (modified_secs, modified_nanos) = modified_parts(&metadata);
+                references.push(FileReference {
+                    path: relative,
+                    source,
+                    mode: file_mode(&metadata),
+                    modified_secs,
+                    modified_nanos,
+                });
+            } else {
+                archive.append_path_with_name(&path, &relative)?;
+                let (modified_secs, modified_nanos) = modified_parts(&metadata);
+                inline_files.push(FileMetadata {
+                    path: relative,
+                    mode: file_mode(&metadata),
+                    modified_secs,
+                    modified_nanos,
+                });
+            }
+        }
+    }
+    archive.finish()?;
+    drop(archive);
+    let inline_archive = CacheDigest::blake3_file(temporary.path())?;
+    cas.store_file(&inline_archive, temporary.path())?;
+    objects.insert(inline_archive.clone());
+    Ok(WorkspaceState {
+        workspace_root: target.workspace_root.clone(),
+        signature: workspace_signature(&target.workspace_root)?,
+        inline_archive,
+        inline_files,
+        references,
+        symlinks,
+    })
+}
+
+/// Restore the state matching the current Cargo workspace into an empty target.
+pub(crate) fn restore(
+    config: &Config,
+    store: &Path,
+    attachment: &CacheDigest,
+    workspace_root: &Path,
+    target_dir: &Path,
+    target_requested: bool,
+) -> Result<Option<RestoreOutcome>> {
+    let cas = LocalCas::new(store);
+    let bundle_path = cas
+        .find(attachment)?
+        .ok_or_else(|| eyre::eyre!("workspace-state attachment is missing"))?;
+    let bundle: Bundle = serde_json::from_slice(&std::fs::read(bundle_path)?)?;
+    if bundle.version != VERSION || bundle.workspaces.is_empty() {
+        bail!("unsupported or invalid Cargo workspace-state attachment");
+    }
+    let signature = workspace_signature(workspace_root)?;
+    let Some(state) = bundle
+        .workspaces
+        .iter()
+        .find(|state| state.workspace_root == workspace_root)
+        .or_else(|| {
+            let mut matches = bundle
+                .workspaces
+                .iter()
+                .filter(|state| state.signature == signature);
+            let first = matches.next()?;
+            matches.next().is_none().then_some(first)
+        })
+    else {
+        return Ok(None);
+    };
+    validate_state(state)?;
+    let destination = crate::target::place(config, workspace_root, target_dir, target_requested)
+        .unwrap_or_else(|| target_dir.to_path_buf());
+    if destination.exists() && std::fs::read_dir(&destination)?.next().is_some() {
+        log::debug!(
+            "leaving the non-empty target directory {} alone",
+            destination.display()
+        );
+        return Ok(None);
+    }
+    let parent = destination
+        .parent()
+        .ok_or_else(|| eyre::eyre!("target directory has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    let staging = tempfile::Builder::new()
+        .prefix(".mbx-workspace-state-")
+        .tempdir_in(parent)?;
+    let staged_target = staging.path().join("target");
+    std::fs::create_dir(&staged_target)?;
+    unpack_inline(&cas, &state.inline_archive, &staged_target)?;
+    for metadata in &state.inline_files {
+        set_file_metadata(
+            &staged_target.join(&metadata.path),
+            metadata.mode,
+            metadata.modified_secs,
+            metadata.modified_nanos,
+        )?;
+    }
+    let executable = std::env::current_exe()?;
+    let bytes = materialize_references(&cas, &executable, &staged_target, &state.references)?;
+    restore_symlinks(&staged_target, &state.symlinks)?;
+    if destination.exists() {
+        std::fs::remove_dir(&destination).wrap_err_with(|| {
+            format!(
+                "could not replace empty target directory {}",
+                destination.display()
+            )
+        })?;
+    }
+    std::fs::rename(&staged_target, &destination)?;
+    crate::target::touch_managed(config, workspace_root, target_dir);
+    Ok(Some(RestoreOutcome {
+        files: state.references.len() as u64,
+        referenced_bytes: bytes,
+    }))
+}
+
+fn unpack_inline(cas: &LocalCas, digest: &CacheDigest, destination: &Path) -> Result<()> {
+    let path = cas
+        .find(digest)?
+        .ok_or_else(|| eyre::eyre!("workspace-state inline archive is missing"))?;
+    let mut archive = tar::Archive::new(File::open(path)?);
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?.into_owned();
+        validate_relative_path(&path)?;
+        let kind = entry.header().entry_type();
+        if !kind.is_file() && !kind.is_dir() && !kind.is_gnu_sparse() {
+            bail!("workspace-state archive contains a non-file entry");
+        }
+        if !entry.unpack_in(destination)? {
+            bail!("workspace-state archive contains an unsafe path");
+        }
+    }
+    Ok(())
+}
+
+fn materialize_references(
+    cas: &LocalCas,
+    executable: &Path,
+    destination: &Path,
+    references: &[FileReference],
+) -> Result<u64> {
+    let sources = references
+        .iter()
+        .map(|reference| {
+            let source = match &reference.source {
+                FileSource::Cas(digest) => cas.path_for(digest)?,
+                FileSource::Mbx => executable.to_path_buf(),
+            };
+            let size = std::fs::metadata(&source)?.len();
+            Ok((reference, source, size))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let workers = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(sources.len().max(1));
+    let next = AtomicUsize::new(0);
+    let error = Mutex::new(None);
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some((reference, source, _)) = sources.get(index) else {
+                        break;
+                    };
+                    if error.lock().unwrap().is_some() {
+                        break;
+                    }
+                    let result = restore_reference(destination, reference, source);
+                    if let Err(found) = result {
+                        *error.lock().unwrap() = Some(found);
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    if let Some(error) = error.into_inner().unwrap() {
+        return Err(error);
+    }
+    Ok(sources.iter().map(|(_, _, size)| size).sum())
+}
+
+fn restore_reference(root: &Path, reference: &FileReference, source: &Path) -> Result<()> {
+    let destination = root.join(&reference.path);
+    let copied = reflink_copy::reflink_or_copy(source, &destination)?;
+    let _ = copied;
+    set_file_metadata(
+        &destination,
+        reference.mode,
+        reference.modified_secs,
+        reference.modified_nanos,
+    )
+}
+
+fn restore_symlinks(root: &Path, links: &[Symlink]) -> Result<()> {
+    for link in links {
+        let destination = root.join(&link.path);
+        create_symlink(&link.target, &destination, link.directory)?;
+    }
+    Ok(())
+}
+
+fn validate_state(state: &WorkspaceState) -> Result<()> {
+    state.signature.validate()?;
+    state.inline_archive.validate()?;
+    for metadata in &state.inline_files {
+        validate_relative_path(&metadata.path)?;
+    }
+    for reference in &state.references {
+        validate_relative_path(&reference.path)?;
+        if let FileSource::Cas(digest) = &reference.source {
+            digest.validate()?;
+        }
+    }
+    for link in &state.symlinks {
+        validate_relative_path(&link.path)?;
+        validate_link(&link.path, &link.target)?;
+    }
+    Ok(())
+}
+
+fn tree_entries(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut found = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let mut entries = std::fs::read_dir(&directory)?.collect::<std::io::Result<Vec<_>>>()?;
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let path = entry.path();
+            if entry.file_type()?.is_dir() {
+                pending.push(path.clone());
+            }
+            found.push(path);
+        }
+    }
+    found.sort();
+    Ok(found)
+}
+
+fn workspace_signature(root: &Path) -> Result<CacheDigest> {
+    let mut bytes = b"cargo-workspace-state-v1\0".to_vec();
+    for name in ["Cargo.toml", "Cargo.lock"] {
+        let path = root.join(name);
+        if path.is_file() {
+            bytes.extend_from_slice(name.as_bytes());
+            bytes.push(0);
+            bytes.extend_from_slice(&std::fs::read(path)?);
+            bytes.push(0);
+        }
+    }
+    Ok(CacheDigest::blake3(&bytes))
+}
+
+fn validate_relative_path(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!("workspace state contains unsafe path {}", path.display());
+    }
+    Ok(())
+}
+
+fn validate_link(path: &Path, target: &Path) -> Result<()> {
+    if target.is_absolute() {
+        bail!("workspace state contains unsafe link {}", path.display());
+    }
+    let mut depth = path
+        .parent()
+        .map_or(0, |parent| parent.components().count());
+    for component in target.components() {
+        match component {
+            Component::Normal(_) => depth += 1,
+            Component::CurDir => {}
+            Component::ParentDir if depth > 0 => depth -= 1,
+            _ => bail!("workspace state contains unsafe link {}", path.display()),
+        }
+    }
+    Ok(())
+}
+
+fn modified_parts(metadata: &std::fs::Metadata) -> (u64, u32) {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| (duration.as_secs(), duration.subsec_nanos()))
+        .unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn file_mode(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::MetadataExt as _;
+    metadata.mode()
+}
+
+#[cfg(not(unix))]
+fn file_mode(metadata: &std::fs::Metadata) -> u32 {
+    u32::from(metadata.permissions().readonly())
+}
+
+fn set_file_metadata(path: &Path, mode: u32, secs: u64, nanos: u32) -> Result<()> {
+    let modified = UNIX_EPOCH + std::time::Duration::new(secs, nanos);
+    File::options()
+        .read(true)
+        .open(path)?
+        .set_times(FileTimes::new().set_modified(modified))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_readonly(mode != 0);
+        std::fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, destination: &Path, _directory: bool) -> Result<()> {
+    std::os::unix::fs::symlink(target, destination)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn create_symlink(target: &Path, destination: &Path, directory: bool) -> Result<()> {
+    if directory {
+        std::os::windows::fs::symlink_dir(target, destination)?;
+    } else {
+        std::os::windows::fs::symlink_file(target, destination)?;
+    }
+    Ok(())
+}

--- a/crates/mbx/src/workspace_state.rs
+++ b/crates/mbx/src/workspace_state.rs
@@ -450,7 +450,12 @@ fn file_mode(metadata: &std::fs::Metadata) -> u32 {
 }
 
 fn set_file_metadata(path: &Path, mode: u32, secs: u64, nanos: u32) -> Result<()> {
-    let modified = UNIX_EPOCH + std::time::Duration::new(secs, nanos);
+    if nanos >= 1_000_000_000 {
+        bail!("workspace state contains an invalid timestamp");
+    }
+    let modified = UNIX_EPOCH
+        .checked_add(std::time::Duration::new(secs, nanos))
+        .ok_or_else(|| eyre::eyre!("workspace state contains an out-of-range timestamp"))?;
     #[cfg(unix)]
     File::options()
         .read(true)
@@ -473,7 +478,7 @@ fn set_file_metadata(path: &Path, mode: u32, secs: u64, nanos: u32) -> Result<()
             .open(path)?
             .set_times(FileTimes::new().set_modified(modified))
             .wrap_err_with(|| format!("could not restore the timestamp of {}", path.display()))?;
-        permissions.set_readonly(mode != 0);
+        permissions.set_readonly(mode == 1);
         std::fs::set_permissions(path, permissions)
             .wrap_err_with(|| format!("could not restore the permissions of {}", path.display()))?;
     }

--- a/crates/mbx/src/workspace_state.rs
+++ b/crates/mbx/src/workspace_state.rs
@@ -451,20 +451,31 @@ fn file_mode(metadata: &std::fs::Metadata) -> u32 {
 
 fn set_file_metadata(path: &Path, mode: u32, secs: u64, nanos: u32) -> Result<()> {
     let modified = UNIX_EPOCH + std::time::Duration::new(secs, nanos);
+    #[cfg(unix)]
     File::options()
         .read(true)
         .open(path)?
-        .set_times(FileTimes::new().set_modified(modified))?;
+        .set_times(FileTimes::new().set_modified(modified))
+        .wrap_err_with(|| format!("could not restore the timestamp of {}", path.display()))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+            .wrap_err_with(|| format!("could not restore the mode of {}", path.display()))?;
     }
     #[cfg(not(unix))]
     {
         let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(path, permissions.clone())?;
+        File::options()
+            .write(true)
+            .open(path)?
+            .set_times(FileTimes::new().set_modified(modified))
+            .wrap_err_with(|| format!("could not restore the timestamp of {}", path.display()))?;
         permissions.set_readonly(mode != 0);
-        std::fs::set_permissions(path, permissions)?;
+        std::fs::set_permissions(path, permissions)
+            .wrap_err_with(|| format!("could not restore the permissions of {}", path.display()))?;
     }
     Ok(())
 }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -954,20 +954,23 @@ fn a_cache_bundle_restores_cargo_workspace_state() {
         b"local",
         "import must not replace an existing non-empty target"
     );
-    let cargo = Command::new(env!("CARGO_BIN_EXE_mbx"))
-        .current_dir(project.path())
-        .args(["build", "--offline", "--verbose"])
-        .env("MBX_CACHE_DIR", destination_store.path())
-        .env("MBX_TARGET_ROOT", destination_targets.path())
-        .env("MBX_LEARNED_INCREMENTAL", "0")
-        .env_remove("CARGO_TARGET_DIR")
-        .output()
-        .unwrap();
-    assert!(cargo.status.success());
+    let (_, cargo_stderr) = cargo_with(
+        project.path(),
+        destination_store.path(),
+        &reports.path().join("restored.json"),
+        &["build", "--offline", "--verbose"],
+        &[
+            (
+                "MBX_TARGET_ROOT",
+                destination_targets.path().to_str().unwrap(),
+            ),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+        ],
+    );
     assert!(
-        !String::from_utf8_lossy(&cargo.stderr).contains("Compiling fixture"),
+        !cargo_stderr.contains("Compiling fixture"),
         "Cargo should accept the restored target as fresh: {}",
-        String::from_utf8_lossy(&cargo.stderr)
+        cargo_stderr
     );
 
     let equivalent_project = tempfile::tempdir().unwrap();

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -883,6 +883,113 @@ fn a_ci_export_group_collects_every_build_in_the_job() {
 }
 
 #[test]
+fn a_cache_bundle_restores_cargo_workspace_state() {
+    let source_store = tempfile::tempdir().unwrap();
+    let destination_store = tempfile::tempdir().unwrap();
+    let destination_targets = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_project(project.path());
+    let group = "github-run-42/workspace-state";
+    build_with(
+        project.path(),
+        source_store.path(),
+        &reports.path().join("source.json"),
+        &[
+            (mbx::session::CACHE_EXPORT_GROUP_ENV, group),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+        ],
+    );
+    std::fs::write(project.path().join("target/scheduler-marker"), b"warm").unwrap();
+    let archive = reports.path().join("workspace-state.tar");
+    let export = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .args(["cache", "export", "--group", group])
+        .arg(&archive)
+        .env("MBX_CACHE_DIR", source_store.path())
+        .output()
+        .unwrap();
+    assert!(
+        export.status.success(),
+        "workspace-state export failed: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+    wipe_target(project.path());
+
+    let import = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .args(["cache", "import"])
+        .arg(&archive)
+        .env("MBX_CACHE_DIR", destination_store.path())
+        .env("MBX_TARGET_ROOT", destination_targets.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        import.status.success(),
+        "workspace-state import failed: {}",
+        String::from_utf8_lossy(&import.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&import.stdout).contains("restored Cargo workspace state"),
+        "import did not report a workspace restore: {}",
+        String::from_utf8_lossy(&import.stdout)
+    );
+    assert_eq!(
+        std::fs::read(project.path().join("target/scheduler-marker")).unwrap(),
+        b"warm"
+    );
+    std::fs::write(project.path().join("target/scheduler-marker"), b"local").unwrap();
+    let repeated_import = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .args(["cache", "import"])
+        .arg(&archive)
+        .env("MBX_CACHE_DIR", destination_store.path())
+        .env("MBX_TARGET_ROOT", destination_targets.path())
+        .output()
+        .unwrap();
+    assert!(repeated_import.status.success());
+    assert_eq!(
+        std::fs::read(project.path().join("target/scheduler-marker")).unwrap(),
+        b"local",
+        "import must not replace an existing non-empty target"
+    );
+    let cargo = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .args(["build", "--offline", "--verbose"])
+        .env("MBX_CACHE_DIR", destination_store.path())
+        .env("MBX_TARGET_ROOT", destination_targets.path())
+        .env("MBX_LEARNED_INCREMENTAL", "0")
+        .env_remove("CARGO_TARGET_DIR")
+        .output()
+        .unwrap();
+    assert!(cargo.status.success());
+    assert!(
+        !String::from_utf8_lossy(&cargo.stderr).contains("Compiling fixture"),
+        "Cargo should accept the restored target as fresh: {}",
+        String::from_utf8_lossy(&cargo.stderr)
+    );
+
+    let equivalent_project = tempfile::tempdir().unwrap();
+    let equivalent_targets = tempfile::tempdir().unwrap();
+    write_project(equivalent_project.path());
+    let equivalent_import = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(equivalent_project.path())
+        .args(["cache", "import"])
+        .arg(&archive)
+        .env("MBX_CACHE_DIR", destination_store.path())
+        .env("MBX_TARGET_ROOT", equivalent_targets.path())
+        .output()
+        .unwrap();
+    assert!(equivalent_import.status.success());
+    assert_eq!(
+        std::fs::read(equivalent_project.path().join("target/scheduler-marker")).unwrap(),
+        b"warm",
+        "a matching workspace signature should restore into another checkout"
+    );
+}
+
+#[test]
 fn incremental_is_opt_in_and_reaches_cargo() {
     let store = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();

--- a/docs/cli/cache/export.md
+++ b/docs/cli/cache/export.md
@@ -3,7 +3,9 @@
 
 - **Usage:** `mbx cache export [--group <GROUP>] <ARCHIVE>`
 
-Export the cache closure of this checkout's last build.
+Export the cache closure of this checkout's last build. The export includes
+Cargo scheduler state for recorded workspaces, with compiler outputs referenced
+from the content-addressed closure instead of duplicated.
 
 ## Arguments
 - **`<ARCHIVE>`** — Tar archive to write.

--- a/docs/cli/cache/export.md
+++ b/docs/cli/cache/export.md
@@ -3,9 +3,7 @@
 
 - **Usage:** `mbx cache export [--group <GROUP>] <ARCHIVE>`
 
-Export the cache closure of this checkout's last build. The export includes
-Cargo scheduler state for recorded workspaces, with compiler outputs referenced
-from the content-addressed closure instead of duplicated.
+Export the cache closure of this checkout's last build. The export includes Cargo scheduler state for recorded workspaces, with compiler outputs referenced from the content-addressed closure instead of duplicated.
 
 ## Arguments
 - **`<ARCHIVE>`** — Tar archive to write.

--- a/docs/cli/cache/import.md
+++ b/docs/cli/cache/import.md
@@ -3,10 +3,7 @@
 
 - **Usage:** `mbx cache import <ARCHIVE>`
 
-Import a cache export into the local store. If the export contains Cargo
-workspace state and the command runs from a matching checkout with an absent or
-empty target directory, restore that state as well. A non-empty target
-directory is never replaced.
+Import a cache export into the local store. If the export contains Cargo workspace state and the command runs from a matching checkout with an absent or empty target directory, restore that state as well. A non-empty target directory is never replaced.
 
 ## Arguments
 - **`<ARCHIVE>`** — Tar archive to import.

--- a/docs/cli/cache/import.md
+++ b/docs/cli/cache/import.md
@@ -3,7 +3,10 @@
 
 - **Usage:** `mbx cache import <ARCHIVE>`
 
-Import a cache export into the local store.
+Import a cache export into the local store. If the export contains Cargo
+workspace state and the command runs from a matching checkout with an absent or
+empty target directory, restore that state as well. A non-empty target
+directory is never replaced.
 
 ## Arguments
 - **`<ARCHIVE>`** — Tar archive to import.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -117,6 +117,13 @@ A restore phase imports a previously cached bundle:
 mbx cache import "$RUNNER_TEMP/mbx-cache.tar"
 ```
 
+The bundle also carries Cargo's scheduler state for each recorded workspace.
+When import runs from a matching checkout whose target directory is absent or
+empty, mbx restores the fingerprints, dep-info, build-script state, and target
+layout alongside the action closure. Large compiler outputs remain CAS objects
+and are reflinked or copied into that layout rather than stored twice. Import
+leaves a non-empty target directory untouched.
+
 A post phase exports the deduplicated closure of every receipt in this job:
 
 ```console


### PR DESCRIPTION
## Summary

- add versioned named attachments to cache-export bundles while preserving v1 output for exports without attachments
- capture Cargo scheduler state at export without duplicating action outputs already present in CAS
- restore matching workspace state into an empty target using parallel reflink/copy materialization and an atomic rename
- preserve file modes and mtimes, recreate safe relative symlinks, and leave non-empty targets untouched
- document the automatic GitHub Action behavior

## Why

An mbx action-result closure can restore compiler outputs, but Cargo still needs its target scheduler metadata to recognize those outputs as fresh after a cache restore. Carrying that metadata alongside the closure makes the real-world small-edit case behave like a warm checkout. CAS-backed artifacts are referenced instead of packed a second time.

The prototype benchmark archive was 408.33 MiB versus rust-cache's 462.93 MiB (11.8% smaller), with only 55.78 MiB of inline scheduler state and manifest data added to the existing mbx bundle. In four paired small-edit trials the median end-to-end times were effectively tied: 38.904s for the hydrated mbx prototype and 38.980s for rust-cache. This PR turns that prototype into the native export/import path.

## Compatibility and safety

- exports with no attachments retain manifest version 1
- imports accept both v1 and v2 manifests
- attachment names and CAS roots are validated before import
- restore only targets an empty directory and stages all data before atomic placement
- equivalent checkouts can match by Cargo.toml/Cargo.lock signature when the absolute path differs

## Verification

- `cargo clippy -p mbx -p mbx-cache-store --all-targets -- -D warnings`
- `cargo test -p mbx-cache-store --lib`
- `cargo test -p mbx -p mbx-cache-store`
- end-to-end export/import test verifies Cargo treats restored output as fresh
- end-to-end safety coverage verifies non-empty targets are preserved and equivalent checkout paths restore correctly

Benchmark runs:
- composition: https://github.com/jdx/mr-boxington/actions/runs/33827619024
- clean paired repeat: https://github.com/jdx/mr-boxington/actions/runs/33828854325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cache exports can include portable Cargo workspace state and named attachments.
  - Cache imports restore matching workspace targets when the destination is absent or empty.
  - Restored files preserve metadata and use efficient file materialization where available.
  - Import results report restored files and referenced data size.
  - Workspace target discovery is supported for individual checkouts and build groups.

- **Bug Fixes**
  - Non-empty target directories are preserved and never overwritten.
  - Unsafe or incomplete workspace state is rejected during export and import.

- **Documentation**
  - Updated cache export, import, and GitHub Actions documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache bundle format and writes into the Cargo target directory; mitigations include manifest validation, staging before rename, and refusing to overwrite non-empty targets.
> 
> **Overview**
> Extends **cache export/import** so bundles can carry **named CAS attachments** (manifest v2) while **v1 manifests** remain the default when nothing extra is attached. Exports can now include **`cargo-workspace-state-v1`**: Cargo scheduler metadata under `target/` with large artifacts **referenced from the existing action closure** instead of duplicated.
> 
> **`mbx cache export`** discovers recorded workspace/target pairs (checkout or `--group`), captures workspace state into `ExportAdditions`, and uses `export_*_with`. **`mbx cache import`** loads attachments via `import_archive_with_attachments` and, when running in a matching Cargo workspace with an **absent or empty** target dir, restores fingerprints, inline tar metadata, CAS-backed files (parallel reflink/copy), symlinks, and mtimes—then **atomically** replaces the target. Non-empty targets are skipped; equivalent checkouts can match via **Cargo.toml/Cargo.lock signature**.
> 
> Store APIs add `WorkspaceTarget` discovery, attachment validation, and tests/docs for the GitHub Actions cache flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ae43f02d575f1cdd9ec49b934b2a79bdd060c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->