### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.8.3"
+version = "1.9.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "blake3",
  "eyre",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.21...mbx-cache-cargo-v0.1.22) - 2026-09-06
+
+### Added
+
+- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
+
+### Other
+
+- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
+- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
+
 ## [0.1.21](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.20...mbx-cache-cargo-v0.1.21) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.21"
+version = "0.1.22"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.13.1...mbx-cache-cc-v0.14.0) - 2026-09-06
+
+### Added
+
+- *(cc)* cache named preprocessor outputs ([#394](https://github.com/jdx/mr-boxington/pull/394))
+- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
+
+### Fixed
+
+- *(cc)* cache gdb and full debug compilations portably ([#384](https://github.com/jdx/mr-boxington/pull/384))
+
+### Other
+
+- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
+- *(cc)* reuse unchanged include directory manifests ([#388](https://github.com/jdx/mr-boxington/pull/388))
+- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
+
 ## [0.12.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.11.5...mbx-cache-cc-v0.12.0) - 2026-09-05
 
 ### Fixed

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.13.1"
+version = "0.14.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.13.1...mbx-cache-core-v0.14.0) - 2026-09-06
+
+### Added
+
+- *(report)* record wrapper phases and export Perfetto traces ([#390](https://github.com/jdx/mr-boxington/pull/390))
+- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
+
+### Other
+
+- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
+- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
+
 ## [0.13.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.13.0...mbx-cache-core-v0.13.1) - 2026-09-05
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.13.1"
+version = "0.14.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.13" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.14" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.13...mbx-cache-protocol-v0.5.14) - 2026-09-06
+
+### Added
+
+- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
+
+### Other
+
+- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
+- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
+
 ## [0.5.13](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.12...mbx-cache-protocol-v0.5.13) - 2026-09-03
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.13"
+version = "0.5.14"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.13.1...mbx-cache-rustc-v0.14.0) - 2026-09-06
+
+### Added
+
+- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
+
+### Other
+
+- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
+- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
+
 ## [0.13.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.12.0...mbx-cache-rustc-v0.13.0) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.13.1"
+version = "0.14.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.20...mbx-cache-store-v0.1.21) - 2026-09-06
+
+### Added
+
+- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
+
+### Other
+
+- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
+- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
+
 ## [0.1.20](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.19...mbx-cache-store-v0.1.20) - 2026-09-05
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.20"
+version = "0.1.21"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/jdx/mr-boxington/compare/v1.8.3...v1.9.0) - 2026-09-06
+
+### Added
+
+- *(verify)* sample compilation identities deterministically ([#391](https://github.com/jdx/mr-boxington/pull/391))
+- *(cc)* cache named preprocessor outputs ([#394](https://github.com/jdx/mr-boxington/pull/394))
+- *(report)* record wrapper phases and export Perfetto traces ([#390](https://github.com/jdx/mr-boxington/pull/390))
+- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
+- *(cli)* publish native completions in packslip ([#381](https://github.com/jdx/mr-boxington/pull/381))
+- explain object cache results in CI summaries ([#377](https://github.com/jdx/mr-boxington/pull/377))
+
+### Fixed
+
+- *(gc)* distinguish logical removal from physical reclamation ([#392](https://github.com/jdx/mr-boxington/pull/392))
+- *(doctor)* probe reflinks from cache to target filesystems ([#387](https://github.com/jdx/mr-boxington/pull/387))
+- *(scheduler)* respect nested cgroup memory limits ([#386](https://github.com/jdx/mr-boxington/pull/386))
+- *(cc)* cache gdb and full debug compilations portably ([#384](https://github.com/jdx/mr-boxington/pull/384))
+- preserve CMake compiler identity across Cargo transitions ([#380](https://github.com/jdx/mr-boxington/pull/380))
+- support multiple Cargo targets in linker selection ([#379](https://github.com/jdx/mr-boxington/pull/379))
+
+### Other
+
+- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
+- *(cache)* compare semantic changes against bare rustc ([#393](https://github.com/jdx/mr-boxington/pull/393))
+- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
+
 ## [1.8.3](https://github.com/jdx/mr-boxington/compare/v1.8.2...v1.8.3) - 2026-09-05
 
 ### Other

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.8.3"
+version = "1.9.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -27,11 +27,11 @@ hex = "0.4"
 jiff = { version = "0.2", default-features = false, features = ["std"] }
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.13.1", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.21", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.13.1", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.13.1", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.20", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.22", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.14.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.14.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.21", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.8.3
+**Version:** 1.9.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.13 -> 0.5.14 (✓ API compatible changes)
* `mbx-cache-core`: 0.13.1 -> 0.14.0 (⚠ API breaking changes)
* `mbx-cache-cargo`: 0.1.21 -> 0.1.22 (✓ API compatible changes)
* `mbx-cache-cc`: 0.13.1 -> 0.14.0 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.13.1 -> 0.14.0 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.20 -> 0.1.21 (✓ API compatible changes)
* `mbx`: 1.8.3 -> 1.9.0 (✓ API compatible changes)

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant AgentEvent::ActionHit 0 -> 1 in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:379
  variant AgentEvent::Bypass 1 -> 2 in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:386
  variant AgentEvent::Unconsulted 2 -> 3 in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:391
  variant AgentEvent::CompilerInvocation 3 -> 4 in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:393
  variant AgentEvent::Verification 4 -> 5 in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:402
  variant AgentEvent::Warning 5 -> 6 in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:409
  variant AgentEvent::ActionDiagnostic 6 -> 7 in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:414

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:WrapperTimingRecorded in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:543
  variant AgentRequest:RecordWrapperTiming in /tmp/.tmps8tW2S/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:298
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.13...mbx-cache-protocol-v0.5.14) - 2026-09-06

### Added

- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.13.1...mbx-cache-core-v0.14.0) - 2026-09-06

### Added

- *(report)* record wrapper phases and export Perfetto traces ([#390](https://github.com/jdx/mr-boxington/pull/390))
- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.21...mbx-cache-cargo-v0.1.22) - 2026-09-06

### Added

- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.13.1...mbx-cache-cc-v0.14.0) - 2026-09-06

### Added

- *(cc)* cache named preprocessor outputs ([#394](https://github.com/jdx/mr-boxington/pull/394))
- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Fixed

- *(cc)* cache gdb and full debug compilations portably ([#384](https://github.com/jdx/mr-boxington/pull/384))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- *(cc)* reuse unchanged include directory manifests ([#388](https://github.com/jdx/mr-boxington/pull/388))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.13.1...mbx-cache-rustc-v0.14.0) - 2026-09-06

### Added

- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.21](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.20...mbx-cache-store-v0.1.21) - 2026-09-06

### Added

- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx`

<blockquote>

## [1.9.0](https://github.com/jdx/mr-boxington/compare/v1.8.3...v1.9.0) - 2026-09-06

### Added

- *(verify)* sample compilation identities deterministically ([#391](https://github.com/jdx/mr-boxington/pull/391))
- *(cc)* cache named preprocessor outputs ([#394](https://github.com/jdx/mr-boxington/pull/394))
- *(report)* record wrapper phases and export Perfetto traces ([#390](https://github.com/jdx/mr-boxington/pull/390))
- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))
- *(cli)* publish native completions in packslip ([#381](https://github.com/jdx/mr-boxington/pull/381))
- explain object cache results in CI summaries ([#377](https://github.com/jdx/mr-boxington/pull/377))

### Fixed

- *(gc)* distinguish logical removal from physical reclamation ([#392](https://github.com/jdx/mr-boxington/pull/392))
- *(doctor)* probe reflinks from cache to target filesystems ([#387](https://github.com/jdx/mr-boxington/pull/387))
- *(scheduler)* respect nested cgroup memory limits ([#386](https://github.com/jdx/mr-boxington/pull/386))
- *(cc)* cache gdb and full debug compilations portably ([#384](https://github.com/jdx/mr-boxington/pull/384))
- preserve CMake compiler identity across Cargo transitions ([#380](https://github.com/jdx/mr-boxington/pull/380))
- support multiple Cargo targets in linker selection ([#379](https://github.com/jdx/mr-boxington/pull/379))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- *(cache)* compare semantic changes against bare rustc ([#393](https://github.com/jdx/mr-boxington/pull/393))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Releases behavioral cache, scheduler, and GC fixes to users; `mbx-cache-core` 0.14.0 breaks the public agent wire API for downstream crates that depend on it.
> 
> **Overview**
> **Release-plz cut** that bumps workspace crate versions, refreshes `Cargo.lock`, adds dated changelog sections, and updates the generated CLI docs version string to **1.9.0**.
> 
> **`mbx` 1.8.3 → 1.9.0** with aligned bumps across `mbx-cache-protocol` (0.5.14), `mbx-cache-core` / `mbx-cache-cc` / `mbx-cache-rustc` (0.14.0), `mbx-cache-cargo` (0.1.22), and `mbx-cache-store` (0.1.21); path dependency version pins in each `Cargo.toml` are updated to match.
> 
> The new changelog entries document what ships in this tag (not introduced in this diff): TUI cache insights, Perfetto/wrapper timing, named preprocessor caching, verify sampling, GC/doctor/scheduler/cc fixes, docs site refresh, and related items. **`mbx-cache-core` 0.14.0** is flagged as a semver break for embedders (agent wire enum changes such as `RecordWrapperTiming` / shifted `AgentEvent` discriminants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116eecd03e2be6bac1bb48016fcb243ab2062656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->