### PR TITLE
ci(release): bump packslip to v1.0.2 and drop the GH_REPO workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,11 +383,7 @@ jobs:
       # jdx/mr-boxington's identity with no key to distribute. Runs after the
       # upload above, which is what guarantees the release exists.
       # See https://packslip.dev.
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
-        # `gh release upload` inside the action has no checkout to infer the
-        # repository from; drop once jdx/packslip#71 ships in a release.
-        env:
-          GH_REPO: ${{ github.repository }}
+      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
         with:
           tag: ${{ inputs.tag }}
           artifacts: release-assets/mbx-*.tar.gz release-assets/mbx-*.zip


### PR DESCRIPTION
v1.0.2 carries jdx/packslip#71, which passes `--repo` on `gh release upload`, so the `GH_REPO` env added in #369 is no longer needed. Pinned to the release commit `5c1cced`, which is what the `v1.0.2` tag points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release CI only: bumps a pinned third-party action and removes a redundant env var with no product or security logic changes.
> 
> **Overview**
> Updates the release workflow’s **packslip** step from **v1.0.1** to **v1.0.2** (pinned at commit `5c1cced`).
> 
> Because **v1.0.2** passes `--repo` on `gh release upload` (jdx/packslip#71), the temporary **`GH_REPO`** env and its comment—added when the action couldn’t infer the repository without a checkout—are removed. Packslip inputs (`tag`, `artifacts`, `bin`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cc560b54b10d1d7ecfdd4b3abb0e3d9089a39f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging process to use the latest packslip action version.
  * Removed an obsolete release configuration workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->