### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bytesize",
  "demand",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.18...mbx-cache-cargo-v0.1.19) - 2026-09-04
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.18](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.17...mbx-cache-cargo-v0.1.18) - 2026-09-04
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.18"
+version = "0.1.19"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.5...mbx-cache-cc-v0.12.0) - 2026-09-04
+
+### Fixed
+
+- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
+
 ## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.4...mbx-cache-cc-v0.11.5) - 2026-09-04
 
 ### Fixed

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.11.5"
+version = "0.12.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.5...mbx-cache-core-v0.12.0) - 2026-09-04
+
+### Fixed
+
+- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
+
 ## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.4...mbx-cache-core-v0.11.5) - 2026-09-04
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.11.5"
+version = "0.12.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.5...mbx-cache-rustc-v0.12.0) - 2026-09-04
+
+### Fixed
+
+- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
+
 ## [0.11.5](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.4...mbx-cache-rustc-v0.11.5) - 2026-09-04
 
 ### Fixed

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.11.5"
+version = "0.12.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.17...mbx-cache-store-v0.1.18) - 2026-09-04
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.17](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.16...mbx-cache-store-v0.1.17) - 2026-09-04
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.17"
+version = "0.1.18"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1](https://github.com/jdx/mr-boxington/compare/v1.8.0...v1.8.1) - 2026-09-04
+
+### Fixed
+
+- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
+
+### Other
+
+- share build-script shim binaries per profile ([#351](https://github.com/jdx/mr-boxington/pull/351))
+- prevent unbounded test and job hangs ([#343](https://github.com/jdx/mr-boxington/pull/343))
+
 ## [1.8.0](https://github.com/jdx/mr-boxington/compare/v1.7.0...v1.8.0) - 2026-09-04
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.8.0"
+version = "1.8.1"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -26,11 +26,11 @@ flate2 = "1"
 hex = "0.4"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.11.5", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.18", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.11.5", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.11.5", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.17", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.19", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.12.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.12.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.18", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.8.0
+**Version:** 1.8.1
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.11.5 -> 0.12.0 (⚠ API breaking changes)
* `mbx-cache-cc`: 0.11.5 -> 0.12.0 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.11.5 -> 0.12.0 (✓ API compatible changes)
* `mbx`: 1.8.0 -> 1.8.1 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.18 -> 0.1.19
* `mbx-cache-store`: 0.1.17 -> 0.1.18

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FileIdentity.object in /tmp/.tmpjR1OxG/mr-boxington/crates/mbx-cache-core/src/agent/file_digest.rs:87

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:FileDigestsResolved in /tmp/.tmpjR1OxG/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:379
  variant AgentRequest:ResolveFileDigests in /tmp/.tmpjR1OxG/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:174
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.5...mbx-cache-core-v0.12.0) - 2026-09-04

### Fixed

- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.5...mbx-cache-cc-v0.12.0) - 2026-09-04

### Fixed

- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.5...mbx-cache-rustc-v0.12.0) - 2026-09-04

### Fixed

- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
</blockquote>

## `mbx`

<blockquote>

## [1.8.1](https://github.com/jdx/mr-boxington/compare/v1.8.0...v1.8.1) - 2026-09-04

### Fixed

- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))

### Other

- share build-script shim binaries per profile ([#351](https://github.com/jdx/mr-boxington/pull/351))
- prevent unbounded test and job hangs ([#343](https://github.com/jdx/mr-boxington/pull/343))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.19](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.18...mbx-cache-cargo-v0.1.19) - 2026-09-04

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.18](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.17...mbx-cache-store-v0.1.18) - 2026-09-04

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The release carries breaking `mbx-cache-core` agent/file-identity API changes and NFS file-digest behavior that affects cache key correctness; CLI users get a patch bump, but embedders must upgrade against the new wire protocol and struct fields.
> 
> **Overview**
> This is a **release-plz** cut that bumps crate versions, refreshes changelogs, updates `Cargo.lock`, and sets the CLI docs version to **1.8.1**. It does not land new feature code here; it publishes work already merged.
> 
> **mbx 1.8.1** documents a fix to **restore NFS digest reuse without read storms** ([#341](https://github.com/jdx/mr-boxington/pull/341)), plus sharing build-script shim binaries per profile ([#351](https://github.com/jdx/mr-boxington/pull/351)) and bounds on test/job hangs ([#343](https://github.com/jdx/mr-boxington/pull/343)).
> 
> **mbx-cache-core 0.12.0** (and aligned **mbx-cache-cc** / **mbx-cache-rustc** releases) ship the same NFS digest fix. **mbx-cache-core** is a **semver-breaking** release for embedders: a new public field on `FileIdentity` and new agent wire variants `ResolveFileDigests` / `FileDigestsResolved`. Dependent workspace crates are bumped to depend on **0.12.0** (or patch bumps where only the core pin changed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec286f4307a4a46362c08bccaca05fc50674650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->