### PR TITLE
bench: compare GHA caches after a small edit

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -388,9 +388,6 @@ jobs:
       - name: Import native mbx bundle
         if: matrix.tool == 'mbx-registry'
         run: mbx cache import "$RUNNER_TEMP/mbx-cache.tar" | tee "$RUNNER_TEMP/mbx-import.log"
-      - name: Verify restored Cargo state
-        if: matrix.tool != 'rust-cache'
-        run: test -d target/.fingerprint
       - id: build
         name: Build edited commit
         env:

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -316,7 +316,7 @@ jobs:
       fail-fast: false
       matrix:
         tool: [rust-cache, mbx, mbx-registry]
-        trial: ${{ fromJSON(inputs.small_edit_trials) }}
+        trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -389,7 +389,7 @@ jobs:
       fail-fast: false
       matrix:
         tool: [rust-cache, mbx, mbx-registry]
-        trial: ${{ fromJSON(inputs.small_edit_trials) }}
+        trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -452,7 +452,9 @@ jobs:
             ~/.cargo/git
       - name: Import native mbx bundle
         if: matrix.tool == 'mbx-registry'
-        run: mbx cache import "$RUNNER_TEMP/mbx-cache.tar" | tee "$RUNNER_TEMP/mbx-import.log"
+        run: |
+          set -o pipefail
+          mbx cache import "$RUNNER_TEMP/mbx-cache.tar" | tee "$RUNNER_TEMP/mbx-import.log"
       - id: build
         name: Build edited commit
         env:

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -428,31 +428,13 @@ jobs:
           cache-all-crates: "true"
           cache-workspace-crates: "true"
           save-if: "false"
-      - name: Require parent rust-cache hit
-        if: matrix.tool == 'rust-cache'
-        env:
-          CACHE_HIT: ${{ steps.rust_cache_restore.outputs.cache-hit }}
-        run: |
-          if [ "$CACHE_HIT" != "true" ]; then
-            echo "::error::rust-cache did not restore the seeded parent cache"
-            exit 1
-          fi
       - if: matrix.tool == 'mbx'
+        id: mbx_restore
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
           version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
-          cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-child
-          restore-keys: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
+          cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           toolchain: 1.97.1
-      # A restore-key match is deliberately not an exact-key hit, so the
-      # action's cache-hit output is false. Verify the restored payload itself.
-      - name: Require parent mbx restore
-        if: matrix.tool == 'mbx'
-        run: |
-          if [ -z "$(find target -type f -print -quit 2>/dev/null)" ]; then
-            echo "::error::mbx did not restore the seeded parent target"
-            exit 1
-          fi
       - if: matrix.tool == 'mbx-registry'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
@@ -482,6 +464,26 @@ jobs:
           finished=$(date +%s%N)
           echo "build_duration_ns=$((finished - started))" >> "$GITHUB_OUTPUT"
           echo "total_duration_ns=$((finished - SMALL_EDIT_STARTED_NS))" >> "$GITHUB_OUTPUT"
+      # Validate after taking the timing so the assertion shell does not bias
+      # one arm. A miss fails the job before it can publish a measurement.
+      - name: Require parent rust-cache hit
+        if: matrix.tool == 'rust-cache'
+        env:
+          CACHE_HIT: ${{ steps.rust_cache_restore.outputs.cache-hit }}
+        run: |
+          if [ "$CACHE_HIT" != "true" ]; then
+            echo "::error::rust-cache did not restore the seeded parent cache"
+            exit 1
+          fi
+      - name: Require parent mbx hit
+        if: matrix.tool == 'mbx'
+        env:
+          CACHE_HIT: ${{ steps.mbx_restore.outputs.cache-hit }}
+        run: |
+          if [ "$CACHE_HIT" != "true" ]; then
+            echo "::error::mbx did not restore the seeded parent cache"
+            exit 1
+          fi
       - name: Record trial
         env:
           BUILD_DURATION_NS: ${{ steps.build.outputs.build_duration_ns }}

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: boolean
         default: false
+      small_edit:
+        description: Compare restored parent caches after hk's next small edit
+        required: false
+        type: boolean
+        default: false
+      small_edit_mbx_version:
+        description: Released mbx version used by the small-edit comparison
+        required: false
+        type: string
+        default: "1.8.0"
 
 permissions: {}
 
@@ -35,6 +45,7 @@ jobs:
   # reproduce with the version they can install.
   check:
     name: Check version drift
+    if: github.event_name != 'workflow_dispatch' || !inputs.small_edit
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -258,3 +269,203 @@ jobs:
             gh pr create --base main --head bench-refresh \
               --title "$TITLE" --body-file "$RUNNER_TEMP/body.md"
           fi
+
+  small-edit-seed:
+    name: Seed ${{ matrix.tool }} (${{ matrix.trial }})
+    if: github.event_name == 'workflow_dispatch' && inputs.small_edit
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [rust-cache, mbx, mbx-registry]
+        trial: [1, 2, 3, 4]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: write
+      contents: read
+    env:
+      MBX_CACHE_EXPORT_GROUP: gha-small-edit-${{ github.run_id }}-${{ matrix.trial }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: jdx/hk
+          ref: 27bb615768b85c9ac88e2abf8895219b44462871
+          persist-credentials: false
+      - name: Install pinned Rust
+        run: rustup toolchain install 1.97.1 --profile minimal --no-self-update
+      - if: matrix.tool == 'rust-cache'
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
+        with:
+          shared-key: gha-small-edit-${{ github.run_id }}-${{ matrix.trial }}
+          add-job-id-key: "false"
+          workspaces: . -> target
+          cache-all-crates: "true"
+          cache-workspace-crates: "true"
+      - if: matrix.tool == 'mbx'
+        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
+        with:
+          version: ${{ inputs.small_edit_mbx_version }}
+          cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
+          save-on-workflow-dispatch: "true"
+          toolchain: 1.97.1
+      - if: matrix.tool == 'mbx-registry'
+        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
+        with:
+          backend: local
+          version: ${{ inputs.small_edit_mbx_version }}
+          toolchain: 1.97.1
+      - name: Seed parent build
+        env:
+          BUILD_DRIVER: "${{ matrix.tool == 'rust-cache' && 'cargo' || 'mbx' }}"
+        run: |
+          "$BUILD_DRIVER" build --locked
+      - name: Export native mbx bundle
+        if: matrix.tool == 'mbx-registry'
+        run: mbx cache export --group "$MBX_CACHE_EXPORT_GROUP" "$RUNNER_TEMP/mbx-cache.tar"
+      - if: matrix.tool == 'mbx-registry'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: gha-small-edit-mbx-registry-${{ github.run_id }}-${{ matrix.trial }}-parent
+          path: |
+            ${{ runner.temp }}/mbx-cache.tar
+            ~/.cargo/registry
+            ~/.cargo/git
+
+  small-edit-measure:
+    name: Measure ${{ matrix.tool }} (${{ matrix.trial }})
+    needs: small-edit-seed
+    if: github.event_name == 'workflow_dispatch' && inputs.small_edit
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [rust-cache, mbx, mbx-registry]
+        trial: [1, 2, 3, 4]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: jdx/hk
+          ref: fc29ead1456ba7c1f62826c284126410a4014b00
+          persist-credentials: false
+      - name: Install pinned Rust
+        run: rustup toolchain install 1.97.1 --profile minimal --no-self-update
+      - name: Start restore-and-build timer
+        run: echo "SMALL_EDIT_STARTED_NS=$(date +%s%N)" >> "$GITHUB_ENV"
+      - if: matrix.tool == 'rust-cache'
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
+        with:
+          shared-key: gha-small-edit-${{ github.run_id }}-${{ matrix.trial }}
+          add-job-id-key: "false"
+          workspaces: . -> target
+          cache-all-crates: "true"
+          cache-workspace-crates: "true"
+          save-if: "false"
+      - if: matrix.tool == 'mbx'
+        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
+        with:
+          version: ${{ inputs.small_edit_mbx_version }}
+          cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-child
+          restore-keys: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
+          toolchain: 1.97.1
+      - if: matrix.tool == 'mbx-registry'
+        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
+        with:
+          backend: local
+          version: ${{ inputs.small_edit_mbx_version }}
+          toolchain: 1.97.1
+      - if: matrix.tool == 'mbx-registry'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: gha-small-edit-mbx-registry-${{ github.run_id }}-${{ matrix.trial }}-parent
+          path: |
+            ${{ runner.temp }}/mbx-cache.tar
+            ~/.cargo/registry
+            ~/.cargo/git
+      - name: Import native mbx bundle
+        if: matrix.tool == 'mbx-registry'
+        run: mbx cache import "$RUNNER_TEMP/mbx-cache.tar" | tee "$RUNNER_TEMP/mbx-import.log"
+      - name: Verify restored Cargo state
+        if: matrix.tool != 'rust-cache'
+        run: test -d target/.fingerprint
+      - id: build
+        name: Build edited commit
+        env:
+          BUILD_DRIVER: "${{ matrix.tool == 'rust-cache' && 'cargo' || 'mbx' }}"
+          MBX_REPORT: ${{ runner.temp }}/mbx-report.json
+        run: |
+          started=$(date +%s%N)
+          "$BUILD_DRIVER" build --locked
+          finished=$(date +%s%N)
+          echo "build_duration_ns=$((finished - started))" >> "$GITHUB_OUTPUT"
+          echo "total_duration_ns=$((finished - SMALL_EDIT_STARTED_NS))" >> "$GITHUB_OUTPUT"
+      - name: Record trial
+        env:
+          BUILD_DURATION_NS: ${{ steps.build.outputs.build_duration_ns }}
+          TOTAL_DURATION_NS: ${{ steps.build.outputs.total_duration_ns }}
+          TOOL: ${{ matrix.tool }}
+          TRIAL: ${{ matrix.trial }}
+          VERSION: ${{ inputs.small_edit_mbx_version }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/small-edit"
+          jq -n --arg tool "$TOOL" --arg version "$VERSION" \
+            --argjson trial "$TRIAL" \
+            --argjson build_duration_ns "$BUILD_DURATION_NS" \
+            --argjson restore_and_build_duration_ns "$TOTAL_DURATION_NS" \
+            '{schema:1,tool:$tool,mbx_version:$version,trial:$trial,build_duration_ns:$build_duration_ns,restore_and_build_duration_ns:$restore_and_build_duration_ns}' \
+            > "$RUNNER_TEMP/small-edit/${TOOL}-${TRIAL}.json"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gha-small-edit-${{ matrix.tool }}-${{ matrix.trial }}
+          path: ${{ runner.temp }}/small-edit/*.json
+          if-no-files-found: error
+          retention-days: 90
+
+  small-edit-report:
+    name: Report small-edit comparison
+    needs: small-edit-measure
+    if: always() && needs.small-edit-measure.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: gha-small-edit-*
+          path: ${{ runner.temp }}/small-edit
+          merge-multiple: true
+      - name: Summarize medians
+        run: |
+          jq -s '
+            def median:
+              sort as $values |
+              ($values | length) as $length |
+              if $length % 2 == 1 then $values[$length / 2 | floor]
+              else (($values[$length / 2 - 1] + $values[$length / 2]) / 2) end;
+            group_by(.tool) | map({
+              tool: .[0].tool,
+              mbx_version: .[0].mbx_version,
+              trials: length,
+              build_seconds: ([.[].build_duration_ns] | median) / 1e9,
+              restore_and_build_seconds: ([.[].restore_and_build_duration_ns] | median) / 1e9
+            })' "$RUNNER_TEMP"/small-edit/*.json \
+            | tee "$RUNNER_TEMP/small-edit-summary.json"
+          {
+            echo '## hk parent-cache + small-edit comparison'
+            echo
+            echo '| Tool | Trials | Median restore + build | Median build |'
+            echo '| :--- | ---: | ---: | ---: |'
+            jq -r '.[] | "| \(.tool) | \(.trials) | \(.restore_and_build_seconds * 100 | round / 100) s | \(.build_seconds * 100 | round / 100) s |"' \
+              "$RUNNER_TEMP/small-edit-summary.json"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gha-small-edit-summary
+          path: ${{ runner.temp }}/small-edit-summary.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -414,9 +414,12 @@ jobs:
         run: |
           chmod +x "$RUNNER_TEMP/mbx-bin/mbx"
           echo "$RUNNER_TEMP/mbx-bin" >> "$GITHUB_PATH"
+      # Start after common runner/bootstrap work but before each cache action.
+      # The action's own setup is part of real workflow wall time, as is restore.
       - name: Start restore-and-build timer
         run: echo "SMALL_EDIT_STARTED_NS=$(date +%s%N)" >> "$GITHUB_ENV"
       - if: matrix.tool == 'rust-cache'
+        id: rust_cache_restore
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
           shared-key: gha-small-edit-${{ github.run_id }}-${{ matrix.trial }}
@@ -425,6 +428,15 @@ jobs:
           cache-all-crates: "true"
           cache-workspace-crates: "true"
           save-if: "false"
+      - name: Require parent rust-cache hit
+        if: matrix.tool == 'rust-cache'
+        env:
+          CACHE_HIT: ${{ steps.rust_cache_restore.outputs.cache-hit }}
+        run: |
+          if [ "$CACHE_HIT" != "true" ]; then
+            echo "::error::rust-cache did not restore the seeded parent cache"
+            exit 1
+          fi
       - if: matrix.tool == 'mbx'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
@@ -432,6 +444,15 @@ jobs:
           cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-child
           restore-keys: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           toolchain: 1.97.1
+      # A restore-key match is deliberately not an exact-key hit, so the
+      # action's cache-hit output is false. Verify the restored payload itself.
+      - name: Require parent mbx restore
+        if: matrix.tool == 'mbx'
+        run: |
+          if [ -z "$(find target -type f -print -quit 2>/dev/null)" ]; then
+            echo "::error::mbx did not restore the seeded parent target"
+            exit 1
+          fi
       - if: matrix.tool == 'mbx-registry'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
@@ -442,6 +463,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: gha-small-edit-mbx-registry-${{ github.run_id }}-${{ matrix.trial }}-parent
+          fail-on-cache-miss: true
           path: |
             ${{ runner.temp }}/mbx-cache.tar
             ~/.cargo/registry
@@ -505,8 +527,21 @@ jobs:
           path: ${{ runner.temp }}/small-edit
           merge-multiple: true
       - name: Summarize medians
+        env:
+          TRIALS: ${{ inputs.small_edit_trials }}
         run: |
           set -o pipefail
+          trial_count=$(jq -er \
+            'if type == "array" and length > 0 then length else error("expected a non-empty trial array") end' \
+            <<< "$TRIALS")
+          expected=$((3 * trial_count))
+          shopt -s nullglob
+          records=("$RUNNER_TEMP"/small-edit/*.json)
+          actual=${#records[@]}
+          if [ "$actual" -ne "$expected" ]; then
+            echo "::error::expected $expected trial records, found $actual"
+            exit 1
+          fi
           jq -s '
             def median:
               sort as $values |

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -22,6 +22,16 @@ on:
         required: false
         type: string
         default: "1.8.0"
+      small_edit_mbx_ref:
+        description: Build this mr-boxington ref instead of installing a release
+        required: false
+        type: string
+        default: ""
+      small_edit_trials:
+        description: JSON array of trial numbers (use [1] for a smoke test)
+        required: false
+        type: string
+        default: "[1,2,3,4]"
 
 permissions: {}
 
@@ -270,14 +280,43 @@ jobs:
               --title "$TITLE" --body-file "$RUNNER_TEMP/body.md"
           fi
 
+  small-edit-build-mbx:
+    name: Build candidate mbx
+    if: github.event_name == 'workflow_dispatch' && inputs.small_edit && inputs.small_edit_mbx_ref != ''
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.small_edit_mbx_ref }}
+          persist-credentials: false
+      - name: Install pinned Rust
+        run: rustup toolchain install 1.97.1 --profile minimal --no-self-update
+      - name: Build candidate
+        run: cargo build --locked --release -p mbx
+      - name: Stage candidate
+        run: |
+          mkdir -p "$RUNNER_TEMP/mbx-bin"
+          cp target/release/mbx "$RUNNER_TEMP/mbx-bin/mbx"
+          git rev-parse HEAD > "$RUNNER_TEMP/mbx-bin/source-revision"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gha-small-edit-mbx-binary
+          path: ${{ runner.temp }}/mbx-bin
+          if-no-files-found: error
+          retention-days: 7
+
   small-edit-seed:
     name: Seed ${{ matrix.tool }} (${{ matrix.trial }})
-    if: github.event_name == 'workflow_dispatch' && inputs.small_edit
+    needs: small-edit-build-mbx
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.small_edit && (needs.small-edit-build-mbx.result == 'success' || needs.small-edit-build-mbx.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
         tool: [rust-cache, mbx, mbx-registry]
-        trial: [1, 2, 3, 4]
+        trial: ${{ fromJSON(inputs.small_edit_trials) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -293,6 +332,17 @@ jobs:
           persist-credentials: false
       - name: Install pinned Rust
         run: rustup toolchain install 1.97.1 --profile minimal --no-self-update
+      - name: Download candidate mbx
+        if: inputs.small_edit_mbx_ref != '' && matrix.tool != 'rust-cache'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gha-small-edit-mbx-binary
+          path: ${{ runner.temp }}/mbx-bin
+      - name: Select candidate mbx
+        if: inputs.small_edit_mbx_ref != '' && matrix.tool != 'rust-cache'
+        run: |
+          chmod +x "$RUNNER_TEMP/mbx-bin/mbx"
+          echo "$RUNNER_TEMP/mbx-bin" >> "$GITHUB_PATH"
       - if: matrix.tool == 'rust-cache'
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.8.1
         with:
@@ -304,7 +354,7 @@ jobs:
       - if: matrix.tool == 'mbx'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
-          version: ${{ inputs.small_edit_mbx_version }}
+          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           save-on-workflow-dispatch: "true"
           toolchain: 1.97.1
@@ -312,7 +362,7 @@ jobs:
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
           backend: local
-          version: ${{ inputs.small_edit_mbx_version }}
+          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           toolchain: 1.97.1
       - name: Seed parent build
         env:
@@ -339,7 +389,7 @@ jobs:
       fail-fast: false
       matrix:
         tool: [rust-cache, mbx, mbx-registry]
-        trial: [1, 2, 3, 4]
+        trial: ${{ fromJSON(inputs.small_edit_trials) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -353,6 +403,17 @@ jobs:
           persist-credentials: false
       - name: Install pinned Rust
         run: rustup toolchain install 1.97.1 --profile minimal --no-self-update
+      - name: Download candidate mbx
+        if: inputs.small_edit_mbx_ref != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gha-small-edit-mbx-binary
+          path: ${{ runner.temp }}/mbx-bin
+      - name: Select candidate mbx
+        if: inputs.small_edit_mbx_ref != '' && matrix.tool != 'rust-cache'
+        run: |
+          chmod +x "$RUNNER_TEMP/mbx-bin/mbx"
+          echo "$RUNNER_TEMP/mbx-bin" >> "$GITHUB_PATH"
       - name: Start restore-and-build timer
         run: echo "SMALL_EDIT_STARTED_NS=$(date +%s%N)" >> "$GITHUB_ENV"
       - if: matrix.tool == 'rust-cache'
@@ -367,7 +428,7 @@ jobs:
       - if: matrix.tool == 'mbx'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
-          version: ${{ inputs.small_edit_mbx_version }}
+          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-child
           restore-keys: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           toolchain: 1.97.1
@@ -375,7 +436,7 @@ jobs:
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
           backend: local
-          version: ${{ inputs.small_edit_mbx_version }}
+          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           toolchain: 1.97.1
       - if: matrix.tool == 'mbx-registry'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -405,14 +466,21 @@ jobs:
           TOTAL_DURATION_NS: ${{ steps.build.outputs.total_duration_ns }}
           TOOL: ${{ matrix.tool }}
           TRIAL: ${{ matrix.trial }}
+          REF: ${{ inputs.small_edit_mbx_ref }}
           VERSION: ${{ inputs.small_edit_mbx_version }}
         run: |
           mkdir -p "$RUNNER_TEMP/small-edit"
-          jq -n --arg tool "$TOOL" --arg version "$VERSION" \
+          if [ -n "$REF" ]; then
+            VERSION=""
+            REVISION=$(cat "$RUNNER_TEMP/mbx-bin/source-revision")
+          else
+            REVISION=""
+          fi
+          jq -n --arg tool "$TOOL" --arg ref "$REF" --arg revision "$REVISION" --arg version "$VERSION" \
             --argjson trial "$TRIAL" \
             --argjson build_duration_ns "$BUILD_DURATION_NS" \
             --argjson restore_and_build_duration_ns "$TOTAL_DURATION_NS" \
-            '{schema:1,tool:$tool,mbx_version:$version,trial:$trial,build_duration_ns:$build_duration_ns,restore_and_build_duration_ns:$restore_and_build_duration_ns}' \
+            '{schema:1,tool:$tool,mbx_version:$version,mbx_ref:$ref,mbx_revision:$revision,trial:$trial,build_duration_ns:$build_duration_ns,restore_and_build_duration_ns:$restore_and_build_duration_ns}' \
             > "$RUNNER_TEMP/small-edit/${TOOL}-${TRIAL}.json"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -448,6 +516,8 @@ jobs:
             group_by(.tool) | map({
               tool: .[0].tool,
               mbx_version: .[0].mbx_version,
+              mbx_ref: .[0].mbx_ref,
+              mbx_revision: .[0].mbx_revision,
               trials: length,
               build_seconds: (([.[].build_duration_ns] | median) / 1e9),
               restore_and_build_seconds: (([.[].restore_and_build_duration_ns] | median) / 1e9)

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -532,7 +532,7 @@ jobs:
           merge-multiple: true
       - name: Summarize medians
         env:
-          TRIALS: ${{ inputs.small_edit_trials }}
+          TRIALS: ${{ inputs.small_edit_trials || '[1,2,3,4]' }}
         run: |
           set -o pipefail
           trial_count=$(jq -er \

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -438,6 +438,7 @@ jobs:
           merge-multiple: true
       - name: Summarize medians
         run: |
+          set -o pipefail
           jq -s '
             def median:
               sort as $values |
@@ -448,8 +449,8 @@ jobs:
               tool: .[0].tool,
               mbx_version: .[0].mbx_version,
               trials: length,
-              build_seconds: ([.[].build_duration_ns] | median) / 1e9,
-              restore_and_build_seconds: ([.[].restore_and_build_duration_ns] | median) / 1e9
+              build_seconds: (([.[].build_duration_ns] | median) / 1e9),
+              restore_and_build_seconds: (([.[].restore_and_build_duration_ns] | median) / 1e9)
             })' "$RUNNER_TEMP"/small-edit/*.json \
             | tee "$RUNNER_TEMP/small-edit-summary.json"
           {


### PR DESCRIPTION
## Summary

- add an opt-in GitHub-hosted benchmark that seeds a parent hk build and measures a fresh runner building the next small edit
- compare rust-cache, native mbx, and mbx plus Cargo registry transport across four trials
- allow an arbitrary mr-boxington ref to be built once and distributed outside the timed region, so PR commits can be tested before release
- allow `[1]` smoke runs and record the exact candidate commit SHA in results

## Validation

- v1.8.0 four-trial run: https://github.com/jdx/mr-boxington/actions/runs/33872661103
- v1.7.0 four-trial run: https://github.com/jdx/mr-boxington/actions/runs/33873536880
- unreleased-ref smoke run: https://github.com/jdx/mr-boxington/actions/runs/33874555511

The smoke run built and tested commit `e121b0bef7b5980abcec2f35b882d8b044eb427f` without publishing a release. Its single-trial restore+build results were 23.10s for rust-cache, 34.91s for mbx plus registry, and 43.95s for stock mbx.

This PR adds measurement infrastructure only; it does not publish the current losing result as a product claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional GitHub Actions benchmark jobs and do not affect releases, auth, or published benchmark numbers unless someone manually dispatches the workflow.
> 
> **Overview**
> Adds an **opt-in manual benchmark** on `bench-refresh` that simulates CI after a small change to **jdx/hk**: seed a parent build’s cache, then on a fresh runner restore and build the next commit.
> 
> New `workflow_dispatch` inputs control **`small_edit`**, released **mbx version**, optional **mr-boxington ref** (built once and reused outside the timed path), and a **JSON trial list** (e.g. `[1]` for smoke). When `small_edit` is on, the usual version-drift **`check`** job is skipped so the weekly refresh path is untouched.
> 
> The pipeline runs **rust-cache**, stock **mbx**, and **mbx + registry bundle** (`mbx-registry`) in parallel per trial: **seed** → **measure** (restore-through-build wall time plus build-only), with **cache-hit checks** so cold restores fail the run. A final job writes **median timings** to the workflow summary and uploads JSON artifacts; it does not update published `benchmarks/results.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d06d2a870f4a8b8317bae52408d546dd821112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a manually triggered benchmark mode for evaluating small edits.
  - Added configurable inputs for the candidate version, source reference, and trial count.
  - Added automated setup, cache preparation, timing measurements, and report generation across multiple trials.
  - Reports median restore-and-build durations to support performance comparisons.
  - Added validation to prevent incomplete or cold benchmark trials from being included in results.
  - Reports now verify that the expected number of measurements is available for each configured trial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->