### PR TITLE
docs: link announcement from homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,3 +23,7 @@ hero:
       text: Benchmarks
       link: /benchmarks
 ---
+
+Read the [announcement: Introducing mr-boxington — fix `target/`](https://jdx.dev/posts/2026-09-05-introducing-mr-boxington/)
+for a walkthrough of automatic cleanup, shared caching, warm worktrees, and
+memory-aware parallel Cargo builds.


### PR DESCRIPTION
Add the launch announcement below the documentation homepage's hero links, with a short description of the walkthrough.

Validation: the published URL returns HTTP 200; the VitePress build passes and its rendered homepage includes the link. Generated documentation checks and `git diff --check` pass. Full `mise run ci` stopped at the behavioral test task because this worktree's Bats submodules are not initialized (exit 127).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only homepage copy and an external link; no runtime or build behavior changes.
> 
> **Overview**
> The documentation **homepage** now includes a short blurb right under the hero action links that points readers to the [Introducing mr-boxington](https://jdx.dev/posts/2026-09-05-introducing-mr-boxington/) announcement and highlights what the post covers: automatic cleanup, shared caching, warm worktrees, and memory-aware parallel Cargo builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c78c18247337b93fe717bcf1bcc9d2610faa189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->