### PR TITLE
fix: verify NFS compiler inputs by content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "fslock",
  "futures-util",
  "hex",
+ "libc",
  "log",
  "mbx-cache-protocol",
  "mockito",

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -432,6 +432,19 @@ impl CcDiscoveredInputs {
         Ok(())
     }
 
+    /// Compatibility form for callers that captured metadata identities.
+    pub fn verify_not_modified_since_with_identities(
+        &self,
+        started_at: SystemTime,
+        before: &BTreeMap<PathBuf, FileIdentity>,
+    ) -> Result<(), CcBypassReason> {
+        let snapshots = before
+            .iter()
+            .map(|(path, identity)| (path.clone(), identity.clone().into()))
+            .collect();
+        self.verify_not_modified_since_with_snapshots(started_at, &snapshots)
+    }
+
     /// Confirm every discovered file before publication, degrading a changed
     /// input to a miss rather than storing an object under a stale key.
     ///

--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -5,7 +5,7 @@ use crate::{
     MAX_MANIFEST_ENTRIES, MAX_PREDICTED_INPUTS, normalize_components,
 };
 use mbx_cache_core::{
-    CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, RecordedFileDigest,
+    CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, FileSnapshot, RecordedFileDigest,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
@@ -302,7 +302,12 @@ impl CcDiscoveredInputs {
             if total_bytes > MAX_INPUT_BYTES {
                 return Err(CcBypassReason::TooManyInputs);
             }
-            let identity = FileIdentity::describe(&path, &metadata);
+            let identity = FileIdentity::for_digest_cache(&path, &metadata).map_err(|error| {
+                CcBypassReason::InputRead {
+                    path: path.clone(),
+                    message: error.to_string(),
+                }
+            })?;
             identified.push((path, identity));
         }
         let queries = identified
@@ -380,33 +385,38 @@ impl CcDiscoveredInputs {
     /// being mistaken for the contents that produced the object; `verify`
     /// closes the remaining race after hashing.
     pub fn verify_not_modified_since(&self, started_at: SystemTime) -> Result<(), CcBypassReason> {
-        self.verify_not_modified_since_with_identities(started_at, &BTreeMap::new())
+        self.verify_not_modified_since_with_snapshots(started_at, &BTreeMap::new())
     }
 
-    /// Reject inputs that changed from identities captured before the driver
+    /// Reject inputs that changed from snapshots captured before the driver
     /// ran, falling back to the wall-clock barrier for discovered headers.
-    pub fn verify_not_modified_since_with_identities(
+    pub fn verify_not_modified_since_with_snapshots(
         &self,
         started_at: SystemTime,
-        before: &BTreeMap<PathBuf, FileIdentity>,
+        before: &BTreeMap<PathBuf, FileSnapshot>,
     ) -> Result<(), CcBypassReason> {
         for input in self.files() {
-            let metadata =
-                std::fs::metadata(&input.path).map_err(|error| CcBypassReason::InputRead {
-                    path: input.path.clone(),
-                    message: error.to_string(),
-                })?;
-            let identity = FileIdentity::describe(&input.path, &metadata);
             if let Some(previous) = before.get(&input.path)
-                && previous.changed.is_some()
+                && previous.proves_content_change()
             {
-                if identity.as_ref() == Some(previous) {
+                let metadata =
+                    std::fs::metadata(&input.path).map_err(|error| CcBypassReason::InputRead {
+                        path: input.path.clone(),
+                        message: error.to_string(),
+                    })?;
+                let identity = FileIdentity::describe(&input.path, &metadata);
+                if previous.matches(identity.as_ref(), &input.digest) {
                     continue;
                 }
                 return Err(CcBypassReason::InputModifiedDuringCompilation(
                     input.path.clone(),
                 ));
             }
+            let metadata =
+                std::fs::metadata(&input.path).map_err(|error| CcBypassReason::InputRead {
+                    path: input.path.clone(),
+                    message: error.to_string(),
+                })?;
             let modified = metadata
                 .modified()
                 .map_err(|error| CcBypassReason::InputRead {

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -273,7 +273,7 @@ fn discovery_rejects_inputs_modified_during_compilation() {
 
 #[cfg(unix)]
 #[test]
-fn precompile_identity_does_not_depend_on_the_host_clock() {
+fn precompile_snapshot_does_not_depend_on_the_host_clock() {
     let directory = tempfile::tempdir().expect("tempdir");
     let root = directory.path();
     write(root, "a.c", "int a(void) { return 0; }\n");
@@ -286,17 +286,19 @@ fn precompile_identity_does_not_depend_on_the_host_clock() {
         &NoFileDigestCache,
     )
     .expect("discovery");
-    let identity = FileIdentity::describe(&source, &std::fs::metadata(&source).unwrap()).unwrap();
-    let before = BTreeMap::from([(source.clone(), identity)]);
+    let snapshot = mbx_cache_core::FileSnapshot::capture(&source)
+        .unwrap()
+        .unwrap();
+    let before = BTreeMap::from([(source.clone(), snapshot)]);
 
     discovered
-        .verify_not_modified_since_with_identities(SystemTime::UNIX_EPOCH, &before)
+        .verify_not_modified_since_with_snapshots(SystemTime::UNIX_EPOCH, &before)
         .expect("an unchanged identity is independent of clock offset");
 
     std::fs::write(&source, "int a(void) { return 1; }\n").expect("rewrite");
     assert_eq!(
         discovered
-            .verify_not_modified_since_with_identities(
+            .verify_not_modified_since_with_snapshots(
                 SystemTime::now() + std::time::Duration::from_secs(60),
                 &before,
             )

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -49,6 +49,9 @@ mockito = "1"
 zstd = "0.13"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [features]
 default = ["rustls"]
 fuzzing = []

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -31,7 +31,8 @@ mod wire;
 pub(crate) use prefetch::select_prefetch_actions;
 
 pub use file_digest::{
-    FileDigestCache, FileDigestScope, FileIdentity, NoFileDigestCache, RecordedFileDigest,
+    FileDigestCache, FileDigestScope, FileIdentity, FileSnapshot, NoFileDigestCache,
+    RecordedFileDigest,
 };
 pub use manifest::{is_task_identity, task_manifest_actions};
 use manifest::{

--- a/crates/mbx-cache-core/src/agent/file_digest.rs
+++ b/crates/mbx-cache-core/src/agent/file_digest.rs
@@ -1,5 +1,6 @@
 use crate::CacheDigest;
 use serde::{Deserialize, Serialize};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -38,6 +39,19 @@ impl FileIdentity {
         })
     }
 
+    /// Describe a file only when metadata can safely stand in for its digest.
+    ///
+    /// Linux NFS may revise cached timestamps without a write and may delay a
+    /// real writer's final timestamps. Returning no identity makes digest
+    /// users hash the file instead of trusting that ambiguous metadata.
+    pub fn for_digest_cache(path: &Path, metadata: &std::fs::Metadata) -> io::Result<Option<Self>> {
+        Ok(digest_cache_identity(
+            path,
+            metadata,
+            metadata_identity_is_unreliable(path)?,
+        ))
+    }
+
     /// Whether the file at this identity's path still has exactly this
     /// identity, so the digest recorded against it still describes the bytes on
     /// disk without reading them again.
@@ -51,6 +65,89 @@ impl FileIdentity {
     pub fn still_describes(&self) -> std::io::Result<bool> {
         let metadata = std::fs::metadata(&self.path)?;
         Ok(Self::describe(&self.path, &metadata).as_ref() == Some(self))
+    }
+}
+
+/// A pre-operation snapshot that can prove whether a file's contents changed.
+///
+/// Most filesystems provide a stable metadata-change token, so the inexpensive
+/// identity is sufficient. Linux NFS can reconcile client and server
+/// timestamps after a writer has closed the file, making two metadata reads
+/// disagree without any intervening write. Those files carry a content digest
+/// instead. Callers use the same comparison either way and do not need to know
+/// which filesystem supplied the file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSnapshot {
+    identity: FileIdentity,
+    content: Option<CacheDigest>,
+}
+
+impl FileSnapshot {
+    /// Capture the strongest comparison the file's filesystem can support.
+    pub fn capture(path: &Path) -> io::Result<Option<Self>> {
+        capture_file_snapshot(path, metadata_identity_is_unreliable(path)?)
+    }
+
+    /// Whether `identity` and `content` still describe this snapshot.
+    pub fn matches(&self, identity: Option<&FileIdentity>, content: &CacheDigest) -> bool {
+        self.content
+            .as_ref()
+            .map_or(identity == Some(&self.identity), |before| before == content)
+    }
+
+    /// Whether a mismatch proves the file's contents changed.
+    pub fn proves_content_change(&self) -> bool {
+        self.content.is_some() || self.identity.changed.is_some()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn metadata_identity_is_unreliable(path: &Path) -> io::Result<bool> {
+    use std::mem::MaybeUninit;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let mut status = MaybeUninit::<libc::statfs>::zeroed();
+    // SAFETY: `path` is NUL-terminated and `status` points to writable,
+    // correctly sized storage. statfs initializes it before returning success.
+    let result = unsafe { libc::statfs(path.as_ptr(), status.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: statfs returned success and initialized `status`.
+    let status = unsafe { status.assume_init() };
+    // libc gives NFS_SUPER_MAGIC a different signedness from statfs::f_type on musl.
+    Ok(status.f_type == 0x6969)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn metadata_identity_is_unreliable(_path: &Path) -> io::Result<bool> {
+    Ok(false)
+}
+
+fn capture_file_snapshot(path: &Path, content_identity: bool) -> io::Result<Option<FileSnapshot>> {
+    let metadata = std::fs::metadata(path)?;
+    let Some(identity) = FileIdentity::describe(path, &metadata) else {
+        return Ok(None);
+    };
+    let content = content_identity
+        .then(|| {
+            CacheDigest::blake3_file(path).map_err(|error| io::Error::other(error.to_string()))
+        })
+        .transpose()?;
+    Ok(Some(FileSnapshot { identity, content }))
+}
+
+fn digest_cache_identity(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    unreliable: bool,
+) -> Option<FileIdentity> {
+    if unreliable {
+        None
+    } else {
+        FileIdentity::describe(path, metadata)
     }
 }
 
@@ -136,5 +233,63 @@ mod tests {
 
         std::fs::remove_file(&path).unwrap();
         assert!(identity.still_describes().is_err());
+    }
+
+    #[test]
+    fn a_metadata_snapshot_detects_a_metadata_change() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("input.rs");
+        std::fs::write(&path, b"fn main() {}").unwrap();
+        let snapshot = capture_file_snapshot(&path, false).unwrap().unwrap();
+
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(SystemTime::UNIX_EPOCH))
+            .unwrap();
+        let identity = FileIdentity::describe(&path, &std::fs::metadata(&path).unwrap());
+        let digest = CacheDigest::blake3_file(&path).unwrap();
+
+        assert!(!snapshot.matches(identity.as_ref(), &digest));
+        assert_eq!(snapshot.proves_content_change(), cfg!(unix));
+    }
+
+    #[test]
+    fn a_content_snapshot_ignores_metadata_churn_but_detects_changed_bytes() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("input.rs");
+        std::fs::write(&path, b"fn main() {}").unwrap();
+        let snapshot = capture_file_snapshot(&path, true).unwrap().unwrap();
+
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(SystemTime::UNIX_EPOCH))
+            .unwrap();
+        let identity = FileIdentity::describe(&path, &std::fs::metadata(&path).unwrap());
+        let digest = CacheDigest::blake3_file(&path).unwrap();
+        assert!(snapshot.matches(identity.as_ref(), &digest));
+        assert!(snapshot.proves_content_change());
+
+        std::fs::write(&path, b"fn main(){ }").unwrap();
+        let identity = FileIdentity::describe(&path, &std::fs::metadata(&path).unwrap());
+        let digest = CacheDigest::blake3_file(&path).unwrap();
+        assert!(!snapshot.matches(identity.as_ref(), &digest));
+    }
+
+    #[test]
+    fn unreliable_metadata_is_not_used_as_a_digest_cache_identity() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("input.rs");
+        std::fs::write(&path, b"fn main() {}").unwrap();
+        let metadata = std::fs::metadata(&path).unwrap();
+
+        let identity = digest_cache_identity(&path, &metadata, false).unwrap();
+
+        assert_eq!(identity.path, path);
+        assert_eq!(identity.len, 12);
+        assert!(digest_cache_identity(&identity.path, &metadata, true).is_none());
     }
 }

--- a/crates/mbx-cache-core/src/agent/file_digest.rs
+++ b/crates/mbx-cache-core/src/agent/file_digest.rs
@@ -71,11 +71,13 @@ impl FileIdentity {
 /// A pre-operation snapshot that can prove whether a file's contents changed.
 ///
 /// Most filesystems provide a stable metadata-change token, so the inexpensive
-/// identity is sufficient. Linux NFS can reconcile client and server
-/// timestamps after a writer has closed the file, making two metadata reads
+/// identity is sufficient. Linux NFS can reconcile the client and server
+/// change times after a writer has closed the file, making two metadata reads
 /// disagree without any intervening write. Those files carry a content digest
-/// instead. Callers use the same comparison either way and do not need to know
-/// which filesystem supplied the file.
+/// instead, while retaining length and modification time as an independent
+/// signal for a write that restored the original bytes. Callers use the same
+/// comparison either way and do not need to know which filesystem supplied the
+/// file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileSnapshot {
     identity: FileIdentity,
@@ -89,10 +91,23 @@ impl FileSnapshot {
     }
 
     /// Whether `identity` and `content` still describe this snapshot.
+    ///
+    /// A content-backed snapshot deliberately ignores the unreliable change
+    /// token, but still requires the modification time to remain stable. That
+    /// prevents a write followed by restoration of the original bytes from
+    /// passing only because the endpoint digests agree.
     pub fn matches(&self, identity: Option<&FileIdentity>, content: &CacheDigest) -> bool {
-        self.content
-            .as_ref()
-            .map_or(identity == Some(&self.identity), |before| before == content)
+        self.content.as_ref().map_or_else(
+            || identity == Some(&self.identity),
+            |before| {
+                before == content
+                    && identity.is_some_and(|after| {
+                        self.identity.path == after.path
+                            && self.identity.len == after.len
+                            && self.identity.modified == after.modified
+                    })
+            },
+        )
     }
 
     /// Whether a mismatch proves the file's contents changed.
@@ -265,22 +280,23 @@ mod tests {
     }
 
     #[test]
-    fn a_content_snapshot_ignores_metadata_churn_but_detects_changed_bytes() {
+    fn a_content_snapshot_ignores_change_token_churn_but_detects_other_changes() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("input.rs");
         std::fs::write(&path, b"fn main() {}").unwrap();
         let snapshot = capture_file_snapshot(&path, true).unwrap().unwrap();
 
-        std::fs::File::options()
-            .write(true)
-            .open(&path)
-            .unwrap()
-            .set_times(std::fs::FileTimes::new().set_modified(SystemTime::UNIX_EPOCH))
-            .unwrap();
-        let identity = FileIdentity::describe(&path, &std::fs::metadata(&path).unwrap());
+        let mut identity =
+            FileIdentity::describe(&path, &std::fs::metadata(&path).unwrap()).unwrap();
+        identity.changed = identity
+            .changed
+            .map(|(seconds, nanos)| (seconds + 1, nanos));
         let digest = CacheDigest::blake3_file(&path).unwrap();
-        assert!(snapshot.matches(identity.as_ref(), &digest));
+        assert!(snapshot.matches(Some(&identity), &digest));
         assert!(snapshot.proves_content_change());
+
+        identity.modified = SystemTime::UNIX_EPOCH;
+        assert!(!snapshot.matches(Some(&identity), &digest));
 
         std::fs::write(&path, b"fn main(){ }").unwrap();
         let identity = FileIdentity::describe(&path, &std::fs::metadata(&path).unwrap());

--- a/crates/mbx-cache-core/src/agent/file_digest.rs
+++ b/crates/mbx-cache-core/src/agent/file_digest.rs
@@ -101,6 +101,15 @@ impl FileSnapshot {
     }
 }
 
+impl From<FileIdentity> for FileSnapshot {
+    fn from(identity: FileIdentity) -> Self {
+        Self {
+            identity,
+            content: None,
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn metadata_identity_is_unreliable(path: &Path) -> io::Result<bool> {
     use std::mem::MaybeUninit;

--- a/crates/mbx-cache-core/src/lib.rs
+++ b/crates/mbx-cache-core/src/lib.rs
@@ -48,8 +48,8 @@ mod uploads;
 pub use agent::{
     AGENT_PROTOCOL_VERSION, ActionDiagnostic, AgentEvent, AgentEventObserver, AgentRemoteCache,
     AgentRequest, AgentResponse, AgentStats, CacheAgent, CompilerStats, FileDigestCache,
-    FileDigestScope, FileIdentity, NoFileDigestCache, RecordedFileDigest, RestoreStats,
-    is_task_identity, task_manifest_actions,
+    FileDigestScope, FileIdentity, FileSnapshot, NoFileDigestCache, RecordedFileDigest,
+    RestoreStats, is_task_identity, task_manifest_actions,
 };
 pub use client::BlockingAgentClient;
 pub use local::{LocalActionCache, LocalCas};

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -290,6 +290,19 @@ impl DiscoveredInputs {
         Ok(())
     }
 
+    /// Compatibility form for callers that captured metadata identities.
+    pub fn verify_not_modified_since_with_identities(
+        &self,
+        started_at: SystemTime,
+        before: &BTreeMap<PathBuf, FileIdentity>,
+    ) -> Result<(), BypassReason> {
+        let snapshots = before
+            .iter()
+            .map(|(path, identity)| (path.clone(), identity.clone().into()))
+            .collect();
+        self.verify_not_modified_since_with_snapshots(started_at, &snapshots)
+    }
+
     /// Rehash every discovered file after compilation and before publication.
     /// This closes the discovery/compile race by degrading changed inputs to a
     /// cache miss rather than storing outputs beneath a stale action key.

--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -3,7 +3,7 @@ use super::{
     MAX_PREDICTED_INPUTS, PathMapping, RustcInvocation, normalize_components,
 };
 use mbx_cache_core::{
-    CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, RecordedFileDigest,
+    CacheDigest, FileDigestCache, FileDigestScope, FileIdentity, FileSnapshot, RecordedFileDigest,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
@@ -173,7 +173,12 @@ impl DiscoveredInputs {
                     message: "input is not a regular file".into(),
                 });
             }
-            let identity = FileIdentity::describe(&path, &metadata);
+            let identity = FileIdentity::for_digest_cache(&path, &metadata).map_err(|error| {
+                BypassReason::InputRead {
+                    path: path.clone(),
+                    message: error.to_string(),
+                }
+            })?;
             identified.push((path, identity));
         }
         let queries = identified
@@ -234,38 +239,42 @@ impl DiscoveredInputs {
     /// the contents that produced the artifact. `verify` closes the remaining
     /// race after hashing.
     pub fn verify_not_modified_since(&self, started_at: SystemTime) -> Result<(), BypassReason> {
-        self.verify_not_modified_since_with_identities(started_at, &BTreeMap::new())
+        self.verify_not_modified_since_with_snapshots(started_at, &BTreeMap::new())
     }
 
-    /// Reject inputs that changed from identities captured before rustc ran,
+    /// Reject inputs that changed from snapshots captured before rustc ran,
     /// falling back to the wall-clock barrier for inputs only dep-info named.
     ///
-    /// Exact identity comparison does not order a client timestamp against a
-    /// filesystem timestamp, so it remains valid when an NFS server and the
-    /// compiler host use different clocks. Only identities carrying a change
-    /// token qualify: without one a same-length rewrite can restore its mtime.
-    pub fn verify_not_modified_since_with_identities(
+    /// A snapshot may use metadata or content depending on what its filesystem
+    /// can compare reliably. Metadata snapshots need a change token: without
+    /// one a same-length rewrite can restore its mtime.
+    pub fn verify_not_modified_since_with_snapshots(
         &self,
         started_at: SystemTime,
-        before: &BTreeMap<PathBuf, FileIdentity>,
+        before: &BTreeMap<PathBuf, FileSnapshot>,
     ) -> Result<(), BypassReason> {
         for input in &self.inputs {
-            let metadata =
-                std::fs::metadata(&input.path).map_err(|error| BypassReason::InputRead {
-                    path: input.path.clone(),
-                    message: error.to_string(),
-                })?;
-            let identity = FileIdentity::describe(&input.path, &metadata);
             if let Some(previous) = before.get(&input.path)
-                && previous.changed.is_some()
+                && previous.proves_content_change()
             {
-                if identity.as_ref() == Some(previous) {
+                let metadata =
+                    std::fs::metadata(&input.path).map_err(|error| BypassReason::InputRead {
+                        path: input.path.clone(),
+                        message: error.to_string(),
+                    })?;
+                let identity = FileIdentity::describe(&input.path, &metadata);
+                if previous.matches(identity.as_ref(), &input.digest) {
                     continue;
                 }
                 return Err(BypassReason::InputModifiedDuringCompilation(
                     input.path.clone(),
                 ));
             }
+            let metadata =
+                std::fs::metadata(&input.path).map_err(|error| BypassReason::InputRead {
+                    path: input.path.clone(),
+                    message: error.to_string(),
+                })?;
             let modified = metadata
                 .modified()
                 .map_err(|error| BypassReason::InputRead {
@@ -751,7 +760,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn precompile_identity_does_not_depend_on_the_host_clock() {
+    fn precompile_snapshot_does_not_depend_on_the_host_clock() {
         let directory = tempfile::tempdir().unwrap();
         let source = directory.path().join("lib.rs");
         std::fs::write(&source, "pub fn library() {0}\n").unwrap();
@@ -766,20 +775,19 @@ mod tests {
         let discovered = invocation
             .discover_inputs(&dep_info, directory.path())
             .unwrap();
-        let identity =
-            FileIdentity::describe(&source, &std::fs::metadata(&source).unwrap()).unwrap();
-        let before = BTreeMap::from([(source.clone(), identity)]);
+        let snapshot = FileSnapshot::capture(&source).unwrap().unwrap();
+        let before = BTreeMap::from([(source.clone(), snapshot)]);
 
         // Every ordinary mtime is after the epoch. The unchanged identity is
         // nevertheless enough proof when the filesystem clock is far ahead.
         discovered
-            .verify_not_modified_since_with_identities(SystemTime::UNIX_EPOCH, &before)
+            .verify_not_modified_since_with_snapshots(SystemTime::UNIX_EPOCH, &before)
             .unwrap();
 
         // Conversely, a filesystem clock far behind must not conceal a write.
         std::fs::write(&source, "pub fn library() {1}\n").unwrap();
         assert_eq!(
-            discovered.verify_not_modified_since_with_identities(
+            discovered.verify_not_modified_since_with_snapshots(
                 SystemTime::now() + std::time::Duration::from_secs(60),
                 &before,
             ),

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -25,8 +25,8 @@ use mbx_cache_cc::{
 };
 use mbx_cache_core::{
     ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode,
-    CcMetadata, FileDigestScope, FileIdentity, PathMapping, RecordedFileDigest, RemoteActionResult,
-    RestoreStats, canonical_json, normalize_mapped_path,
+    CcMetadata, FileDigestScope, FileIdentity, FileSnapshot, PathMapping, RecordedFileDigest,
+    RemoteActionResult, RestoreStats, canonical_json, normalize_mapped_path,
 };
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
@@ -270,8 +270,8 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         .iter()
         .map(|path| absolute(path, &working_dir))
         .collect::<Vec<_>>();
-    let input_identities =
-        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
+    let input_snapshots =
+        crate::util::snapshot_compiler_inputs(required_inputs.iter().map(PathBuf::as_path));
     let demand = crate::scheduler::Demand::new(&compilation_name(&invocation), false);
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));
     let started = Instant::now();
@@ -318,7 +318,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         &depfile,
         &output,
         compilation_started,
-        &input_identities,
+        &input_snapshots,
         &task,
         &invocation_digest,
         duration_ns,
@@ -360,7 +360,7 @@ fn publish(
     depfile: &Path,
     output: &Output,
     compilation_started: SystemTime,
-    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
+    input_snapshots: &std::io::Result<BTreeMap<PathBuf, FileSnapshot>>,
     task: &str,
     invocation_digest: &CacheDigest,
     duration_ns: u64,
@@ -370,11 +370,11 @@ fn publish(
     remote_claim: Option<&str>,
     portable: &Portable,
 ) -> Result<()> {
-    let input_identities = input_identities
+    let input_snapshots = input_snapshots
         .as_ref()
         .map_err(|error| eyre::eyre!(error.to_string()))?;
     let discovered = discover(invocation, context, depfile)?;
-    discovered.verify_not_modified_since_with_identities(compilation_started, input_identities)?;
+    discovered.verify_not_modified_since_with_snapshots(compilation_started, input_snapshots)?;
     verify_search_path_unchanged(searchable, before)?;
     discovered.verify()?;
     discovered.apply_to(context)?;

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -9,8 +9,8 @@ use crate::{session, util::workspace_root};
 use eyre::{Context, Result, bail};
 use mbx_cache_core::{
     ActionDiagnostic, ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory,
-    CacheFileNode, FileDigestScope, FileIdentity, RecordedFileDigest, RemoteActionResult,
-    RestoreStats, RustcMetadata, canonical_json,
+    CacheFileNode, FileDigestScope, FileIdentity, FileSnapshot, RecordedFileDigest,
+    RemoteActionResult, RestoreStats, RustcMetadata, canonical_json,
 };
 use mbx_cache_rustc::{
     ActionContext, ActionInput, BypassReason, CompilerIdentity, DiscoveredInputs, LinkerIdentity,
@@ -431,8 +431,8 @@ pub(crate) fn compile(
     // capacity happened before rustc ran and belongs to the valid compilation
     // it is about to perform, not to the overlap this snapshot detects.
     let required_inputs = invocation.required_inputs_in(&working_dir);
-    let input_identities =
-        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
+    let input_snapshots =
+        crate::util::snapshot_compiler_inputs(required_inputs.iter().map(PathBuf::as_path));
     let compilation_started = SystemTime::now();
     let compiler_timer = Instant::now();
     let mut command = compiler_command(rustc, wrapper_argument);
@@ -488,10 +488,10 @@ pub(crate) fn compile(
                 &working_dir,
                 &portable,
                 compilation_started,
-                &input_identities,
+                &input_snapshots,
             )
         {
-            if discard_modified_compiler_result(&outputs, &input_identities, &error) {
+            if discard_modified_compiler_result(&outputs, &input_snapshots, &error) {
                 let _ = replay_bytes(&[], &output.stderr);
                 return Ok(ExitCode::FAILURE);
             }
@@ -527,12 +527,12 @@ pub(crate) fn compile(
         let publication: Result<Option<ActionDiagnostic>> =
             if let Some(discovered) = current_manifest_inputs {
                 (|| {
-                    let input_identities = input_identities
+                    let input_snapshots = input_snapshots
                         .as_ref()
                         .map_err(|error| eyre::eyre!(error.to_string()))?;
-                    discovered.verify_not_modified_since_with_identities(
+                    discovered.verify_not_modified_since_with_snapshots(
                         compilation_started,
-                        input_identities,
+                        input_snapshots,
                     )?;
                     discovered.verify()?;
                     learned.record_compiled();
@@ -540,14 +540,14 @@ pub(crate) fn compile(
                 })()
             } else {
                 (|| {
-                    let input_identities = input_identities
+                    let input_snapshots = input_snapshots
                         .as_ref()
                         .map_err(|error| eyre::eyre!(error.to_string()))?;
                     let (candidates, discovered) =
                         action_from_dep_info(&compilation, &outputs.dep_info)?;
-                    discovered.verify_not_modified_since_with_identities(
+                    discovered.verify_not_modified_since_with_snapshots(
                         compilation_started,
-                        input_identities,
+                        input_snapshots,
                     )?;
                     discovered.verify()?;
                     learned.record_compiled();
@@ -593,7 +593,7 @@ pub(crate) fn compile(
             };
         match publication {
             Ok(diagnostic) => current_diagnostic = diagnostic,
-            Err(error) if discard_modified_compiler_result(&outputs, &input_identities, &error) => {
+            Err(error) if discard_modified_compiler_result(&outputs, &input_snapshots, &error) => {
                 compiler_input_invalid = true;
             }
             Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
@@ -623,20 +623,20 @@ pub(crate) fn compile(
 ///
 /// Other publication failures only prevent caching: rustc's local result is
 /// still valid and Cargo can use it. A content change or an overlap proved by
-/// a pre-compilation file identity instead means the artifact cannot be
+/// a pre-compilation file snapshot instead means the artifact cannot be
 /// trusted. A timestamp-only overlap remains a conservative cache bypass: it
 /// is not reliable enough across skewed filesystem clocks to fail the build.
 fn compiler_input_was_modified(
     error: &eyre::Report,
-    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
+    input_snapshots: &std::io::Result<BTreeMap<PathBuf, FileSnapshot>>,
 ) -> bool {
     match error.downcast_ref::<BypassReason>() {
         Some(BypassReason::InputChanged(_)) => true,
-        Some(BypassReason::InputModifiedDuringCompilation(path)) => input_identities
+        Some(BypassReason::InputModifiedDuringCompilation(path)) => input_snapshots
             .as_ref()
             .ok()
-            .and_then(|identities| identities.get(path))
-            .is_some_and(|identity| identity.changed.is_some()),
+            .and_then(|snapshots| snapshots.get(path))
+            .is_some_and(FileSnapshot::proves_content_change),
         _ => false,
     }
 }
@@ -644,10 +644,10 @@ fn compiler_input_was_modified(
 /// Reject and remove a successful compiler result whose inputs changed while it ran.
 fn discard_modified_compiler_result(
     outputs: &RustcOutputs,
-    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
+    input_snapshots: &std::io::Result<BTreeMap<PathBuf, FileSnapshot>>,
     error: &eyre::Report,
 ) -> bool {
-    if !compiler_input_was_modified(error, input_identities) {
+    if !compiler_input_was_modified(error, input_snapshots) {
         return false;
     }
     if let Err(discard_error) = discard_compiler_outputs(outputs) {
@@ -665,9 +665,9 @@ fn validate_compiler_inputs(
     working_dir: &Path,
     portable: &Portable,
     compilation_started: SystemTime,
-    input_identities: &std::io::Result<BTreeMap<PathBuf, FileIdentity>>,
+    input_snapshots: &std::io::Result<BTreeMap<PathBuf, FileSnapshot>>,
 ) -> Result<()> {
-    let input_identities = input_identities
+    let input_snapshots = input_snapshots
         .as_ref()
         .map_err(|error| eyre::eyre!(error.to_string()))?;
     let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
@@ -677,7 +677,7 @@ fn validate_compiler_inputs(
         &portable.mappings,
         session::file_digest_cache(),
     )?;
-    discovered.verify_not_modified_since_with_identities(compilation_started, input_identities)?;
+    discovered.verify_not_modified_since_with_snapshots(compilation_started, input_snapshots)?;
     discovered.verify()?;
     Ok(())
 }
@@ -716,8 +716,8 @@ fn compile_execution_only_build_script(
     let demand = crate::scheduler::Demand::new(invocation.crate_name(), true);
     let permit = crate::scheduler::pool().and_then(|pool| pool.admit(&demand));
     let required_inputs = invocation.required_inputs_in(working_dir);
-    let input_identities =
-        crate::util::snapshot_file_identities(required_inputs.iter().map(PathBuf::as_path));
+    let input_snapshots =
+        crate::util::snapshot_compiler_inputs(required_inputs.iter().map(PathBuf::as_path));
     let compilation_started = SystemTime::now();
     let started = Instant::now();
     let output = compiler_command(rustc, wrapper_argument)
@@ -739,10 +739,10 @@ fn compile_execution_only_build_script(
             working_dir,
             portable,
             compilation_started,
-            &input_identities,
+            &input_snapshots,
         )
     {
-        if discard_modified_compiler_result(outputs, &input_identities, &error) {
+        if discard_modified_compiler_result(outputs, &input_snapshots, &error) {
             let _ = replay_bytes(&[], &output.stderr);
             return Ok(ExitCode::FAILURE);
         }

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -614,10 +614,14 @@ fn materialized_outputs_are_independent_from_the_cas() {
 
 #[test]
 fn only_compiler_input_mutations_invalidate_local_outputs() {
-    let directory = tempfile::tempdir().unwrap();
-    let path = directory.path().join("lib.rs");
-    std::fs::write(&path, b"source").unwrap();
-    let snapshot = FileSnapshot::capture(&path).unwrap().unwrap();
+    let path = PathBuf::from("src/lib.rs");
+    let identity = FileIdentity {
+        path: path.clone(),
+        len: 6,
+        modified: SystemTime::UNIX_EPOCH,
+        changed: Some((1, 2)),
+    };
+    let snapshot = FileSnapshot::from(identity);
     let snapshots = Ok(BTreeMap::from([(path.clone(), snapshot)]));
     let changed =
         eyre::Report::new(BypassReason::InputChanged(path.clone())).wrap_err("publication failed");

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -614,23 +614,20 @@ fn materialized_outputs_are_independent_from_the_cas() {
 
 #[test]
 fn only_compiler_input_mutations_invalidate_local_outputs() {
-    let path = PathBuf::from("src/lib.rs");
-    let identity = FileIdentity {
-        path: path.clone(),
-        len: 6,
-        modified: SystemTime::UNIX_EPOCH,
-        changed: Some((1, 2)),
-    };
-    let identities = Ok(BTreeMap::from([(path.clone(), identity)]));
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("lib.rs");
+    std::fs::write(&path, b"source").unwrap();
+    let snapshot = FileSnapshot::capture(&path).unwrap().unwrap();
+    let snapshots = Ok(BTreeMap::from([(path.clone(), snapshot)]));
     let changed =
         eyre::Report::new(BypassReason::InputChanged(path.clone())).wrap_err("publication failed");
     let overlapping = eyre::Report::new(BypassReason::InputModifiedDuringCompilation(path));
 
-    assert!(compiler_input_was_modified(&changed, &identities));
-    assert!(compiler_input_was_modified(&overlapping, &identities));
+    assert!(compiler_input_was_modified(&changed, &snapshots));
+    assert!(compiler_input_was_modified(&overlapping, &snapshots));
     assert!(!compiler_input_was_modified(
         &eyre::eyre!("the cache is unavailable"),
-        &identities
+        &snapshots
     ));
 }
 

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -1,45 +1,45 @@
 use eyre::{Context, Result};
-use mbx_cache_core::FileIdentity;
+use mbx_cache_core::FileSnapshot;
 use std::collections::BTreeMap;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-/// Capture clock-independent identities for compiler inputs known up front.
+/// Capture clock-independent snapshots for compiler inputs known up front.
 #[cfg(unix)]
-pub(crate) fn snapshot_file_identities<'a>(
+pub(crate) fn snapshot_compiler_inputs<'a>(
     paths: impl IntoIterator<Item = &'a Path>,
-) -> std::io::Result<BTreeMap<PathBuf, FileIdentity>> {
+) -> std::io::Result<BTreeMap<PathBuf, FileSnapshot>> {
     paths
         .into_iter()
         .map(|path| {
-            let metadata = std::fs::metadata(path).map_err(|error| {
+            let snapshot = FileSnapshot::capture(path).map_err(|error| {
                 std::io::Error::new(
                     error.kind(),
                     format!(
-                        "failed to capture compiler input identity for {}: {error}",
+                        "failed to capture compiler input snapshot for {}: {error}",
                         path.display()
                     ),
                 )
             })?;
-            let identity = FileIdentity::describe(path, &metadata).ok_or_else(|| {
+            let snapshot = snapshot.ok_or_else(|| {
                 std::io::Error::new(
                     std::io::ErrorKind::Unsupported,
                     format!(
-                        "filesystem supplied no identity for compiler input {}",
+                        "filesystem supplied no snapshot for compiler input {}",
                         path.display()
                     ),
                 )
             })?;
-            Ok((path.to_path_buf(), identity))
+            Ok((path.to_path_buf(), snapshot))
         })
         .collect()
 }
 
 #[cfg(not(unix))]
-pub(crate) fn snapshot_file_identities<'a>(
+pub(crate) fn snapshot_compiler_inputs<'a>(
     _paths: impl IntoIterator<Item = &'a Path>,
-) -> std::io::Result<BTreeMap<PathBuf, FileIdentity>> {
+) -> std::io::Result<BTreeMap<PathBuf, FileSnapshot>> {
     Ok(BTreeMap::new())
 }
 
@@ -571,11 +571,11 @@ mod tests {
     fn compiler_input_snapshot_fails_closed() {
         let directory = tempfile::tempdir().unwrap();
         let missing = directory.path().join("missing-input");
-        let error = snapshot_file_identities([missing.as_path()]).unwrap_err();
+        let error = snapshot_compiler_inputs([missing.as_path()]).unwrap_err();
         assert!(
             error
                 .to_string()
-                .contains("failed to capture compiler input identity")
+                .contains("failed to capture compiler input snapshot")
         );
     }
 


### PR DESCRIPTION
## Summary

Fix false `compiler input was modified during compilation` failures when an mbx-managed target lives on Linux NFS, without changing the fast metadata path on local filesystems.

The rustc and cc adapters now capture a filesystem-agnostic `FileSnapshot` before compilation. On ordinary filesystems that remains the existing cheap `(path, length, mtime, ctime)` identity. On Linux NFS it is a BLAKE3 content snapshot, because NFS client metadata reconciliation makes `ctime` unsuitable as a stable content-change token.

NFS compiler inputs also skip the session digest ledger's metadata lookup and are hashed directly. This is deliberately conservative: the same delayed attribute reconciliation that caused the pre/post false positive could otherwise let stale metadata validate a remembered digest.

The NFS decision is confined to `mbx-cache-core`; rustc and cc only capture and compare snapshots. There is no configuration or NFS-specific adapter behavior.

## What the investigation ruled out

The original report attributed the changes to cache-hit materialization. That was plausible, but incorrect: stock mbx 1.7 reproduced the hard `.rmeta` failures in a cold build using a unique `RUSTFLAGS` namespace, with zero cache hits.

Instrumentation around failing inputs showed stable bytes, length, and mtime while NFS-reported ctime changed after the producer had exited, including moving backward. Two narrower attempts did not fix it:

- forcing a synchronous attribute refresh with `statx(AT_STATX_FORCE_SYNC)`;
- calling `fsync` before taking the metadata snapshot.

Treating only forward timestamp movement as a write would also be unsound, since the observed reconciliation moved timestamps in both directions. Moving the target back to local storage avoids the symptom but gives up the managed reflink target that makes mbx valuable across many worktrees.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check -p mbx --target x86_64-unknown-linux-musl`
- cold build of `BrokkAi/mjolnir` against its real NFSv4.2-backed managed target: completed without modified-input failures
- immediate repeat: 645 hits, 6 misses, no discarded results, 24.65s
- settled repeat: 86 hits, 0 misses, 3 existing native-library bypasses, no discarded results, 14.11s

Follow-up to https://github.com/jdx/mr-boxington/discussions/334.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compiler inputs now use file snapshots to verify actual content changes.
  - Added content-digest checks for filesystems with unreliable metadata.
- **Bug Fixes**
  - Reduced unnecessary cache bypasses caused by timestamp-only file changes.
  - Improved detection of compiler input modifications during builds.
- **Refactor**
  - Updated compiler and C/C++ build workflows to use snapshot-based input validation.
  - Preserved compatibility for existing identity-based validation interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->