### PR TITLE
fix(bench): ignore stdin compiler probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Test benchmark driver
+        run: python3 -m unittest discover -s benchmarks -p 'test_*.py'
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - name: Build documentation
         env:

--- a/benchmarks/real_world.py
+++ b/benchmarks/real_world.py
@@ -176,8 +176,9 @@ def count_compilers() -> int | None:
     Counted by what the process actually is rather than by what started it:
     a shim is invoked under its own name and execs nothing, so matching the
     `rustc` executable itself is what separates the compilations from the
-    wrappers in front of them. Cargo's target-info queries carry
-    `--crate-name` too and compile nothing, so `--print` is excluded.
+    wrappers in front of them. Cargo's target-info and stdin probes carry
+    `--crate-name` too and compile nothing, so `--print` and a standalone
+    stdin argument are excluded just as the scheduler excludes them.
     """
     try:
         listing = subprocess.run(
@@ -189,9 +190,14 @@ def count_compilers() -> int | None:
         return None
     count = 0
     for line in listing.stdout.splitlines():
-        if "--crate-name" not in line or "--print" in line:
+        arguments = line.split()
+        if not arguments or (
+            "--crate-name" not in arguments
+            or any(argument.startswith("--print") for argument in arguments)
+            or "-" in arguments
+        ):
             continue
-        executable = line.split(maxsplit=1)[0]
+        executable = arguments[0]
         if Path(executable).name in ("rustc", "rustc.exe"):
             count += 1
     return count

--- a/benchmarks/real_world.py
+++ b/benchmarks/real_world.py
@@ -191,8 +191,12 @@ def count_compilers() -> int | None:
     count = 0
     for line in listing.stdout.splitlines():
         arguments = line.split()
+        has_crate_name = any(
+            argument == "--crate-name" or argument.startswith("--crate-name=")
+            for argument in arguments
+        )
         if not arguments or (
-            "--crate-name" not in arguments
+            not has_crate_name
             or any(argument.startswith("--print") for argument in arguments)
             or "-" in arguments
         ):

--- a/benchmarks/test_real_world.py
+++ b/benchmarks/test_real_world.py
@@ -1,0 +1,27 @@
+import subprocess
+import unittest
+from unittest import mock
+
+import real_world
+
+
+class CountCompilersTest(unittest.TestCase):
+    def test_excludes_wrappers_and_probe_invocations(self) -> None:
+        listing = "\n".join(
+            (
+                "/opt/rust/bin/rustc --crate-name real src/lib.rs --emit=link",
+                "/opt/rust/bin/rustc --crate-name ___ -",
+                "/opt/rust/bin/rustc --crate-name ___ --print=file-names",
+                "/usr/bin/mbx /opt/rust/bin/rustc --crate-name wrapped src/lib.rs",
+            )
+        )
+        completed = subprocess.CompletedProcess(
+            ["ps", "-Ao", "args="], 0, stdout=listing, stderr=""
+        )
+
+        with mock.patch.object(real_world.subprocess, "run", return_value=completed):
+            self.assertEqual(real_world.count_compilers(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/test_real_world.py
+++ b/benchmarks/test_real_world.py
@@ -10,6 +10,7 @@ class CountCompilersTest(unittest.TestCase):
         listing = "\n".join(
             (
                 "/opt/rust/bin/rustc --crate-name real src/lib.rs --emit=link",
+                "/opt/rust/bin/rustc --crate-name=also_real src/main.rs --emit=link",
                 "/opt/rust/bin/rustc --crate-name ___ -",
                 "/opt/rust/bin/rustc --crate-name ___ --print=file-names",
                 "/usr/bin/mbx /opt/rust/bin/rustc --crate-name wrapped src/lib.rs",
@@ -20,7 +21,7 @@ class CountCompilersTest(unittest.TestCase):
         )
 
         with mock.patch.object(real_world.subprocess, "run", return_value=completed):
-            self.assertEqual(real_world.count_compilers(), 1)
+            self.assertEqual(real_world.count_compilers(), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the external contention sampler exclude rustc stdin probes, matching mbx scheduler semantics
- parse process arguments consistently when distinguishing real compiler work from queries and wrappers
- add a focused unit test and run benchmark-driver tests in CI

## Why

The v1.8.0 docs refresh measured the scheduled contention batch at 10 compiler processes against 8 permits. The raw logs show that rustc stdin probes—which mbx intentionally lets bypass the pool because they compile nothing—were counted as compiler work by the benchmark. That made an otherwise successful refresh fail its validity gate.

Failed refresh: https://github.com/jdx/mr-boxington/actions/runs/33883205829

## Validation

- `python3 -m unittest discover -s benchmarks -p "test_*.py"`
- `python3 -m compileall -q benchmarks/real_world.py benchmarks/test_real_world.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes benchmark measurement and CI test wiring only; no runtime scheduler or product behavior is modified.
> 
> **Overview**
> Fixes **contention benchmark validity** by aligning external `peak_compilers` sampling with how mbx treats non-compiling `rustc` invocations.
> 
> `count_compilers()` now tokenizes `ps` lines and only counts real `rustc`/`rustc.exe` processes that have `--crate-name`, while skipping `--print` queries, **stdin probe** invocations (`-` as an argument), and wrapper-led command lines. That stops probe processes from inflating peak concurrency and tripping the “peak vs permits” gate.
> 
> Adds **`test_real_world.py`** with a mocked `ps` listing and wires **`python3 -m unittest discover -s benchmarks`** into the CI **docs** job before doc checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34306b3cdada4f9ef19121bee26b3ecd9e89f853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler detection to ignore wrapper commands, print queries, and standard-input probe invocations.
  * Recognizes compiler processes using both space-separated and equals-sign crate-name arguments.
  * Compiler counts now more accurately reflect actual compiler processes.

* **Tests**
  * Added coverage for excluding wrapper and probe processes from compiler counts.
  * Documentation builds now run the benchmark unit tests first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->