### PR TITLE
chore(ci): bump packslip to v1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,7 +383,7 @@ jobs:
       # jdx/mr-boxington's identity with no key to distribute. Runs after the
       # upload above, which is what guarantees the release exists.
       # See https://packslip.dev.
-      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           tag: ${{ inputs.tag }}
           artifacts: release-assets/mbx-*.tar.gz release-assets/mbx-*.zip


### PR DESCRIPTION
Update the release workflow to use packslip v1.1.1 at its immutable commit SHA. This release pins the nested provenance action, so repositories enforcing full-length action SHAs can load the composite action.

Validation: `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin in the attach job; no application or release logic changes beyond whatever packslip v1.1.1 differs in provenance signing behavior.
> 
> **Overview**
> Bumps the release workflow’s **`jdx/packslip`** step from **v1.0.2** to **v1.1.1**, pinning the immutable commit **`a0d434ad57571c62dbd0ab5095b4eff607a71fd3`**. Inputs (`tag`, `artifacts`, `bin`) are unchanged; only the action version used after release asset upload for signed provenance attestation is updated.
> 
> The v1.1.1 line is intended to fix composite-action loading when repos require full-length action SHAs, by pinning packslip’s nested provenance dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e6e7d6a3409663f66f396f2acaedf13a16cdf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use a newer artifact attestation action, improving compatibility and reliability during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->