### PR TITLE
ci(release): set GH_REPO for the packslip upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,6 +384,10 @@ jobs:
       # upload above, which is what guarantees the release exists.
       # See https://packslip.dev.
       - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+        # `gh release upload` inside the action has no checkout to infer the
+        # repository from; drop once jdx/packslip#71 ships in a release.
+        env:
+          GH_REPO: ${{ github.repository }}
         with:
           tag: ${{ inputs.tag }}
           artifacts: release-assets/mbx-*.tar.gz release-assets/mbx-*.zip


### PR DESCRIPTION
The packslip action uploads its bundle with `gh release upload "$TAG" "$BUNDLE" --clobber` and no `--repo`, so `gh` falls back to asking git which repository it is in. The job that runs it only downloads artifacts and has no checkout, so the upload fails with

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

after the packslip has already been created and verified.

This is what broke the v1.8.2 release: https://github.com/jdx/mr-boxington/actions/runs/33975086489/job/101332822913

Setting `GH_REPO` on the step is what jdx/communique already does. The fix in the action itself is jdx/packslip#71; this workaround can be dropped once a packslip release carrying it is pinned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)