### PR TITLE
fix: preserve CMake compiler identity across Cargo transitions

### DIFF
--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -72,7 +72,6 @@ pub fn run_cargo_shim() -> Result<ExitCode> {
     };
     let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
     if mbx_disabled() {
-        preserve_native_compiler_paths();
         return run_real_cargo(&real_cargo, &arguments);
     }
     if enclosing_session(std::env::var_os(crate::session::SOCKET_ENV).as_deref())
@@ -150,41 +149,6 @@ fn mbx_disabled_value(value: Option<&OsStr>) -> bool {
         let value = value.to_string_lossy();
         value != "0" && !value.eq_ignore_ascii_case("false")
     })
-}
-
-/// Keep native build-system configuration reusable while bypassing the cache.
-///
-/// CMake records the absolute compiler path it sees. An mbx build points host
-/// C and C++ compilation at persistent shims, so handing a later disabled
-/// build the platform compiler directly makes CMake invalidate and reconfigure
-/// the same build directory. The persistent shim is already transparent
-/// without a session; preserve its path here without starting an agent or
-/// caching any compilation.
-fn preserve_native_compiler_paths() {
-    if crate::session::CC_CRATE_ENV
-        .iter()
-        .any(|name| std::env::var_os(name).is_some())
-    {
-        return;
-    }
-    let Ok((config, _)) = Config::load_for_cli() else {
-        return;
-    };
-    if !config.cc {
-        return;
-    }
-    let shims = config.cache_dir.join("shims");
-    for (variable, stem) in [
-        ("HOST_CC", crate::session::CC_SHIM_STEM),
-        ("HOST_CXX", crate::session::CXX_SHIM_STEM),
-    ] {
-        let shim = shims.join(crate::session::shim_file_name(stem));
-        if shim.is_file() {
-            // SAFETY: Cargo shim dispatch is single-threaded before its child
-            // process starts.
-            unsafe { std::env::set_var(variable, shim) };
-        }
-    }
 }
 
 fn enclosing_session(session_socket: Option<&OsStr>) -> bool {

--- a/crates/mbx/src/main.rs
+++ b/crates/mbx/src/main.rs
@@ -12,6 +12,9 @@ fn main() -> ExitCode {
     if mbx::session::is_rustdoc_shim() {
         return mbx::session::run_rustdoc_shim();
     }
+    if let Some(code) = mbx::session::cmake::dispatch() {
+        return code;
+    }
     if let Some(language) = mbx::session::is_cc_shim() {
         return mbx::session::run_cc_shim(language);
     }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -27,6 +27,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 mod client;
+pub mod cmake;
 mod diagnostics;
 mod server;
 mod shims;
@@ -99,6 +100,7 @@ pub struct CacheSession {
     rustc_shim: PathBuf,
     rustdoc_shim: PathBuf,
     cc_shims: Option<CcShims>,
+    cmake_environment: BTreeMap<String, String>,
     staging: PathBuf,
     verify: bool,
     incremental: bool,
@@ -156,6 +158,10 @@ impl CacheSession {
         } else {
             None
         };
+        let cmake_environment = match &cc_shims {
+            Some(shims) => cmake::environment(&config.cache_dir.join("shims"), shims)?,
+            None => BTreeMap::new(),
+        };
         let staging = session_dir.join("staging");
         std::fs::create_dir(&staging)?;
         let store = config.store_dir();
@@ -205,6 +211,7 @@ impl CacheSession {
             rustc_shim: shim,
             rustdoc_shim,
             cc_shims,
+            cmake_environment,
             staging,
             verify: config.verify,
             incremental: config.incremental,
@@ -382,6 +389,7 @@ impl CacheSession {
             self.rustdoc_shim.to_string_lossy().into_owned(),
         );
         self.begin_cc(environment);
+        environment.extend(self.cmake_environment.clone());
         if self.incremental {
             // Hand the decision back to cargo, which compiles local packages
             // incrementally in dev profiles and never in release. Not

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -100,7 +100,7 @@ pub struct CacheSession {
     rustc_shim: PathBuf,
     rustdoc_shim: PathBuf,
     cc_shims: Option<CcShims>,
-    cmake_environment: BTreeMap<String, String>,
+    cmake_shims_dir: PathBuf,
     staging: PathBuf,
     verify: bool,
     incremental: bool,
@@ -158,10 +158,6 @@ impl CacheSession {
         } else {
             None
         };
-        let cmake_environment = match &cc_shims {
-            Some(shims) => cmake::environment(&config.cache_dir.join("shims"), shims)?,
-            None => BTreeMap::new(),
-        };
         let staging = session_dir.join("staging");
         std::fs::create_dir(&staging)?;
         let store = config.store_dir();
@@ -211,7 +207,7 @@ impl CacheSession {
             rustc_shim: shim,
             rustdoc_shim,
             cc_shims,
-            cmake_environment,
+            cmake_shims_dir: config.cache_dir.join("shims"),
             staging,
             verify: config.verify,
             incremental: config.incremental,
@@ -388,8 +384,19 @@ impl CacheSession {
             "RUSTDOC".into(),
             self.rustdoc_shim.to_string_lossy().into_owned(),
         );
-        self.begin_cc(environment);
-        environment.extend(self.cmake_environment.clone());
+        if let Some(shims) = &self.cc_shims {
+            // Select CMake from the final per-build environment, just as we
+            // do for compilers. Do this before injecting compiler shims: if
+            // installing the CMake adapter fails, leave native builds plain
+            // rather than exposing an unstable compiler identity to CMake.
+            match cmake::environment(&self.cmake_shims_dir, shims, environment) {
+                Ok(cmake_environment) => {
+                    self.begin_cc(environment);
+                    environment.extend(cmake_environment);
+                }
+                Err(error) => warn!("native compiler caching is unavailable: {error:#}"),
+            }
+        }
         if self.incremental {
             // Hand the decision back to cargo, which compiles local packages
             // incrementally in dev profiles and never in release. Not

--- a/crates/mbx/src/session/cmake.rs
+++ b/crates/mbx/src/session/cmake.rs
@@ -1,0 +1,261 @@
+//! Keep compiler identity stable when cmake-rs inherits mbx's CC shims.
+//!
+//! CMake discards configuration options when CMAKE_<LANG>_COMPILER changes.
+//! Translate our compiler paths to their real drivers before configuration,
+//! and cache C/C++ through launchers instead. ASM keeps its real driver too,
+//! but CMake does not support an ASM compiler launcher.
+
+use super::shims::{CcShims, is_target_triple, link_path_shim, resolve_on_path};
+use super::{record_cc_bypass, reserve_stderr_for_compiler, run_transparent_cc, session_socket};
+use eyre::Result;
+use mbx_cache_cc::CcLanguage;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+const PROGRAMS: &str = "MBX_CMAKE_PROGRAMS";
+const COMPILERS: &str = "MBX_CMAKE_COMPILERS";
+const SHIM: &str = "mbx-cmake";
+const C_LAUNCHER: &str = "mbx-cmake-launch-c";
+const CXX_LAUNCHER: &str = "mbx-cmake-launch-cxx";
+
+pub(super) fn environment(
+    directory: &Path,
+    compilers: &CcShims,
+) -> Result<BTreeMap<String, String>> {
+    let executable = std::env::current_exe()?;
+    let mut environment = BTreeMap::new();
+    let mut programs = BTreeMap::new();
+    let mut choices: BTreeMap<_, _> = std::env::vars()
+        .filter(|(name, _)| {
+            matches!(name.as_str(), "CMAKE" | "HOST_CMAKE" | "TARGET_CMAKE")
+                || name.strip_prefix("CMAKE_").is_some_and(is_target_triple)
+        })
+        .collect();
+    if !choices.contains_key("CMAKE")
+        && let Some(program) = resolve_on_path(&super::shim_file_name("cmake"))
+    {
+        choices.insert("CMAKE".into(), program.to_string_lossy().into_owned());
+    }
+    for (variable, program) in choices {
+        let name = format!("{SHIM}-{}", variable.to_ascii_lowercase().replace('.', "_"));
+        let shim = directory.join(super::shim_file_name(&name));
+        // Nested sessions must keep the outer shim's original program.
+        let program = read_map(PROGRAMS)
+            .remove(
+                Path::new(&program)
+                    .file_stem()
+                    .and_then(OsStr::to_str)
+                    .unwrap_or_default(),
+            )
+            .unwrap_or_else(|| PathBuf::from(program));
+        link_path_shim(&executable, &shim)?;
+        programs.insert(name, program);
+        environment.insert(variable, shim.to_string_lossy().into_owned());
+    }
+    if programs.is_empty() {
+        return Ok(environment);
+    }
+    let mut pins = BTreeMap::new();
+    for (shim, real) in compilers.cc.iter().chain(compilers.cxx.iter()) {
+        pins.insert(cmake_path(shim), real.clone());
+    }
+    for compiler in &compilers.targeted {
+        pins.insert(cmake_path(&compiler.shim), compiler.real.clone());
+    }
+    for launcher in [C_LAUNCHER, CXX_LAUNCHER] {
+        link_path_shim(
+            &executable,
+            &directory.join(super::shim_file_name(launcher)),
+        )?;
+    }
+    environment.insert(PROGRAMS.into(), serde_json::to_string(&programs)?);
+    environment.insert(COMPILERS.into(), serde_json::to_string(&pins)?);
+    Ok(environment)
+}
+
+fn read_map(name: &str) -> BTreeMap<String, PathBuf> {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| serde_json::from_str(&value).ok())
+        .unwrap_or_default()
+}
+
+fn cmake_path(path: &Path) -> String {
+    let path = path.to_string_lossy().into_owned();
+    // cmake-rs writes forward slashes even when cc-rs returned a Windows path.
+    if cfg!(windows) {
+        path.replace('\\', "/")
+    } else {
+        path
+    }
+}
+
+/// Dispatch before mbx's CLI: CMake launchers also survive outside a session.
+pub fn dispatch() -> Option<ExitCode> {
+    let invoked = PathBuf::from(std::env::args_os().next()?);
+    let name = invoked.file_stem()?.to_str()?;
+    if matches!(name, C_LAUNCHER | CXX_LAUNCHER) {
+        let language = if name == C_LAUNCHER {
+            CcLanguage::C
+        } else {
+            CcLanguage::Cxx
+        };
+        reserve_stderr_for_compiler();
+        let mut arguments = std::env::args_os().skip(1);
+        let Some(compiler) = arguments.next() else {
+            eprintln!("mbx[error]: CMake launcher requires a compiler");
+            return Some(ExitCode::FAILURE);
+        };
+        let arguments: Vec<_> = arguments.collect();
+        if session_socket().is_some() {
+            match crate::cc::compile(&compiler, &arguments, language) {
+                Ok(code) => return Some(code),
+                Err(error) => record_cc_bypass(&error),
+            }
+        }
+        return Some(run_transparent_cc(compiler, arguments));
+    }
+    if !name.starts_with(&format!("{SHIM}-")) {
+        return None;
+    }
+    let program = read_map(PROGRAMS)
+        .remove(name)
+        .unwrap_or_else(|| "cmake".into());
+    let mut arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let mut command = Command::new(program);
+    // --build, --install, -E, -P, and probes must pass through verbatim.
+    if !arguments.iter().any(|arg| {
+        matches!(
+            arg.to_str(),
+            Some("--build" | "--install" | "-E" | "-P" | "--version" | "--help")
+        )
+    }) {
+        for (variable, launcher) in rewrite_compilers(&mut arguments, &read_map(COMPILERS)) {
+            // Environment defaults preserve launchers chosen on the command
+            // line, in an existing cache, or by the caller's environment.
+            if std::env::var_os(variable).is_none() {
+                command.env(
+                    variable,
+                    invoked
+                        .parent()
+                        .unwrap()
+                        .join(super::shim_file_name(launcher)),
+                );
+            }
+        }
+    }
+    let status = command.args(arguments).status();
+    Some(match status {
+        Ok(status) => crate::materialize::exit_code(status),
+        Err(error) => {
+            eprintln!("mbx[error]: failed to execute CMake: {error}");
+            ExitCode::FAILURE
+        }
+    })
+}
+
+fn rewrite_compilers(
+    arguments: &mut [OsString],
+    pins: &BTreeMap<String, PathBuf>,
+) -> Vec<(&'static str, &'static str)> {
+    let mut launchers = Vec::new();
+    // Both -DNAME[:TYPE]=value and -D NAME[:TYPE]=value are accepted by CMake.
+    // Only exact paths installed by this session are ours to replace.
+    let mut after_define = false;
+    for argument in arguments {
+        let Some(text) = argument.to_str() else {
+            after_define = false;
+            continue;
+        };
+        let definition = if let Some(value) = text.strip_prefix("-D") {
+            value
+        } else if after_define {
+            text
+        } else {
+            continue;
+        };
+        after_define = text == "-D";
+        let Some((key, value)) = definition.split_once('=') else {
+            continue;
+        };
+        let variable = key.split(':').next().unwrap();
+        if !matches!(
+            variable,
+            "CMAKE_C_COMPILER" | "CMAKE_CXX_COMPILER" | "CMAKE_ASM_COMPILER"
+        ) {
+            continue;
+        }
+        let Some(real) = pins.get(&cmake_path(Path::new(value))) else {
+            continue;
+        };
+        match variable {
+            "CMAKE_C_COMPILER" => launchers.push(("CMAKE_C_COMPILER_LAUNCHER", C_LAUNCHER)),
+            "CMAKE_CXX_COMPILER" => launchers.push(("CMAKE_CXX_COMPILER_LAUNCHER", CXX_LAUNCHER)),
+            _ => {}
+        }
+        let prefix = if text.starts_with("-D") { "-D" } else { "" };
+        *argument = format!("{prefix}{key}={}", cmake_path(real)).into();
+    }
+    launchers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compiler_definitions_keep_types_spaces_and_unrelated_options() {
+        let mut arguments: Vec<OsString> = [
+            "-S",
+            "source tree",
+            "-D",
+            "CMAKE_C_COMPILER:FILEPATH=/cache dir/mbx-cc",
+            "-DCMAKE_CXX_COMPILER=/cache dir/mbx-cxx",
+            "-DCMAKE_ASM_COMPILER=/cache dir/mbx-cc",
+            "-DCMAKE_C_COMPILER_LAUNCHER=user-launcher",
+            "-DBUILD_TESTING=OFF",
+            "-DSOME_COMPILER=/cache dir/mbx-cc",
+        ]
+        .into_iter()
+        .map(Into::into)
+        .collect();
+        let pins = BTreeMap::from([
+            ("/cache dir/mbx-cc".into(), "/tool chain/cc".into()),
+            ("/cache dir/mbx-cxx".into(), "/tool chain/c++".into()),
+        ]);
+        let launchers = rewrite_compilers(&mut arguments, &pins);
+        assert_eq!(
+            arguments,
+            [
+                "-S",
+                "source tree",
+                "-D",
+                "CMAKE_C_COMPILER:FILEPATH=/tool chain/cc",
+                "-DCMAKE_CXX_COMPILER=/tool chain/c++",
+                "-DCMAKE_ASM_COMPILER=/tool chain/cc",
+                "-DCMAKE_C_COMPILER_LAUNCHER=user-launcher",
+                "-DBUILD_TESTING=OFF",
+                "-DSOME_COMPILER=/cache dir/mbx-cc",
+            ]
+            .map(OsString::from)
+        );
+        assert_eq!(
+            launchers,
+            vec![
+                ("CMAKE_C_COMPILER_LAUNCHER", C_LAUNCHER),
+                ("CMAKE_CXX_COMPILER_LAUNCHER", CXX_LAUNCHER),
+            ]
+        );
+    }
+
+    #[test]
+    fn compiler_overrides_are_not_rewritten_or_wrapped() {
+        let mut arguments = [OsString::from("-DCMAKE_C_COMPILER=/custom/mbx-cc")];
+        let original = arguments.clone();
+        let pins = BTreeMap::from([("/cache/mbx-cc".into(), "/usr/bin/cc".into())]);
+        assert!(rewrite_compilers(&mut arguments, &pins).is_empty());
+        assert_eq!(arguments, original);
+    }
+}

--- a/crates/mbx/src/session/cmake.rs
+++ b/crates/mbx/src/session/cmake.rs
@@ -23,11 +23,17 @@ const CXX_LAUNCHER: &str = "mbx-cmake-launch-cxx";
 pub(super) fn environment(
     directory: &Path,
     compilers: &CcShims,
+    build_environment: &BTreeMap<String, String>,
 ) -> Result<BTreeMap<String, String>> {
     let executable = std::env::current_exe()?;
     let mut environment = BTreeMap::new();
     let mut programs = BTreeMap::new();
     let mut choices: BTreeMap<_, _> = std::env::vars()
+        .chain(
+            build_environment
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        )
         .filter(|(name, _)| {
             matches!(name.as_str(), "CMAKE" | "HOST_CMAKE" | "TARGET_CMAKE")
                 || name.strip_prefix("CMAKE_").is_some_and(is_target_triple)
@@ -42,7 +48,10 @@ pub(super) fn environment(
         let name = format!("{SHIM}-{}", variable.to_ascii_lowercase().replace('.', "_"));
         let shim = directory.join(super::shim_file_name(&name));
         // Nested sessions must keep the outer shim's original program.
-        let program = read_map(PROGRAMS)
+        let program = build_environment
+            .get(PROGRAMS)
+            .and_then(|encoded| serde_json::from_str::<BTreeMap<String, PathBuf>>(encoded).ok())
+            .unwrap_or_else(|| read_map(PROGRAMS))
             .remove(
                 Path::new(&program)
                     .file_stem()

--- a/crates/mbx/src/session/shims.rs
+++ b/crates/mbx/src/session/shims.rs
@@ -298,7 +298,7 @@ pub fn install_path_shims(directory: &Path) -> Result<Option<PathShims>> {
 /// replaced, and `rename` leaves it resolvable at every instant where removing
 /// and recreating would not.
 #[cfg(unix)]
-fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
+pub(super) fn link_path_shim(executable: &Path, destination: &Path) -> Result<()> {
     // Absolutized for the same reason [`symlink_shim`] does it: a symlink is
     // resolved from the directory holding it, which here is the cache's shim
     // directory and never the caller's. `current_exe` has been absolute on
@@ -350,7 +350,7 @@ pub(super) fn link_path_shim(executable: &Path, destination: &Path) -> Result<()
 }
 
 #[cfg(not(any(unix, windows)))]
-fn link_path_shim(_executable: &Path, _destination: &Path) -> Result<()> {
+pub(super) fn link_path_shim(_executable: &Path, _destination: &Path) -> Result<()> {
     eyre::bail!("PATH shims are not supported on this platform")
 }
 

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -74,6 +74,51 @@ fn test_config(cache_dir: &Path) -> Config {
 }
 
 #[tokio::test]
+async fn cmake_selection_uses_the_final_build_environment() {
+    let cache = tempfile::tempdir().unwrap();
+    let session_dir = tempfile::tempdir().unwrap();
+    let mut session = CacheSession::start(session_dir.path(), &test_config(cache.path()))
+        .await
+        .unwrap();
+    // Exercise CMake selection even on a runner with no native toolchain.
+    session.cc_shims = Some(CcShims {
+        cc: None,
+        cxx: None,
+        targeted: Vec::new(),
+    });
+    let workspace = tempfile::tempdir().unwrap();
+    let selected = BTreeMap::from([
+        ("CMAKE".to_string(), "/per-build/cmake".to_string()),
+        ("HOST_CMAKE".into(), "/per-build/host-cmake".into()),
+        ("TARGET_CMAKE".into(), "/per-build/target-cmake".into()),
+        (
+            "CMAKE_aarch64_unknown_linux_gnu".into(),
+            "/per-build/arm-cmake".into(),
+        ),
+    ]);
+    let mut environment = selected.clone();
+    session
+        .begin(
+            workspace.path(),
+            &workspace.path().join("target"),
+            &["build".into()],
+            &mut environment,
+        )
+        .await;
+    let programs: BTreeMap<String, PathBuf> =
+        serde_json::from_str(&environment["MBX_CMAKE_PROGRAMS"]).unwrap();
+    for (variable, program) in selected {
+        let shim = Path::new(&environment[&variable]);
+        assert!(shim.is_file());
+        assert_eq!(
+            programs[shim.file_stem().unwrap().to_str().unwrap()],
+            PathBuf::from(program)
+        );
+    }
+    session.finish().await.unwrap();
+}
+
+#[tokio::test]
 async fn session_environment_directs_cargo_at_the_shim() {
     let cache = tempfile::tempdir().unwrap();
     let session_dir = tempfile::tempdir().unwrap();

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -11,6 +11,8 @@ setup() {
   # choice would make mbx stand aside and the fixture prove nothing.
   unset CARGO_TARGET_DIR MBX_INCREMENTAL CARGO_INCREMENTAL CI MBX_CC MBX_CACHE_LINKS
   unset CC CXX HOST_CC HOST_CXX TARGET_CC TARGET_CXX MBX_REAL_CC MBX_REAL_CXX
+  unset CMAKE HOST_CMAKE TARGET_CMAKE CMAKE_TOOLCHAIN_FILE
+  unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER
   export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store"
   # Every test in this file measures the compiler shim a build script calls.
   # Keep execution caching from restoring the script before it reaches that
@@ -70,6 +72,127 @@ EOF
 # Find the fixture's object beneath a target directory.
 object_in() {
   find "$1" -name hello.o -type f | head -n 1
+}
+
+cmake_transition() {
+  if ! command -v cmake >/dev/null 2>&1 || ! command -v make >/dev/null 2>&1; then
+    skip "cmake and make are required"
+  fi
+  if ! command -v c++ >/dev/null 2>&1; then
+    skip "a C++ compiler is required"
+  fi
+  export CMAKE_GENERATOR="Unix Makefiles"
+  cat >"$PROJECT/CMakeLists.txt" <<'EOF'
+cmake_minimum_required(VERSION 3.20)
+project(transition C CXX ASM)
+# Like packaged aws-lc, the optional source trees are absent. A compiler
+# identity change makes CMake restart and lose the command-line OFF values.
+option(BUILD_TESTING "Build unpackaged tests" ON)
+option(BUILD_TOOL "Build unpackaged tools" ON)
+if(BUILD_TESTING OR BUILD_TOOL)
+  message(FATAL_ERROR "optional sources are not packaged")
+endif()
+add_library(hello STATIC src/hello.c src/extra.cpp)
+target_include_directories(hello PRIVATE include)
+EOF
+  echo 'int extra_value() { return 42; }' >"$PROJECT/src/extra.cpp"
+  cat >"$PROJECT/build.rs" <<'EOF'
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=RECONFIGURE");
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    // This must survive every transition: the test reuses build-script state.
+    let marker = out.join("runs");
+    let runs = std::fs::read_to_string(&marker).unwrap_or_default();
+    let cmake = env::var_os("CMAKE").unwrap_or_else(|| "cmake".into());
+    let cc = env::var("HOST_CC").unwrap_or_else(|_| "cc".into());
+    let cxx = env::var("HOST_CXX").unwrap_or_else(|_| "c++".into());
+    // Mirror cmake-rs: resolve cc::Tool::path(), then pass each compiler
+    // explicitly, including ASM, which uses the C compiler.
+    let resolve = |compiler: &str| {
+        env::split_paths(&env::var_os("PATH").unwrap())
+            .map(|dir| dir.join(compiler))
+            .find(|path| path.is_file()).unwrap()
+    };
+    let status = Command::new(&cmake)
+        .args(["-S", ".", "-B"]).arg(out.join("build"))
+        .arg(format!("-DCMAKE_C_COMPILER={}", resolve(&cc).display()))
+        .arg(format!("-DCMAKE_CXX_COMPILER={}", resolve(&cxx).display()))
+        .arg(format!("-DCMAKE_ASM_COMPILER={}", resolve(&cc).display()))
+        .args(["-DBUILD_TESTING=OFF", "-DBUILD_TOOL=OFF"])
+        .status().unwrap();
+    assert!(status.success());
+    // Force a real native compilation on every run, including the plain
+    // Cargo fallback after the session that installed any launcher has ended.
+    let status = Command::new(&cmake).arg("--build").arg(out.join("build"))
+        .arg("--clean-first").status().unwrap();
+    assert!(status.success());
+    std::fs::write(marker, format!("{runs}{}\n", env::var("RECONFIGURE").unwrap())).unwrap();
+}
+EOF
+  export CARGO_TARGET_DIR="$BATS_TEST_TMPDIR/reused-target"
+  export CARGO_INCREMENTAL=0
+  export MBX_INCREMENTAL=0 MBX_LEARNED_INCREMENTAL=0
+  export RUSTC_WRAPPER= RUSTC_WORKSPACE_WRAPPER=
+  local step cache original_compilers
+  for step in cargo-1 mbx-2 cargo-3 mbx-4; do
+    if [[ "$step" == cargo-* ]]; then
+      run env RECONFIGURE="$step" MBX_DISABLE=1 RUSTC_WRAPPER= RUSTC_WORKSPACE_WRAPPER= \
+        cargo build --offline --manifest-path "$PROJECT/Cargo.toml"
+    else
+      run env RECONFIGURE="$step" MBX_STATS_REPORT="$BATS_TEST_TMPDIR/$step.json" \
+        "$MBX_BIN" build --offline --manifest-path "$PROJECT/Cargo.toml"
+    fi
+    assert_success
+    cache="$(find "$CARGO_TARGET_DIR" -name CMakeCache.txt -type f)"
+    [ -n "$cache" ]
+    local compilers
+    compilers="$(grep -E '^CMAKE_(C|CXX|ASM)_COMPILER:' "$cache" | sed -E 's/:[^=]*=/=/')"
+    if [[ "$step" == cargo-1 ]]; then
+      original_compilers="$compilers"
+    fi
+    [ "$compilers" = "$original_compilers" ]
+    run grep -E '^BUILD_(TESTING|TOOL):BOOL=OFF$' "$cache"
+    assert_success
+    [ "${#lines[@]}" -eq 2 ]
+  done
+  run cat "$(dirname "$(dirname "$cache")")/runs"
+  assert_output $'cargo-1\nmbx-2\ncargo-3\nmbx-4'
+}
+
+@test "CMake build scripts can switch between Cargo and mbx in one target directory" {
+  cmake_transition
+  # Cleaning native outputs before the second mbx run must still allow both
+  # C and C++ objects to restore through CMake's persisted launchers, alongside
+  # the Rust library whose build-script output has not changed.
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*3' "$BATS_TEST_TMPDIR/mbx-4.json"
+  assert_success
+}
+
+@test "CMake compiler transitions preserve a configured launcher" {
+  local launcher="$BATS_TEST_TMPDIR/user-launcher"
+  cat >"$launcher" <<'EOF'
+#!/bin/sh
+echo called >> "$LAUNCHER_LOG"
+exec "$@"
+EOF
+  chmod +x "$launcher"
+  export LAUNCHER_LOG="$BATS_TEST_TMPDIR/launcher.log"
+  export CMAKE_C_COMPILER_LAUNCHER="$launcher"
+  export CMAKE_CXX_COMPILER_LAUNCHER="$launcher"
+  cmake_transition
+  local cache
+  cache="$(find "$CARGO_TARGET_DIR" -name CMakeCache.txt -type f)"
+  run grep -Fx "CMAKE_C_COMPILER_LAUNCHER:STRING=$launcher" "$cache"
+  assert_success
+  run grep -Fx "CMAKE_CXX_COMPILER_LAUNCHER:STRING=$launcher" "$cache"
+  assert_success
+  run cat "$LAUNCHER_LOG"
+  assert_success
+  # At least the two native sources on all four runs; some CMake versions
+  # also launch the compiler through this command during their initial probes.
+  [ "${#lines[@]}" -ge 8 ]
 }
 
 @test "a build script's C object restores into a distinct target directory" {

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -75,6 +75,7 @@ object_in() {
 }
 
 cmake_transition() {
+  local plain_cargo="${1:-cargo}"
   if ! command -v cmake >/dev/null 2>&1 || ! command -v make >/dev/null 2>&1; then
     skip "cmake and make are required"
   fi
@@ -139,7 +140,7 @@ EOF
   for step in cargo-1 mbx-2 cargo-3 mbx-4; do
     if [[ "$step" == cargo-* ]]; then
       run env RECONFIGURE="$step" MBX_DISABLE=1 RUSTC_WRAPPER= RUSTC_WORKSPACE_WRAPPER= \
-        cargo build --offline --manifest-path "$PROJECT/Cargo.toml"
+        "$plain_cargo" build --offline --manifest-path "$PROJECT/Cargo.toml"
     else
       run env RECONFIGURE="$step" MBX_STATS_REPORT="$BATS_TEST_TMPDIR/$step.json" \
         "$MBX_BIN" build --offline --manifest-path "$PROJECT/Cargo.toml"
@@ -193,6 +194,14 @@ EOF
   # At least the two native sources on all four runs; some CMake versions
   # also launch the compiler through this command during their initial probes.
   [ "${#lines[@]}" -ge 8 ]
+}
+
+@test "the installed Cargo shim can disable caching without changing CMake compiler identity" {
+  export CARGO_HOME="$BATS_TEST_TMPDIR/cargo-home"
+  mkdir -p "$CARGO_HOME"
+  run "$MBX_BIN" setup
+  assert_success
+  cmake_transition "$XDG_DATA_HOME/mbx/bin/cargo"
 }
 
 @test "a build script's C object restores into a distinct target directory" {

--- a/test/cc_build_script_cache.bats
+++ b/test/cc_build_script_cache.bats
@@ -198,10 +198,11 @@ EOF
 
 @test "the installed Cargo shim can disable caching without changing CMake compiler identity" {
   export CARGO_HOME="$BATS_TEST_TMPDIR/cargo-home"
+  export MBX_TEST_SHIM_DIR="$BATS_TEST_TMPDIR/cargo-shim"
   mkdir -p "$CARGO_HOME"
   run "$MBX_BIN" setup
   assert_success
-  cmake_transition "$XDG_DATA_HOME/mbx/bin/cargo"
+  cmake_transition "$MBX_TEST_SHIM_DIR/cargo"
 }
 
 @test "a build script's C object restores into a distinct target directory" {

--- a/test/setup.bats
+++ b/test/setup.bats
@@ -356,7 +356,7 @@ EOF
   assert_output "1"
 }
 
-@test "disabled Cargo preserves persistent native compiler paths" {
+@test "disabled Cargo leaves native compiler choices unchanged" {
   local real_bin="$BATS_TEST_TMPDIR/disabled-real-bin"
   local executable_suffix=""
   if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
@@ -376,8 +376,14 @@ EOF
   run env MBX_DISABLE=1 PATH="$MBX_SHIM_DIR:$real_bin:/usr/bin:/bin" cargo build
 
   assert_success
-  assert_line "HOST_CC=$cc_shim"
-  assert_line "HOST_CXX=$cxx_shim"
+  assert_line "HOST_CC="
+  assert_line "HOST_CXX="
+
+  run env MBX_DISABLE=1 HOST_CC=custom-cc HOST_CXX=custom-cxx \
+    PATH="$MBX_SHIM_DIR:$real_bin:/usr/bin:/bin" cargo build
+  assert_success
+  assert_line "HOST_CC=custom-cc"
+  assert_line "HOST_CXX=custom-cxx"
 }
 
 @test "the Cargo shim reuses its workspace metadata probe" {


### PR DESCRIPTION
Switching an existing Cargo target directory to mbx replaces the compiler paths passed by cmake-rs with mbx shims. CMake resets its cache when those identities change and can discard command-line options such as `BUILD_TESTING=OFF` and `BUILD_TOOL=OFF`. With `aws-lc-sys = 0.44.0`, configuration then fails because its packaged sources omit the optional tools and tests.

Keep the real C, C++, and ASM compiler paths in CMake configuration, and route C/C++ compilation through persistent compiler launchers. Launchers forward directly to the compiler outside an mbx session, so returning to plain Cargo remains safe. Select CMake executables from the final per-build environment, preserving host and target overrides and user launchers. Disabled invocations through the installed Cargo shim leave native compiler choices unchanged. ASM uses its real compiler directly because CMake does not support an ASM compiler launcher.

Add offline regression tests that force configuration and native compilation through Cargo → mbx → Cargo → mbx in the same target and build-script output directories, both with raw Cargo and the installed Cargo shim in disabled mode. Assert stable compiler identities, preserved OFF options, native cache hits, and custom launcher preservation. Unit tests cover typed and split compiler definitions, paths with spaces, unrelated compiler overrides, and per-build CMake selections.

Validation:
- Reproduced the failure with the explicit mbx 1.8.3 executable and the supplied aws-lc fixture.
- After restoring the plain-Cargo baseline, verified patched mbx and the subsequent plain Cargo fallback succeed without clearing CMake state between them.
- Full `mise run -j 1 ci` passed, including all 46 Bats tests, using an isolated Cargo home and bounded build/test concurrency to avoid this host's global wrapper configuration and process limits.

Existing CMake state already corrupted by the old transition still requires the one-time cleanup; this change prevents the compiler-identity reset rather than repairing damaged caches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session environment injection and early process dispatch for CMake/native builds; failures degrade to uncached CC with a warning rather than aborting startup.
> 
> **Overview**
> **CMake no longer sees mbx CC/C++ shim paths as the configured compiler**, which used to force cache resets and drop options like `BUILD_TESTING=OFF` when switching between plain Cargo and mbx in the same target dir.
> 
> Session startup now installs a **CMake adapter**: `CMAKE` / `HOST_CMAKE` / target overrides are pointed at persistent shims that rewrite `-D CMAKE_C_COMPILER` / `CMAKE_CXX_COMPILER` to the **real** toolchain paths and set `CMAKE_*_COMPILER_LAUNCHER` to mbx launchers so C/C++ still go through the cache. ASM stays on the real C driver (no ASM launcher). Early `main` dispatch handles launcher and cmake shim argv0; setup runs before CC shims and **warns and skips native CC caching** if adapter install fails.
> 
> **Disabled Cargo** no longer forces `HOST_CC`/`HOST_CXX` back to persistent shims via `preserve_native_compiler_paths`—explicit caller env is left alone.
> 
> Regression coverage adds **Cargo → mbx → Cargo → mbx** CMake build-script flows (including `MBX_DISABLE` via the installed cargo shim), custom launcher preservation, and unit tests for `-D` rewriting and per-build CMake selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e571e545c7bdad7021ceb78830c453defc8dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-build CMake compiler and launcher selections, including host, target, and target-specific configurations.
  * CMake builds now retain their selected compiler identity when switching between standard Cargo and mbx builds.

* **Bug Fixes**
  * Improved handling of nested CMake sessions and custom compiler settings.
  * Prevented inherited CMake settings from unexpectedly affecting builds.
  * CMake caching setup failures now fall back gracefully without interrupting session startup.
  * Disabled caching now preserves explicitly configured native compiler settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
