### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "bytesize",
  "demand",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.20...mbx-cache-cargo-v0.1.21) - 2026-09-05
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.20](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.19...mbx-cache-cargo-v0.1.20) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.20"
+version = "0.1.21"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.13.0"
+version = "0.13.1"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.13.0...mbx-cache-core-v0.13.1) - 2026-09-05
+
+### Fixed
+
+- tolerate NFS mtime reconciliation in content snapshots ([#370](https://github.com/jdx/mr-boxington/pull/370))
+
 ## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.12.0...mbx-cache-core-v0.13.0) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.13.0"
+version = "0.13.1"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.13.0"
+version = "0.13.1"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.19...mbx-cache-store-v0.1.20) - 2026-09-05
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.19](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.18...mbx-cache-store-v0.1.19) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.19"
+version = "0.1.20"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.3](https://github.com/jdx/mr-boxington/compare/v1.8.2...v1.8.3) - 2026-09-05
+
+### Other
+
+- updated the following local packages: mbx-cache-core, mbx-cache-cc, mbx-cache-rustc, mbx-cache-cargo, mbx-cache-store
+
 ## [1.8.2](https://github.com/jdx/mr-boxington/compare/v1.8.1...v1.8.2) - 2026-09-05
 
 ### Other

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.8.2"
+version = "1.8.3"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -26,11 +26,11 @@ flate2 = "1"
 hex = "0.4"
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.20", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.13.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.13.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.19", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.21", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.13.1", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.13.1", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.20", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.8.2
+**Version:** 1.8.3
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.13.0 -> 0.13.1 (✓ API compatible changes)
* `mbx-cache-cc`: 0.13.0 -> 0.13.1
* `mbx-cache-rustc`: 0.13.0 -> 0.13.1
* `mbx-cache-cargo`: 0.1.20 -> 0.1.21
* `mbx-cache-store`: 0.1.19 -> 0.1.20
* `mbx`: 1.8.2 -> 1.8.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.13.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.13.0...mbx-cache-core-v0.13.1) - 2026-09-05

### Fixed

- tolerate NFS mtime reconciliation in content snapshots ([#370](https://github.com/jdx/mr-boxington/pull/370))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.5...mbx-cache-cc-v0.12.0) - 2026-09-05

### Fixed

- restore NFS digest reuse without read storms ([#341](https://github.com/jdx/mr-boxington/pull/341))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.12.0...mbx-cache-rustc-v0.13.0) - 2026-09-05

### Other

- take the bookkeeping out of the hot edit loop ([#362](https://github.com/jdx/mr-boxington/pull/362))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.21](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.20...mbx-cache-cargo-v0.1.21) - 2026-09-05

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.20](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.19...mbx-cache-store-v0.1.20) - 2026-09-05

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx`

<blockquote>

## [1.8.3](https://github.com/jdx/mr-boxington/compare/v1.8.2...v1.8.3) - 2026-09-05

### Other

- updated the following local packages: mbx-cache-core, mbx-cache-cc, mbx-cache-rustc, mbx-cache-cargo, mbx-cache-store
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile churn plus republishing a patch that improves NFS snapshot behavior in cache-core; no new code in this diff beyond release metadata.
> 
> **Overview**
> **Release-only PR** (release-plz) that publishes **mbx 1.8.3** and bumps the workspace cache crates so they depend on **mbx-cache-core 0.13.1**.
> 
> The user-facing fix in this train is documented in **mbx-cache-core**: **tolerate NFS mtime reconciliation in content snapshots** ([#370](https://github.com/jdx/mr-boxington/pull/370)). **mbx-cache-cc**, **mbx-cache-rustc**, **mbx-cache-cargo**, and **mbx-cache-store** get patch/minor version bumps mainly to pick up that core release; their changelogs note dependency updates.
> 
> The diff updates **`Cargo.toml`** / **`Cargo.lock`**, per-crate **`CHANGELOG.md`** entries, and the generated CLI docs **version** (`docs/cli/index.md` → 1.8.3)—no application logic changes in this PR itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05af813d77a3f23130206c8db8e006d58f289f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->