### PR TITLE
chore(release): bump packslip action to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,7 +383,7 @@ jobs:
       # jdx/mr-boxington's identity with no key to distribute. Runs after the
       # upload above, which is what guarantees the release exists.
       # See https://packslip.dev.
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
         with:
           tag: ${{ inputs.tag }}
           artifacts: release-assets/mbx-*.tar.gz release-assets/mbx-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,7 +383,7 @@ jobs:
       # jdx/mr-boxington's identity with no key to distribute. Runs after the
       # upload above, which is what guarantees the release exists.
       # See https://packslip.dev.
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         with:
           tag: ${{ inputs.tag }}
           artifacts: release-assets/mbx-*.tar.gz release-assets/mbx-*.zip


### PR DESCRIPTION
## Summary
- Bumps the pinned `jdx/packslip` action from v0.3.0 to v1.0.0.
- v1.0.0 declares the manifest format stable, fixes the `packslip.dev/releases/v1` predicate URL that previously 404d, and requires every artifact to declare a format (already satisfied here — every artifact is an archive, which infers its format from the file name).

## Test plan
- [ ] Next tagged release runs the packslip step successfully and uploads `packslip.sigstore.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single third-party action pin bump in CI with unchanged inputs; release signing behavior may differ only per packslip v1 release notes.
> 
> **Overview**
> Updates the release workflow’s pinned **`jdx/packslip`** step from **v0.3.0** to **v1.0.1** (commit `a6eddff…`). The step still runs after release assets upload with the same inputs (`tag`, `mbx-*.tar.gz` / `mbx-*.zip`, `bin: mbx`) to produce the keyless signed provenance manifest (`packslip.sigstore.json`).
> 
> This picks up the v1 line’s stable manifest format and predicate URL fixes described in the PR notes; no other workflow steps or packslip configuration change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725b3149251c0be26919512f360250c34ec55c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging process to use a newer packaging tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->