### PR TITLE
docs: feature announcement in homepage hero

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,9 @@ hero:
     alt: Mr Boxington, a friendly cache box
   actions:
     - theme: brand
+      text: Read the announcement
+      link: https://jdx.dev/posts/2026-09-05-introducing-mr-boxington/
+    - theme: alt
       text: Get started
       link: /getting-started
     - theme: alt
@@ -23,7 +26,3 @@ hero:
       text: Benchmarks
       link: /benchmarks
 ---
-
-Read the [announcement: Introducing mr-boxington — fix `target/`](https://jdx.dev/posts/2026-09-05-introducing-mr-boxington/)
-for a walkthrough of automatic cleanup, shared caching, warm worktrees, and
-memory-aware parallel Cargo builds.


### PR DESCRIPTION
Move the launch announcement from the text below the homepage content to the first, highlighted hero action. “Read the announcement” now sits directly under the introduction, followed by “Get started” and the other documentation links. Remove the previous lower-page link.

Validation: VitePress production build and offline link checks pass. Verified the rendered announcement is the first brand-styled hero button and appears only once. `git diff --check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only homepage layout change with no runtime or security impact.
> 
> **Overview**
> **Promotes the launch post in the VitePress homepage hero** instead of burying it below the fold.
> 
> The first **brand** hero action is now **Read the announcement**, linking to the Introducing mr-boxington post. **Get started**, **How it works**, and the other doc links follow as **alt** actions. The standalone announcement paragraph under the hero frontmatter is removed so the CTA appears once, as the primary button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f96b9264955707c6bd9f86098a355b1d8a0159f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->