### PR TITLE
docs: redesign the benchmarks page

### DIFF
--- a/docs/.vitepress/theme/BenchmarkResults.vue
+++ b/docs/.vitepress/theme/BenchmarkResults.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!data" class="mbx-bench-empty">
+  <div v-if="!data" class="bench-empty">
     <p>
       No benchmark run has been published yet. The
       <a
@@ -10,109 +10,106 @@
       merges.
     </p>
   </div>
-  <div v-else class="mbx-bench">
+  <div v-else class="bench">
+    <nav v-if="tiles.length" class="bench-summary" aria-label="At a glance">
+      <a
+        v-for="tile in tiles"
+        :key="tile.id"
+        :href="`#${tile.id}`"
+        class="bench-tile"
+        :class="{ 'is-ahead': tile.ahead }"
+      >
+        <span class="bench-tile-name">{{ tile.name }}</span>
+        <span class="bench-tile-value">{{ tile.value }}</span>
+        <span class="bench-tile-note">{{ tile.note }}</span>
+      </a>
+    </nav>
+
     <section
-      v-for="scenario in data.scenarios"
-      :key="scenario.scenario"
-      class="mbx-bench-scenario"
+      v-for="card in cards"
+      :id="card.id"
+      :key="card.id"
+      class="bench-card"
     >
-      <header class="mbx-bench-header">
+      <header class="bench-head">
         <div>
-          <h3 :id="scenario.scenario">{{ scenario.scenario }}</h3>
-          <p class="mbx-bench-caption">{{ scenario.description }}</p>
+          <h3 class="bench-title">
+            <span class="bench-kicker">{{ card.name }}</span>
+            {{ card.title }}
+          </h3>
+          <p class="bench-caption">{{ card.caption }}</p>
         </div>
-        <span v-if="scenario.kind !== 'contention'" class="mbx-bench-direction">
-          lower is better
-        </span>
+        <span class="bench-axis">wall clock · lower is better</span>
       </header>
-      <div
-        v-if="scenario.kind === 'contention' && scenario.results.length"
-        class="mbx-bench-chart"
-        role="list"
-        aria-label="Contention benchmark results"
-      >
-        <div
-          v-for="cell in contentionRows(scenario)"
-          :key="cell.tool"
-          class="mbx-bench-row"
-          :class="{ 'is-subject': cell.tool === 'mbx' }"
-          role="listitem"
-        >
-          <div class="mbx-bench-tool">
-            <code>{{ cell.label }}</code>
-            <span v-if="cell.badge" class="mbx-bench-fastest">{{
-              cell.badge
-            }}</span>
-            <span v-if="cell.fastest" class="mbx-bench-fastest">fastest</span>
-          </div>
-          <div class="mbx-bench-bar-track" aria-hidden="true">
-            <span
-              class="mbx-bench-bar"
-              :class="{ 'is-subject': cell.tool === 'mbx' }"
-              :style="{ width: `${cell.width}%` }"
-            />
-          </div>
-          <strong class="mbx-bench-seconds">{{ cell.seconds }}</strong>
-          <div class="mbx-bench-meta">
-            <span v-if="cell.comparison">{{ cell.comparison }}</span>
-            <span v-if="cell.spread">{{ cell.spread }}</span>
-            <span>{{ cell.compilers }}</span>
-            <span>{{ cell.memory }}</span>
-          </div>
-        </div>
+
+      <table v-if="card.rows.length" class="bench-table">
+        <thead class="bench-sr-only">
+          <tr>
+            <th scope="col">Tool</th>
+            <th scope="col">Relative wall clock</th>
+            <th scope="col">Median and range</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="row in card.rows"
+            :key="row.tool"
+            :class="{ 'is-mbx': row.mbx }"
+            :title="row.tooltip"
+          >
+            <th scope="row" class="bench-tool">
+              <span class="bench-tool-line">
+                <span class="bench-tool-name">{{ row.label }}</span>
+                <span v-if="row.tag" class="bench-tag">{{ row.tag }}</span>
+                <span v-if="row.fastest" class="bench-tag is-fastest"
+                  >fastest</span
+                >
+              </span>
+              <small v-if="row.note" class="bench-sub">{{ row.note }}</small>
+            </th>
+            <td class="bench-bar-cell">
+              <div class="bench-track" aria-hidden="true">
+                <span
+                  class="bench-bar"
+                  :class="{ 'is-mbx': row.mbx }"
+                  :style="{ width: `${row.width}%` }"
+                />
+                <span
+                  v-if="row.range"
+                  class="bench-range"
+                  :style="{
+                    left: `${row.range.left}%`,
+                    width: `${row.range.width}%`,
+                  }"
+                />
+              </div>
+            </td>
+            <td class="bench-time">
+              {{ row.time }}
+              <small v-if="row.spread" class="bench-sub">{{
+                row.spread
+              }}</small>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="bench-foot">
+        <p v-if="card.verdict" class="bench-verdict">{{ card.verdict }}</p>
+        <p v-for="line in card.notes" :key="line" class="bench-footnote">
+          {{ line }}
+        </p>
+        <p v-if="card.skipped" class="bench-footnote">
+          Not measured: {{ card.skipped }}
+        </p>
+        <p v-if="card.provenance" class="bench-footnote">
+          Measured separately on {{ card.provenance.runner }}.
+          <a :href="card.provenance.url">View run</a>.
+        </p>
       </div>
-      <div
-        v-else-if="scenario.results.length"
-        class="mbx-bench-chart"
-        role="list"
-        :aria-label="`${scenario.scenario} benchmark results`"
-      >
-        <div
-          v-for="cell in rows(scenario)"
-          :key="cell.tool"
-          class="mbx-bench-row"
-          :class="{ 'is-subject': cell.tool === 'mbx' }"
-          role="listitem"
-        >
-          <div class="mbx-bench-tool">
-            <code>{{ cell.tool }}</code>
-            <span v-if="cell.fastest" class="mbx-bench-fastest">fastest</span>
-          </div>
-          <div class="mbx-bench-bar-track" aria-hidden="true">
-            <span
-              class="mbx-bench-bar"
-              :class="{ 'is-subject': cell.tool === 'mbx' }"
-              :style="{ width: `${cell.width}%` }"
-            />
-          </div>
-          <strong class="mbx-bench-seconds">{{ cell.seconds }}</strong>
-          <div class="mbx-bench-meta">
-            <span v-if="cell.comparison">{{ cell.comparison }}</span>
-            <span v-if="cell.hits !== '—'">{{ cell.hits }} cache hits</span>
-            <span v-if="cell.spread">{{ cell.spread }}</span>
-            <span v-if="cell.warmup">{{ cell.warmup }}</span>
-          </div>
-        </div>
-      </div>
-      <p v-if="inconclusive(scenario)" class="mbx-bench-inconclusive">
-        {{ inconclusive(scenario) }}
-      </p>
-      <p v-if="scenario.skipped.length" class="mbx-bench-skipped">
-        Not measured: {{ scenario.skipped.join("; ") }}
-      </p>
-      <p
-        v-if="scenario.workflow_run && scenario.runner"
-        class="mbx-bench-scenario-provenance"
-      >
-        Measured separately on {{ scenario.runner }}.
-        <a
-          :href="`https://github.com/jdx/mr-boxington/actions/runs/${scenario.workflow_run}`"
-          >View run</a
-        >.
-      </p>
     </section>
 
-    <p class="mbx-bench-provenance">
+    <p class="bench-provenance">
       Measured on {{ data.platform }} ({{ data.runner }}) with Rust
       {{ data.toolchain }}, building <code>{{ data.subject }}</code> at
       <code>{{ data.revision.slice(0, 7) }}</code> under {{ versionList }}.
@@ -132,178 +129,401 @@ import { computed } from "vue";
 import { data } from "../benchmarks.data";
 import type { BenchmarkCell, BenchmarkScenario } from "../benchmarks.data";
 
-// Bars are scaled within a scenario, never across them: each card answers
-// which tool was faster on that workload, not how the workloads compare to
-// each other. The bar has its own fixed-width track beside the duration label,
-// so the slowest result fills the track and every other result is proportional.
-function barWidth(duration: number, slowest: number) {
-  return Math.max(2, (duration / slowest) * 100);
-}
+// Page copy for the scenarios the harness knows. A scenario it does not know
+// falls back to the description the harness wrote into results.json.
+const COPY: Record<string, { title: string; caption: string }> = {
+  warm: {
+    title: "CI rebuilds a commit it has already built",
+    caption:
+      "The store is warm from an earlier build of the same commit and target/ is empty. Cargo is left out: with nothing to reuse it would repeat that earlier build.",
+  },
+  commit: {
+    title: "CI builds the next push",
+    caption:
+      "The caches were warmed at the parent commit and build the child. Cargo has no cache to restore, so its row is the uncached build.",
+  },
+  edit: {
+    title: "One line changed, rebuilt in place",
+    caption:
+      "The local edit loop with incremental compilation on. Cargo's own incremental rebuild is the thing to beat here, not a control.",
+  },
+  contention: {
+    title: "Six CI jobs on one runner",
+    caption:
+      "Overlapping check, Clippy, and test-compilation jobs. Run one after another, then all at once with and without mbx's machine-wide compiler limit.",
+  },
+};
 
-// How far one tool moved between its own repeats. This is the page's noise
-// floor, measured on the same machine, in the same scenario, minutes apart.
-function spread(cell: BenchmarkCell) {
-  const trials = cell.wall_durations_ns;
-  if (!trials || trials.length < 2) return 0;
-  return Math.max(...trials) - Math.min(...trials);
-}
+const CONTENTION_LABELS: Record<string, { label: string; tag: string | null }> =
+  {
+    "mbx-sequential": { label: "sequential", tag: null },
+    "mbx-unscheduled": { label: "parallel", tag: "scheduler off" },
+    mbx: { label: "parallel", tag: "mbx scheduler" },
+  };
 
-// Why this scenario may not name a winner, or null when it may. A lead
-// smaller than a tool's own spread across repeats is noise, not a result.
-// Contention is exempt: it compares one binary against itself with the
-// scheduler on and off.
-function inconclusive(scenario: BenchmarkScenario): string | null {
-  const ordered = [...scenario.results].sort(
-    (left, right) => left.wall_duration_ns - right.wall_duration_ns,
-  );
-  // A tool that failed the scenario is left out of the card, so the one
-  // that remains has beaten nothing.
-  if (ordered.length < 2) {
-    return ordered.length === 1
-      ? "Only one tool completed this scenario, so nothing is marked fastest."
-      : null;
-  }
-  const [best, next] = ordered;
-  // A single trial shows no spread, so it names nobody.
-  if (
-    (best.wall_durations_ns?.length ?? 0) < 2 ||
-    (next.wall_durations_ns?.length ?? 0) < 2
-  ) {
-    return "Measured once per tool, so no tool is marked fastest here.";
-  }
-  const margin = next.wall_duration_ns - best.wall_duration_ns;
-  const floor = Math.max(spread(best), spread(next));
-  if (margin > floor) return null;
-  return (
-    `No tool is marked fastest: the ${seconds(margin)}s between the fastest ` +
-    `two is inside the ${seconds(floor)}s one of them moved across its own ` +
-    `repeats.`
-  );
-}
-
-// Tenths everywhere else on the page, but a margin this rule rejects can be
-// smaller than that, and "the 0.0s between them" reads as a rounding error
-// rather than as the reason nothing is marked fastest.
 function seconds(ns: number) {
-  const value = ns / 1e9;
-  return value < 0.1 ? value.toFixed(2) : value.toFixed(1);
+  const s = ns / 1e9;
+  if (s >= 60) return `${Math.floor(s / 60)}m ${(s % 60).toFixed(0)}s`;
+  return `${s.toFixed(1)}s`;
 }
 
-function spreadLabel(cell: BenchmarkCell) {
-  const trials = cell.wall_durations_ns ?? [];
-  if (trials.length < 2) return null;
-  const low = (Math.min(...trials) / 1e9).toFixed(1);
-  const high = (Math.max(...trials) / 1e9).toFixed(1);
-  return `${trials.length} runs, ${low}–${high}s`;
+// A margin the fastest rule rejects can be smaller than a tenth, and "0.0s"
+// reads as a rounding error rather than as the reason nothing is marked.
+function fine(ns: number) {
+  const s = ns / 1e9;
+  return `${s < 0.1 ? s.toFixed(2) : s.toFixed(1)}s`;
 }
 
-function rows(scenario: BenchmarkScenario) {
-  const slowest = Math.max(
-    ...scenario.results.map((cell) => cell.wall_duration_ns),
-    1,
-  );
-  const fastest = Math.min(
-    ...scenario.results.map((cell) => cell.wall_duration_ns),
-  );
-  const separated = inconclusive(scenario) === null;
-  // A Cargo result is meaningful only inside the scenario that measured it,
-  // and it is not the same kind of result in each. In the commit case it is
-  // deliberately an uncached control: Cargo has no portable store to seed
-  // from the parent commit, and its target is fresh. In the edit case it
-  // keeps its target and its incremental state, so it is the thing the caches
-  // have to beat rather than a control. The run says which it was.
-  const baseline = scenario.results.find((cell) => cell.tool === "cargo");
-  const baselineLabel = scenario.baseline ?? "uncached baseline";
-  return scenario.results.map((cell) => {
-    const seconds = cell.wall_duration_ns / 1e9;
-    const ratio = baseline
-      ? baseline.wall_duration_ns / cell.wall_duration_ns
-      : null;
+function trials(cell: BenchmarkCell) {
+  return cell.wall_durations_ns ?? [cell.wall_duration_ns];
+}
+
+// How far one tool moved between its own repeats: the noise floor, measured
+// on the same machine, in the same scenario, minutes apart.
+function spread(cell: BenchmarkCell) {
+  const t = trials(cell);
+  return t.length < 2 ? 0 : Math.max(...t) - Math.min(...t);
+}
+
+// Two results are separated when the gap between them is wider than either
+// tool's own spread. Anything closer is noise, and a single trial has no
+// spread to compare against, so it separates nothing.
+function separated(a: BenchmarkCell, b: BenchmarkCell) {
+  if (trials(a).length < 2 || trials(b).length < 2) return false;
+  const margin = Math.abs(a.wall_duration_ns - b.wall_duration_ns);
+  return margin > Math.max(spread(a), spread(b));
+}
+
+function byTime(cells: BenchmarkCell[]) {
+  return [...cells].sort((a, b) => a.wall_duration_ns - b.wall_duration_ns);
+}
+
+function name(cell: BenchmarkCell) {
+  return cell.tool === "cargo" ? "Cargo" : cell.tool;
+}
+
+function ratio(x: number) {
+  return `${x.toFixed(2)}×`;
+}
+
+// Bars and whiskers share one scale per card: the slowest single trial fills
+// the track. Cards are never scaled against each other, since each answers
+// which tool was faster on its own workload.
+function scale(cells: BenchmarkCell[]) {
+  return Math.max(...cells.flatMap(trials), 1);
+}
+
+function geometry(cell: BenchmarkCell, max: number) {
+  const t = trials(cell);
+  const range =
+    t.length < 2
+      ? null
+      : {
+          left: (Math.min(...t) / max) * 100,
+          width: ((Math.max(...t) - Math.min(...t)) / max) * 100,
+        };
+  return {
+    width: Math.max(1, (cell.wall_duration_ns / max) * 100),
+    range,
+    spread: range
+      ? `${(Math.min(...t) / 1e9).toFixed(1)}–${(Math.max(...t) / 1e9).toFixed(1)}s`
+      : "",
+    tooltip: `${t.length} ${t.length === 1 ? "run" : "runs"}: ${t
+      .map(seconds)
+      .join(", ")}`,
+  };
+}
+
+interface Row {
+  tool: string;
+  label: string;
+  tag: string | null;
+  fastest: boolean;
+  mbx: boolean;
+  width: number;
+  range: { left: number; width: number } | null;
+  time: string;
+  spread: string;
+  note: string;
+  tooltip: string;
+}
+
+interface Card {
+  id: string;
+  name: string;
+  title: string;
+  caption: string;
+  rows: Row[];
+  verdict: string | null;
+  notes: string[];
+  skipped: string;
+  provenance: { runner: string; url: string } | null;
+}
+
+interface Tile {
+  id: string;
+  name: string;
+  value: string;
+  note: string;
+  ahead: boolean;
+}
+
+function buildCard(scenario: BenchmarkScenario): {
+  card: Card;
+  tile: Tile | null;
+} {
+  const copy = COPY[scenario.scenario];
+  const cells = byTime(scenario.results);
+  const max = scale(cells);
+  const baseline = cells.find((c) => c.tool === "cargo") ?? null;
+  const baselineTag = baseline
+    ? (scenario.baseline ?? "uncached baseline").replace(/ baseline$/, "")
+    : null;
+  const [best, next] = cells;
+  const decisive = best && next ? separated(best, next) : false;
+
+  const rows: Row[] = cells.map((cell) => {
+    const g = geometry(cell, max);
+    let note = "";
+    if (baseline && cell !== baseline) {
+      const r = baseline.wall_duration_ns / cell.wall_duration_ns;
+      note = separated(cell, baseline)
+        ? r >= 1
+          ? `${ratio(r)} faster than Cargo`
+          : `${fine(cell.wall_duration_ns - baseline.wall_duration_ns)} behind Cargo`
+        : "level with Cargo";
+    }
     return {
       tool: cell.tool,
-      fastest: separated && cell.wall_duration_ns === fastest,
-      warmup: cell.warmup_wall_duration_ns
-        ? `first edit after a build ${(cell.warmup_wall_duration_ns / 1e9).toFixed(1)}s`
-        : null,
-      spread: spreadLabel(cell),
-      seconds:
-        seconds >= 60
-          ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
-          : `${seconds.toFixed(1)}s`,
-      width: barWidth(cell.wall_duration_ns, slowest),
-      comparison: !baseline
+      label: name(cell),
+      tag: cell === baseline ? baselineTag : null,
+      fastest: decisive && cell === best,
+      mbx: cell.tool === "mbx",
+      time: seconds(cell.wall_duration_ns),
+      note,
+      ...g,
+    };
+  });
+
+  // The verdict names a fastest tool only across a gap wider than the noise.
+  let verdict: string | null;
+  if (cells.length === 0) verdict = null;
+  else if (cells.length === 1)
+    verdict = `Only ${name(best)} completed this scenario, so nothing is marked fastest.`;
+  else if (trials(best).length < 2 || trials(next).length < 2)
+    verdict = "Measured once per tool, so nothing is marked fastest.";
+  else if (decisive)
+    verdict =
+      `${name(best)} fastest, ${fine(next.wall_duration_ns - best.wall_duration_ns)} ahead of ${name(next)}. ` +
+      `That lead is wider than either tool's own range across ${trials(best).length} runs.`;
+  else
+    verdict =
+      `Too close to call: ${name(best)} and ${name(next)} finished ${fine(next.wall_duration_ns - best.wall_duration_ns)} apart, ` +
+      `inside the ${fine(Math.max(spread(best), spread(next)))} one of them moved across its own runs.`;
+
+  const mbx = cells.find((c) => c.tool === "mbx") ?? null;
+  if (verdict && mbx && mbx !== best && mbx !== next) {
+    verdict += separated(mbx, best)
+      ? ` mbx finished ${fine(mbx.wall_duration_ns - best.wall_duration_ns)} behind ${name(best)}.`
+      : " mbx finished within that same noise.";
+  }
+
+  const notes: string[] = [];
+  const restored = cells.filter(
+    (c) => c.stats?.hits !== undefined && c.stats?.restored_output_files,
+  );
+  for (const c of restored) {
+    notes.push(
+      `${name(c)} restored ${c.stats!.restored_output_files!.toLocaleString("en-US")} output files on ${c.stats!.hits!.toLocaleString("en-US")} cache hits.`,
+    );
+  }
+  const warm = cells.filter((c) => c.warmup_wall_duration_ns);
+  if (warm.length) {
+    notes.push(
+      "First edit after a build, before the loop settles: " +
+        warm
+          .map((c) => `${name(c)} ${seconds(c.warmup_wall_duration_ns!)}`)
+          .join(", ") +
+        ".",
+    );
+  }
+
+  // The tile answers the page's question in one line: where did mbx land.
+  let tile: Tile | null = null;
+  if (mbx) {
+    const other =
+      baseline ?? cells.find((c) => c !== mbx && c.tool !== "cargo") ?? null;
+    let note = "";
+    if (other) {
+      const r = other.wall_duration_ns / mbx.wall_duration_ns;
+      note = !separated(mbx, other)
+        ? `level with ${name(other)}`
+        : r >= 1
+          ? `${ratio(r)} faster than ${name(other)}`
+          : `${fine(mbx.wall_duration_ns - other.wall_duration_ns)} behind ${name(other)}`;
+    }
+    tile = {
+      id: scenario.scenario,
+      name: scenario.scenario,
+      value: seconds(mbx.wall_duration_ns),
+      note,
+      ahead: decisive && best === mbx,
+    };
+  }
+
+  return {
+    card: {
+      id: scenario.scenario,
+      name: scenario.scenario,
+      title: copy?.title ?? scenario.scenario,
+      caption: copy?.caption ?? scenario.description,
+      rows,
+      verdict,
+      notes,
+      skipped: scenario.skipped.join("; "),
+      provenance: provenance(scenario),
+    },
+    tile,
+  };
+}
+
+// Contention compares one binary against itself, so it asks a different
+// question: did running the jobs at once beat running them in turn, and did
+// the scheduler get there by sharing the machine or by oversubscribing it.
+function contentionCard(scenario: BenchmarkScenario): {
+  card: Card;
+  tile: Tile | null;
+} {
+  const copy = COPY[scenario.scenario];
+  const cells = scenario.results;
+  const max = scale(cells);
+  const scheduled = cells.find((c) => c.tool === "mbx") ?? null;
+  const unscheduled = cells.find((c) => c.tool === "mbx-unscheduled") ?? null;
+  const sequential = cells.find((c) => c.tool === "mbx-sequential") ?? null;
+  const fastest = byTime(cells)[0];
+  const decisive =
+    scheduled && unscheduled ? separated(scheduled, unscheduled) : false;
+
+  const rows: Row[] = cells.map((cell) => {
+    const g = geometry(cell, max);
+    const labels = CONTENTION_LABELS[cell.tool] ?? {
+      label: cell.tool,
+      tag: null,
+    };
+    const peak = cell.peak_compilers ?? 0;
+    const compilers = cell.permits
+      ? `${peak} of ${cell.permits} permits used`
+      : `${peak} compilers at peak`;
+    // Only Linux reports free memory, and only Linux runs this benchmark.
+    // Zero would be a real reading (a machine that ran itself out), so it is
+    // never folded into the "not measured" case.
+    const memory =
+      cell.min_available_bytes === null ||
+      cell.min_available_bytes === undefined
         ? null
-        : cell === baseline
-          ? baselineLabel
-          : ratio! >= 1
-            ? `${ratio!.toFixed(2)}× faster than cargo`
-            : `${(1 / ratio!).toFixed(2)}× slower than cargo`,
-      hits: cell.stats?.hits ?? "—",
-    };
-  });
-}
-
-// The contention scenario asks a different question than the others -- not
-// whether parallel lint beat its sequential baseline and what the machine
-// looked like while both Cargo processes ran -- so it gets machine-wide
-// columns rather than the ordinary cache-build comparison.
-function contentionRows(scenario: BenchmarkScenario) {
-  const slowest = Math.max(
-    ...scenario.results.map((cell) => cell.wall_duration_ns),
-    1,
-  );
-  const parallelControl = scenario.results.find(
-    (cell) => cell.tool === "mbx-unscheduled",
-  );
-  const fastest = Math.min(
-    ...scenario.results.map((cell) => cell.wall_duration_ns),
-  );
-  const separated = inconclusive(scenario) === null;
-  return scenario.results.map((cell) => {
-    const seconds = cell.wall_duration_ns / 1e9;
-    const available = cell.min_available_bytes;
-    const delta = parallelControl
-      ? (cell.wall_duration_ns - parallelControl.wall_duration_ns) / 1e9
-      : null;
+        : `${(cell.min_available_bytes / 1e9).toFixed(1)} GB free at the low`;
     return {
       tool: cell.tool,
-      label:
-        cell.tool === "mbx-sequential"
-          ? "sequential"
-          : cell.tool === "mbx-unscheduled"
-            ? "parallel · scheduler off"
-            : "parallel · mbx scheduled",
-      badge:
-        cell.tool === "mbx-sequential"
-          ? "context"
-          : cell.tool === "mbx-unscheduled"
-            ? "parallel control"
-            : null,
-      fastest: separated && cell.wall_duration_ns === fastest,
-      seconds:
-        seconds >= 60
-          ? `${Math.floor(seconds / 60)}m ${(seconds % 60).toFixed(0)}s`
-          : `${seconds.toFixed(1)}s`,
-      width: barWidth(cell.wall_duration_ns, slowest),
-      comparison:
-        delta === null || cell.tool !== "mbx"
-          ? null
-          : `${Math.abs(delta).toFixed(1)}s ${delta >= 0 ? "slower" : "faster"} than scheduler off`,
-      spread: spreadLabel(cell),
-      compilers: cell.permits
-        ? `${cell.peak_compilers ?? 0} of ${cell.permits} compiler slots used`
-        : `${cell.peak_compilers ?? 0} peak compilers`,
-      // Only Linux reports it, and only Linux runs the published benchmark.
-      // Zero is a real reading -- a machine that ran itself out -- and it is
-      // the single most interesting cell on the page, so it must not be
-      // rounded away into the same dash that means "never measured".
-      memory:
-        available === null || available === undefined
-          ? "—"
-          : `${(available / 1e9).toFixed(1)} GB minimum free`,
+      label: labels.label,
+      tag: labels.tag,
+      fastest: decisive && cell === fastest && cell === scheduled,
+      mbx: cell.tool === "mbx",
+      time: seconds(cell.wall_duration_ns),
+      note: [compilers, memory].filter(Boolean).join(", "),
+      ...g,
     };
   });
+
+  let verdict: string | null = null;
+  if (scheduled && unscheduled) {
+    const gap = unscheduled.wall_duration_ns - scheduled.wall_duration_ns;
+    if (trials(scheduled).length < 2 || trials(unscheduled).length < 2)
+      verdict = "Measured once per row, so nothing is marked fastest.";
+    else if (!decisive)
+      verdict = `The scheduler made no measurable difference: ${fine(Math.abs(gap))} between the parallel rows, inside their own ranges.`;
+    else {
+      verdict =
+        gap > 0
+          ? `With the scheduler on, the parallel batch finished ${fine(gap)} sooner`
+          : `With the scheduler on, the parallel batch finished ${fine(-gap)} later`;
+      if (sequential) {
+        const seq = sequential.wall_duration_ns - scheduled.wall_duration_ns;
+        verdict += ` than unscheduled and ${fine(Math.abs(seq))} ${seq > 0 ? "sooner" : "later"} than running the jobs in turn`;
+      } else verdict += " than unscheduled";
+      verdict += `, peaking at ${scheduled.peak_compilers ?? 0} compilers instead of ${unscheduled.peak_compilers ?? 0}.`;
+    }
+  }
+
+  const notes: string[] = [];
+  const hits = cells.filter((c) => c.stats?.hits !== undefined);
+  if (hits.length === cells.length && cells.length) {
+    notes.push(
+      "Cache hits over the batch: " +
+        cells
+          .map((c) => {
+            const l = CONTENTION_LABELS[c.tool];
+            const label = l
+              ? [l.label, l.tag].filter(Boolean).join(", ")
+              : c.tool;
+            return `${label} ${c.stats!.hits!.toLocaleString("en-US")}`;
+          })
+          .join("; ") +
+        ". The scheduler holds identical compilations until the first finishes, so the other jobs hit the store instead of repeating the work.",
+    );
+  }
+
+  const tile: Tile | null = scheduled
+    ? {
+        id: scenario.scenario,
+        name: scenario.scenario,
+        value: seconds(scheduled.wall_duration_ns),
+        note: !unscheduled
+          ? ""
+          : !decisive
+            ? "level with the scheduler off"
+            : unscheduled.wall_duration_ns > scheduled.wall_duration_ns
+              ? `${fine(unscheduled.wall_duration_ns - scheduled.wall_duration_ns)} sooner than scheduler off`
+              : `${fine(scheduled.wall_duration_ns - unscheduled.wall_duration_ns)} later than scheduler off`,
+        ahead: decisive && fastest === scheduled,
+      }
+    : null;
+
+  return {
+    card: {
+      id: scenario.scenario,
+      name: scenario.scenario,
+      title: copy?.title ?? scenario.scenario,
+      caption: copy?.caption ?? scenario.description,
+      rows,
+      verdict,
+      notes,
+      skipped: scenario.skipped.join("; "),
+      provenance: provenance(scenario),
+    },
+    tile,
+  };
 }
+
+function provenance(scenario: BenchmarkScenario) {
+  return scenario.workflow_run && scenario.runner
+    ? {
+        runner: scenario.runner,
+        url: `https://github.com/jdx/mr-boxington/actions/runs/${scenario.workflow_run}`,
+      }
+    : null;
+}
+
+const built = computed(() =>
+  (data?.scenarios ?? []).map((scenario) =>
+    scenario.kind === "contention"
+      ? contentionCard(scenario)
+      : buildCard(scenario),
+  ),
+);
+const cards = computed(() => built.value.map((b) => b.card));
+const tiles = computed(() =>
+  built.value.map((b) => b.tile).filter((t): t is Tile => t !== null),
+);
 
 const versionList = computed(() => {
   if (!data) return "";
@@ -311,192 +531,346 @@ const versionList = computed(() => {
     Object.entries(data.versions)
       .filter(([, value]) => value)
       // `cargo -V` already says "cargo"; only mbx reports a bare number.
-      .map(([name, value]) =>
-        value!.startsWith(name) ? value! : `${name} ${value}`,
-      )
+      .map(([n, value]) => (value!.startsWith(n) ? value! : `${n} ${value}`))
       .join(", ")
   );
 });
 </script>
 
 <style scoped>
-.mbx-bench-scenario {
-  background: linear-gradient(
-    145deg,
-    color-mix(in srgb, var(--vp-c-bg-soft) 96%, var(--vp-c-brand-1) 4%),
-    var(--vp-c-bg-soft)
-  );
-  border: 1px solid
-    color-mix(in srgb, var(--vp-c-divider) 80%, var(--vp-c-brand-1) 20%);
-  border-radius: 14px;
-  margin: 28px 0;
-  overflow: hidden;
+.bench {
+  margin: 24px 0 32px;
 }
-.mbx-bench-header {
+
+/* ---------- at a glance ---------- */
+
+.bench-summary {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  margin-bottom: 28px;
+}
+.bench-tile {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px 13px;
+  text-decoration: none;
+  transition: border-color 0.2s;
+}
+.bench-tile:hover {
+  border-color: var(--vp-c-brand-1);
+}
+.bench-tile-name {
+  color: var(--vp-c-text-2);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.bench-tile-value {
+  color: var(--vp-c-text-1);
+  font-family: var(--mbx-display);
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+.bench-tile.is-ahead .bench-tile-value {
+  color: var(--vp-c-brand-1);
+}
+.bench-tile-note {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+/* ---------- cards ---------- */
+
+.bench-card {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  margin: 20px 0;
+  overflow: hidden;
+  scroll-margin-top: 80px;
+}
+.bench-head {
   align-items: flex-start;
   display: flex;
   gap: 20px;
   justify-content: space-between;
-  padding: 20px 22px 18px;
+  padding: 18px 20px 14px;
 }
-.mbx-bench-header h3 {
+.bench-title {
   border: 0;
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
   margin: 0;
   padding: 0;
 }
-.mbx-bench-caption {
+.bench-kicker {
+  color: var(--vp-c-brand-1);
+  display: block;
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  margin-bottom: 2px;
+  text-transform: uppercase;
+}
+.bench-caption {
   color: var(--vp-c-text-2);
   font-size: 14px;
   line-height: 1.5;
-  margin: 5px 0 0;
+  margin: 6px 0 0;
+  max-width: 62ch;
 }
-.mbx-bench-direction {
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 999px;
-  color: var(--vp-c-text-2);
+.bench-axis {
+  color: var(--vp-c-text-3);
   flex: none;
   font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  line-height: 1;
-  padding: 6px 9px;
+  letter-spacing: 0.04em;
+  padding-top: 4px;
   text-transform: uppercase;
-}
-.mbx-bench-chart {
-  border-top: 1px solid var(--vp-c-divider);
-}
-.mbx-bench-row {
-  align-items: center;
-  display: grid;
-  gap: 8px 18px;
-  grid-template-columns: minmax(120px, 0.8fr) minmax(180px, 2fr) auto;
-  padding: 16px 22px;
-}
-.mbx-bench-row + .mbx-bench-row {
-  border-top: 1px solid var(--vp-c-divider);
-}
-.mbx-bench-row.is-subject {
-  background: color-mix(in srgb, var(--vp-c-brand-soft) 58%, transparent);
-}
-.mbx-bench-tool {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-.mbx-bench-tool code {
-  background: transparent;
-  color: var(--vp-c-text-1);
-  font-size: 14px;
-  font-weight: 650;
-  padding: 0;
-}
-.mbx-bench-fastest {
-  background: color-mix(in srgb, var(--vp-c-brand-1) 14%, transparent);
-  border: 1px solid color-mix(in srgb, var(--vp-c-brand-1) 32%, transparent);
-  border-radius: 999px;
-  color: var(--vp-c-brand-1);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  line-height: 1;
-  padding: 4px 6px;
-  text-transform: uppercase;
-}
-.mbx-bench-bar-track {
-  background: color-mix(in srgb, var(--vp-c-divider) 58%, transparent);
-  border-radius: 999px;
-  display: block;
-  height: 12px;
-  overflow: hidden;
-  width: 100%;
-}
-.mbx-bench-bar {
-  background: var(--vp-c-text-3);
-  border-radius: inherit;
-  display: block;
-  height: 100%;
-  min-width: 3px;
-}
-.mbx-bench-bar.is-subject {
-  background: linear-gradient(90deg, var(--vp-c-brand-2), var(--vp-c-brand-1));
-  box-shadow: 0 0 14px color-mix(in srgb, var(--vp-c-brand-1) 32%, transparent);
-}
-.mbx-bench-seconds {
-  color: var(--vp-c-text-1);
-  font-family: var(--vp-font-family-mono);
-  font-size: 14px;
-  font-variant-numeric: tabular-nums;
-  justify-self: end;
   white-space: nowrap;
 }
-.mbx-bench-meta {
-  color: var(--vp-c-text-2);
-  display: flex;
-  flex-wrap: wrap;
-  font-size: 11px;
-  gap: 6px;
-  grid-column: 2 / 4;
+
+/* ---------- rows ---------- */
+
+.bench-table {
+  border-collapse: collapse;
+  display: table;
+  margin: 0;
+  table-layout: auto;
+  width: 100%;
 }
-.mbx-bench-meta span {
-  background: color-mix(in srgb, var(--vp-c-bg) 72%, transparent);
+.bench-table tr {
+  background: transparent;
+  border: 0;
+}
+.bench-table td,
+.bench-table th {
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 14px;
+  padding: 12px 10px;
+  text-align: left;
+  vertical-align: middle;
+}
+.bench-table td:first-child,
+.bench-table th:first-child {
+  padding-left: 20px;
+}
+.bench-table td:last-child,
+.bench-table th:last-child {
+  padding-right: 20px;
+}
+.bench-table tr.is-mbx {
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 45%, transparent);
+}
+.bench-sr-only {
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+.bench-tool {
+  max-width: 260px;
+  width: 1%;
+}
+.bench-tool-line {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+  white-space: nowrap;
+}
+.bench-sub {
+  color: var(--vp-c-text-3);
+  display: block;
+  font-family: var(--vp-font-family-sans);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  margin-top: 3px;
+  white-space: nowrap;
+}
+.bench-time .bench-sub {
+  font-family: var(--vp-font-family-mono);
+  font-variant-numeric: tabular-nums;
+}
+.bench-tool-name {
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-weight: 600;
+}
+.bench-tag {
   border: 1px solid var(--vp-c-divider);
   border-radius: 999px;
+  color: var(--vp-c-text-2);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
   line-height: 1;
-  padding: 5px 7px;
+  padding: 3px 6px;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
-.mbx-bench-inconclusive,
-.mbx-bench-skipped,
-.mbx-bench-scenario-provenance,
-.mbx-bench-provenance {
+.bench-tag.is-fastest {
+  background: color-mix(in srgb, var(--vp-c-brand-1) 14%, transparent);
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 40%, transparent);
+  color: var(--vp-c-brand-1);
+}
+.bench-bar-cell {
+  min-width: 200px;
+  width: 100%;
+}
+.bench-track {
+  height: 14px;
+  position: relative;
+  width: 100%;
+}
+.bench-bar {
+  background: var(--vp-c-text-3);
+  border-radius: 0 3px 3px 0;
+  display: block;
+  height: 8px;
+  left: 0;
+  opacity: 0.55;
+  position: absolute;
+  top: 3px;
+}
+.bench-bar.is-mbx {
+  background: var(--vp-c-brand-1);
+  opacity: 1;
+}
+/* The whisker spans the fastest and slowest run; ticks mark its ends. */
+.bench-range {
+  border-top: 2px solid var(--vp-c-text-1);
+  display: block;
+  height: 0;
+  position: absolute;
+  top: 6px;
+}
+.bench-range::before,
+.bench-range::after {
+  background: var(--vp-c-text-1);
+  content: "";
+  height: 8px;
+  position: absolute;
+  top: -5px;
+  width: 2px;
+}
+.bench-range::before {
+  left: 0;
+}
+.bench-range::after {
+  right: 0;
+}
+.bench-time {
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  text-align: right !important;
+  white-space: nowrap;
+  width: 1%;
+}
+
+/* ---------- card footer ---------- */
+
+.bench-foot {
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 14px 20px 16px;
+}
+.bench-foot:empty {
+  display: none;
+}
+.bench-verdict {
+  color: var(--vp-c-text-1);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+.bench-footnote {
   color: var(--vp-c-text-2);
   font-size: 13px;
+  line-height: 1.5;
+  margin: 6px 0 0;
 }
-.mbx-bench-inconclusive,
-.mbx-bench-skipped,
-.mbx-bench-scenario-provenance {
-  border-top: 1px solid var(--vp-c-divider);
-  margin: 0;
-  padding: 16px 22px;
+.bench-provenance {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  line-height: 1.5;
 }
-.mbx-bench-empty {
+.bench-empty {
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
   padding: 16px 20px;
 }
-.mbx-bench-empty p {
+.bench-empty p {
   margin: 0;
 }
-@media (max-width: 640px) {
-  .mbx-bench-header {
+
+@media (max-width: 720px) {
+  .bench-head {
     display: block;
-    padding: 18px 16px 16px;
+    padding: 16px 16px 12px;
   }
-  .mbx-bench-direction {
-    display: inline-block;
-    margin-top: 12px;
+  .bench-axis {
+    display: block;
+    margin-top: 10px;
   }
-  .mbx-bench-row {
-    gap: 10px 14px;
+  .bench-table,
+  .bench-table tbody {
+    display: block;
+  }
+  .bench-table tr {
+    display: grid;
+    gap: 0 12px;
     grid-template-columns: minmax(0, 1fr) auto;
-    padding: 15px 16px;
+    padding: 12px 16px;
   }
-  .mbx-bench-tool {
+  .bench-table tr + tr {
+    border-top: 1px solid var(--vp-c-divider);
+  }
+  .bench-table td,
+  .bench-table th {
+    border: 0;
+    max-width: none;
+    min-width: 0;
+    padding: 0;
+    width: auto;
+  }
+  .bench-tool {
     grid-column: 1;
     grid-row: 1;
   }
-  .mbx-bench-seconds {
+  .bench-tool-line {
+    flex-wrap: wrap;
+    white-space: normal;
+  }
+  .bench-sub {
+    white-space: normal;
+  }
+  .bench-time {
     grid-column: 2;
     grid-row: 1;
   }
-  .mbx-bench-bar-track {
+  .bench-bar-cell {
     grid-column: 1 / -1;
     grid-row: 2;
+    margin: 8px 0 0;
   }
-  .mbx-bench-meta {
-    grid-column: 1 / -1;
-    grid-row: 3;
-    margin-top: -2px;
+  .bench-foot {
+    padding: 12px 16px 14px;
   }
 }
 </style>

--- a/docs/.vitepress/theme/BenchmarkResults.vue
+++ b/docs/.vitepress/theme/BenchmarkResults.vue
@@ -163,8 +163,11 @@ const CONTENTION_LABELS: Record<string, { label: string; tag: string | null }> =
 
 function seconds(ns: number) {
   const s = ns / 1e9;
-  if (s >= 60) return `${Math.floor(s / 60)}m ${(s % 60).toFixed(0)}s`;
-  return `${s.toFixed(1)}s`;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  // Rounded once, then split: rounding the remainder on its own turns
+  // 119.6s into "1m 60s".
+  const whole = Math.round(s);
+  return `${Math.floor(whole / 60)}m ${whole % 60}s`;
 }
 
 // A margin the fastest rule rejects can be smaller than a tenth, and "0.0s"
@@ -185,11 +188,17 @@ function spread(cell: BenchmarkCell) {
   return t.length < 2 ? 0 : Math.max(...t) - Math.min(...t);
 }
 
+// Whether both cells were measured more than once. A single trial has no
+// spread to compare against, so it can neither separate two results nor
+// call them level.
+function repeated(a: BenchmarkCell, b: BenchmarkCell) {
+  return trials(a).length >= 2 && trials(b).length >= 2;
+}
+
 // Two results are separated when the gap between them is wider than either
-// tool's own spread. Anything closer is noise, and a single trial has no
-// spread to compare against, so it separates nothing.
+// tool's own spread. Anything closer is noise.
 function separated(a: BenchmarkCell, b: BenchmarkCell) {
-  if (trials(a).length < 2 || trials(b).length < 2) return false;
+  if (!repeated(a, b)) return false;
   const margin = Math.abs(a.wall_duration_ns - b.wall_duration_ns);
   return margin > Math.max(spread(a), spread(b));
 }
@@ -287,11 +296,15 @@ function buildCard(scenario: BenchmarkScenario): {
     let note = "";
     if (baseline && cell !== baseline) {
       const r = baseline.wall_duration_ns / cell.wall_duration_ns;
-      note = separated(cell, baseline)
-        ? r >= 1
-          ? `${ratio(r)} faster than Cargo`
-          : `${fine(cell.wall_duration_ns - baseline.wall_duration_ns)} behind Cargo`
-        : "level with Cargo";
+      // Measured once, the row makes no claim either way: the verdict below
+      // already says why.
+      note = !repeated(cell, baseline)
+        ? ""
+        : separated(cell, baseline)
+          ? r >= 1
+            ? `${ratio(r)} faster than Cargo`
+            : `${fine(cell.wall_duration_ns - baseline.wall_duration_ns)} behind Cargo`
+          : "level with Cargo";
     }
     return {
       tool: cell.tool,
@@ -356,11 +369,13 @@ function buildCard(scenario: BenchmarkScenario): {
     let note = "";
     if (other) {
       const r = other.wall_duration_ns / mbx.wall_duration_ns;
-      note = !separated(mbx, other)
-        ? `level with ${name(other)}`
-        : r >= 1
-          ? `${ratio(r)} faster than ${name(other)}`
-          : `${fine(mbx.wall_duration_ns - other.wall_duration_ns)} behind ${name(other)}`;
+      note = !repeated(mbx, other)
+        ? "measured once"
+        : !separated(mbx, other)
+          ? `level with ${name(other)}`
+          : r >= 1
+            ? `${ratio(r)} faster than ${name(other)}`
+            : `${fine(mbx.wall_duration_ns - other.wall_duration_ns)} behind ${name(other)}`;
     }
     tile = {
       id: scenario.scenario,
@@ -479,11 +494,13 @@ function contentionCard(scenario: BenchmarkScenario): {
         value: seconds(scheduled.wall_duration_ns),
         note: !unscheduled
           ? ""
-          : !decisive
-            ? "level with the scheduler off"
-            : unscheduled.wall_duration_ns > scheduled.wall_duration_ns
-              ? `${fine(unscheduled.wall_duration_ns - scheduled.wall_duration_ns)} sooner than scheduler off`
-              : `${fine(scheduled.wall_duration_ns - unscheduled.wall_duration_ns)} later than scheduler off`,
+          : !repeated(scheduled, unscheduled)
+            ? "measured once"
+            : !decisive
+              ? "level with the scheduler off"
+              : unscheduled.wall_duration_ns > scheduled.wall_duration_ns
+                ? `${fine(unscheduled.wall_duration_ns - scheduled.wall_duration_ns)} sooner than scheduler off`
+                : `${fine(scheduled.wall_duration_ns - unscheduled.wall_duration_ns)} later than scheduler off`,
         ahead: decisive && fastest === scheduled,
       }
     : null;

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,125 +1,89 @@
 # Benchmarks
 
-The subject is [jdx/hk](https://github.com/jdx/hk), a mid-size Rust CLI with C
-dependencies, pinned to a fixed commit. mbx's own workspace is too small to
-measure anything useful against. Every scenario is one CI actually hits.
-
-The build scenarios run the same `cargo build --locked` through plain Cargo,
-[mbx](/), and [kache](https://github.com/kunobi-ninja/kache), where each tool
-can make a meaningful comparison. Timings are wall clock around one build.
-Where Cargo appears, the cache rows compare only with that result. In the
-commit scenario it is an uncached control; in the edit scenario it is the
-incremental rebuild the caches have to beat. The warm scenario omits Cargo
-because a fresh `target/` gives it nothing to reuse. The contention scenario
-compares sequential and parallel lint strategies and measures the machine
-instead of a single build.
-
-Every timed scenario runs three times per tool. The card shows the middle run
-and the range across all three. A tool is marked fastest only when its lead
-over the next one is wider than either tool's own range; otherwise the card
-says so.
+mbx is measured against plain Cargo and
+[kache](https://github.com/kunobi-ninja/kache) on [jdx/hk](https://github.com/jdx/hk),
+a mid-size Rust CLI with C dependencies, pinned to one commit and built with
+`cargo build --locked`. Each scenario is a shape CI or a developer actually
+hits. The numbers come from a GitHub Actions run, never a laptop, and the page
+will not name a fastest tool when the gap is inside run-to-run noise.
 
 <BenchmarkResults />
 
-## What each scenario reproduces
+## Reading the cards
 
-### warm
+Every timed scenario runs three times per tool from a fresh clone and an
+empty store. The bar is the middle run and the whisker through it spans the
+fastest and slowest. A tool is marked fastest only when its lead over the next
+one is wider than either tool's own whisker; otherwise the card says so and
+names nobody.
 
-A store warmed by a first build of the same commit, then a fresh `target/`.
-This is the common CI shape: a runner restores a cache, then builds a commit
-it has already seen. cargo is not run, because with a wiped `target/` it would
-repeat that first build.
+The Cargo row means something different in each scenario, so the card tags it.
+In the commit scenario it is the uncached build CI does without a cache. In
+the edit scenario it is the incremental rebuild the caches have to keep up
+with. The warm scenario has no Cargo row, because with an empty `target/`
+Cargo would repeat the build that warmed the store.
 
-### commit
+## The scenarios
 
-The store is warmed at one commit and the build runs at the next one.
-Push-to-push CI: most of the dependency graph is unchanged, a few crates are
-not. cargo's baseline here is a cold build, because that is what cargo does
-with an empty `target/`.
+### Warm build
 
-### edit
+A first build warms the store, then `target/` is wiped and the same commit
+builds again. This is a runner restoring its cache and building something it
+has already seen.
 
-A full build, then edits to the subject's own source rebuilt in the same
-`target/` with incremental compilation on. This is the local edit loop rather
-than a CI job. Almost nothing needs rebuilding, so the cache's own bookkeeping
-is most of what shows up. Cargo is the thing to beat here, not a control.
+### Next commit
 
-The scenario also runs without `CI` set, because it is the one scenario about
-a developer's machine rather than a runner. mbx reads that variable and turns
-[learned incremental reuse](/configuration#learned-incremental-reuse) off when
-it is set, on the reasoning that a fresh runner has no earlier state to build
-on and never edits code anyway. Leaving it set measured the loop with the
-feature that makes the loop fast switched off: every edit recompiled the crate
-in full. It is cleared for every tool, not just mbx.
+The store is warmed at one commit and the build runs at the next. Most of the
+dependency graph is unchanged and a few crates are not. Cargo's row is a cold
+build, since with an empty `target/` that is all it can do.
 
-The first edit after a build is thrown away and the second is timed, because
-the tools do not reach a first edit in the same state. Cargo's own build
-already wrote its incremental state, so its first edit is already a
-steady-state edit. mbx overrides `CARGO_INCREMENTAL` to 0 and gives an edited
-crate [private incremental
-state](/configuration#learned-incremental-reuse) instead, which the first edit
-has to build from nothing. Timing that one would compare Cargo's second
-rebuild against mbx's first and report a setup cost paid once as though it
-were the loop. The card shows what that first edit cost beside the steady
-number, because it is a real wait, just not a repeated one.
+### Local edit
 
-### contention
+A full build, then one line of hk's own source changed and rebuilt in the same
+`target/` with incremental compilation on. Almost nothing recompiles, so the
+cache's own bookkeeping is most of what shows up. Two details keep it honest:
 
-Six overlapping Rust CI jobs from an empty store: default and all-targets/all-
-features variants of `cargo check`, Clippy, and test compilation. The
-`sequential` row is context, with the commands sharing one target directory.
-The parallel rows use separate targets so Cargo's target lock does not
-serialize them, matching separate CI steps. The scheduler comparison is
-between those two parallel rows.
+- `CI` is unset for every tool. mbx switches
+  [learned incremental reuse](/configuration#learned-incremental-reuse) off
+  when it sees that variable, on the reasoning that a fresh runner never edits
+  code. With it set, every edit recompiled the crate in full.
+- The first edit after a build is discarded and the second is timed. Cargo's
+  own build already wrote its incremental state, while mbx builds an edited
+  crate's [private state](/configuration#learned-incremental-reuse) on the
+  first edit and reuses it afterwards. The card shows what that first edit
+  cost, since a developer waits for it once per fresh build.
 
-All three rows use the same mbx binary. The `mbx` and `mbx-unscheduled` rows
-run the parallel shape with the
-[machine-wide scheduler](/configuration#machine-wide-compile-scheduling) on
-and off, which isolates what mbx contributes from parallelism itself. Cargo
-bounds only the compilers it starts and knows nothing about the Cargo process
-beside it; the scheduler gives both processes one machine-wide permit pool and
-deduplicates identical work in flight. The wall clock shows whether the switch
-beats the sequential baseline. Peak compilers and lowest free memory show
-whether it got there by sharing the machine or by oversubscribing it.
+### Six parallel jobs
 
-## How the comparison is kept fair
+Six overlapping Rust CI jobs from an empty store: default and
+all-targets/all-features variants of `cargo check`, Clippy, and test
+compilation. The sequential row runs them in turn in one `target/`. The two
+parallel rows give each job its own `target/`, as separate CI steps would,
+and differ only in whether the
+[machine-wide scheduler](/configuration#machine-wide-compile-scheduling) is
+on. Cargo bounds the compilers it starts itself and knows nothing about the
+Cargo process beside it; the scheduler gives every process one pool of permits
+and holds identical compilations until the first finishes. Peak compilers and
+lowest free memory show whether a faster batch shared the machine or
+oversubscribed it.
 
-- The registry is fetched once, before any timed build, into a shared
-  `CARGO_HOME`. No cell is timed while it downloads crates.
-- Trials share nothing. Each one clones the subject again and starts from its
-  own empty store.
-- The toolchain is pinned per subject. hk does not pin one itself, and a
-  runner-image Rust bump changes every invocation digest at once, which would
-  land in the series as a step change that looks like a cache that stopped
+## Keeping it fair
+
+- The registry is fetched once, before any timed build. No cell is timed
+  while it downloads crates.
+- Every trial starts from a fresh clone, an empty store, and a new `target/`.
+  Nothing carries over between tools or between runs.
+- The toolchain is pinned. hk does not pin one, and a runner-image Rust bump
+  would change every cache key at once and look like a cache that stopped
   working.
-- Each cell gets its own store and `target/`, created fresh. No tool benefits
-  from another's leftovers.
-- `CARGO_INCREMENTAL=0` is set, matching CI, except in the edit scenario.
-  Any `RUSTC_WRAPPER` inherited from the caller is cleared so the uncached
-  baseline is uncached.
-- Both caches run local-only. A remote would measure a network.
-- Every scenario's rows come from one CI run, so the tools within it are
-  comparable. A scenario refreshed separately carries its own run link;
-  otherwise the provenance line below the cards applies.
-
-## Validity gates
-
-A benchmark that measured nothing still renders numbers, so the run fails and
-nothing publishes unless:
-
-- the warm build reports cache hits and restored output files; a fast build
-  that restored nothing was fast for some other reason;
-- each warm build beat the cold build that seeded it;
-- the edit rebuild compiled something; an edit that never reached the
-  compiler would render as a very fast rebuild;
-- no Cargo baseline ran under mbx; a `cargo` that is itself an mbx shim
-  would use the cache it is the control for;
-- the contention run sampled the machine, saw compilers running, and kept the
-  scheduled batch inside its permits, and the unscheduled batch went past
-  them; a bound nothing pushed against proves nothing.
-
-A run that fails these is not rendered here at all. The page shows its empty
-state instead.
+- `CARGO_INCREMENTAL=0` matches CI everywhere except the edit scenario. Any
+  inherited `RUSTC_WRAPPER` is cleared, and the run fails if the Cargo
+  baseline turns out to be an mbx shim.
+- Both caches run local-only. A remote would measure the network.
+- A run that measured nothing is discarded rather than rendered. That is any
+  run where a warm build restored nothing or was no faster than the build that
+  seeded it, where the edit rebuild compiled nothing, or where the scheduled
+  contention batch went past its permits or the unscheduled one never did.
 
 ## Running it yourself
 
@@ -127,26 +91,24 @@ state instead.
 mise run bench
 ```
 
-That builds mbx, clones the pinned subject, and runs the warm, next-commit,
-and edit scenarios once each. kache is included when it is on `PATH` and
-skipped with a note when it is not. `mise run bench:refresh` is what CI runs:
-every scenario, three trials of each, writing `benchmarks/results.json`.
-`--trials` sets the repeat count. The page will not name a fastest tool
-from a single trial.
+That builds mbx, clones hk, and runs the warm, commit, and edit scenarios once
+each. kache is included when it is on `PATH` and noted as skipped otherwise.
+`mise run bench:refresh` is what CI runs: every scenario, three trials each,
+written to `benchmarks/results.json`.
 
-The numbers on this page are refreshed by the
-[bench-refresh workflow](https://github.com/jdx/mr-boxington/actions/workflows/bench-refresh.yml),
-which runs weekly, only when the published numbers were measured with an older
-mbx than the one on `main`, and opens a pull request instead of publishing
-directly. Nobody's laptop numbers reach this page.
+The
+[bench-refresh workflow](https://github.com/jdx/mr-boxington/actions/workflows/bench-refresh.yml)
+runs weekly, only when the published numbers were measured with an older mbx
+than the one on `main`, and opens a pull request rather than publishing
+directly.
 
 ## What this does not measure
 
-Everything hk does not do. hk is a mid-size CLI, and a project with a very
-different dependency shape (heavy proc macros, a large C component, many small
-leaf crates) will see different ratios. It is also Linux-only:
-[the limits page](/limits) covers what changes on macOS and Windows.
+Anything hk does not do. A project with a very different dependency shape,
+such as heavy proc macros, a large C component, or many small leaf crates,
+will see different ratios. The benchmark is Linux-only, and
+[limits](/limits) covers what changes on macOS and Windows.
 
-For instruction-counted measurements of mbx's own startup path, and
-cold/warm correctness runs against this workspace, see
+Instruction-counted measurements of mbx's own startup path, and cold and warm
+correctness runs against this workspace, live in
 [`benchmarks/`](https://github.com/jdx/mr-boxington/tree/main/benchmarks).


### PR DESCRIPTION
## Summary

Stacked on #359. Rewrites [the benchmarks page](https://mr-boxington.jdx.dev/benchmarks) around one question per scenario, with the answer before the reader scrolls.

- **A row of tiles at the top**: mbx's median per scenario and where it landed against the tool that matters there (kache in warm, Cargo in commit and edit, the unscheduled batch in contention). A tile is amber only when mbx is the separated fastest.
- **Cards are now small tables**: tool, a bar for the median with a whisker spanning the three runs, and the median with its range. The comparison to Cargo sits under the tool name instead of in a row of pills. Rows sort fastest first.
- **One verdict sentence per card**, same rule as #359: a tool is named fastest only across a gap wider than either tool's own spread. When mbx is neither of the top two, the verdict says where it finished and whether that gap is real.
- **Prose cut to about half**: reading the cards, the four scenarios, fairness and validity gates merged into one list, running it yourself, what is not measured.
- Scenario titles and captions live in the component keyed by scenario name, with the harness description as the fallback so an unknown scenario still renders.

## Validation

- `aube run docs:build` clean; lychee passes on the built page (the FAQ's `/benchmarks#warm` anchor still resolves to the card).
- Rendered at 1280px and 390px in headless Chromium; both layouts checked.
- Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and VitePress presentation only; benchmark harness data shape is unchanged and risk is limited to how results are interpreted on the docs site.
> 
> **Overview**
> **Redesigns the published benchmarks UI** so each scenario answers “where did mbx land?” before you scroll, with clearer noise-aware winners.
> 
> Adds an **“At a glance”** nav of anchor tiles (mbx median per scenario, comparison note, brand highlight only when mbx is a separated fastest). Scenario blocks become **table cards**: sorted rows, median bar plus **whisker** for min–max across trials, Cargo/baseline tags and comparisons under the tool name, a **one-sentence verdict**, and footnotes for cache restores, warmup edits, skips, and per-scenario CI provenance. Contention keeps its own card builder (scheduler on/off vs sequential) with compiler/memory subnotes. Presentation logic moves into `buildCard` / `contentionCard` with shared `separated` / `geometry` helpers; scenario titles and captions live in a `COPY` map with harness fallback. CSS is renamed (`bench-*`) with responsive table layout.
> 
> **`benchmarks.md` is tightened** around “reading the cards,” renamed scenario headings, merged fairness/validity bullets, and the same rule that gaps inside run-to-run noise never get a fastest label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5270c72c48d7023d863f309cdb901a29950358e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned benchmark results with cards, summary tiles, sortable timing rows, run ranges, tool comparisons, verdicts, cache and warmup notes, skipped measurements, and provenance.
  - Added noise-aware fastest-result detection, contention-specific comparisons, formatted durations, and responsive tables.
- **Documentation**
  - Updated benchmark guidance with renamed scenarios, clearer visualization explanations, fairness criteria, and revised tool comparison details.
  - Clarified that inconclusive performance differences are not assigned a fastest tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->