### PR TITLE
ci: prevent unbounded test and job hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -34,6 +35,7 @@ jobs:
 
   lint:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
@@ -71,6 +73,7 @@ jobs:
             runner: namespace-profile-endev-linux-arm64;overrides.cache-tag=cache
             target: aarch64-unknown-linux-musl
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     env:
       # Empty for the host-target jobs, which pass no `--target` at all and
       # keep cargo's default directory layout.
@@ -137,6 +140,7 @@ jobs:
 
   compatibility:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 15
     env:
       RUSTUP_TOOLCHAIN: "1.91"
     steps:
@@ -157,6 +161,7 @@ jobs:
 
   supply-chain:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   build:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 15
     permissions:
       contents: read
       pages: write
@@ -58,6 +59,7 @@ jobs:
       id-token: write
     needs: build
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 10
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/perf-pr-preflight.yml
+++ b/.github/workflows/perf-pr-preflight.yml
@@ -10,5 +10,6 @@ permissions:
 jobs:
   complete:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: echo "The default-branch controller will independently validate this pull request."

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   authorize:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       authorized: ${{ steps.pr.outputs.authorized }}
       base_ref: ${{ steps.pr.outputs.base_ref }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,6 +34,7 @@ jobs:
   release-plz-release:
     name: Release
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 30
     # Forks should never attempt to publish.
     if: ${{ github.repository_owner == 'jdx' }}
     permissions:
@@ -159,6 +160,7 @@ jobs:
     needs: release-plz-release
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 15
     continue-on-error: true
     permissions:
       contents: read
@@ -197,6 +199,7 @@ jobs:
     needs: [release-plz-release, upload-assets, enhance-release]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:
@@ -209,6 +212,7 @@ jobs:
   release-plz-pr:
     name: Release PR
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 20
     if: ${{ github.repository_owner == 'jdx' }}
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
   build:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:
@@ -318,6 +319,7 @@ jobs:
     # than one that arrives late, and the draft stays unpublished either way.
     needs: build
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -32,12 +32,7 @@ fn write_named_project(directory: &Path, name: &str) {
     // Manifest identity follows the lockfile, and cargo would otherwise write
     // it during the first build -- changing the identity between two runs that
     // are supposed to share a manifest.
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success(), "the fixture should resolve offline");
+    generate_lockfile(directory);
 }
 
 /// Write a workspace where one member depends on another.
@@ -74,12 +69,7 @@ fn write_dependent_project(directory: &Path) {
         "pub fn doubled() -> u32 { base::value() * 2 }\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success(), "the fixture should resolve offline");
+    generate_lockfile(directory);
 }
 
 /// Write a workspace whose dependency builds before a member that fails.
@@ -107,16 +97,25 @@ fn write_partially_failing_project(directory: &Path) {
         "use good as _;\ncompile_error!(\"expected failure\");\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success(), "the fixture should resolve offline");
+    generate_lockfile(directory);
 }
 
 fn cargo() -> std::ffi::OsString {
     std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into())
+}
+
+/// Generate a fixture lockfile without contending on the developer or CI
+/// runner's package cache. The integration tests run concurrently and these
+/// registry-free fixtures do not need anything from the shared Cargo home.
+fn generate_lockfile(directory: &Path) {
+    let cargo_home = tempfile::tempdir().unwrap();
+    let status = Command::new(cargo())
+        .current_dir(directory)
+        .args(["generate-lockfile", "--offline"])
+        .env("CARGO_HOME", cargo_home.path())
+        .status()
+        .expect("cargo should run");
+    assert!(status.success(), "the fixture should resolve offline");
 }
 
 #[cfg(unix)]
@@ -1656,12 +1655,7 @@ fn write_execution_cached_project(directory: &Path, declares_inputs: bool) {
          pub const MANIFEST_COPY: &str = env!(\"MANIFEST_COPY\");\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .unwrap();
-    assert!(status.success());
+    generate_lockfile(directory);
 }
 
 /// Write a build script with a Rust build-dependency. Cargo compares the
@@ -1695,12 +1689,7 @@ fn write_build_dependent_script_project(directory: &Path) {
         "pub fn value() -> u32 { 1 }\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .unwrap();
-    assert!(status.success());
+    generate_lockfile(directory);
 }
 
 #[test]
@@ -1822,12 +1811,7 @@ fn write_default_input_project(directory: &Path, execution_log: &Path) {
         "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .unwrap();
-    assert!(status.success());
+    generate_lockfile(directory);
 }
 
 #[test]
@@ -2070,12 +2054,7 @@ fn write_generated_project(directory: &Path, generated: Generated) {
         }
     };
     std::fs::write(directory.join("src/lib.rs"), lib).unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success());
+    generate_lockfile(directory);
 }
 
 /// Turning sharing off preserves the old checkout-specific behavior for a
@@ -2982,12 +2961,7 @@ fn main() {
         "pub fn value() -> u32 { 7 }\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success(), "the fixture should resolve offline");
+    generate_lockfile(directory);
 }
 
 /// Whether a C compiler is available to compile the fixture at all.
@@ -3117,12 +3091,7 @@ fn main() {
         "pub fn value() -> u32 { 7 }\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success(), "the fixture should resolve offline");
+    generate_lockfile(directory);
 }
 
 /// A header generated into `OUT_DIR` is cached like any other, even though the
@@ -3247,12 +3216,7 @@ fn main() {
         "pub fn value() -> u32 { 7 }\n",
     )
     .unwrap();
-    let status = Command::new(cargo())
-        .current_dir(directory)
-        .args(["generate-lockfile", "--offline"])
-        .status()
-        .expect("cargo should run");
-    assert!(status.success(), "the fixture should resolve offline");
+    generate_lockfile(directory);
 }
 
 /// A prediction that no longer describes the tree must not strand the


### PR DESCRIPTION
## Summary

- generate integration-test fixture lockfiles with a disposable Cargo home
- avoid contention on the runner-wide Cargo package-cache lock when the build tests run in parallel
- add explicit, workload-appropriate timeouts to every executable GitHub Actions job

## Why

The macOS CI job can hang indefinitely with all but one or two build integration tests complete. The last output is Cargo waiting for its package-cache lock, and the remaining test varies between runs. Fixture setup currently starts many cargo generate-lockfile processes concurrently against the same Cargo home even though these fixtures only use workspace or path dependencies.

Explicit job timeouts provide a second line of defense so a future deadlock or stalled external service cannot consume a runner indefinitely. The reusable upload-assets job cannot declare timeout-minutes itself; its underlying release build and attach jobs are bounded at 60 and 10 minutes.

## Validation

- cargo fmt --all --check
- cargo test -p mbx --test build (58 passed)
- three concurrent executions of the build integration-test binary (174 passed)
- parsed every workflow and verified each executable job declares timeout-minutes
- macOS CI completed successfully after the Cargo-home isolation change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI configuration and test fixture isolation only; no production runtime behavior is modified.
> 
> **Overview**
> Addresses macOS CI stalls where parallel `mbx` build integration tests block on Cargo’s shared package-cache lock during fixture `generate-lockfile`, and adds job-level timeouts so stuck workflows cannot hold runners forever.
> 
> **Integration tests:** Fixture setup now calls a shared `generate_lockfile` that runs `cargo generate-lockfile --offline` with a temporary `CARGO_HOME`, so concurrent tests no longer contend on the runner’s global Cargo home for path-only fixtures.
> 
> **GitHub Actions:** Executable jobs across `ci.yml`, `docs.yml`, perf, release, release-plz, and `zizmor.yml` get explicit `timeout-minutes` tuned to each workload (e.g. 20m for the test matrix, 60m for release builds, 5m for lightweight gates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ff3d72ba3aceec6dc5f0524cc27d4fe8b1d40f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of concurrent integration tests by isolating temporary package caches during lockfile generation.

* **Chores**
  * Added execution time limits across continuous integration, documentation, performance, release, and security workflows.
  * Prevents stalled automation jobs from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->