### PR TITLE
fix(scheduler): respect nested cgroup memory limits

### DIFF
--- a/crates/mbx/src/cgroup.rs
+++ b/crates/mbx/src/cgroup.rs
@@ -1,0 +1,266 @@
+//! Resolve memory limits at the process's cgroup and every visible ancestor.
+//!
+//! Parent usage includes sibling workloads. Subtracting only the leaf's usage
+//! from a parent's limit would overestimate how much memory a compiler can use.
+use crate::util::{parse_cgroup_stat, read_cgroup_text};
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct Memory {
+    pub limit: Option<u64>,
+    pub headroom: Option<u64>,
+}
+
+#[derive(Debug)]
+struct Domain {
+    mount: PathBuf,
+    current: PathBuf,
+    v2: bool,
+}
+
+pub(crate) fn memory() -> Memory {
+    let domains = std::fs::read_to_string("/proc/self/cgroup")
+        .ok()
+        .zip(std::fs::read_to_string("/proc/self/mountinfo").ok())
+        .map(|(groups, mounts)| domains(&groups, &mounts))
+        .unwrap_or_default();
+    if domains.is_empty() {
+        // Preserve detection in containers that hide proc membership or mounts.
+        return snapshot(&[
+            Domain {
+                mount: "/sys/fs/cgroup".into(),
+                current: "/sys/fs/cgroup".into(),
+                v2: true,
+            },
+            Domain {
+                mount: "/sys/fs/cgroup/memory".into(),
+                current: "/sys/fs/cgroup/memory".into(),
+                v2: false,
+            },
+        ]);
+    }
+    snapshot(&domains)
+}
+
+fn domains(groups: &str, mounts: &str) -> Vec<Domain> {
+    let memberships: Vec<_> = groups
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.splitn(3, ':');
+            fields.next()?;
+            let controllers = fields.next()?;
+            let path = Path::new(fields.next()?);
+            let v2 = controllers.is_empty();
+            (v2 || controllers.split(',').any(|name| name == "memory")).then_some((v2, path))
+        })
+        .collect();
+    mounts
+        .lines()
+        .filter_map(|line| {
+            let (left, right) = line.split_once(" - ")?;
+            let fields: Vec<_> = left.split_whitespace().collect();
+            let mut options = right.split_whitespace();
+            let fs = options.next()?;
+            options.next()?;
+            let super_options = options.next()?;
+            let v2 = match fs {
+                "cgroup2" => true,
+                "cgroup" if super_options.split(',').any(|name| name == "memory") => false,
+                _ => return None,
+            };
+            let root = mount_path(fields.get(3)?)?;
+            let mount = mount_path(fields.get(4)?)?;
+            let (_, member) = memberships
+                .iter()
+                .find(|(version, path)| *version == v2 && path.starts_with(&root))?;
+            // Membership is relative to the cgroup namespace. Mount roots use
+            // that same namespace; component checks reject prefix lookalikes and
+            // proc paths that would escape the visible mount through '..'.
+            if !safe_absolute(member) || !safe_absolute(&root) || !safe_absolute(&mount) {
+                return None;
+            }
+            let current = mount.join(member.strip_prefix(&root).ok()?);
+            Some(Domain { mount, current, v2 })
+        })
+        .collect()
+}
+
+fn safe_absolute(path: &Path) -> bool {
+    path.is_absolute() && !path.components().any(|c| matches!(c, Component::ParentDir))
+}
+
+/// mountinfo escapes spaces, tabs, newlines and backslashes with octal bytes.
+fn mount_path(value: &str) -> Option<PathBuf> {
+    let mut bytes = Vec::new();
+    let mut input = value.as_bytes().iter().copied();
+    while let Some(byte) = input.next() {
+        if byte == b'\\' {
+            let mut decoded = 0u16;
+            for _ in 0..3 {
+                let digit = input.next()?;
+                if !(b'0'..=b'7').contains(&digit) {
+                    return None;
+                }
+                decoded = decoded * 8 + u16::from(digit - b'0');
+            }
+            bytes.push(u8::try_from(decoded).ok()?);
+        } else {
+            bytes.push(byte);
+        }
+    }
+    Some(OsString::from_vec(bytes).into())
+}
+
+fn snapshot(domains: &[Domain]) -> Memory {
+    let mut result = Memory::default();
+    for domain in domains {
+        for directory in domain.current.ancestors() {
+            if !directory.starts_with(&domain.mount) {
+                break;
+            }
+            let (limit_name, usage_name, reclaim_field) = if domain.v2 {
+                ("memory.max", "memory.current", "inactive_file")
+            } else {
+                (
+                    "memory.limit_in_bytes",
+                    "memory.usage_in_bytes",
+                    "total_inactive_file",
+                )
+            };
+            let Some(limit) = std::fs::read_to_string(directory.join(limit_name))
+                .ok()
+                .and_then(|s| {
+                    if s.trim() == "0" {
+                        Some(0)
+                    } else {
+                        read_cgroup_text(&s)
+                    }
+                })
+            else {
+                continue;
+            };
+            let usage = std::fs::read_to_string(directory.join(usage_name))
+                .ok()
+                .and_then(|s| s.trim().parse::<u64>().ok());
+            let reclaimable = std::fs::read_to_string(directory.join("memory.stat"))
+                .ok()
+                .and_then(|s| parse_cgroup_stat(&s, reclaim_field))
+                .unwrap_or(0);
+            let headroom = usage.map_or(limit, |used| {
+                limit.saturating_sub(used.saturating_sub(reclaimable))
+            });
+            result.limit = Some(result.limit.map_or(limit, |old| old.min(limit)));
+            result.headroom = Some(result.headroom.map_or(headroom, |old| old.min(headroom)));
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_memory(path: &Path, limit: &str, usage: u64, inactive: u64, v2: bool) {
+        std::fs::create_dir_all(path).unwrap();
+        let (limit_name, usage_name, field) = if v2 {
+            ("memory.max", "memory.current", "inactive_file")
+        } else {
+            (
+                "memory.limit_in_bytes",
+                "memory.usage_in_bytes",
+                "total_inactive_file",
+            )
+        };
+        std::fs::write(path.join(limit_name), limit).unwrap();
+        std::fs::write(path.join(usage_name), usage.to_string()).unwrap();
+        std::fs::write(path.join("memory.stat"), format!("{field} {inactive}\n")).unwrap();
+    }
+
+    #[test]
+    fn nested_membership_uses_parent_headroom_including_siblings() {
+        let temp = tempfile::tempdir().unwrap();
+        let mount = temp.path();
+        write_memory(mount, "max", 0, 0, true);
+        write_memory(&mount.join("slice"), "1000", 950, 100, true);
+        write_memory(&mount.join("slice/build"), "800", 200, 50, true);
+        let mounts = format!("1 0 0:1 / {} rw - cgroup2 cgroup rw", mount.display());
+        let domains = domains("0::/slice/build\n", &mounts);
+        assert_eq!(
+            snapshot(&domains),
+            Memory {
+                limit: Some(800),
+                headroom: Some(150)
+            }
+        );
+        write_memory(&mount.join("slice"), "1000", 1100, 0, true);
+        assert_eq!(snapshot(&domains).headroom, Some(0));
+    }
+
+    #[test]
+    fn v1_memory_controller_and_subtree_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let mount = temp.path().join("memory mount");
+        write_memory(&mount, "1000", 950, 300, false);
+        write_memory(&mount.join("build"), "9223372036854771712", 100, 0, false);
+        let escaped = mount.to_string_lossy().replace(' ', "\\040");
+        let mounts = format!("1 0 0:1 /slice {escaped} rw - cgroup cgroup rw,memory\n");
+        let found = domains("2:cpu,cpuacct:/other\n3:memory:/slice/build\n", &mounts);
+        assert_eq!(found[0].current, mount.join("build"));
+        assert_eq!(
+            snapshot(&found),
+            Memory {
+                limit: Some(1000),
+                headroom: Some(350)
+            }
+        );
+        assert!(domains("3:memory:/slice-other/build", &mounts).is_empty());
+    }
+
+    #[test]
+    fn bind_mounts_do_not_hide_visible_ancestor_limits() {
+        let temp = tempfile::tempdir().unwrap();
+        let full = temp.path().join("full");
+        let bind = temp.path().join("bind");
+        write_memory(&full, "1000", 900, 0, true);
+        write_memory(&full.join("slice"), "max", 0, 0, true);
+        write_memory(&bind, "max", 0, 0, true);
+        let mounts = format!(
+            "1 0 0:1 /slice {} rw - cgroup2 cgroup rw\n2 0 0:1 / {} rw - cgroup2 cgroup rw",
+            bind.display(),
+            full.display()
+        );
+        assert_eq!(snapshot(&domains("0::/slice", &mounts)).headroom, Some(100));
+    }
+
+    #[test]
+    fn missing_stats_count_all_usage_and_zero_limit_is_real() {
+        let temp = tempfile::tempdir().unwrap();
+        write_memory(temp.path(), "1000", 700, 600, true);
+        let domains = [Domain {
+            mount: temp.path().into(),
+            current: temp.path().into(),
+            v2: true,
+        }];
+        std::fs::remove_file(temp.path().join("memory.stat")).unwrap();
+        assert_eq!(snapshot(&domains).headroom, Some(300));
+        std::fs::write(temp.path().join("memory.max"), "0").unwrap();
+        assert_eq!(
+            snapshot(&domains),
+            Memory {
+                limit: Some(0),
+                headroom: Some(0)
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_mounts_and_escaping_memberships_are_ignored() {
+        let mounts = "broken\n1 0 0:1 / /sys/fs/cgroup rw - cgroup2 cgroup rw";
+        assert!(domains("0::/../escape", mounts).is_empty());
+        assert!(domains("0::relative", mounts).is_empty());
+        assert_eq!(mount_path("/a\\040b\\134c"), Some("/a b\\c".into()));
+        assert!(mount_path("/bad\\999").is_none());
+    }
+}

--- a/crates/mbx/src/lib.rs
+++ b/crates/mbx/src/lib.rs
@@ -22,6 +22,8 @@
 //! whose documentation advertises `store` and `session` invites exactly the
 //! dependency the paragraph above rules out.
 
+#[cfg(target_os = "linux")]
+mod cgroup;
 #[doc(hidden)]
 pub mod cli;
 #[doc(hidden)]

--- a/crates/mbx/src/util.rs
+++ b/crates/mbx/src/util.rs
@@ -336,71 +336,15 @@ pub fn memory_total_bytes() -> Option<u64> {
     #[allow(clippy::useless_conversion)]
     let total = u64::try_from(info.totalram).ok()?;
     let physical = total.checked_mul(unit).filter(|total| *total > 0)?;
-    Some(match cgroup_memory_limit() {
+    Some(match crate::cgroup::memory().limit {
         Some(limit) => physical.min(limit),
         None => physical,
     })
 }
 
-/// The memory ceiling this process's cgroup imposes, if it imposes one.
-///
-/// Read at the root of the cgroup filesystem, which is what a container sees
-/// of its own limit through a cgroup namespace -- the ordinary Docker,
-/// Podman, and Kubernetes arrangement. A process placed in a nested cgroup
-/// *without* such a namespace reads the root's limit instead and is budgeted
-/// as though the nesting were not there; that is the same answer it had
-/// before any of this, so it loses nothing.
-#[cfg(target_os = "linux")]
-fn cgroup_memory_limit() -> Option<u64> {
-    // v2 states "max" for unlimited; v1 states a number so large it means the
-    // same thing, so anything at or above the host's addressable range is
-    // treated as no limit rather than as a budget.
-    read_cgroup_value("/sys/fs/cgroup/memory.max")
-        .or_else(|| read_cgroup_value("/sys/fs/cgroup/memory/memory.limit_in_bytes"))
-}
-
-/// Memory the cgroup is holding that the kernel would not simply reclaim.
-///
-/// Not `memory.current`, which counts the page cache. A build fills that
-/// immediately -- every source it reads and every artifact it writes lands
-/// there -- and nearly all of it is evictable, so a container that had merely
-/// compiled something would look as though it were out of memory. Subtracting
-/// the inactive file pages leaves the working set, which is the same figure
-/// Kubernetes reports for a container and the one worth comparing a
-/// compilation's appetite against.
-#[cfg(target_os = "linux")]
-fn cgroup_memory_usage() -> Option<u64> {
-    let current = read_cgroup_amount("/sys/fs/cgroup/memory.current")
-        .or_else(|| read_cgroup_amount("/sys/fs/cgroup/memory/memory.usage_in_bytes"))?;
-    // Absent or unreadable stats leave the page cache counted, which errs
-    // toward deferring a compilation rather than toward an OOM kill.
-    let reclaimable = read_cgroup_stat("/sys/fs/cgroup/memory.stat", "inactive_file")
-        .or_else(|| read_cgroup_stat("/sys/fs/cgroup/memory/memory.stat", "total_inactive_file"))
-        .unwrap_or(0);
-    Some(current.saturating_sub(reclaimable))
-}
-
-/// One cgroup limit, or `None` for absent, unparseable, or "no limit".
-#[cfg(target_os = "linux")]
-fn read_cgroup_value(path: &str) -> Option<u64> {
-    read_cgroup_text(&std::fs::read_to_string(path).ok()?)
-}
-
-/// One plain cgroup number, where zero is a reading rather than an absence.
-#[cfg(target_os = "linux")]
-fn read_cgroup_amount(path: &str) -> Option<u64> {
-    std::fs::read_to_string(path).ok()?.trim().parse().ok()
-}
-
-/// One field of a cgroup `memory.stat`, which is `name value` per line.
-#[cfg(target_os = "linux")]
-fn read_cgroup_stat(path: &str, field: &str) -> Option<u64> {
-    parse_cgroup_stat(&std::fs::read_to_string(path).ok()?, field)
-}
-
 /// The parsing half, separated so it can be tested without a cgroup mount.
 #[cfg(any(target_os = "linux", test))]
-fn parse_cgroup_stat(contents: &str, field: &str) -> Option<u64> {
+pub(crate) fn parse_cgroup_stat(contents: &str, field: &str) -> Option<u64> {
     contents.lines().find_map(|line| {
         let (name, value) = line.split_once(' ')?;
         (name == field).then(|| value.trim().parse().ok())?
@@ -409,7 +353,7 @@ fn parse_cgroup_stat(contents: &str, field: &str) -> Option<u64> {
 
 /// The parsing half, separated so it can be tested without a cgroup mount.
 #[cfg(any(target_os = "linux", test))]
-fn read_cgroup_text(contents: &str) -> Option<u64> {
+pub(crate) fn read_cgroup_text(contents: &str) -> Option<u64> {
     let value = contents.trim();
     if value == "max" {
         return None;
@@ -471,11 +415,9 @@ pub fn memory_available_bytes() -> Option<u64> {
         .parse::<u64>()
         .ok()?;
     let host = kibibytes.checked_mul(1024)?;
-    let available = match (cgroup_memory_limit(), cgroup_memory_usage()) {
-        (Some(limit), Some(used)) => host.min(limit.saturating_sub(used)),
-        (Some(limit), None) => host.min(limit),
-        _ => host,
-    };
+    let available = crate::cgroup::memory()
+        .headroom
+        .map_or(host, |free| host.min(free));
     // Zero is a real answer here -- a cgroup at its limit has nothing left --
     // and the caller has to be able to tell it from "cannot measure".
     Some(available)


### PR DESCRIPTION
A compiler inside a nested cgroup could be budgeted against the host or namespace root, overlooking a tighter parent limit. Resolve v1 memory and v2 membership through `/proc/self/cgroup` and mountinfo, then cap both total memory and available headroom across visible ancestors. Each ancestor's usage includes sibling workloads; reclaimable inactive file pages remain discounted.

Preserve root-path fallback when proc discovery is unavailable. Cover subtree and escaped mount paths, bind mounts, sibling pressure, exhausted/zero limits, missing statistics, and malformed membership with filesystem fixtures.

Validation: `cargo test -p mbx cgroup --lib` (7 passed); `mise run ci` passed. Inspired by kache's cgroup discovery in kunobi-ninja/kache#895; implemented for mbx's existing memory admission policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux memory admission inputs for the scheduler; incorrect cgroup resolution could over-admit compilations or defer them unnecessarily, but logic is defensive with fallbacks and broad test coverage.
> 
> **Overview**
> **Replaces root-only cgroup reads** with discovery of the process’s actual cgroup path (v1 and v2) via `/proc/self/cgroup` and mountinfo, then walks **every visible ancestor** to compute the tightest **limit** and **headroom**. Headroom uses each ancestor’s full usage (including sibling workloads), still discounting reclaimable inactive file pages from `memory.stat`.
> 
> `memory_total_bytes` and `memory_available_bytes` now delegate to `cgroup::memory()` instead of fixed `/sys/fs/cgroup` paths; cgroup parsing helpers move to `pub(crate)` for reuse. When proc-based discovery fails, behavior falls back to the previous unified cgroup root paths. **Filesystem fixture tests** cover nested slices, v1 subtree mounts, bind mounts, sibling pressure, zero limits, missing stats, and malformed paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90dc97569cf15a6000390c63abe58b93d8206021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->