### PR TITLE
docs: complete social and search metadata

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,10 +16,12 @@ if (!versionMatch) {
   throw new Error("could not read the mbx version from crates/mbx/Cargo.toml");
 }
 const latestVersion = versionMatch[1];
+const siteUrl = "https://mr-boxington.jdx.dev";
 
 export default defineConfig({
   title: "mr boxington",
-  description: "Put mbx in front of any cargo command. Every build on the machine shares one self-pruning cache, and you can run multiple Cargo builds in parallel.",
+  description:
+    "Put mbx in front of any cargo command. Every build on the machine shares one self-pruning cache, and you can run multiple Cargo builds in parallel.",
   lang: "en-US",
   lastUpdated: true,
   appearance: "force-dark",
@@ -151,7 +153,12 @@ gtag('js', new Date());
 gtag('config', 'G-0MDX8ZJYFY');`,
     ],
     ["link", { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" }],
-    ["link", { rel: "alternate icon", href: "/favicon.png", type: "image/png" }],
+    [
+      "link",
+      { rel: "icon", href: "/favicon.png", type: "image/png", sizes: "64x64" },
+    ],
+    ["link", { rel: "apple-touch-icon", href: "/favicon.png" }],
+    ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
     [
       "link",
@@ -167,10 +174,15 @@ gtag('config', 'G-0MDX8ZJYFY');`,
     ["meta", { name: "theme-color", content: "#d69b42" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:site_name", content: "mr boxington" }],
+    ["meta", { property: "og:locale", content: "en_US" }],
     ["meta", { property: "og:title", content: "mr boxington" }],
     [
       "meta",
-      { property: "og:description", content: "Put mbx in front of any cargo command. Every build on the machine shares one self-pruning cache, and you can run multiple Cargo builds in parallel." },
+      {
+        property: "og:description",
+        content:
+          "Put mbx in front of any cargo command. Every build on the machine shares one self-pruning cache, and you can run multiple Cargo builds in parallel.",
+      },
     ],
     [
       "meta",
@@ -181,6 +193,52 @@ gtag('config', 'G-0MDX8ZJYFY');`,
     ],
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
+    [
+      "meta",
+      {
+        property: "og:image:alt",
+        content: "mr boxington — a shared, self-pruning Cargo build cache",
+      },
+    ],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:site", content: "@jdxcode" }],
+    [
+      "meta",
+      { name: "twitter:image", content: "https://mr-boxington.jdx.dev/og.png" },
+    ],
+    [
+      "meta",
+      {
+        name: "twitter:image:alt",
+        content: "mr boxington — a shared, self-pruning Cargo build cache",
+      },
+    ],
   ],
+  transformHead({ pageData, title, description }) {
+    const url = new URL(
+      pageData.relativePath.replace(/index\.md$/, "").replace(/\.md$/, ""),
+      `${siteUrl}/`,
+    ).toString();
+
+    return [
+      ["link", { rel: "canonical", href: url }],
+      ["meta", { property: "og:url", content: url }],
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { name: "twitter:title", content: title }],
+      ["meta", { name: "twitter:description", content: description }],
+      [
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "WebPage",
+          name: title,
+          description,
+          url,
+          isPartOf: { "@type": "WebSite", name: "mr boxington", url: siteUrl },
+        }),
+      ],
+    ];
+  },
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+title: Shared, self-pruning Cargo build cache
 
 hero:
   name: "mr boxington"

--- a/docs/public/site.webmanifest
+++ b/docs/public/site.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "mr boxington",
+  "short_name": "mbx",
+  "icons": [{ "src": "/favicon.png", "sizes": "64x64", "type": "image/png" }],
+  "theme_color": "#d69b42",
+  "background_color": "#111111",
+  "display": "standalone"
+}


### PR DESCRIPTION
## Summary

- add per-page canonical, Open Graph, Twitter, and structured data metadata
- publish the existing icon as a standard favicon and Apple touch icon
- add a web app manifest and improve the homepage title

## Testing

- npm run docs:build
- verified generated homepage and nested-page metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static metadata only; no runtime product or auth behavior changes.
> 
> **Overview**
> Expands the VitePress docs site with **per-page SEO and social sharing**: a shared `siteUrl`, a `transformHead` hook that emits canonical URLs, page-specific Open Graph/Twitter title and description, and JSON-LD `WebPage` structured data.
> 
> **Global head** gains PWA-style assets (`site.webmanifest`, sized PNG favicon, Apple touch icon) plus richer default OG/Twitter tags (locale, image alt text, `@jdxcode`). The homepage front matter sets an explicit document **title** for search/snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee29808021f6c08fc89248bdf7757513dec110c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a descriptive title to the documentation homepage.
  - Improved page metadata for clearer search-engine and social-media previews.
  - Added canonical links and structured page information to improve discoverability.
  - Added localized metadata and descriptive image information.

- **Style**
  - Added expanded favicon and Apple device icon support.
  - Added a web app manifest with application branding, theme colors, and standalone display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->