### PR TITLE
docs: describe the target-tree GitHub cache and drop the performance warning

### DIFF
--- a/docs/compared.md
+++ b/docs/compared.md
@@ -122,25 +122,21 @@ rustc through `RUSTC_WRAPPER`, so they cannot be combined for the same build.
 
 ## Tarball CI caches
 
-::: warning Current GitHub Actions results
-mbx performs well for local development. Remote caching works and is actively
-improving, but does not yet consistently outperform
-[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
-runners. Benchmark your complete workflow before switching. Investigations,
-discussions, and pull requests to improve it are welcome.
-:::
-
 Actions such as `actions/cache` over `target/` (or `Swatinem/rust-cache`)
 save and restore the whole directory as one archive. That is simple and needs
 no extra tooling, but the archive is all-or-nothing: one changed crate still
 uploads and downloads everything, the entry grows until it hits the platform's
 size cap, and stale artifacts accumulate inside it.
 
-mbx restores exactly the actions a build needs from a store it prunes itself.
-[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) uses
-GitHub Actions cache as the transport for that store, so per-action
-granularity rides on the platform cache you already have. See
-[GitHub Actions](/github-action).
+On GitHub-hosted runners,
+[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
+restores the same pruned target tree those actions do, so its restore and
+build times match rust-cache on Linux and macOS, and it then runs the build
+through mbx: the
+compile scheduler, the toolchain guard, and per-action reuse inside the job.
+The per-action store is what the [cache server](/cache-server) transports,
+where one entry can serve every job and branch instead of one archive per
+job. See [GitHub Actions](/github-action).
 
 ## Cargo's incremental compilation
 

--- a/docs/cookbook/migrate.md
+++ b/docs/cookbook/migrate.md
@@ -25,11 +25,11 @@ steps:
   - run: mbx test --workspace
 ```
 
-One thing the swap gives up: rust-cache also cached Cargo's download caches
-under `~/.cargo`, and the plain action does not, so each run re-fetches the
-registry. To keep those cached too, use the
-[manual GitHub cache setup](/github-action#manual-github-cache-setup), which
-shares one entry between Cargo's download caches and the mbx store.
+The action's default entry carries Cargo's target directory and its download
+caches under `~/.cargo`, so nothing rust-cache restored is lost in the swap.
+The `github-cache-mode: objects` payload omits the download caches; pair it
+with the [manual GitHub cache setup](/github-action#manual-github-cache-setup)
+to keep them.
 
 Leave release jobs out of the migration: a production release should not
 restore any compiler cache, mbx's or the one being removed. See the

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -5,20 +5,15 @@ installs mbx and connects it to either GitHub Actions cache or an mbx-compatible
 server. The examples below show the inputs that matter for each backend; the
 action's repository documents the complete list.
 
-::: warning Current performance
-mbx performs well for local development. Remote caching works and is actively
-improving, but does not yet consistently outperform
-[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
-runners. Benchmark your complete workflow before switching. Investigations,
-discussions, and pull requests to improve it are welcome.
-:::
-
 ## GitHub Actions cache
 
-The default backend restores the action closure from the previous compatible
-cache entry, imports that bundle before any build steps, and afterward exports
-the deduplicated closure of every `mbx` command the job completed. An entry
-carries what the job actually used rather than the whole local store. A new
+The default backend restores Cargo's pruned target directory and its registry
+from the previous compatible cache entry, the same shape of entry
+[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) restores, so a
+job that changes a few files recompiles only those crates. Paired measurements
+on GitHub-hosted Linux and macOS runners put restore-plus-build within noise
+of rust-cache, ahead on build and test jobs, with a cache entry of the same
+size; Windows runners still restore more slowly. A new
 immutable entry is saved after a push to the repository's default branch, and
 after a trusted `workflow_dispatch` run when the action's
 `save-on-workflow-dispatch` input is enabled. Pull requests, including pull
@@ -34,9 +29,14 @@ steps:
   - run: mbx test --workspace
 ```
 
-The action assigns `MBX_CACHE_EXPORT_GROUP` for the job itself, so a workflow
-does not configure the export. Change `cache-generation` when a cache format or
-policy change should start fresh:
+The earlier payload, mbx's own object store exported as the closure of every
+`mbx` command the job completed, remains available as
+`github-cache-mode: objects`. It suits builds that must share one entry across
+differing target directories or checkout layouts; it omits the Cargo registry,
+which Cargo then downloads again during the build, and measured about ten
+seconds slower per job. The action assigns `MBX_CACHE_EXPORT_GROUP` for that
+mode itself. Change `cache-generation` when a cache format or policy change
+should start fresh:
 
 ```yaml
 - uses: jdx/mr-boxington-action@v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,11 +23,3 @@ hero:
       text: Benchmarks
       link: /benchmarks
 ---
-
-::: warning GitHub Actions performance
-mbx performs well for local development. Remote caching works and is actively
-improving, but does not yet consistently outperform
-[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) on GitHub-hosted
-runners. Benchmark your complete workflow before switching. Investigations,
-discussions, and pull requests to improve it are welcome.
-:::


### PR DESCRIPTION
## Summary

- remove the "does not yet consistently outperform rust-cache" warning from the landing page, the GitHub Action page, and the comparison page
- describe what `jdx/mr-boxington-action` v1.3.0 restores by default (Cargo's pruned target tree and registry) and keep `github-cache-mode: objects` documented as the alternative payload
- update the migration note: the default entry now carries Cargo's download caches, so nothing rust-cache restored is lost

## Evidence

Paired same-runner trials on GitHub-hosted runners (mbx from `main` after #351, action target payload vs Swatinem/rust-cache): Linux build 20.4s vs 23.8s, test 20.2s vs 22.0s, clippy tie, Cargo.lock bump tie, macOS tie; Windows tied in paired trials but trails on restore in hk's warm benchmark, so the text says so. Runs: https://github.com/jdx/mr-boxington/actions/runs/33930437472, https://github.com/jdx/mr-boxington/actions/runs/33934293168, https://github.com/jdx/mr-boxington/actions/runs/33934130710, https://github.com/jdx/mr-boxington/actions/runs/33934271731, https://github.com/jdx/mr-boxington/actions/runs/33930480404.

hk's own warm benchmark with mbx 1.8.1 (two dispatches): Linux target cache 40–44s vs rust-cache 61–62s end to end; macOS 26–34s vs 27–44s. https://github.com/jdx/hk/actions/runs/33938344754, https://github.com/jdx/hk/actions/runs/33938574599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only messaging and migration guidance; no runtime, auth, or cache behavior changes in this repo.
> 
> **Overview**
> Documentation now reflects **`jdx/mr-boxington-action`**’s default GitHub cache payload (pruned **`target/`** plus Cargo registry under **`~/.cargo`**, rust-cache–shaped) instead of leading with mbx’s per-job object-store closure.
> 
> The **“does not yet consistently outperform rust-cache”** admonitions are removed from the home page, GitHub Action page, and comparison page. New copy states paired Linux/macOS restore+build is **on par or ahead** of rust-cache at similar entry size, with **slower Windows restores** called out. **`github-cache-mode: objects`** stays documented as the alternate payload (cross-layout sharing, no registry, ~10s/job slower).
> 
> The **rust-cache migration** note is updated: the default swap **keeps download caches**; only **`objects`** mode needs the manual cache setup to retain them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c2e6a0456e7635dff64d8edf935603b127b251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated GitHub Actions caching guidance to describe restored Cargo build and registry data.
  - Documented the `objects` cache mode, including its registry omission and performance considerations.
  - Clarified migration behavior from `rust-cache` and `actions/cache`, including options for retaining Cargo download caches.
  - Updated cache performance measurements and removed outdated performance warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->