### PR TITLE
fix(gc): distinguish logical removal from physical reclamation

### DIFF
--- a/crates/mbx/src/cli/cache.rs
+++ b/crates/mbx/src/cli/cache.rs
@@ -269,6 +269,8 @@ pub(super) struct CacheStatsReport {
 #[derive(serde::Serialize)]
 pub(super) struct GcReport {
     pub(super) version: u8,
+    /// Byte counts sum file lengths, not physical blocks released.
+    pub(super) byte_accounting: &'static str,
     pub(super) max_bytes: u64,
     pub(super) dry_run: bool,
     pub(super) action_store: GcActionStoreReport,
@@ -368,7 +370,7 @@ pub(super) fn cache_remove(config: &Config, workspace: &Path) -> Result<()> {
             },
         );
         println!(
-            "freed managed target directory ({})",
+            "removed managed target directory ({} logical)",
             ByteSize::b(bytes).display().iec()
         );
     }

--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -143,7 +143,7 @@ fn cargo_with_settings_bypass_log_and_roots(
     };
     if let Some(bytes) = removed_target_bytes {
         crate::session::note(&format!(
-            "mbx[gc]: freed {} by removing the existing target/ directory",
+            "mbx[gc]: removed the existing target/ directory ({} logical)",
             ByteSize::b(bytes).display().iec()
         ));
     }

--- a/crates/mbx/src/cli/gc.rs
+++ b/crates/mbx/src/cli/gc.rs
@@ -105,6 +105,7 @@ pub(super) fn run(
         let pruned = pruned?;
         print_json(&GcReport {
             version: 1,
+            byte_accounting: "logical",
             max_bytes,
             dry_run,
             action_store: GcActionStoreReport {
@@ -137,9 +138,9 @@ fn print_incremental_removals(outcome: &crate::incremental::PruneOutcome, dry_ru
     if outcome.removed_directories == 0 {
         return;
     }
-    let verb = if dry_run { "would free" } else { "freed" };
+    let verb = if dry_run { "would remove" } else { "removed" };
     println!(
-        "{verb} {} learned incremental directories ({})",
+        "{verb} {} learned incremental directories ({} logical)",
         outcome.removed_directories,
         ByteSize::b(outcome.removed_bytes).display().iec()
     );
@@ -181,9 +182,9 @@ pub(super) fn print_gc_store_outcome(outcome: &store::GcOutcome, dry_run: bool) 
 
 /// One line describing the target directories a sweep freed.
 pub(super) fn target_removals(outcome: &target::CollectionOutcome, dry_run: bool) -> String {
-    let verb = if dry_run { "would free" } else { "freed" };
+    let verb = if dry_run { "would remove" } else { "removed" };
     format!(
-        "{verb} {} target directories ({}, {} abandoned and {} live); {} remain",
+        "{verb} {} target directories ({} logical, {} abandoned and {} live); {} logical remain",
         outcome.removed_views,
         ByteSize::b(outcome.removed_bytes).display().iec(),
         outcome.removed_stale_views,
@@ -198,7 +199,7 @@ pub(super) fn target_removals(outcome: &target::CollectionOutcome, dry_run: bool
 /// describing the same outcome two different ways.
 pub(super) fn evictions(outcome: &store::GcOutcome) -> String {
     format!(
-        "evicted {} objects and {} action results ({}); {} remain",
+        "evicted {} objects and {} action results ({} logical); {} logical remain",
         outcome.removed_objects,
         outcome.removed_action_results,
         ByteSize::b(outcome.removed_bytes).display().iec(),

--- a/crates/mbx/src/savings.rs
+++ b/crates/mbx/src/savings.rs
@@ -42,13 +42,15 @@ pub(crate) struct Tally {
     pub cached_compilations: u64,
     pub avoided_compiler_ns: u64,
     pub reflinked_bytes: u64,
+    /// Sum of removed file lengths; does not measure physical reclamation.
     pub freed_target_bytes: u64,
+    /// Logical bytes removed from the store.
     pub freed_store_bytes: u64,
-    /// Automatic sweeps only. Older ledgers combined automatic and explicit GC,
+    /// Logical bytes removed by automatic sweeps only. Older ledgers combined automatic and explicit GC,
     /// so this counter has its own start date instead of backfilling a guess.
     pub auto_pruned_bytes: u64,
     pub auto_pruned_since_secs: u64,
-    /// Bytes the user asked to have removed: a confirmed `target/` migration,
+    /// Logical bytes the user asked to have removed: a confirmed `target/` migration,
     /// or `mbx cache remove`. Kept apart from the collection counters because
     /// every line about those brags that nobody had to do anything -- which is
     /// exactly untrue of a removal somebody confirmed.
@@ -69,7 +71,9 @@ pub(crate) struct Delta {
     pub cached_compilations: u64,
     pub avoided_compiler_ns: u64,
     pub reflinked_bytes: u64,
+    /// Sum of removed file lengths; does not measure physical reclamation.
     pub freed_target_bytes: u64,
+    /// Logical bytes removed from the store.
     pub freed_store_bytes: u64,
     pub auto_pruned_bytes: u64,
     pub freed_requested_bytes: u64,
@@ -259,25 +263,25 @@ fn facts_worth_telling(tally: &Tally, facts: &SessionFacts) -> Vec<Candidate> {
         });
     }
     if freed >= MIN_FREED_BYTES {
-        let size = iec(freed);
+        let size = format!("{} logical", iec(freed));
         eligible.push(Candidate {
             cheeky: tellings![
                 "mbx[savings]: {size} of build debris binned so far. cargo clean remains unemployed.",
                 "mbx[savings]: has quietly disposed of {size} of build leftovers. nobody saw anything.",
-                "mbx[savings]: {size} reclaimed to date. the disk sends its regards.",
+                "mbx[savings]: {size} of old files removed to date. the broom sends its regards.",
                 "mbx[savings]: {size} of build debris has left the building.",
                 "mbx[savings]: swept up {size} so far. the broom is content-addressed.",
                 "mbx[savings]: {size} tidied away. you may continue not thinking about it.",
-                "mbx[savings]: {size} reclaimed while you were busy compiling other things.",
+                "mbx[savings]: {size} of old files removed while you were busy compiling other things.",
                 "mbx[savings]: {size} of old build output has been shown the door.",
                 "mbx[savings]: disposed of {size} without being asked. that is rather the point.",
                 "mbx[savings]: the sweep found {size} nobody would miss. nobody has.",
             ],
-            plain: format!("mbx[savings]: {size} reclaimed by collection so far"),
+            plain: format!("mbx[savings]: {size} of files removed by collection so far"),
         });
     }
     if tally.freed_target_bytes >= MIN_FREED_TARGET_BYTES {
-        let size = iec(tally.freed_target_bytes);
+        let size = format!("{} logical", iec(tally.freed_target_bytes));
         eligible.push(Candidate {
             cheeky: tellings![
                 "mbx[savings]: {size} of target/ had outlived its checkouts. it has been dealt with.",
@@ -291,7 +295,7 @@ fn facts_worth_telling(tally: &Tally, facts: &SessionFacts) -> Vec<Candidate> {
                 "mbx[savings]: escorted {size} of ownerless outputs off the premises.",
                 "mbx[savings]: worktrees come and go. their {size} now goes with them.",
             ],
-            plain: format!("mbx[savings]: {size} of abandoned target directories reclaimed"),
+            plain: format!("mbx[savings]: {size} of abandoned target directories removed"),
         });
     }
     if tally.reflinked_bytes >= MIN_REFLINKED_BYTES {

--- a/crates/mbx/src/stats.rs
+++ b/crates/mbx/src/stats.rs
@@ -54,6 +54,7 @@ pub(crate) struct Report {
 
 #[derive(Serialize)]
 pub(crate) struct Lifetime {
+    byte_accounting: &'static str,
     since_unix_secs: Option<u64>,
     builds: u64,
     cached_compilations: u64,
@@ -96,6 +97,7 @@ pub(crate) fn collect(store: &Path, target_root: &Path) -> Result<Report> {
 impl From<&savings::Tally> for Lifetime {
     fn from(tally: &savings::Tally) -> Self {
         Self {
+            byte_accounting: "logical",
             since_unix_secs: (tally.since_secs > 0).then_some(tally.since_secs),
             builds: tally.builds,
             cached_compilations: tally.cached_compilations,
@@ -118,6 +120,10 @@ fn size(bytes: u64) -> String {
     ByteSize::b(bytes).display().iec().to_string()
 }
 
+fn logical_size(bytes: u64) -> String {
+    format!("{} logical", size(bytes))
+}
+
 impl Lifetime {
     pub(crate) fn since(&self) -> String {
         self.since_unix_secs
@@ -135,13 +141,13 @@ impl Lifetime {
             ),
             ("builds", self.builds.to_string()),
             ("cache hits", self.cached_compilations.to_string()),
-            ("pruned by mbx", size(self.pruned_bytes)),
+            ("pruned by mbx", logical_size(self.pruned_bytes)),
             (
                 "  targets / cache",
                 format!(
                     "{} / {}",
-                    size(self.pruned_target_bytes),
-                    size(self.pruned_store_bytes)
+                    logical_size(self.pruned_target_bytes),
+                    logical_size(self.pruned_store_bytes)
                 ),
             ),
             (
@@ -151,13 +157,16 @@ impl Lifetime {
                     |since| {
                         format!(
                             "{} {}",
-                            size(self.automatically_pruned_bytes),
+                            logical_size(self.automatically_pruned_bytes),
                             savings::since(since)
                         )
                     },
                 ),
             ),
-            ("requested removals", size(self.requested_removal_bytes)),
+            (
+                "requested removals",
+                logical_size(self.requested_removal_bytes),
+            ),
             (
                 "copying avoided",
                 format!("{} reflinked (cumulative)", size(self.reflinked_bytes)),
@@ -170,7 +179,7 @@ impl Lifetime {
         if self.automatically_pruned_bytes > 0 {
             Some(format!(
                 "{} taken out with the trash. You did not lift a finger.",
-                size(self.automatically_pruned_bytes)
+                logical_size(self.automatically_pruned_bytes)
             ))
         } else if self.cached_compilations > 0 {
             Some(format!(
@@ -218,7 +227,7 @@ impl Report {
             "Sharing is a lower-bound estimate of logical cache bytes, excluding targets.".into(),
         );
         lines.push(
-            "Pruned totals include automatic sweeps and mbx gc; requested removals are separate."
+            "Pruned totals are logical file sizes, not physical space reclaimed; requested removals are separate."
                 .into(),
         );
         lines.push("Compiler time and reflinked bytes are cumulative, not wall time or current disk savings.".into());

--- a/crates/mbx/src/tui/dashboard.rs
+++ b/crates/mbx/src/tui/dashboard.rs
@@ -116,7 +116,7 @@ pub(super) fn header(frame: &mut Frame, area: Rect, app: &App) {
             .use_unicode(true),
         Rect::new(store.x, store.y + 1, store.width, 1),
     );
-    let evictions = card(frame, columns[2], "Evictions / 5m", theme::PURPLE);
+    let evictions = card(frame, columns[2], "Evictions / 5m · logical", theme::PURPLE);
     frame.render_widget(
         Paragraph::new(vec![
             Line::from(vec![
@@ -130,7 +130,7 @@ pub(super) fn header(frame: &mut Frame, area: Rect, app: &App) {
                 ),
             ]),
             Line::styled(
-                format!("{} lifetime", size(app.savings.freed_store_bytes)),
+                format!("{} logical lifetime", size(app.savings.freed_store_bytes)),
                 Style::new().fg(theme::MUTED),
             ),
         ]),
@@ -425,7 +425,7 @@ pub(super) fn store(frame: &mut Frame, area: Rect, app: &App) -> bool {
     }
     notes.extend([
         Line::styled(
-            "Pruned totals include automatic sweeps and mbx gc. Requested removals are separate.",
+            "Pruned totals are logical file sizes, not physical space reclaimed. Requested removals are separate.",
             Style::new().fg(theme::MUTED),
         ),
         Line::styled(

--- a/crates/mbx/src/tui/ui.rs
+++ b/crates/mbx/src/tui/ui.rs
@@ -209,13 +209,13 @@ pub(super) fn pressure(frame: &mut Frame, area: Rect, app: &App) {
     let thrashing = app.health.possible_thrashing(app.store_budget);
     let message = if thrashing {
         format!(
-            "! POSSIBLE CACHE THRASHING · {} evicted / 5m · {:.0}% misses",
+            "! POSSIBLE CACHE THRASHING · {} logical evicted / 5m · {:.0}% misses",
             size(app.health.evicted),
             app.health.miss_rate()
         )
     } else {
         format!(
-            "Evicted {} / 5m · {} total{}",
+            "Evicted {} logical / 5m · {} logical total{}",
             size(app.health.evicted),
             size(app.savings.freed_store_bytes),
             if app.gc_auto { "" } else { " · auto GC off" }
@@ -750,7 +750,7 @@ fn store_lines(app: &App, width: u16) -> Vec<Line<'static>> {
         if app.gc_auto { "on" } else { "off" }
     )));
     lines.push(Line::from(format!(
-        "evicted while watching (last 5m): {}",
+        "evicted while watching (last 5m): {} logical",
         size(app.health.evicted)
     )));
     lines.push(Line::from(format!(
@@ -763,7 +763,7 @@ fn store_lines(app: &App, width: u16) -> Vec<Line<'static>> {
             Style::new().fg(theme::MISS).bold(),
         ));
         lines.push(Line::from(format!(
-            "{} evicted with {:.0}% misses in the last 5m.",
+            "{} logical evicted with {:.0}% misses in the last 5m.",
             size(app.health.evicted),
             app.health.miss_rate()
         )));
@@ -811,7 +811,7 @@ fn store_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     }
     lines.push(Line::default());
     lines.push(Line::from(
-        "Pruned totals include automatic sweeps and mbx gc.",
+        "Pruned totals are logical file sizes, not physical space reclaimed.",
     ));
     lines.push(Line::from(
         "Reflinks are cumulative, not current disk savings.",

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -2685,7 +2685,7 @@ mod target_views {
             "the target directory of a checkout that is gone should be freed"
         );
         assert!(
-            output.contains("freed 1 target directories"),
+            output.contains("removed 1 target directories"),
             "gc should say what it freed: {output}"
         );
     }
@@ -2765,11 +2765,11 @@ mod target_views {
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
-            stdout.contains("freed 1 target directories"),
+            stdout.contains("removed 1 target directories"),
             "successful target collection should still be reported"
         );
         assert!(
-            stdout.contains("freed 1 learned incremental directories"),
+            stdout.contains("removed 1 learned incremental directories"),
             "successful incremental collection should still be reported: {stdout}"
         );
         assert!(

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -137,3 +137,17 @@ workspaces and are reclaimed by normal garbage collection.
 Creating the link requires Developer Mode or a privileged process on Windows.
 If Windows cannot create it, mbx lets Cargo use its ordinary target directory.
 :::
+
+### Collection byte counts
+
+Collection reports **logical bytes**: the sum of removed file lengths. The
+`removed_bytes` and `remaining_bytes` fields in `mbx gc --json` use this measure;
+`byte_accounting: "logical"` identifies it explicitly. The lifetime `savings`
+object in `mbx stats --json` also carries that marker. Lifetime savings totals
+and cleanup messages use the same measure. Existing `freed_*_bytes` fields in
+the saved lifetime tally retain their names for compatibility.
+
+Physical disk space released can differ. Reflinks and hard links may leave data
+referenced by another file; sparse files may occupy fewer blocks than their
+length. Filesystem snapshots and delayed allocation also affect reclamation.
+These counters do not estimate physical space released.

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -125,6 +125,7 @@ setup() {
   run "$MBX_BIN" gc --json
   assert_success
   assert_output --partial '"action_store"'
+  assert_output --partial '"byte_accounting": "logical"'
   assert_output --partial '"targets"'
 
   run "$MBX_BIN" doctor --json


### PR DESCRIPTION
Cleanup currently sums file lengths but describes the total as disk space freed. With reflinks, hard links, sparse files, snapshots, or delayed allocation, that number can differ from physical reclamation.

Label GC, target-removal, TUI, and lifetime collection totals as logical bytes removed. Add `byte_accounting: "logical"` to `mbx gc --json` and the lifetime savings object in `mbx stats --json`, and document the semantics. Existing numeric JSON fields and persisted `freed_*_bytes` tally fields keep their names and values for compatibility; physical space released is not estimated.

Validation: `mise run ci` passes, including the updated cleanup integration assertions. No collection or retention behavior changes.

Inspired by kunobi-ninja/kache#870 and #937.
