### PR TITLE
fix: support multiple Cargo targets in linker selection

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -222,11 +222,18 @@ fn cargo_with_settings_bypass_log_and_roots(
                 &mut environment,
             )
             .await;
+        // Clear inherited selections, including when this build uses the system linker.
+        environment.insert(session::MANAGED_LINKER_ENV.into(), String::new());
+        environment.insert(session::MANAGED_TARGET_LINKERS_ENV.into(), String::new());
         if let Some(selection) = &managed_linker {
-            environment.insert(
-                session::MANAGED_LINKER_ENV.into(),
-                selection.executable.to_string_lossy().into_owned(),
-            );
+            match selection {
+                crate::managed_linker::Selection::Single(executable) => {
+                    environment.insert(session::MANAGED_LINKER_ENV.into(), executable.to_string_lossy().into_owned());
+                }
+                crate::managed_linker::Selection::Targets(executables) => {
+                    environment.insert(session::MANAGED_TARGET_LINKERS_ENV.into(), serde_json::to_string(executables)?);
+                }
+            }
         }
         // Stated explicitly for the same reason as the session's own keys: an
         // unset value would let the shim inherit one from the parent, with no

--- a/crates/mbx/src/managed_linker.rs
+++ b/crates/mbx/src/managed_linker.rs
@@ -37,7 +37,14 @@ pub(crate) fn resolve(
     if !targets.is_empty() {
         let mut selections = BTreeMap::new();
         for target in targets {
-            let target = normalize_cargo_target(&target, cargo_arguments)?;
+            let rustc_target = normalize_cargo_target(&target, cargo_arguments)?;
+            // Keep path-keyed policy compatible with the Cargo argument. Only
+            // the host directive needs its concrete triple for policy lookup.
+            let policy_target = if target == "host-tuple" {
+                &rustc_target
+            } else {
+                &target
+            };
             if let Some(executable) = resolve_target(
                 settings,
                 cache_dir,
@@ -45,9 +52,9 @@ pub(crate) fn resolve(
                 cargo_arguments,
                 &profile,
                 environment.clone(),
-                Some(&target),
+                Some(policy_target),
             )? {
-                selections.insert(target, executable);
+                selections.insert(rustc_target, executable);
             }
         }
         return Ok((!selections.is_empty()).then_some(Selection::Targets(selections)));
@@ -708,6 +715,47 @@ mod tests {
             panic!("expected target-specific selection");
         };
         assert_eq!(selections, BTreeMap::from([(host, executable)]));
+    }
+
+    #[test]
+    fn relative_json_target_keeps_its_profile_policy() {
+        let directory = tempfile::tempdir_in(std::env::current_dir().unwrap()).unwrap();
+        let target = directory.path().join("custom.json");
+        fs::write(&target, "{}").unwrap();
+        let relative = target
+            .strip_prefix(std::env::current_dir().unwrap())
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let executable = std::env::current_exe().unwrap();
+        let settings = LinkerSettings {
+            profiles: BTreeMap::from([(
+                "dev".into(),
+                BTreeMap::from([(relative.clone(), format!("path:{}", executable.display()))]),
+            )]),
+            ..Default::default()
+        };
+        let Some(Selection::Targets(selections)) = resolve(
+            &settings,
+            directory.path(),
+            &HttpSettings::default(),
+            &["build".into(), "--target".into(), relative],
+        )
+        .unwrap() else {
+            panic!("expected target-specific selection");
+        };
+        assert_eq!(
+            selections,
+            BTreeMap::from([(
+                fs::canonicalize(target)
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_owned(),
+                executable
+            )])
+        );
     }
 
     #[cfg(unix)]

--- a/crates/mbx/src/managed_linker.rs
+++ b/crates/mbx/src/managed_linker.rs
@@ -37,6 +37,7 @@ pub(crate) fn resolve(
     if !targets.is_empty() {
         let mut selections = BTreeMap::new();
         for target in targets {
+            let target = normalize_cargo_target(&target, cargo_arguments)?;
             if let Some(executable) = resolve_target(
                 settings,
                 cache_dir,
@@ -68,6 +69,7 @@ pub(crate) fn resolve(
     .map(Selection::Single))
 }
 
+/// Resolve one profile/target selector to an executable; system needs no override.
 fn resolve_target(
     settings: &LinkerSettings,
     cache_dir: &Path,
@@ -450,6 +452,7 @@ fn cargo_profile(arguments: &[String]) -> String {
     })
 }
 
+/// Collect repeated Cargo target flags, stopping before program arguments.
 fn cargo_targets(arguments: &[String]) -> Vec<String> {
     let mut targets = Vec::new();
     let mut arguments = arguments
@@ -466,6 +469,40 @@ fn cargo_targets(arguments: &[String]) -> Vec<String> {
         }
     }
     targets
+}
+
+/// Match Cargo's target spelling before using it as a rustc routing key.
+fn normalize_cargo_target(target: &str, cargo_arguments: &[String]) -> Result<String> {
+    // Cargo substitutes this directive before trimming ordinary target names.
+    if target == "host-tuple" {
+        let mut command = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+        if let Some(toolchain) = cargo_arguments
+            .first()
+            .filter(|argument| argument.starts_with('+'))
+        {
+            command.arg(toolchain);
+        }
+        let output = command
+            .arg("-vV")
+            .output()
+            .wrap_err("failed to query Cargo's host target")?;
+        if !output.status.success() {
+            bail!("Cargo could not report its host target");
+        }
+        return String::from_utf8(output.stdout)?
+            .lines()
+            .find_map(|line| line.strip_prefix("host: ").map(str::to_owned))
+            .ok_or_else(|| eyre::eyre!("Cargo did not report its host target"));
+    }
+    let target = target.trim();
+    if target.ends_with(".json") {
+        return fs::canonicalize(target)
+            .wrap_err_with(|| format!("failed to canonicalize Cargo target `{target}`"))?
+            .into_os_string()
+            .into_string()
+            .map_err(|_| eyre::eyre!("Cargo target path is not valid Unicode"));
+    }
+    Ok(target.to_owned())
 }
 
 fn rustc_command(cargo_arguments: &[String]) -> Command {
@@ -625,6 +662,52 @@ mod tests {
             selections,
             BTreeMap::from([("aarch64-apple-darwin".into(), executable)])
         );
+    }
+
+    #[test]
+    fn normalizes_cargo_host_directive_and_target_paths() {
+        assert_eq!(
+            normalize_cargo_target("host-tuple", &[]).unwrap(),
+            host_target(&[]).unwrap()
+        );
+        assert_eq!(
+            normalize_cargo_target(" aarch64-apple-darwin ", &[]).unwrap(),
+            "aarch64-apple-darwin"
+        );
+        let directory = tempfile::tempdir_in(std::env::current_dir().unwrap()).unwrap();
+        let target = directory.path().join("custom.json");
+        fs::write(&target, "{}").unwrap();
+        let relative = target
+            .strip_prefix(std::env::current_dir().unwrap())
+            .unwrap();
+        assert_eq!(
+            normalize_cargo_target(relative.to_str().unwrap(), &[]).unwrap(),
+            fs::canonicalize(&target).unwrap().to_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn host_directive_uses_concrete_target_profile_policy() {
+        let cache = tempfile::tempdir().unwrap();
+        let host = normalize_cargo_target("host-tuple", &[]).unwrap();
+        let executable = std::env::current_exe().unwrap();
+        let settings = LinkerSettings {
+            profiles: BTreeMap::from([(
+                "dev".into(),
+                BTreeMap::from([(host.clone(), format!("path:{}", executable.display()))]),
+            )]),
+            ..Default::default()
+        };
+        let Some(Selection::Targets(selections)) = resolve(
+            &settings,
+            cache.path(),
+            &HttpSettings::default(),
+            &["build".into(), "--target=host-tuple".into()],
+        )
+        .unwrap() else {
+            panic!("expected target-specific selection");
+        };
+        assert_eq!(selections, BTreeMap::from([(host, executable)]));
     }
 
     #[cfg(unix)]

--- a/crates/mbx/src/managed_linker.rs
+++ b/crates/mbx/src/managed_linker.rs
@@ -7,6 +7,7 @@ use reqwest::blocking::Client;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
+use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::{BufReader, Read as _, Write as _};
 use std::path::{Path, PathBuf};
@@ -16,8 +17,9 @@ const LINKER_ENV: &str = "MBX_LINKER";
 
 /// A linker selected for one Cargo invocation.
 #[derive(Debug, Clone)]
-pub(crate) struct Selection {
-    pub(crate) executable: PathBuf,
+pub(crate) enum Selection {
+    Single(PathBuf),
+    Targets(BTreeMap<String, PathBuf>),
 }
 
 /// Resolve and, where necessary, install the linker selected for this build.
@@ -31,29 +33,63 @@ pub(crate) fn resolve(
     let environment = std::env::var(LINKER_ENV)
         .ok()
         .filter(|value| !value.trim().is_empty());
+    let targets = cargo_targets(cargo_arguments);
+    if !targets.is_empty() {
+        let mut selections = BTreeMap::new();
+        for target in targets {
+            if let Some(executable) = resolve_target(
+                settings,
+                cache_dir,
+                http,
+                cargo_arguments,
+                &profile,
+                environment.clone(),
+                Some(&target),
+            )? {
+                selections.insert(target, executable);
+            }
+        }
+        return Ok((!selections.is_empty()).then_some(Selection::Targets(selections)));
+    }
     let target = if environment.is_none() && settings.profiles.contains_key(&profile) {
-        cargo_target(cargo_arguments)?.or_else(|| host_target(cargo_arguments))
+        host_target(cargo_arguments)
     } else {
-        cargo_target(cargo_arguments)?
+        None
     };
+    Ok(resolve_target(
+        settings,
+        cache_dir,
+        http,
+        cargo_arguments,
+        &profile,
+        environment,
+        target.as_deref(),
+    )?
+    .map(Selection::Single))
+}
+
+fn resolve_target(
+    settings: &LinkerSettings,
+    cache_dir: &Path,
+    http: &HttpSettings,
+    cargo_arguments: &[String],
+    profile: &str,
+    environment: Option<String>,
+    target: Option<&str>,
+) -> Result<Option<PathBuf>> {
     let configured = environment
-        .or_else(|| settings.for_build(&profile, target.as_deref()))
+        .or_else(|| settings.for_build(profile, target))
         .unwrap_or_else(|| settings.default.clone());
     let spec = Spec::parse(&configured)?;
     match spec {
         Spec::System => Ok(None),
-        Spec::Path(path) => Ok(Some(Selection {
-            executable: which::which(&path)
-                .wrap_err_with(|| format!("failed to find selected linker `{}`", path.display()))?,
-        })),
-        Spec::RustLld => Ok(Some(Selection {
-            executable: rust_lld(target.as_deref(), cache_dir, cargo_arguments)?,
-        })),
+        Spec::Path(path) => Ok(Some(which::which(&path).wrap_err_with(|| {
+            format!("failed to find selected linker `{}`", path.display())
+        })?)),
+        Spec::RustLld => Ok(Some(rust_lld(target, cache_dir, cargo_arguments)?)),
         Spec::Managed { provider, version } => {
             let installed = install(provider, &version, cache_dir, http)?;
-            Ok(Some(Selection {
-                executable: installed,
-            }))
+            Ok(Some(installed))
         }
     }
 }
@@ -414,8 +450,8 @@ fn cargo_profile(arguments: &[String]) -> String {
     })
 }
 
-fn cargo_target(arguments: &[String]) -> Result<Option<String>> {
-    let mut target = None;
+fn cargo_targets(arguments: &[String]) -> Vec<String> {
+    let mut targets = Vec::new();
     let mut arguments = arguments
         .iter()
         .take_while(|argument| argument.as_str() != "--");
@@ -425,13 +461,11 @@ fn cargo_target(arguments: &[String]) -> Result<Option<String>> {
         } else {
             argument.strip_prefix("--target=").map(str::to_owned)
         };
-        if let Some(value) = value
-            && target.replace(value).is_some()
-        {
-            bail!("managed linker selection supports one Cargo --target per invocation");
+        if let Some(value) = value {
+            targets.push(value);
         }
     }
-    Ok(target)
+    targets
 }
 
 fn rustc_command(cargo_arguments: &[String]) -> Command {
@@ -511,20 +545,85 @@ mod tests {
     }
 
     #[test]
-    fn target_flag_is_unambiguous() {
-        assert_eq!(cargo_target(&["build".into()]).unwrap(), None);
+    fn parses_multiple_targets_without_reading_program_arguments() {
+        assert!(cargo_targets(&["build".into()]).is_empty());
         assert_eq!(
-            cargo_target(&["build".into(), "--target=aarch64-apple-darwin".into()]).unwrap(),
-            Some("aarch64-apple-darwin".into())
-        );
-        assert!(
-            cargo_target(&[
+            cargo_targets(&[
                 "build".into(),
                 "--target".into(),
-                "one".into(),
-                "--target=two".into(),
-            ])
-            .is_err()
+                "aarch64-apple-darwin".into(),
+                "--target=x86_64-apple-darwin".into(),
+                "--".into(),
+                "--target=ignored".into(),
+            ]),
+            ["aarch64-apple-darwin", "x86_64-apple-darwin"]
+        );
+    }
+
+    #[test]
+    fn system_linker_accepts_universal_macos_build() {
+        let cache = tempfile::tempdir().unwrap();
+        let arguments = [
+            "build",
+            "--release",
+            "--bin",
+            "usage",
+            "--manifest-path",
+            "cli/Cargo.toml",
+            "--target",
+            "aarch64-apple-darwin",
+            "--target",
+            "x86_64-apple-darwin",
+        ]
+        .map(str::to_owned);
+        assert!(
+            resolve(
+                &LinkerSettings::default(),
+                cache.path(),
+                &HttpSettings::default(),
+                &arguments
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn resolves_each_targets_profile_policy() {
+        let cache = tempfile::tempdir().unwrap();
+        let executable = std::env::current_exe().unwrap();
+        let settings = LinkerSettings {
+            profiles: BTreeMap::from([(
+                "release".into(),
+                BTreeMap::from([
+                    (
+                        "aarch64-apple-darwin".into(),
+                        format!("path:{}", executable.display()),
+                    ),
+                    ("x86_64-apple-darwin".into(), "system".into()),
+                ]),
+            )]),
+            ..Default::default()
+        };
+        let arguments = [
+            "build",
+            "--release",
+            "--target=aarch64-apple-darwin",
+            "--target=x86_64-apple-darwin",
+        ]
+        .map(str::to_owned);
+        let Some(Selection::Targets(selections)) = resolve(
+            &settings,
+            cache.path(),
+            &HttpSettings::default(),
+            &arguments,
+        )
+        .unwrap() else {
+            panic!("expected target-specific selection");
+        };
+        assert_eq!(
+            selections,
+            BTreeMap::from([("aarch64-apple-darwin".into(), executable)])
         );
     }
 

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -78,6 +78,7 @@ pub(crate) const BUILD_SCRIPT_SHIM_PATH_ENV: &str = "MBX_BUILD_SCRIPT_SHIM_PATH"
 pub(crate) const LEARNED_INCREMENTAL_ENV: &str = "MBX_LEARNED_INCREMENTAL";
 pub(crate) const LEARNED_INCREMENTAL_MAX_SIZE_ENV: &str = "MBX_LEARNED_INCREMENTAL_MAX_SIZE";
 pub(crate) const INCREMENTAL_ROOT_ENV: &str = "MBX_INCREMENTAL_ROOT";
+pub(crate) const MANAGED_TARGET_LINKERS_ENV: &str = "MBX_MANAGED_TARGET_LINKERS";
 pub(crate) const MANAGED_LINKER_ENV: &str = "MBX_MANAGED_LINKER";
 pub const CACHE_LINKS_ENV: &str = "MBX_CACHE_LINKS";
 /// Group completed builds for one later cache export, used by CI actions.
@@ -1300,6 +1301,12 @@ pub fn run_rustc_shim() -> ExitCode {
         return ExitCode::from(1);
     };
     let mut arguments = arguments.collect::<Vec<_>>();
+    if let Ok(selections) = std::env::var(MANAGED_TARGET_LINKERS_ENV)
+        && let Ok(selections) = serde_json::from_str::<BTreeMap<String, PathBuf>>(&selections)
+        && let Some(linker) = target_linker(&arguments, &selections)
+    {
+        use_managed_linker(&mut arguments, linker.as_os_str());
+    }
     if let Some(linker) = std::env::var_os(MANAGED_LINKER_ENV).filter(|path| !path.is_empty()) {
         use_managed_linker(&mut arguments, &linker);
     }
@@ -1326,6 +1333,27 @@ pub fn run_rustc_shim() -> ExitCode {
     }
 
     run_transparent_rustc(rustc, arguments)
+}
+
+/// Explicit Cargo targets must not affect host build scripts or proc macros.
+fn target_linker<'a>(
+    arguments: &[OsString],
+    selections: &'a BTreeMap<String, PathBuf>,
+) -> Option<&'a PathBuf> {
+    let mut arguments = arguments.iter();
+    while let Some(argument) = arguments.next() {
+        let target = if argument == "--target" {
+            arguments.next().and_then(|value| value.to_str())
+        } else {
+            argument
+                .to_str()
+                .and_then(|value| value.strip_prefix("--target="))
+        };
+        if let Some(target) = target {
+            return selections.get(target);
+        }
+    }
+    None
 }
 
 /// Route native links through the selected executable while leaving metadata

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1350,7 +1350,15 @@ fn target_linker<'a>(
                 .and_then(|value| value.strip_prefix("--target="))
         };
         if let Some(target) = target {
-            return selections.get(target);
+            return selections.get(target).or_else(|| {
+                // Cargo versions can pass JSON paths without Windows' verbatim
+                // prefix. Canonicalize both spellings to the stored routing key.
+                if !target.ends_with(".json") {
+                    return None;
+                }
+                let canonical = std::fs::canonicalize(target).ok()?;
+                selections.get(canonical.to_str()?)
+            });
         }
     }
     None

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -1245,3 +1245,27 @@ fn managed_target_linkers_follow_rustc_target_and_leave_host_alone() {
         );
     }
 }
+
+#[test]
+fn json_target_linkers_match_equivalent_paths() {
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("custom.json");
+    std::fs::write(&target, "{}").unwrap();
+    let canonical = std::fs::canonicalize(&target).unwrap();
+    let linker = PathBuf::from("/tools/linker");
+    let selections = BTreeMap::from([(canonical.to_str().unwrap().to_owned(), linker.clone())]);
+    // tempdir's ordinary Windows path lacks canonicalize's verbatim prefix.
+    assert_eq!(
+        target_linker(&["--target".into(), target.into_os_string()], &selections),
+        Some(&linker)
+    );
+    #[cfg(unix)]
+    {
+        let alias = directory.path().join("alias.json");
+        std::os::unix::fs::symlink(&canonical, &alias).unwrap();
+        assert_eq!(
+            target_linker(&["--target".into(), alias.into_os_string()], &selections),
+            Some(&linker)
+        );
+    }
+}

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -1213,3 +1213,35 @@ fn targeted_shim_names_dispatch_to_their_language() {
         assert_eq!(format!("{language:?}"), expected, "{stem}");
     }
 }
+
+#[test]
+fn managed_target_linkers_follow_rustc_target_and_leave_host_alone() {
+    let selections = BTreeMap::from([
+        (
+            "aarch64-apple-darwin".into(),
+            PathBuf::from("/tools/arm/ld64.lld"),
+        ),
+        (
+            "x86_64-apple-darwin".into(),
+            PathBuf::from("/tools/intel/ld64.lld"),
+        ),
+    ]);
+    for (argument, expected) in [
+        (
+            vec!["--target", "aarch64-apple-darwin"],
+            Some("/tools/arm/ld64.lld"),
+        ),
+        (
+            vec!["--target=x86_64-apple-darwin"],
+            Some("/tools/intel/ld64.lld"),
+        ),
+        (vec!["--crate-name", "build_script_build"], None),
+        (vec!["--target=other"], None),
+    ] {
+        let arguments = argument.into_iter().map(OsString::from).collect::<Vec<_>>();
+        assert_eq!(
+            target_linker(&arguments, &selections).map(|p| p.as_path()),
+            expected.map(Path::new)
+        );
+    }
+}


### PR DESCRIPTION
Cargo accepts repeated `--target` flags, and `upload-rust-binary-action` uses them to build both macOS architectures in one invocation. mbx rejected these builds before compilation, even with the default system linker, causing [usage’s universal macOS release build](https://github.com/jdx/usage/actions/runs/33987850906/job/101364811217) to fail.

Resolve linker settings separately for each explicit target and pass the selections to the rustc shim. Apply each selection only to its matching target, leaving host build scripts and proc macros on their existing linker. Clear inherited internal linker selections between builds.

Validation:
- mbx library suite: 385 passed, 1 ignored, including regression coverage for the failing invocation, per-target policy, and host isolation.
- `cargo clippy -p mbx --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check` and `git diff --check`
- Built a fixture with a build script for both `aarch64-apple-darwin` and `x86_64-apple-darwin` in one release invocation, using both `system` and managed `rust-lld`; verified the system build produced both Mach-O architectures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how linkers are chosen and injected into every rustc link invocation for multi-target builds; mis-routing could break cross-compiles or universal releases, though behavior is narrowly scoped and heavily tested.
> 
> **Overview**
> **Multi-target Cargo builds** (e.g. universal macOS with repeated `--target`) no longer fail at linker resolution. mbx used to reject more than one `--target`; it now resolves linker policy **per target** and routes managed linkers only where rustc actually passes `--target`.
> 
> `Selection` becomes **single path vs per-triple map**. The cargo CLI clears inherited `MBX_MANAGED_LINKER` / `MBX_MANAGED_TARGET_LINKERS`, then publishes either one executable or a JSON map via new `MBX_MANAGED_TARGET_LINKERS`. The rustc shim picks the linker from that map when arguments include `--target`, including `host-tuple` normalization and canonical JSON target paths—**host build scripts and proc macros stay on the default linker**.
> 
> Regression tests cover universal system-linker builds, per-target profile policy, and shim routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c79e559dd0e4562452f65d85afa5903cc82ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting managed linkers independently for multiple Rust compilation targets.
  * Managed linker selection recognizes both `--target <triple>` and `--target=<triple>` formats.
  * Added support for target-specific linker configuration in multi-target builds.
  * System-linker builds now preserve per-target linker settings.

* **Bug Fixes**
  * Prevented host builds from using a managed linker intended for another target.
  * Improved linker configuration handling when switching between single-target and multi-target builds.

* **Tests**
  * Added coverage for multi-target linker selection and target-specific routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->