### PR TITLE
ci: skip unused benchmark tool installs

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -113,6 +113,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
+          install: false
         env:
           MISE_LOCKED: "1"
       # The comparison should track kache itself, not the version that happened


### PR DESCRIPTION
## Summary

- keep `mise-action` available to install the explicit kache comparator
- skip installing the repository-wide development toolset in the full benchmark refresh
- remove the irrelevant Node download that fails in the network-restricted performance environment

## Validation

- parsed `.github/workflows/bench-refresh.yml` with Ruby YAML
- `git diff --check`
- observed the pre-fix failure in [bench-refresh run 33881305391](https://github.com/jdx/mr-boxington/actions/runs/33881305391)

*AI-assisted — Tool: Codex; model: GPT-5.6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tweak on the benchmark refresh job; no application or runtime behavior changes.
> 
> **Overview**
> The **Refresh benchmarks** job now passes **`install: false`** to `jdx/mise-action`, so the workflow still bootstraps mise but no longer installs the full repo toolset from `mise.lock` on the network-restricted perf runner.
> 
> Kache remains installed explicitly in the following **Install latest benchmark comparator** step via `mise install github:kunobi-ninja/kache@latest`, avoiding unnecessary downloads (e.g. Node) that were failing in that environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb3ba401e8d93d70d6cb65c06ebd4d1534f409e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->