### PR TITLE
chore: release

### DIFF
--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.12.0...mbx-cache-cc-v0.13.0) - 2026-09-05
+
+### Other
+
+- release ([#365](https://github.com/jdx/mr-boxington/pull/365))
+
 ## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.5...mbx-cache-cc-v0.12.0) - 2026-09-05
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.12.0 -> 0.13.0
* `mbx-cache-cargo`: 0.1.19 -> 0.1.20
* `mbx-cache-cc`: 0.12.0 -> 0.13.0
* `mbx-cache-rustc`: 0.12.0 -> 0.13.0
* `mbx-cache-store`: 0.1.18 -> 0.1.19
* `mbx`: 1.8.1 -> 1.8.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.12.0...mbx-cache-core-v0.13.0) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.20](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.19...mbx-cache-cargo-v0.1.20) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.12.0...mbx-cache-cc-v0.13.0) - 2026-09-05

### Other

- release ([#365](https://github.com/jdx/mr-boxington/pull/365))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.12.0...mbx-cache-rustc-v0.13.0) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.19](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.18...mbx-cache-store-v0.1.19) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx`

<blockquote>

## [1.8.2](https://github.com/jdx/mr-boxington/compare/v1.8.1...v1.8.2) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release publishing already-merged code; no new logic in the diff itself.
> 
> **Overview**
> **Automated release** (release-plz) that bumps crate versions and changelog entries across the workspace: `mbx-cache-core`, `mbx-cache-cc`, and `mbx-cache-rustc` to **0.13.0**; `mbx-cache-cargo` to **0.1.20**; `mbx-cache-store` to **0.1.19**; and **`mbx`** to **1.8.2**, with matching `Cargo.lock` updates.
> 
> The shipped functional note for most packages is moving **bookkeeping out of the hot edit loop** ([#362](https://github.com/jdx/mr-boxington/pull/362)). This diff only adds the **`mbx-cache-cc` 0.13.0** changelog section (dated 2026-09-05) under `[Unreleased]`, with an “Other” entry pointing at this release PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eafc95826eb59e166d484e8c23eb2b8fb628162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->