### PR TITLE
fix(ci): run released small-edit measurements

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -385,7 +385,11 @@ jobs:
   small-edit-measure:
     name: Measure ${{ matrix.tool }} (${{ matrix.trial }})
     needs: small-edit-seed
-    if: github.event_name == 'workflow_dispatch' && inputs.small_edit
+    # `small-edit-seed` deliberately tolerates the candidate-build job being
+    # skipped when benchmarking a released mbx. Preserve that tolerance here:
+    # without `always()`, GitHub propagates the transitive skipped dependency
+    # and silently skips this matrix even though every seed job succeeded.
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.small_edit && needs.small-edit-seed.result == 'success'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- prevent GitHub from propagating the intentionally skipped candidate-build dependency into the measurement matrix
- require the seed matrix itself to succeed before measuring

## Verification

- `mise run lint`
- reproduced in run 33903080647: all seed jobs succeeded while measurement/report were skipped

This enables released-version small-edit comparisons against rust-cache without cutting or building a new mbx release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to job gating; no runtime or application code affected.
> 
> **Overview**
> Fixes **`small-edit-measure`** being skipped when comparing against a **released** mbx (no `small_edit_mbx_ref`), even after all seed jobs succeed.
> 
> The job’s `if` now uses **`always()`** and requires **`needs.small-edit-seed.result == 'success'`**, matching how **`small-edit-seed`** tolerates a skipped **`small-edit-build-mbx`**. Without `always()`, GitHub treats the transitive skipped build dependency as a reason to skip the measurement matrix.
> 
> Inline comments document this so future edits don’t drop the guard and break released-version small-edit benchmarks again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fdf5ec65f2127a6b8a6909a18f564e4de33dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark refresh workflows now continue correctly when candidate builds are skipped while benchmarking a released version.
  * Benchmark measurement runs only after the seed step completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->