### PR TITLE
perf(cc): reuse unchanged include directory manifests

### DIFF
--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -632,10 +632,34 @@ fn is_includable(name: &str) -> bool {
 /// of them. A directory that does not exist has an empty manifest, which is
 /// what makes "the directory was created" a key change rather than an error.
 fn include_manifest(directory: &Path, budget: &mut usize) -> Result<CacheDigest, CcBypassReason> {
+    include_manifest_with(directory, budget, &|path| std::fs::read_dir(path))
+}
+
+fn include_manifest_with(
+    directory: &Path,
+    budget: &mut usize,
+    read_dir: &impl Fn(&Path) -> std::io::Result<std::fs::ReadDir>,
+) -> Result<CacheDigest, CcBypassReason> {
+    #[cfg(unix)]
+    if let Some(memo) = manifest_memo::find(directory) {
+        *budget = budget.saturating_add(memo.entries);
+        if *budget > MAX_MANIFEST_ENTRIES {
+            return Err(CcBypassReason::TooManyInputs);
+        }
+        return Ok(memo.digest);
+    }
+    #[cfg(unix)]
+    let mut directories = Vec::new();
+    #[cfg(unix)]
+    let initial_budget = *budget;
     let mut names = Vec::new();
     let mut pending = vec![(directory.to_path_buf(), String::new())];
     while let Some((current, prefix)) = pending.pop() {
-        let entries = match std::fs::read_dir(&current) {
+        // Capture before enumeration and validate again after the complete
+        // walk. A directory changed while being read cannot seed the memo.
+        #[cfg(unix)]
+        directories.push((current.clone(), manifest_memo::Identity::read(&current)));
+        let entries = match read_dir(&current) {
             Ok(entries) => entries,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
             Err(error) => {
@@ -680,7 +704,104 @@ fn include_manifest(directory: &Path, budget: &mut usize) -> Result<CacheDigest,
         }
     }
     names.sort();
-    Ok(CacheDigest::blake3(names.join("\n").as_bytes()))
+    let digest = CacheDigest::blake3(names.join("\n").as_bytes());
+    #[cfg(unix)]
+    manifest_memo::record(directory, &digest, *budget - initial_budget, directories);
+    Ok(digest)
+}
+
+// A wrapper checks the same manifests during prediction, discovery, and
+// publication. Reuse their exact name digest while every directory is unchanged.
+// This is process-local: no persisted timestamps can outlive a filesystem mount.
+#[cfg(unix)]
+mod manifest_memo {
+    use super::*;
+    use std::os::unix::fs::MetadataExt;
+    use std::sync::{Mutex, OnceLock};
+
+    const MAX_ROOTS: usize = 32;
+    const MAX_DIRECTORIES: usize = 4096;
+    static MEMOS: OnceLock<Mutex<BTreeMap<PathBuf, Memo>>> = OnceLock::new();
+
+    #[derive(Clone, PartialEq, Eq)]
+    pub(super) struct Identity {
+        device: u64,
+        inode: u64,
+        modified: (i64, i64),
+        changed: (i64, i64),
+        mode: u32,
+    }
+    impl Identity {
+        pub(super) fn read(path: &Path) -> Option<Self> {
+            let metadata = std::fs::metadata(path).ok()?;
+            // Whole-second timestamps cannot distinguish rapid edits. Preserve
+            // enumeration on filesystems that expose only that precision.
+            if !metadata.is_dir() || metadata.mtime_nsec() == 0 || metadata.ctime_nsec() == 0 {
+                return None;
+            }
+            // Reuse the digest ledger's filesystem qualification. In particular,
+            // Linux NFS identities omit ctime and must keep enumerating names.
+            let changed = FileIdentity::for_digest_cache(path, &metadata)
+                .ok()??
+                .changed?;
+            Some(Self {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+                modified: (metadata.mtime(), metadata.mtime_nsec()),
+                changed,
+                mode: metadata.mode(),
+            })
+        }
+    }
+    #[derive(Clone)]
+    pub(super) struct Memo {
+        pub digest: CacheDigest,
+        pub entries: usize,
+        directories: Vec<(PathBuf, Identity)>,
+    }
+    impl Memo {
+        fn valid(&self) -> bool {
+            self.directories
+                .iter()
+                .all(|(path, identity)| Identity::read(path).as_ref() == Some(identity))
+        }
+    }
+    pub(super) fn find(directory: &Path) -> Option<Memo> {
+        let memo = MEMOS.get()?.lock().ok()?.get(directory)?.clone();
+        memo.valid().then_some(memo)
+    }
+    pub(super) fn record(
+        directory: &Path,
+        digest: &CacheDigest,
+        entries: usize,
+        directories: Vec<(PathBuf, Option<Identity>)>,
+    ) {
+        if directories.is_empty() || directories.len() > MAX_DIRECTORIES {
+            return;
+        }
+        let Some(directories) = directories
+            .into_iter()
+            .map(|(path, identity)| Some((path, identity?)))
+            .collect::<Option<Vec<_>>>()
+        else {
+            return;
+        };
+        let memo = Memo {
+            digest: digest.clone(),
+            entries,
+            directories,
+        };
+        if !memo.valid() {
+            return;
+        }
+        let Ok(mut memos) = MEMOS.get_or_init(Default::default).lock() else {
+            return;
+        };
+        if memos.len() >= MAX_ROOTS {
+            memos.clear();
+        }
+        memos.insert(directory.to_path_buf(), memo);
+    }
 }
 
 /// Whether a preprocessor input can make the assembler read another file.

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -606,3 +606,112 @@ fn a_rendered_caller_depfile_reads_back_and_quotes_like_the_driver() {
     let plain = CcDepfile::render(&targets[1..], &files[..1], Path::new("/src/a.c"), false);
     assert_eq!(plain, "out/a\\ b.o: \\\n /src/a.c\n");
 }
+
+#[cfg(unix)]
+#[test]
+fn unchanged_manifests_reuse_enumeration_but_still_charge_the_budget() {
+    use std::cell::Cell;
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir(root.path().join("nested")).unwrap();
+    for n in 0..1000 {
+        std::fs::write(
+            root.path().join(format!("nested/header{n}.h")),
+            b"#define X 1",
+        )
+        .unwrap();
+    }
+    let reads = Cell::new(0);
+    let enumerate = |path: &Path| {
+        reads.set(reads.get() + 1);
+        std::fs::read_dir(path)
+    };
+    let first = include_manifest_with(root.path(), &mut 0, &enumerate).unwrap();
+    assert_eq!(reads.get(), 2);
+    // Unsupported timestamp precision deliberately preserves the full walk.
+    if manifest_memo::find(root.path()).is_none() {
+        return;
+    }
+    reads.set(0);
+    let mut budget = 0;
+    let second = include_manifest_with(root.path(), &mut budget, &enumerate).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(reads.get(), 0);
+    assert_eq!(budget, 1000);
+    assert!(matches!(
+        include_manifest_with(root.path(), &mut (MAX_MANIFEST_ENTRIES - 999), &enumerate),
+        Err(CcBypassReason::TooManyInputs)
+    ));
+    assert_eq!(reads.get(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn memo_detects_nested_header_creation_removal_and_precompiled_headers() {
+    let root = tempfile::tempdir().unwrap();
+    let nested = root.path().join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    std::fs::write(nested.join("a.h"), b"#define X 1").unwrap();
+    let original = include_manifest(root.path(), &mut 0).unwrap();
+    for name in ["optional.h", "a.h.gch", "new.inc"] {
+        std::fs::write(nested.join(name), b"new").unwrap();
+        let changed = include_manifest(root.path(), &mut 0).unwrap();
+        assert_ne!(original, changed, "{name} appearing must invalidate");
+        std::fs::remove_file(nested.join(name)).unwrap();
+        assert_eq!(original, include_manifest(root.path(), &mut 0).unwrap());
+    }
+    let new_dir = nested.join("new");
+    std::fs::create_dir(&new_dir).unwrap();
+    std::fs::write(new_dir.join("a.h"), b"another").unwrap();
+    assert_ne!(original, include_manifest(root.path(), &mut 0).unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn memo_does_not_mask_directory_replacement_or_missing_roots() {
+    let root = tempfile::tempdir().unwrap();
+    let include = root.path().join("include");
+    let empty = include_manifest(&include, &mut 0).unwrap();
+    std::fs::create_dir(&include).unwrap();
+    std::fs::write(include.join("a.h"), b"a").unwrap();
+    let first = include_manifest(&include, &mut 0).unwrap();
+    assert_ne!(empty, first);
+    std::fs::rename(&include, root.path().join("old")).unwrap();
+    std::fs::create_dir(&include).unwrap();
+    std::fs::write(include.join("b.h"), b"b").unwrap();
+    assert_ne!(first, include_manifest(&include, &mut 0).unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn mutation_during_enumeration_does_not_seed_a_stale_memo() {
+    use std::cell::Cell;
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("a.h"), b"a").unwrap();
+    let mutated = Cell::new(false);
+    let enumerate = |path: &Path| {
+        let entries = std::fs::read_dir(path)?;
+        if !mutated.replace(true) {
+            std::fs::write(path.join("b.h"), b"b")?;
+        }
+        Ok(entries)
+    };
+    include_manifest_with(root.path(), &mut 0, &enumerate).unwrap();
+    assert!(manifest_memo::find(root.path()).is_none());
+    let stable = include_manifest(root.path(), &mut 0).unwrap();
+    assert_eq!(stable, include_manifest(root.path(), &mut 0).unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn restoring_directory_mtime_does_not_hide_a_new_header() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("a.h"), b"a").unwrap();
+    let modified = root.path().metadata().unwrap().modified().unwrap();
+    let before = include_manifest(root.path(), &mut 0).unwrap();
+    std::fs::write(root.path().join("b.h"), b"b").unwrap();
+    std::fs::File::open(root.path())
+        .unwrap()
+        .set_modified(modified)
+        .unwrap();
+    assert_ne!(before, include_manifest(root.path(), &mut 0).unwrap());
+}


### PR DESCRIPTION
A C/C++ wrapper enumerates include trees repeatedly while validating a prediction, discovering inputs, and checking publication. Reuse the exact existing name-manifest digest when every traversed directory retains its device/inode, modification/change timestamps, and mode. Validate identities before reusing a memo and after the initial enumeration; bound the process-local memo and charge its entries against the original input budget on every hit.

This adapts the goal of kunobi-ninja/kache#933 conservatively: retain complete include-name manifests so optional headers, header shadowing, and implicit precompiled headers still invalidate the key. Missing directories, coarse timestamps, Linux NFS identities without a reliable change token, and Windows keep the original enumeration path. It does not persist predictions across wrapper processes or remove the initial manifest-entry cap.

Validation: `mise run ci` passed. Regression tests cover nested header additions/removals, new subdirectories, precompiled headers, replaced and absent directories, mutations during enumeration, restored mtimes, and budget enforcement. A 1,000-header fixture performs two directory enumerations initially and zero on an unchanged repeat; this is an operation-count check, not a claimed end-to-end build speedup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how include-directory name manifests are computed for cache keys; incorrect memo invalidation could miss new shadowing headers or PCH substitution, though the design re-validates identities and skips unsafe filesystems.
> 
> **Overview**
> On **Unix**, repeated walks of the same include directory tree during input discovery and manifest snapshots can skip `read_dir` when a process-local memo still matches every traversed directory’s device/inode, nanosecond mtime/ctime, and mode.
> 
> `include_manifest` now delegates to **`include_manifest_with`** (injectable directory enumeration for tests). After a full walk it may **record** digest, entry count, and per-directory identities; on a **hit** it returns the cached Blake3 name manifest but still **adds the memo’s entry count to `MAX_MANIFEST_ENTRIES` budget** so limits behave like a fresh enumeration.
> 
> Memo seeding is **conservative**: no cache on coarse timestamps, paths where **`FileIdentity`** cannot supply ctime (e.g. Linux NFS), directories that change mid-walk, or when identity re-check fails after recording. **`manifest_memo`** caps stored roots and clears when full.
> 
> New **Unix regression tests** cover zero extra enumerations on unchanged trees, budget charging on hits, header/PCH/shadow invalidation, directory replacement, concurrent mutation during enumeration, and mtime restore tricks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023386130607a6e4822ec39b04353c9f0efc4ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->