### PR TITLE
fix(cc): cache gdb and full debug compilations portably

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -1198,3 +1198,28 @@ fn assembler_input_directives_bypass_only_preprocessed_assembly() {
     c.validate_discovered_inputs([source.as_path()])
         .expect("assembler syntax in C text is irrelevant");
 }
+
+#[test]
+fn debug_dialects_and_levels_have_distinct_action_keys() {
+    let mut keys = BTreeSet::new();
+    for flag in [
+        "-g0", "-gfull", "-ggdb", "-ggdb0", "-ggdb1", "-ggdb2", "-ggdb3",
+    ] {
+        let (workspace, target) = checkout("debug");
+        let invocation = CcInvocation::parse(&argv(&[flag, "-c", "-o", "out.o", "src/a.c"]))
+            .expect("object-only debug option should be admitted");
+        let mut context = context(&workspace, &target);
+        context.inputs.push(CcActionInput {
+            path: workspace.join("src/a.c"),
+            digest: digest_of("source"),
+        });
+        let action = invocation.action(context).unwrap();
+        assert!(
+            keys.insert(action.digest.hash),
+            "{flag} must remain in the key"
+        );
+    }
+    for flag in ["-ggdb4", "-gfull-extra", "-gmodules", "-gsplit-dwarf"] {
+        assert!(CcInvocation::parse(&argv(&[flag, "-c", "-o", "out.o", "src/a.c"])).is_err());
+    }
+}

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -239,6 +239,12 @@ const SUPPORTED_G_FLAGS: &[&str] = &[
     "-gdwarf-3",
     "-gdwarf-4",
     "-gdwarf-5",
+    "-gfull",
+    "-ggdb",
+    "-ggdb0",
+    "-ggdb1",
+    "-ggdb2",
+    "-ggdb3",
 ];
 
 const SUPPORTED_BARE_FLAGS: &[&str] = &[

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -48,7 +48,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let identity = compiler_identity(compiler, language)?;
     // Appended before anything parses, so the flag is part of the key the same
     // way the caller's own prefix maps are.
-    let portable = Portable::detect(&mappings, identity.family);
+    let portable = Portable::detect(&mappings, identity.family, &working_dir);
     let arguments = portable.applied_to(arguments);
     let arguments = arguments.as_ref();
     let invocation = CcInvocation::parse_for(arguments, identity.family)?;
@@ -523,25 +523,41 @@ struct Portable {
 }
 
 impl Portable {
-    fn detect(mappings: &[PathMapping], family: CcCompilerFamily) -> Self {
+    fn detect(mappings: &[PathMapping], family: CcCompilerFamily, working_dir: &Path) -> Self {
         let mut portable = Self {
             arguments: Vec::new(),
             values: Vec::new(),
         };
-        if !session::share_out_dir_requested() {
-            return portable;
-        }
-        for name in PORTABLE_ENVIRONMENT {
-            let Some(value) = std::env::var(name)
-                .ok()
-                .filter(|value| Path::new(value).is_absolute())
-            else {
-                continue;
-            };
-            // A value under no known root is one no key could agree on
-            // anyway, so there is nothing to remap and nothing to promise.
+        // Debug information records the compiler's working directory even
+        // when every source argument is relative. Normalize it as well as
+        // OUT_DIR so equivalent checkouts produce identical debug objects.
+        // Clang honors the logical PWD (e.g. /var on macOS), while Rust's
+        // current_dir reports /private/var. Map both spellings only when they
+        // identify the same directory.
+        let physical_dir =
+            std::fs::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf());
+        let logical_dir = std::env::var("PWD").ok().filter(|value| {
+            Path::new(value).is_absolute()
+                && std::fs::canonicalize(value).is_ok_and(|path| path == physical_dir)
+        });
+        let values = working_dir
+            .to_str()
+            .map(str::to_owned)
+            .into_iter()
+            .chain(logical_dir)
+            .chain(
+                PORTABLE_ENVIRONMENT
+                    .iter()
+                    .filter(|_| session::share_out_dir_requested())
+                    .filter_map(|name| std::env::var(name).ok()),
+            );
+        for value in values.filter(|value| Path::new(value).is_absolute()) {
+            // Resolve aliases for mapping without changing the spelling the
+            // compiler's debug information needs to replace.
+            let canonical = std::fs::canonicalize(&value).unwrap_or_else(|_| PathBuf::from(&value));
             let Ok(placeholder) =
                 normalize_mapped_path(Path::new(&value), Path::new("/"), mappings)
+                    .or_else(|_| normalize_mapped_path(&canonical, Path::new("/"), mappings))
             else {
                 continue;
             };

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -523,11 +523,8 @@ struct Portable {
 }
 
 impl Portable {
+    /// Normalize debug paths for the working directory and shared build outputs.
     fn detect(mappings: &[PathMapping], family: CcCompilerFamily, working_dir: &Path) -> Self {
-        let mut portable = Self {
-            arguments: Vec::new(),
-            values: Vec::new(),
-        };
         // Debug information records the compiler's working directory even
         // when every source argument is relative. Normalize it as well as
         // OUT_DIR so equivalent checkouts produce identical debug objects.
@@ -551,7 +548,27 @@ impl Portable {
                     .filter(|_| session::share_out_dir_requested())
                     .filter_map(|name| std::env::var(name).ok()),
             );
-        for value in values.filter(|value| Path::new(value).is_absolute()) {
+        Self::from_values(mappings, family, values)
+    }
+
+    /// Map each spelling once, retaining distinct aliases needed by the compiler.
+    fn from_values(
+        mappings: &[PathMapping],
+        family: CcCompilerFamily,
+        values: impl IntoIterator<Item = String>,
+    ) -> Self {
+        let mut portable = Self {
+            arguments: Vec::new(),
+            values: Vec::new(),
+        };
+        let mut seen = BTreeSet::new();
+        for value in values
+            .into_iter()
+            .filter(|value| Path::new(value).is_absolute())
+        {
+            if !seen.insert(value.clone()) {
+                continue;
+            }
             // Resolve aliases for mapping without changing the spelling the
             // compiler's debug information needs to replace.
             let canonical = std::fs::canonicalize(&value).unwrap_or_else(|_| PathBuf::from(&value));

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -537,11 +537,15 @@ impl Portable {
             Path::new(value).is_absolute()
                 && std::fs::canonicalize(value).is_ok_and(|path| path == physical_dir)
         });
+        // This working-directory remap is for GCC/Clang debug objects. MSVC
+        // ignores /pathmap without /experimental:deterministic; preserve its
+        // existing compilation mode rather than injecting an ignored map.
         let values = working_dir
             .to_str()
             .map(str::to_owned)
             .into_iter()
             .chain(logical_dir)
+            .filter(|_| !family.is_msvc())
             .chain(
                 PORTABLE_ENVIRONMENT
                     .iter()

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -241,3 +241,28 @@ fn a_portable_compilation_remaps_its_paths_and_refuses_an_output_that_kept_one()
     assert!(inert.outputs_are_clean(&dirty));
     assert!(matches!(inert.applied_to(&arguments), Cow::Borrowed(_)));
 }
+
+/// PWD and OUT_DIR can repeat the working directory without changing the key.
+#[test]
+fn duplicate_portable_paths_do_not_change_compiler_arguments() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().to_str().unwrap().to_owned();
+    let child = directory.path().join("out").to_str().unwrap().to_owned();
+    let mappings = [PathMapping::new(directory.path(), "workspace")];
+    for family in [
+        CcCompilerFamily::Gcc,
+        CcCompilerFamily::Clang,
+        #[cfg(windows)]
+        CcCompilerFamily::Msvc,
+    ] {
+        let unique = Portable::from_values(&mappings, family, [root.clone(), child.clone()]);
+        let repeated = Portable::from_values(
+            &mappings,
+            family,
+            [root.clone(), root.clone(), child.clone(), child.clone()],
+        );
+        assert_eq!(unique.arguments.len(), 2);
+        assert_eq!(repeated.arguments, unique.arguments);
+        assert_eq!(repeated.values, unique.values);
+    }
+}

--- a/test/cc_standalone_exec.bats
+++ b/test/cc_standalone_exec.bats
@@ -150,3 +150,43 @@ EOF
   # Nothing was cached, so no store was ever created.
   assert_not_exists "$MBX_CACHE_DIR"
 }
+
+@test "gdb and full debug objects restore across checkouts and invalidate on source changes" {
+  local flag
+  for flag in -ggdb -gfull; do
+    # GCC does not support Apple's -gfull; exercise it wherever the driver does.
+    echo 'int probe(void) { return 0; }' >"$BATS_TEST_TMPDIR/probe.c"
+    if ! cc "$flag" -c "$BATS_TEST_TMPDIR/probe.c" -o "$BATS_TEST_TMPDIR/probe.o" 2>/dev/null; then
+      continue
+    fi
+    local first="$BATS_TEST_TMPDIR/first-$flag"
+    local second="$BATS_TEST_TMPDIR/second-$flag"
+    local report="$BATS_TEST_TMPDIR/report-$flag.json"
+    write_project "$first"
+    write_project "$second"
+    (cd "$first" && "$MBX_BIN" exec make "CFLAGS=$flag -Iinclude" hello)
+    (cd "$second" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec make "CFLAGS=$flag -Iinclude" hello)
+    run grep -E '"hits"[[:space:]]*:[[:space:]]*2' "$report"
+    assert_success
+    run cmp "$first/hello.o" "$second/hello.o"
+    assert_success
+    "$second/hello"
+
+    # A successful fresh compiler run must reproduce the cached debug objects.
+    rm "$second/hello.o" "$second/main.o"
+    (cd "$second" && MBX_VERIFY=1 MBX_STATS_REPORT="$report" "$MBX_BIN" exec make "CFLAGS=$flag -Iinclude" hello)
+    run grep -E '"verifications"[[:space:]]*:[[:space:]]*2' "$report"
+    assert_success
+    run grep -E '"divergences"[[:space:]]*:[[:space:]]*0' "$report"
+    assert_success
+    "$second/hello"
+
+    echo 'int hello_value(void) { return 9; }' >"$second/src/hello.c"
+    rm "$second/hello.o" "$second/hello"
+    (cd "$second" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec make "CFLAGS=$flag -Iinclude" hello)
+    run grep -E '"hits"[[:space:]]*:[[:space:]]*0' "$report"
+    assert_success
+    run "$second/hello"
+    assert_failure
+  done
+}


### PR DESCRIPTION
A mise build bypassed 291 C/C++ compilations because mbx rejected `-ggdb` (267 invocations) and `-gfull` (24). Admit these object-only debug options and the `-ggdb0` through `-ggdb3` levels, retaining each spelling in the action key.

Normalize the GCC/Clang working directory in debug information before caching; preserve MSVC's existing compilation mode. On macOS, Clang can use logical `PWD` (`/var/...`) while Rust reports the physical path (`/private/var/...`), so map both spellings only when they identify the same directory. Deduplicate repeated path spellings so setting an identical `PWD` does not change the action key. Keep rejecting objects that still embed a normalized path, and leave unknown debug options and split/external debug outputs rejected.

Validation:
- All 872 workspace Rust tests passed; workspace Clippy passed with all features and targets.
- All 48 behavioral tests passed, including the 13 C/C++ tests. The new test checks two cross-checkout hits, zero shadow-verification divergences, and invalidation after a source change. The cache-hit regression fails with released 1.8.3.
- Optimized release build completed; the same regression passed against the release binary, with two hits and zero verification divergences for each flag.
- A local mise build using the flag fix completed with 1,037 hits, 106 misses, and no `cc-unknown-flag` bypasses.
- Generated CLI documentation has no changes; the documentation build and offline link check passed.

The aggregate `mise run ci` was attempted but hit the existing local `compiler input was modified during compilation` failure in its Rust wrapper. Workspace tests and Clippy were rerun directly without that outer wrapper; behavioral tests used mbx with caching enabled.

Native-library linking and external OpenSSL path handling remain conservatively bypassed; this change addresses the measured debug-option bypasses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes C/C++ cache admission, action keys, and injected compiler flags that affect debug object bytes; MSVC working-directory behavior is intentionally unchanged but publish-time cleanliness checks still gate sharing.
> 
> **Overview**
> **Enables caching** for object-only GCC/Clang debug flags that were previously bypassed: `-gfull`, `-ggdb`, and `-ggdb0` through `-ggdb3`, with each spelling kept in the action key. Unsupported variants (e.g. `-ggdb4`, `-gsplit-dwarf`) stay rejected.
> 
> **Portable debug paths** are broadened so equivalent checkouts can share debug objects: the compiler working directory is always normalized via `-fdebug-prefix-map` (GCC/Clang only), including logical `PWD` when it aliases the physical cwd (macOS `/var` vs `/private/var`). `OUT_DIR` mapping still applies only when OUT_DIR sharing is enabled. Duplicate paths no longer produce extra prefix-map flags, and mapping can fall back to a canonical path spelling.
> 
> Coverage adds cache-key tests for admitted debug flags, a unit test for deduplicated portable flags, and a Bats flow that checks cross-checkout hits, verification, and invalidation after source edits for `-ggdb` / `-gfull`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1c557ae56a92451c9c2e257ba294f738dea5d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional GCC and Clang debug options, including `-gfull` and `-ggdb` through `-ggdb3`.
  - Improved debug-information handling when compiling from different checkout locations, helping cached build artifacts remain reusable across equivalent paths.

- **Bug Fixes**
  - Corrected cache behavior so source changes invalidate previously cached compilation results.
  - Improved cache-key differentiation for supported debug dialects and levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
