### PR TITLE
feat: explain object cache results in CI summaries

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -158,7 +158,7 @@ fn cargo_with_settings_bypass_log_and_roots(
     // something about it. Placement is best-effort, so wait until it has
     // finished and probe the directory cargo will actually use rather than
     // predicting that a managed target will win.
-    if !cargo_help_requested(arguments) && !was_explained(&config.store_dir()) {
+    if !policy::is_ci() && !cargo_help_requested(arguments) && !was_explained(&config.store_dir()) {
         let target_dir = placement.directory.as_deref().unwrap_or(&roots.target_dir);
         let reflinks = crate::util::reflinks_work(&config.cache_dir, target_dir);
         crate::session::note(&first_run_notice(config, retention, reflinks));

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -107,11 +107,12 @@ pub(crate) struct RawConfig {
     /// Write a JSON build report to this path.
     #[usage(env = "MBX_STATS_REPORT")]
     stats_report: Option<PathBuf>,
-    /// Detail printed after a build: one line, the full breakdown, or nothing.
+    /// Detail printed after a build. Auto uses an explanatory CI report in CI
+    /// and one line locally; short, ci, full, and off select a fixed style.
     #[usage(
         env = "MBX_SUMMARY",
-        default = "short",
-        choices("off", "short", "full")
+        default = "auto",
+        choices("auto", "off", "short", "ci", "full")
     )]
     summary: String,
     /// Compile and consult the cache, then compare outputs.
@@ -580,10 +581,22 @@ impl Default for CliSettings {
 /// How much of the per-build cache summary is printed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum SummaryStyle {
-    Off,
     #[default]
+    Auto,
+    Off,
     Short,
+    Ci,
     Full,
+}
+
+impl SummaryStyle {
+    pub(crate) fn resolve(self, ci: bool) -> Self {
+        match self {
+            Self::Auto if ci => Self::Ci,
+            Self::Auto => Self::Short,
+            style => style,
+        }
+    }
 }
 
 impl std::str::FromStr for SummaryStyle {
@@ -591,11 +604,13 @@ impl std::str::FromStr for SummaryStyle {
 
     fn from_str(value: &str) -> Result<Self> {
         match value {
+            "auto" => Ok(Self::Auto),
             "off" => Ok(Self::Off),
             "short" => Ok(Self::Short),
+            "ci" => Ok(Self::Ci),
             "full" => Ok(Self::Full),
             other => Err(eyre::eyre!(
-                "summary must be off, short, or full, not {other:?}"
+                "summary must be auto, off, short, ci, or full, not {other:?}"
             )),
         }
     }
@@ -1865,13 +1880,24 @@ default = "rust-lld"
     }
 
     #[test]
-    fn summaries_default_to_short_with_off_and_full_as_choices() {
+    fn summaries_default_to_auto_and_allow_fixed_styles() {
         let (_, settings) = configured_for_cli(None, &[]).unwrap();
-        assert_eq!(settings.summary, SummaryStyle::Short);
-        let (_, settings) = configured_for_cli(None, &[("MBX_SUMMARY", "off")]).unwrap();
-        assert_eq!(settings.summary, SummaryStyle::Off);
-        let (_, settings) = configured_for_cli(None, &[("MBX_SUMMARY", "full")]).unwrap();
-        assert_eq!(settings.summary, SummaryStyle::Full);
+        assert_eq!(settings.summary, SummaryStyle::Auto);
+        assert_eq!(settings.summary.resolve(false), SummaryStyle::Short);
+        assert_eq!(settings.summary.resolve(true), SummaryStyle::Ci);
+        for (value, style) in [
+            ("off", SummaryStyle::Off),
+            ("short", SummaryStyle::Short),
+            ("ci", SummaryStyle::Ci),
+            ("full", SummaryStyle::Full),
+        ] {
+            let (_, settings) = configured_for_cli(None, &[("MBX_SUMMARY", value)]).unwrap();
+            assert_eq!(settings.summary.resolve(false), style);
+            assert_eq!(settings.summary.resolve(true), style);
+            let (_, settings) =
+                configured_for_cli(Some(&format!("summary = {value:?}")), &[]).unwrap();
+            assert_eq!(settings.summary.resolve(true), style);
+        }
         assert!(
             configured_for_cli(None, &[("MBX_SUMMARY", "verbose")]).is_err(),
             "an unknown style is an error, not a silent default"

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -590,6 +590,7 @@ pub(crate) enum SummaryStyle {
 }
 
 impl SummaryStyle {
+    /// Select the environment's default report while preserving explicit styles.
     pub(crate) fn resolve(self, ci: bool) -> Self {
         match self {
             Self::Auto if ci => Self::Ci,

--- a/crates/mbx/src/policy.rs
+++ b/crates/mbx/src/policy.rs
@@ -6,6 +6,11 @@
 
 use mbx_cache_core::RemoteCacheMode;
 
+/// Whether output is being read in a CI job rather than on a developer's machine.
+pub(crate) fn is_ci() -> bool {
+    env_truthy(std::env::var("CI").ok()) || env_truthy(std::env::var("GITHUB_ACTIONS").ok())
+}
+
 /// Resolve the remote-cache mode that is actually permitted here.
 ///
 /// Returns `None` when the configured mode leaves nothing to do.

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -57,7 +57,7 @@ pub(crate) use stats::display_stats;
 pub(crate) use stats::session_was_active;
 #[cfg(test)]
 use stats::{
-    cache_misses, short_summary, should_display_short_stats, should_display_stats,
+    cache_misses, ci_summary, short_summary, should_display_short_stats, should_display_stats,
     stale_manifest_note,
 };
 

--- a/crates/mbx/src/session/stats.rs
+++ b/crates/mbx/src/session/stats.rs
@@ -148,11 +148,18 @@ pub(crate) fn display_stats(stats: &AgentStats, config: &Config, style: SummaryS
             path.display()
         );
     }
-    match style {
+    match style.resolve(crate::policy::is_ci()) {
+        SummaryStyle::Auto => unreachable!("auto summary was resolved"),
         SummaryStyle::Off => return,
         SummaryStyle::Short => {
             if should_display_short_stats(stats) {
                 note(&short_summary(stats));
+            }
+            return;
+        }
+        SummaryStyle::Ci => {
+            if should_display_short_stats(stats) {
+                note(&ci_summary(stats));
             }
             return;
         }
@@ -333,16 +340,66 @@ pub(super) fn short_summary(stats: &AgentStats) -> String {
     )
 }
 
+/// These counters cover mbx objects, not a CI action's archive transfers or
+/// artifacts Cargo found fresh before invoking a compiler wrapper.
+pub(super) fn ci_summary(stats: &AgentStats) -> String {
+    let mut lines =
+        vec![short_summary(stats).replacen("mbx[cache]: ", "mbx[cache]: object cache: ", 1)];
+    lines.push(format!(
+        "mbx[cache]: {} session; {} estimated compiler time avoided (summed across compilations)",
+        format_nanos(stats.session_duration_ns),
+        format_nanos(stats.avoided_compiler_duration_ns),
+    ));
+    if stats.unconsulted > 0 {
+        lines.push(format!(
+            "mbx[cache]: {} compilations had no usable prior inputs or matching prediction for a lookup",
+            stats.unconsulted,
+        ));
+        if let Some(explanation) = stale_manifest_note(stats) {
+            lines.push(explanation);
+        }
+    }
+    let mut bypasses = stats
+        .bypasses
+        .iter()
+        .filter(|(kind, _)| !routine_probe(kind))
+        .collect::<Vec<_>>();
+    bypasses.sort_by(|left, right| right.1.cmp(left.1).then(left.0.cmp(right.0)));
+    if !bypasses.is_empty() {
+        lines.push(format!(
+            "mbx[cache]: bypass reasons: {}",
+            bypasses
+                .into_iter()
+                .map(|(kind, count)| format!("{count} {kind}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
+    }
+    if stats.background_upload_failures > 0 {
+        lines.push(format!(
+            "mbx[cache]: {} background uploads failed; see warnings above",
+            stats.background_upload_failures,
+        ));
+    }
+    lines.push(
+        "mbx[cache]: Cargo artifact reuse and CI cache archive transfers are not included above"
+            .to_string(),
+    );
+    lines.join("\n")
+}
+
+fn routine_probe(kind: &str) -> bool {
+    matches!(
+        kind,
+        "compiler-query" | "standard-input" | "cc-compiler-query" | "cc-standard-input"
+    )
+}
+
 fn unexpected_bypasses(stats: &AgentStats) -> u64 {
     stats
         .bypasses
         .iter()
-        .filter(|(kind, _)| {
-            !matches!(
-                kind.as_str(),
-                "compiler-query" | "standard-input" | "cc-compiler-query" | "cc-standard-input"
-            )
-        })
+        .filter(|(kind, _)| !routine_probe(kind))
         .map(|(_, count)| count)
         .sum()
 }
@@ -356,6 +413,7 @@ pub(super) fn should_display_short_stats(stats: &AgentStats) -> bool {
         || stats.downloaded_bytes > 0
         || stats.uploaded_bytes > 0
         || stats.background_uploads > 0
+        || stats.background_upload_failures > 0
         || unexpected_bypasses(stats) > 0
         || stats.avoided_compiler_duration_ns > 0
         || stats.remote_failures > 0

--- a/crates/mbx/src/session/stats.rs
+++ b/crates/mbx/src/session/stats.rs
@@ -388,6 +388,7 @@ pub(super) fn ci_summary(stats: &AgentStats) -> String {
     lines.join("\n")
 }
 
+/// Identify compiler discovery and stdin probes that are routine build traffic.
 fn routine_probe(kind: &str) -> bool {
     matches!(
         kind,
@@ -395,6 +396,7 @@ fn routine_probe(kind: &str) -> bool {
     )
 }
 
+/// Count bypasses worth reporting, excluding routine compiler probes.
 fn unexpected_bypasses(stats: &AgentStats) -> u64 {
     stats
         .bypasses
@@ -404,6 +406,8 @@ fn unexpected_bypasses(stats: &AgentStats) -> u64 {
         .sum()
 }
 
+/// Show short and CI reports only for cache activity or failures, so compiler
+/// probes alone do not turn a no-op build into a cache report.
 pub(super) fn should_display_short_stats(stats: &AgentStats) -> bool {
     stats.lookups > 0
         || stats.unconsulted > 0

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -729,6 +729,72 @@ fn short_summary_omits_routine_compiler_probe_bypasses() {
 }
 
 #[test]
+fn ci_summary_explains_a_cold_object_cache_and_real_bypasses() {
+    let stats = agent_stats(|stats| {
+        stats.unconsulted = 669;
+        stats.session_duration_ns = 202_000_000_000;
+        stats.bypasses = BTreeMap::from([
+            ("compiler-query".into(), 7),
+            ("standard-input".into(), 3),
+            ("native-library".into(), 4),
+            ("linking-disabled".into(), 160),
+        ]);
+    });
+    let summary = ci_summary(&stats);
+    assert!(
+        summary.contains("object cache: 0 hits, 0 misses, 669 not looked up, 164 bypassed"),
+        "{summary}"
+    );
+    assert!(
+        summary.contains("no usable prior inputs or matching prediction"),
+        "{summary}"
+    );
+    assert!(
+        summary.contains("160 linking-disabled, 4 native-library"),
+        "{summary}"
+    );
+    assert!(!summary.contains("compiler-query"), "{summary}");
+    assert!(!summary.contains("standard-input"), "{summary}");
+    assert!(
+        summary.contains("Cargo artifact reuse and CI cache archive transfers are not included"),
+        "{summary}"
+    );
+}
+
+#[test]
+fn ci_summary_preserves_verification_and_failure_diagnostics() {
+    let stats = agent_stats(|stats| {
+        stats.lookups = 10;
+        stats.hits = 6;
+        stats.verifications = 2;
+        stats.divergences = 1;
+        stats.remote_failures = 3;
+        stats.background_upload_failures = 4;
+        stats.avoided_compiler_duration_ns = 10_000_000_000;
+    });
+    let summary = ci_summary(&stats);
+    assert!(summary.contains("6 hits, 2 misses"), "{summary}");
+    assert!(summary.contains("2 verified, 1 diverged"), "{summary}");
+    assert!(summary.contains("3 remote failures"), "{summary}");
+    assert!(summary.contains("4 background uploads failed"), "{summary}");
+    assert!(
+        summary.contains("estimated compiler time avoided (summed across compilations)"),
+        "{summary}"
+    );
+    let upload_only = agent_stats(|stats| stats.background_upload_failures = 1);
+    assert!(should_display_short_stats(&upload_only));
+}
+
+#[test]
+fn ci_summary_explains_an_unmatched_manifest() {
+    let stats = agent_stats(|stats| {
+        stats.unconsulted = 20;
+        stats.predictions_loaded = 20;
+    });
+    assert!(ci_summary(&stats).contains("none matched this build"));
+}
+
+#[test]
 fn an_off_summary_still_writes_the_versioned_stats_report() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("nested").join("stats.json");

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -350,14 +350,16 @@ Write a JSON build report to this path.
 ### `summary`
 
 - **Type:** `string`
-- **Default:** `short`
+- **Default:** `auto`
 - **Set with:** `MBX_SUMMARY`
 
-Detail printed after a build: one line, the full breakdown, or nothing.
+Detail printed after a build. Auto uses an explanatory CI report in CI and one line locally; short, ci, full, and off select a fixed style.
 
 **Choices:**
+- `auto`
 - `off`
 - `short`
+- `ci`
 - `full`
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,7 @@ learned_incremental_max_size = "8GiB"  # or "none"
 share_out_dir = true
 build_script_execution = true
 cc = true
-summary = "short"        # or "off", "full"
+summary = "auto"         # or "short", "ci", "full", "off"
 savings = "quips"        # or "plain", "off"
 
 [linker]
@@ -249,9 +249,17 @@ anything.
 ## Build summaries
 
 `summary` controls the cache report printed to stderr after a build
-(`MBX_SUMMARY` from the environment). `short`, the default, prints one line
-and leaves routine `compiler-query` and `standard-input` probes out of its
-bypass count. `full` prints the detailed timing, compiler, bypass, transfer,
+(`MBX_SUMMARY` from the environment). `auto`, the default, selects `ci` when
+`CI` or `GITHUB_ACTIONS` is `1`, `true`, or `yes` (case-insensitive), and `short`
+otherwise. `short` prints one line and leaves routine `compiler-query` and
+`standard-input` probes out of its bypass count. `ci` adds session timing,
+estimated compiler time avoided, explanations for compilations that could not
+be looked up, and bypass reasons. Its object-cache counts and transfers exclude
+artifacts Cargo reused directly and archives restored or saved by a CI action.
+Compiler time avoided is summed across compilations, not elapsed job time saved.
+CI also skips the first-build notice about local cache management.
+
+Set a fixed style to override automatic selection. `full` prints the detailed timing, compiler, bypass, transfer,
 and materialization breakdown. `off` prints no cache summary, while still
 writing `MBX_STATS_REPORT` when configured. Cargo's `-q` and `--quiet` also
 suppress the summary for that invocation.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -5,6 +5,13 @@ installs mbx and connects it to either GitHub Actions cache or an mbx-compatible
 server. The examples below show the inputs that matter for each backend; the
 action's repository documents the complete list.
 
+mbx automatically uses its explanatory CI build summary in GitHub Actions and
+skips local first-run onboarding. The summary describes mbx's **object cache**;
+it does not count artifacts Cargo reused directly from the restored target
+directory or the action's archive downloads and uploads. The action reports
+archive restore/save results separately. Use `MBX_SUMMARY=short`, `full`, or
+`off` to override the default; see [build summaries](/configuration#build-summaries).
+
 ## GitHub Actions cache
 
 The default backend restores Cargo's pruned target directory and its registry

--- a/e2e-win/Cache.Tests.ps1
+++ b/e2e-win/Cache.Tests.ps1
@@ -55,7 +55,7 @@ fn main() {
         Remove-Item -Recurse -Force target
         $warm = & mbx build 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0 -Because $warm
-        $warm | Should -Match 'mbx\[cache\]: [1-9][0-9]* hits'
+        $warm | Should -Match 'mbx\[cache\]: (?:object cache: )?[1-9][0-9]* hits'
     }
 
     It 'restores a natively linked executable' {
@@ -76,7 +76,7 @@ edition = "2024"
         Remove-Item -Recurse -Force target
         $warm = & mbx build --release 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0 -Because $warm
-        $warm | Should -Match 'mbx\[cache\]: [1-9][0-9]* hits'
+        $warm | Should -Match 'mbx\[cache\]: (?:object cache: )?[1-9][0-9]* hits'
         Test-Path target\release\native-link-fixture.exe | Should -BeTrue
     }
 
@@ -91,7 +91,7 @@ edition = "2024"
         Remove-Item hello.obj
         $warm = & mbx exec cl.exe /nologo /Z7 /Brepro /Fohello.obj /c src\hello.c 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0 -Because $warm
-        $warm | Should -Match 'mbx\[cache\]: 1 hit'
+        $warm | Should -Match 'mbx\[cache\]: (?:object cache: )?1 hits'
         Test-Path hello.obj | Should -BeTrue
     }
 }

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -168,6 +168,7 @@ setup() {
 }
 
 @test "the first build explains what mbx set up, once" {
+  export CI=false GITHUB_ACTIONS=false
   local project="$BATS_TEST_TMPDIR/first-run"
   mkdir -p "$project/src"
   cat >"$project/Cargo.toml" <<'EOF'
@@ -198,4 +199,50 @@ EOF
   run "$MBX_BIN" build --offline --manifest-path "$project/Cargo.toml"
   assert_success
   refute_output --partial "first build on this machine"
+}
+
+@test "CI explains object cache results without consuming local onboarding" {
+  cargo init --lib --vcs none ci-output
+  cd ci-output
+
+  run env CI=true MBX_STATS_REPORT="$PWD/stats.json" "$MBX_BIN" check --offline
+  assert_success
+  refute_output --partial "first build on this machine"
+  assert_output --partial "object cache:"
+  assert_output --partial "no usable prior inputs or matching prediction"
+  assert_output --partial "Cargo artifact reuse and CI cache archive transfers"
+  assert_file_exist "$PWD/stats.json"
+
+  # No-op builds should not print a report just for Cargo's compiler probes.
+  run env CI=true "$MBX_BIN" check --offline
+  assert_success
+  refute_output --partial "mbx[cache]:"
+
+  for style in short full off; do
+    touch src/lib.rs
+    run env CI=true MBX_SUMMARY="$style" "$MBX_BIN" check --offline
+    assert_success
+    refute_output --partial "object cache:"
+    if [[ "$style" == off ]]; then
+      refute_output --partial "mbx[cache]:"
+    else
+      assert_output --partial "mbx[cache]:"
+    fi
+  done
+
+  touch src/lib.rs
+  run env CI=false GITHUB_ACTIONS=true "$MBX_BIN" check --offline --quiet
+  assert_success
+  refute_output --partial "mbx[cache]:"
+  refute_output --partial "first build on this machine"
+
+  touch src/lib.rs
+  run env CI=false GITHUB_ACTIONS=true "$MBX_BIN" check --offline
+  assert_success
+  assert_output --partial "object cache:"
+  refute_output --partial "first build on this machine"
+
+  run env CI=false GITHUB_ACTIONS=false "$MBX_BIN" check --offline
+  assert_success
+  assert_output --partial "first build on this machine"
 }


### PR DESCRIPTION
CI logs can show a successful Cargo target-cache restore followed by mbx reporting `0 hits, 0 misses` and hundreds of compilations not looked up. These measure different caches, and the local first-run onboarding adds noise on fresh runners. The [pacvamp job](https://github.com/jdx/pacvamp/actions/runs/33983883163/job/101353807382?pr=82) demonstrates this confusion.

Default `summary=auto` now selects an explanatory `ci` report when `CI` or `GITHUB_ACTIONS` is truthy, retaining the short report locally. The CI report labels object-cache statistics, explains skipped lookups and bypass reasons, and shows session duration and estimated compiler time avoided. It explicitly excludes Cargo artifact reuse and CI archive transfers. Fixed `short`, `ci`, `full`, and `off` settings remain available; quiet and no-op builds stay quiet.

Skip first-run onboarding in CI without consuming the local notice. Update configuration and action documentation, including the generated CLI reference.

Validation: `mise run ci` passed (Rust tests, Clippy, formatting, generated docs, internal links, and Bats including wasm). One Bats case skipped because no alternate linker was available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to stderr summaries, config defaults, and CI detection for onboarding; cache behavior and remote-cache policy are unchanged aside from log wording.
> 
> **Overview**
> **`MBX_SUMMARY` now defaults to `auto`**, which picks the new **`ci`** style when `CI` or `GITHUB_ACTIONS` is truthy and keeps the one-line **`short`** report locally. Explicit `off`, `short`, `ci`, and `full` still override that resolution.
> 
> The **`ci`** report re-labels cache stats as **object cache**, adds session timing, summed compiler time avoided, lookup/bypass explanations (routine compiler probes still hidden), background upload failures, and a footer clarifying that Cargo target reuse and CI archive transfers are out of scope. **`display_stats`** resolves `auto` via `policy::is_ci()` before printing.
> 
> **First-run onboarding** is no longer shown in CI, and that path does not mark the local “explained once” state—so developers still get the notice on their machine. Short/CI summaries also print when **background upload failures** occur, and probe-only no-op builds stay quiet.
> 
> Docs and tests (unit, Bats, Windows e2e) are updated for the new default and optional `object cache:` prefix in hit lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ee8ec68ac91b3ee90f293841791d2b494d2195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic summary formatting that provides concise local output and detailed CI-oriented reports.
  * CI summaries now include timing, estimated compiler time avoided, bypass explanations, and upload failure details.
  * Added configuration options for automatic and CI-specific summary styles.

* **Bug Fixes**
  * Suppressed first-run setup notices in CI environments.
  * CI summaries now highlight background upload failures.

* **Documentation**
  * Updated configuration and GitHub Actions documentation with the new summary behavior and overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->