### PR TITLE
perf(cache): avoid redundant import copies and hashes

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -314,7 +314,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry, mbx-direct]
+        tool: [rust-cache, mbx, mbx-registry]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -357,7 +357,7 @@ jobs:
           cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           save-on-workflow-dispatch: "true"
           toolchain: 1.97.1
-      - if: matrix.tool == 'mbx-registry' || matrix.tool == 'mbx-direct'
+      - if: matrix.tool == 'mbx-registry'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
           backend: local
@@ -379,15 +379,6 @@ jobs:
             ${{ runner.temp }}/mbx-cache.tar
             ~/.cargo/registry
             ~/.cargo/git
-      - if: matrix.tool == 'mbx-direct'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          key: gha-small-edit-mbx-direct-${{ github.run_id }}-${{ matrix.trial }}-parent
-          path: |
-            ~/.cache/mbx
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
 
   small-edit-measure:
     name: Measure ${{ matrix.tool }} (${{ matrix.trial }})
@@ -400,7 +391,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry, mbx-direct]
+        tool: [rust-cache, mbx, mbx-registry]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -447,7 +438,7 @@ jobs:
           version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           toolchain: 1.97.1
-      - if: matrix.tool == 'mbx-registry' || matrix.tool == 'mbx-direct'
+      - if: matrix.tool == 'mbx-registry'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
           backend: local
@@ -462,17 +453,6 @@ jobs:
             ${{ runner.temp }}/mbx-cache.tar
             ~/.cargo/registry
             ~/.cargo/git
-      - if: matrix.tool == 'mbx-direct'
-        id: mbx_direct_restore
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          key: gha-small-edit-mbx-direct-${{ github.run_id }}-${{ matrix.trial }}-parent
-          fail-on-cache-miss: true
-          path: |
-            ~/.cache/mbx
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
       - name: Import native mbx bundle
         if: matrix.tool == 'mbx-registry'
         run: |
@@ -507,15 +487,6 @@ jobs:
         run: |
           if [ "$CACHE_HIT" != "true" ]; then
             echo "::error::mbx did not restore the seeded parent cache"
-            exit 1
-          fi
-      - name: Require direct mbx cache hit
-        if: matrix.tool == 'mbx-direct'
-        env:
-          CACHE_HIT: ${{ steps.mbx_direct_restore.outputs.cache-hit }}
-        run: |
-          if [ "$CACHE_HIT" != "true" ]; then
-            echo "::error::direct mbx cache did not restore the seeded parent cache"
             exit 1
           fi
       - name: Record trial
@@ -570,7 +541,7 @@ jobs:
           trial_count=$(jq -er \
             'if type == "array" and length > 0 then length else error("expected a non-empty trial array") end' \
             <<< "$TRIALS")
-          expected=$((4 * trial_count))
+          expected=$((3 * trial_count))
           shopt -s nullglob
           records=("$RUNNER_TEMP"/small-edit/*.json)
           actual=${#records[@]}

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -314,13 +314,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry]
+        tool: [rust-cache, mbx, mbx-registry, mbx-server]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       actions: write
       contents: read
+      id-token: write
     env:
       MBX_CACHE_EXPORT_GROUP: gha-small-edit-${{ github.run_id }}-${{ matrix.trial }}
     steps:
@@ -363,6 +364,15 @@ jobs:
           backend: local
           version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           toolchain: 1.97.1
+      - if: matrix.tool == 'mbx-server'
+        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
+        with:
+          backend: server
+          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
+          toolchain: 1.97.1
+          server-url: https://cache.mise.jdx.dev
+          namespace: jdx/hk
+          oidc-audience: https://cache.mise.jdx.dev
       - name: Seed parent build
         env:
           BUILD_DRIVER: "${{ matrix.tool == 'rust-cache' && 'cargo' || 'mbx' }}"
@@ -391,13 +401,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry]
+        tool: [rust-cache, mbx, mbx-registry, mbx-server]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       actions: read
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -444,6 +455,15 @@ jobs:
           backend: local
           version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           toolchain: 1.97.1
+      - if: matrix.tool == 'mbx-server'
+        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
+        with:
+          backend: server
+          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
+          toolchain: 1.97.1
+          server-url: https://cache.mise.jdx.dev
+          namespace: jdx/hk
+          oidc-audience: https://cache.mise.jdx.dev
       - if: matrix.tool == 'mbx-registry'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -541,7 +561,7 @@ jobs:
           trial_count=$(jq -er \
             'if type == "array" and length > 0 then length else error("expected a non-empty trial array") end' \
             <<< "$TRIALS")
-          expected=$((3 * trial_count))
+          expected=$((4 * trial_count))
           shopt -s nullglob
           records=("$RUNNER_TEMP"/small-edit/*.json)
           actual=${#records[@]}

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -570,7 +570,7 @@ jobs:
           trial_count=$(jq -er \
             'if type == "array" and length > 0 then length else error("expected a non-empty trial array") end' \
             <<< "$TRIALS")
-          expected=$((3 * trial_count))
+          expected=$((4 * trial_count))
           shopt -s nullglob
           records=("$RUNNER_TEMP"/small-edit/*.json)
           actual=${#records[@]}

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -314,7 +314,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry]
+        tool: [rust-cache, mbx, mbx-registry, mbx-direct]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -357,7 +357,7 @@ jobs:
           cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           save-on-workflow-dispatch: "true"
           toolchain: 1.97.1
-      - if: matrix.tool == 'mbx-registry'
+      - if: matrix.tool == 'mbx-registry' || matrix.tool == 'mbx-direct'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
           backend: local
@@ -379,6 +379,15 @@ jobs:
             ${{ runner.temp }}/mbx-cache.tar
             ~/.cargo/registry
             ~/.cargo/git
+      - if: matrix.tool == 'mbx-direct'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: gha-small-edit-mbx-direct-${{ github.run_id }}-${{ matrix.trial }}-parent
+          path: |
+            ~/.cache/mbx
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
 
   small-edit-measure:
     name: Measure ${{ matrix.tool }} (${{ matrix.trial }})
@@ -391,7 +400,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry]
+        tool: [rust-cache, mbx, mbx-registry, mbx-direct]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -438,7 +447,7 @@ jobs:
           version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           cache-key: gha-small-edit-mbx-${{ github.run_id }}-${{ matrix.trial }}-parent
           toolchain: 1.97.1
-      - if: matrix.tool == 'mbx-registry'
+      - if: matrix.tool == 'mbx-registry' || matrix.tool == 'mbx-direct'
         uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
         with:
           backend: local
@@ -453,6 +462,17 @@ jobs:
             ${{ runner.temp }}/mbx-cache.tar
             ~/.cargo/registry
             ~/.cargo/git
+      - if: matrix.tool == 'mbx-direct'
+        id: mbx_direct_restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: gha-small-edit-mbx-direct-${{ github.run_id }}-${{ matrix.trial }}-parent
+          fail-on-cache-miss: true
+          path: |
+            ~/.cache/mbx
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
       - name: Import native mbx bundle
         if: matrix.tool == 'mbx-registry'
         run: |
@@ -487,6 +507,15 @@ jobs:
         run: |
           if [ "$CACHE_HIT" != "true" ]; then
             echo "::error::mbx did not restore the seeded parent cache"
+            exit 1
+          fi
+      - name: Require direct mbx cache hit
+        if: matrix.tool == 'mbx-direct'
+        env:
+          CACHE_HIT: ${{ steps.mbx_direct_restore.outputs.cache-hit }}
+        run: |
+          if [ "$CACHE_HIT" != "true" ]; then
+            echo "::error::direct mbx cache did not restore the seeded parent cache"
             exit 1
           fi
       - name: Record trial

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -314,14 +314,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry, mbx-server]
+        tool: [rust-cache, mbx, mbx-registry]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       actions: write
       contents: read
-      id-token: write
     env:
       MBX_CACHE_EXPORT_GROUP: gha-small-edit-${{ github.run_id }}-${{ matrix.trial }}
     steps:
@@ -364,15 +363,6 @@ jobs:
           backend: local
           version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           toolchain: 1.97.1
-      - if: matrix.tool == 'mbx-server'
-        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
-        with:
-          backend: server
-          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
-          toolchain: 1.97.1
-          server-url: https://cache.mise.jdx.dev
-          namespace: jdx/hk
-          oidc-audience: https://cache.mise.jdx.dev
       - name: Seed parent build
         env:
           BUILD_DRIVER: "${{ matrix.tool == 'rust-cache' && 'cargo' || 'mbx' }}"
@@ -401,14 +391,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [rust-cache, mbx, mbx-registry, mbx-server]
+        tool: [rust-cache, mbx, mbx-registry]
         trial: ${{ fromJSON(inputs.small_edit_trials || '[1,2,3,4]') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       actions: read
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -455,15 +444,6 @@ jobs:
           backend: local
           version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
           toolchain: 1.97.1
-      - if: matrix.tool == 'mbx-server'
-        uses: jdx/mr-boxington-action@f9de1362243ccf1c4f11a56c240725d0371ef4fa # v1.2.0
-        with:
-          backend: server
-          version: ${{ inputs.small_edit_mbx_ref == '' && inputs.small_edit_mbx_version || '' }}
-          toolchain: 1.97.1
-          server-url: https://cache.mise.jdx.dev
-          namespace: jdx/hk
-          oidc-audience: https://cache.mise.jdx.dev
       - if: matrix.tool == 'mbx-registry'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -561,7 +541,7 @@ jobs:
           trial_count=$(jq -er \
             'if type == "array" and length > 0 then length else error("expected a non-empty trial array") end' \
             <<< "$TRIALS")
-          expected=$((4 * trial_count))
+          expected=$((3 * trial_count))
           shopt -s nullglob
           records=("$RUNNER_TEMP"/small-edit/*.json)
           actual=${#records[@]}

--- a/crates/mbx-cache-core/src/local.rs
+++ b/crates/mbx-cache-core/src/local.rs
@@ -70,6 +70,17 @@ impl LocalCas {
         self.store_file_inner(digest, source, true)
     }
 
+    /// Verify a staged file, then move it into the CAS when possible.
+    ///
+    /// This is useful for imports that already own their source file: unlike
+    /// [`Self::store_file`], it does not need to preserve that staging copy.
+    pub fn adopt_file(&self, digest: &CacheDigest, source: &Path) -> Result<PathBuf> {
+        if !digest.matches_file(source)? {
+            bail!("file does not match the declared CAS digest");
+        }
+        self.adopt_verified_file(digest, source)
+    }
+
     /// Store a file whose digest was already verified by this crate.
     pub(crate) fn store_verified_file(
         &self,
@@ -353,6 +364,34 @@ mod tests {
         assert!(!source.exists());
         assert_eq!(fs::read(&stored).unwrap(), b"cached object");
         assert_eq!(cas.find(&digest).unwrap(), Some(stored));
+    }
+
+    #[test]
+    fn adopts_files_after_verifying_their_digest() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path().join("cache"));
+        let source = directory.path().join("blob");
+        fs::write(&source, b"cached object").unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+
+        let stored = cas.adopt_file(&digest, &source).unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(fs::read(stored).unwrap(), b"cached object");
+    }
+
+    #[test]
+    fn refuses_to_adopt_a_file_with_the_wrong_digest() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path().join("cache"));
+        let source = directory.path().join("blob");
+        fs::write(&source, b"other object").unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+
+        assert!(cas.adopt_file(&digest, &source).is_err());
+
+        assert!(source.exists());
+        assert!(!cas.path_for(&digest).unwrap().exists());
     }
 
     #[test]

--- a/crates/mbx-cache-core/src/local.rs
+++ b/crates/mbx-cache-core/src/local.rs
@@ -70,17 +70,6 @@ impl LocalCas {
         self.store_file_inner(digest, source, true)
     }
 
-    /// Verify a staged file, then move it into the CAS when possible.
-    ///
-    /// This is useful for imports that already own their source file: unlike
-    /// [`Self::store_file`], it does not need to preserve that staging copy.
-    pub fn adopt_file(&self, digest: &CacheDigest, source: &Path) -> Result<PathBuf> {
-        if !digest.matches_file(source)? {
-            bail!("file does not match the declared CAS digest");
-        }
-        self.adopt_verified_file(digest, source)
-    }
-
     /// Store a file whose digest was already verified by this crate.
     pub(crate) fn store_verified_file(
         &self,
@@ -95,11 +84,7 @@ impl LocalCas {
     /// Remote downloads are staged beneath the cache root, so the usual path
     /// is an atomic same-filesystem rename. If a caller supplies a path on a
     /// different filesystem, fall back to the copy-based store operation.
-    pub(crate) fn adopt_verified_file(
-        &self,
-        digest: &CacheDigest,
-        source: &Path,
-    ) -> Result<PathBuf> {
+    pub fn adopt_verified_file(&self, digest: &CacheDigest, source: &Path) -> Result<PathBuf> {
         if fs::metadata(source)?.len() != digest.size {
             bail!("staged blob size does not match the declared CAS digest");
         }
@@ -364,34 +349,6 @@ mod tests {
         assert!(!source.exists());
         assert_eq!(fs::read(&stored).unwrap(), b"cached object");
         assert_eq!(cas.find(&digest).unwrap(), Some(stored));
-    }
-
-    #[test]
-    fn adopts_files_after_verifying_their_digest() {
-        let directory = tempfile::tempdir().unwrap();
-        let cas = LocalCas::new(directory.path().join("cache"));
-        let source = directory.path().join("blob");
-        fs::write(&source, b"cached object").unwrap();
-        let digest = CacheDigest::blake3(b"cached object");
-
-        let stored = cas.adopt_file(&digest, &source).unwrap();
-
-        assert!(!source.exists());
-        assert_eq!(fs::read(stored).unwrap(), b"cached object");
-    }
-
-    #[test]
-    fn refuses_to_adopt_a_file_with_the_wrong_digest() {
-        let directory = tempfile::tempdir().unwrap();
-        let cas = LocalCas::new(directory.path().join("cache"));
-        let source = directory.path().join("blob");
-        fs::write(&source, b"other object").unwrap();
-        let digest = CacheDigest::blake3(b"cached object");
-
-        assert!(cas.adopt_file(&digest, &source).is_err());
-
-        assert!(source.exists());
-        assert!(!cas.path_for(&digest).unwrap().exists());
     }
 
     #[test]

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -675,6 +675,10 @@ fn require_object(
     objects: &mut BTreeSet<PathBuf>,
     digest: &CacheDigest,
 ) -> Result<()> {
+    let expected = cas.path_for(digest)?;
+    if objects.contains(&expected) {
+        return Ok(());
+    }
     let path = cas
         .find(digest)?
         .ok_or_else(|| eyre::eyre!("cache object is missing for {}", digest.hash))?;

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -540,9 +540,10 @@ pub fn import_archive_with_attachments(store: &Path, archive: &Path) -> Result<I
         let source = staging.path().join(relative);
         let digest = addressed_digest(staging.path(), &source, false)
             .ok_or_else(|| eyre::eyre!("invalid cache object path {}", relative.display()))?;
-        // The extracted file belongs to this import. Verify it in staging and
-        // move it into the CAS instead of copying every archive object again.
-        cas.adopt_file(&digest, &source)?;
+        // `strict_closure` verified every path in `objects` against its
+        // content-addressed name. Preserve that proof and move the owned
+        // staging file instead of hashing or copying the bytes again.
+        cas.adopt_verified_file(&digest, &source)?;
     }
     let action_cache = mbx_cache_core::LocalActionCache::new(store);
     for path in &result_paths {

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -540,7 +540,9 @@ pub fn import_archive_with_attachments(store: &Path, archive: &Path) -> Result<I
         let source = staging.path().join(relative);
         let digest = addressed_digest(staging.path(), &source, false)
             .ok_or_else(|| eyre::eyre!("invalid cache object path {}", relative.display()))?;
-        cas.store_file(&digest, &source)?;
+        // The extracted file belongs to this import. Verify it in staging and
+        // move it into the CAS instead of copying every archive object again.
+        cas.adopt_file(&digest, &source)?;
     }
     let action_cache = mbx_cache_core::LocalActionCache::new(store);
     for path in &result_paths {


### PR DESCRIPTION
## Summary

- atomically adopt verified archive objects instead of copying them into the CAS
- carry closure validation forward so shared and adopted objects are not rehashed
- retain digest validation, poisoned-destination repair, concurrency handling, and cross-filesystem copy fallback

## Measurements

The released mbx 1.8.0 path took 37.4s median restore+build in the production-shaped small-edit benchmark, versus 21.7s for rust-cache.

With this PR, the latest four-trial run measured 30.0s for `mbx-registry` versus 21.7s for rust-cache. This is 7.4s (about 20%) faster than the released mbx path, while still 8.3s (38%) behind rust-cache.

A direct store+target experiment was rejected because it doubled the compressed cache size (894 MB versus 457 MB for rust-cache) and still lost. A server-backed arm was also removed after a smoke run showed that `workflow_dispatch` cannot publish under mbx's trust policy and the shared production namespace could not provide trial isolation.

## Verification

- `cargo fmt --all --check`
- `cargo test -p mbx-cache-core -p mbx-cache-store`
- `mise run lint`
- GHA comparison runs 33904483101, 33906310538, and 33907198766

Stacked on #348 so its released/candidate small-edit measurement matrix runs correctly.



Replaces #349, which GitHub closed when its stacked base branch (#348) was merged and deleted; the branch is rebased onto `main` with the same 15-line change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused CAS import path; existing safety behaviors are preserved and covered by cache-core/cache-store tests.
> 
> **Overview**
> **Cache archive import** no longer re-hashes and copies every staged CAS object into the local store. After `strict_closure` has already validated paths against their content-addressed names, import now calls **`adopt_verified_file`** so blobs are moved in with rename when possible (same behavior as remote staging: digest checks, poisoned-destination repair, concurrency, cross-filesystem copy fallback).
> 
> **`adopt_verified_file`** is **`pub`** so `mbx-cache-store` can use it. **`require_object`** skips a **`find`** when the expected CAS path is already in the closure set, avoiding duplicate lookups for shared objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b26affe2b2ccf2bcc6075c1a372166247df469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved cache imports by reusing files that have already been verified, reducing unnecessary hashing and copying.
  - Avoided redundant lookups when required cache objects are already available, resulting in more efficient cache access.

- **Refactor**
  - Expanded cache functionality for broader internal integration without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->