### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -138,6 +138,10 @@ jobs:
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     permissions:
       contents: write
+      # A called workflow's token can only be narrower than its caller's, so
+      # the packslip's signing and attestation permissions are granted here.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,10 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      # The packslip is signed with this job's OIDC identity and its
+      # artifacts are attested; neither is possible without these.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -370,6 +374,20 @@ jobs:
             exit 1
           fi
           gh release upload "$TAG" release-assets/* --repo "${{ github.repository }}" --clobber
+
+      # SHA256SUMS says the files did not change in transit; the packslip
+      # says who built them. It is one signed document holding every
+      # archive's digest, the executable inside it, the shared objects it
+      # needs from the host, and the build provenance of each file, signed
+      # keylessly with this job's identity, so a download is checked against
+      # jdx/mr-boxington's identity with no key to distribute. Runs after the
+      # upload above, which is what guarantees the release exists.
+      # See https://packslip.dev.
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          tag: ${{ inputs.tag }}
+          artifacts: release-assets/mbx-*.tar.gz release-assets/mbx-*.zip
+          bin: mbx
 
       # Called from release-plz.yml, undrafting is that workflow's job — it
       # happens after this one returns. Run by hand, nothing else will do it,


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

`SHA256SUMS` says the files did not change in transit. It says nothing about who built them, which platform each one is for, or what they need from the host. Each release now also publishes `packslip.sigstore.json` — one signed document listing:

- every archive's sha256 and sha512
- the executable inside each one (`mbx`, `mbx.exe` on Windows)
- the shared objects each build needs from the host, read out of the binaries
- a build-provenance attestation per file, linked by digest
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so an installer verifies a download against the identity `github.com/jdx/mr-boxington` instead of a key this project would have to distribute.

### Changes

- `attach` gains `id-token: write` and `attestations: write` (needed to sign and to attest).
- `release-plz.yml` grants `upload-assets` the same two. A called workflow's token can only be equal to or narrower than its caller's, so without this the new step cannot sign or attest.
- The `jdx/packslip` action, pinned to v0.3.0, placed after the `gh release upload` step — that step is what guarantees the release exists on the dispatch recovery path, and the packslip has to be uploaded to something.

It runs while the release is still a draft, so the bundle is in place before `release-plz` undrafts it; on `workflow_dispatch` it lands before the "Publish the release" step below it. `SHA256SUMS` stays out of the `artifacts` glob — it is a sidecar, not something anyone installs.

### Verification

Rehearsed `packslip create` locally against real release assets of this shape: platform, format, and `bin` resolved for every archive, and host requirements were read straight out of the binaries. `zizmor --offline` reports no findings on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release attach path and widens workflow OIDC/attestation permissions, but changes are additive and run only on draft releases before publish.
> 
> **Overview**
> Each release now publishes a **packslip** (`packslip.sigstore.json`) alongside existing archives and `SHA256SUMS`, giving installers a keyless Sigstore-signed manifest of digests, embedded `mbx` binaries, host library requirements, and build provenance tied to the repo tag and commit.
> 
> The **`attach`** job in `release.yml` runs pinned **`jdx/packslip@v0.3.0`** after `gh release upload` (while the release is still a draft) over `mbx-*.tar.gz` / `mbx-*.zip`, excluding `SHA256SUMS` from the artifact glob. **`upload-assets`** in `release-plz.yml` and **`attach`** both gain **`id-token: write`** and **`attestations: write`** so the reusable workflow can sign and attest via OIDC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaa30f93eeeb7ad98c15543d15db673ece1c21b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Release artifacts now include signed attestation metadata.
  * Uploaded archives are accompanied by a signed packslip document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
