### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "bytesize",
  "demand",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.19...mbx-cache-cargo-v0.1.20) - 2026-09-05
+
+### Other
+
+- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
+
 ## [0.1.19](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.18...mbx-cache-cargo-v0.1.19) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.19"
+version = "0.1.20"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.12.0"
+version = "0.13.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.12.0...mbx-cache-core-v0.13.0) - 2026-09-05
+
+### Other
+
+- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
+
 ## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.11.5...mbx-cache-core-v0.12.0) - 2026-09-05
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.12.0"
+version = "0.13.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.12.0...mbx-cache-rustc-v0.13.0) - 2026-09-05
+
+### Other
+
+- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
+
 ## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.11.5...mbx-cache-rustc-v0.12.0) - 2026-09-05
 
 ### Fixed

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.12.0"
+version = "0.13.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.18...mbx-cache-store-v0.1.19) - 2026-09-05
+
+### Other
+
+- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
+
 ## [0.1.18](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.17...mbx-cache-store-v0.1.18) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.18"
+version = "0.1.19"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2](https://github.com/jdx/mr-boxington/compare/v1.8.1...v1.8.2) - 2026-09-05
+
+### Other
+
+- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
+
 ## [1.8.1](https://github.com/jdx/mr-boxington/compare/v1.8.0...v1.8.1) - 2026-09-05
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.8.1"
+version = "1.8.2"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -26,11 +26,11 @@ flate2 = "1"
 hex = "0.4"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.12.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.19", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.12.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.12.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.18", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.20", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.13.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.13.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.19", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.8.1
+**Version:** 1.8.2
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.12.0 -> 0.13.0 (⚠ API breaking changes)
* `mbx-cache-cargo`: 0.1.19 -> 0.1.20 (✓ API compatible changes)
* `mbx-cache-cc`: 0.12.0 -> 0.13.0
* `mbx-cache-rustc`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.18 -> 0.1.19 (✓ API compatible changes)
* `mbx`: 1.8.1 -> 1.8.2 (✓ API compatible changes)

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field pins of variant AgentRequest::StoreExecutableIdentity in /tmp/.tmpmpuwDr/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:243
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.12.0...mbx-cache-core-v0.13.0) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.20](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.19...mbx-cache-cargo-v0.1.20) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.5...mbx-cache-cc-v0.12.0) - 2026-09-05

### Fixed

- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.12.0...mbx-cache-rustc-v0.13.0) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.19](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.18...mbx-cache-store-v0.1.19) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx`

<blockquote>

## [1.8.2](https://github.com/jdx/mr-boxington/compare/v1.8.1...v1.8.2) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Releases a breaking `mbx-cache-core` agent wire variant change; embedders must update match/construct sites, while CLI users only need the version bump.
> 
> **Overview**
> **Release-only PR** that bumps crate versions, refreshes `Cargo.lock`, records changelog entries, and updates the generated CLI docs version string (**1.8.1 → 1.8.2**).
> 
> It ships the work from [#362](https://github.com/jdx/mr-boxington/pull/362): **hot-edit bookkeeping is moved off the build critical path** (incremental workspace edit loops). Affected packages: `mbx` **1.8.2**, `mbx-cache-core` **0.13.0**, `mbx-cache-cc` / `mbx-cache-rustc` **0.13.0**, `mbx-cache-cargo` **0.1.20**, `mbx-cache-store` **0.1.19**.
> 
> **Embedder note:** `mbx-cache-core` has a **semver-breaking** wire/API change—`AgentRequest::StoreExecutableIdentity` gains an optional `pins` field for cross-session executable identity pinning. Downstream crates in this repo already depend on **0.13.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55debf540978ae7ca943cf647f0d5ba60b5dc7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->