### PR TITLE
ci: disable pre-v1 API compatibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,6 @@ jobs:
       - fuzz
       - lint
       - supply-chain
-      - public-api
       - test
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     timeout-minutes: 1
@@ -205,7 +204,6 @@ jobs:
           needs.lint.result != 'success' ||
           needs.compatibility.result != 'success' ||
           needs.supply-chain.result != 'success' ||
-          needs.public-api.result != 'success' ||
           needs.test.result != 'success'
         run: exit 1
       - run: echo "All CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,53 +163,6 @@ jobs:
         with:
           command: check
 
-  public-api:
-    name: public API compatibility
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-      - name: Find packages present in both revisions
-        id: semver-packages
-        if: github.event_name == 'pull_request'
-        shell: bash
-        env:
-          BASE_REF: ${{ github.base_ref }}
-          # The CLI crate's library target exists so the binary and its
-          # integration tests can share application code; it is not an API
-          # anything outside this workspace is meant to build against, which
-          # `crates/mbx/src/lib.rs` says outright. Checking it would mean a
-          # major bump every time the CLI gains a setting, or contorting
-          # internal types to avoid one. mbx-cache-protocol is the crate with a
-          # promise to keep; mbx-cache-core and mbx-cache-rustc are internals on
-          # 0.x. All three stay checked, so a bump that breaks one is at least
-          # deliberate -- semver-checks understands 0.x rules.
-          UNCHECKED_PACKAGES: mbx
-        run: |
-          baseline_dir="$(mktemp -d)"
-          git worktree add --detach "$baseline_dir" "origin/$BASE_REF"
-          packages="$({
-            comm -12 \
-              <(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members as $members | [.packages[] | select(.id as $id | $members | index($id)) | .name] | sort | .[]') \
-              <(cargo metadata --manifest-path "$baseline_dir/Cargo.toml" --no-deps --format-version 1 | jq -r '.workspace_members as $members | [.packages[] | select(.id as $id | $members | index($id)) | .name] | sort | .[]')
-          } | { grep -vxF "$UNCHECKED_PACKAGES" || true; } | paste -sd, -)"
-          # An empty list would make the action check every package rather than
-          # nothing, so say what happened instead. `|| true` above keeps grep's
-          # no-match exit out of pipefail's way so this message is reachable.
-          if [ -z "$packages" ]; then
-            echo "no shared packages left to check" >&2
-            exit 1
-          fi
-          echo "packages=$packages" >> "$GITHUB_OUTPUT"
-      - name: Check workspace API against the PR base
-        if: github.event_name == 'pull_request'
-        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
-        with:
-          baseline-rev: origin/${{ github.base_ref }}
-          feature-group: all-features
-          package: ${{ steps.semver-packages.outputs.packages }}
-
   fuzz:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,21 +7,9 @@ from the commits that touched it and writes the bump in the release PR, so a
 version edited by hand in a feature PR either collides with that calculation or
 is silently overwritten by it. See [RELEASING.md](RELEASING.md) for the flow.
 
-This holds even when `cargo semver-checks` fails in CI. That check compares the
-branch against its base and reports what the change would require; it is
-telling you the shape of the change, not asking for a bump. A failure means one
-of two things:
-
-- The break is unintended. Fix the API instead. Adding a field to a struct with
-  all-public fields breaks exhaustive literals, so add a method or a
-  constructor rather than a field. Additive methods, new types, and new enum
-  variants on `#[non_exhaustive]` enums are all free.
-- The break is intended and worth it. Say so in the pull request and leave the
-  version alone. Whoever merges decides how it releases; release-plz will pick
-  the right number from the commits.
-
-Chasing the check with a bump is also self-defeating: `main` moves, the bump
-collides on the next rebase, and it has to be raised again.
+This also holds for breaking API changes: describe an intended break in the
+commit and pull request, then let release-plz choose the version in the release
+pull request.
 
 ## Documentation is generated
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,23 +59,11 @@ so semver itself says a minor bump may break them. `mbx-cache-cargo` and
 
 Nobody edits a version in a feature pull request. release-plz owns every
 number, and one written by hand either collides with its calculation or is
-overwritten by it. A failing `cargo semver-checks` reports what a change would
-require; it is not a request for a bump. Either the break is unintended, and
-the API is what to fix, or it is intended, and the pull request should say so
+overwritten by it. If an API break is intended, the pull request should say so
 and leave the version alone.
 
 An intended break is declared on the commit — `feat!:`, or a `BREAKING
-CHANGE:` footer — and leaves the `public API compatibility` check red, because
-the version it compares against cannot move until the release PR exists. That
-red check is the expected state of an honest breaking change, not a problem to
-solve inside the pull request.
-
-Read that job's output as a list of what broke, not as an instruction. Its
-summary says "semver requires new major version" whatever the crate's
-position, so for the crates on `0.x` it names a bump Cargo does not want —
-there, a break is a minor. The lint names above the summary are the useful
-part: they say which items changed shape, which is what a reviewer needs to
-judge whether the break was intended.
+CHANGE:` footer — so release-plz can choose the appropriate next version.
 
 release-plz computes each line from the commits that touched it and updates the
 path dependencies' version requirements, so a release can move one crate and

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -105,17 +105,16 @@ manifest readable but not updatable.
 
 ## Rust API compatibility
 
-Published Rust APIs follow semantic versioning independently of the wire
-protocols. Pull requests that touch workspace crates run `cargo-semver-checks`
-against the pull request's base commit with all features enabled. Wire format
-changes still require the protocol-version steps above.
+Published Rust APIs are versioned independently of the wire protocols. The
+subcrates remain on `0.x`, so their APIs may change in a minor release and CI
+does not currently enforce API compatibility. Wire format changes still require
+the protocol-version steps above.
 
 A breaking API change is declared, not numbered by hand: the commit carries
 `feat!:` or a `BREAKING CHANGE:` footer, and release-plz prices it into the
 version when it opens the release PR.
 [RELEASING.md](https://github.com/jdx/mr-boxington/blob/main/RELEASING.md)
-covers what that means for contributors, including why an intended break
-leaves the semver check red until the release PR exists.
+covers what that means for contributors.
 
 The published crates do not all share a version, because they do not promise
 the same things:

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -37,8 +37,8 @@ retires a setting fails instead of ignoring what you wrote.
 The local shim/agent protocol requires exact protocol and application-version
 equality. Embedders can connect to it, but must upgrade their client alongside
 mbx when that exact-match version changes. The remote cache protocol is
-versioned under `/v1/` with explicit evolution rules, and published Rust crates
-follow semantic versioning enforced by `cargo-semver-checks` in CI. See
+versioned under `/v1/` with explicit evolution rules. Published Rust subcrates
+remain on `0.x`, so their APIs may change in a minor release. See
 [protocol compatibility](/protocol-compatibility) for the details.
 
 `mbx-cache-cargo`, `mbx-cache-store`, `mbx-cache-core`, `mbx-cache-rustc`, and


### PR DESCRIPTION
## Summary

- remove the public API compatibility CI job while the published subcrates remain pre-1.0
- update contributor, release, and compatibility documentation to match

## Validation

- mise run build:docs
- CI workflow parses as valid YAML
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; no runtime or API behavior changes, though PRs will no longer be blocked by semver-check failures.
> 
> **Overview**
> **Removes the `public API compatibility` CI job** that ran `cargo-semver-checks` on pull requests against the base branch (with package filtering that skipped `mbx`). The **`final` gate** no longer waits on or requires that job.
> 
> Contributor and stability docs are updated to match: **no CI enforcement of Rust API semver** while published subcrates stay on `0.x`; intended breaks are still declared via conventional commits and **release-plz** sets versions in the release PR—not by bumping versions or “fixing” a red semver job in feature PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb936c91c690ef66c6a0b21331238b6ce9dde1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->