### PR TITLE
test(cache): compare semantic changes against bare rustc

### DIFF
--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -10,6 +10,9 @@ use std::process::Command;
 #[cfg(unix)]
 use std::process::Stdio;
 
+#[path = "build/semantic_oracle.rs"]
+mod semantic_oracle;
+
 fn write_project(directory: &Path) {
     write_named_project(directory, "fixture");
 }

--- a/crates/mbx/tests/build/semantic_oracle.rs
+++ b/crates/mbx/tests/build/semantic_oracle.rs
@@ -1,0 +1,221 @@
+//! A real compiler is the authority for whether a perturbation changes behavior.
+//! Every case proves a hit before the edit, then compares the changed cached
+//! build with an uncached rustc build and requires that the old entry missed.
+use super::*;
+
+#[derive(Clone, Copy)]
+struct State {
+    cfg: &'static str,
+    environment: &'static str,
+    included: &'static str,
+    module_a: &'static str,
+    module_b: &'static str,
+    assertions: bool,
+}
+
+const BASE: State = State {
+    cfg: "oracle_a",
+    environment: "env-a",
+    included: "include-a",
+    module_a: "a",
+    module_b: "b",
+    assertions: false,
+};
+
+fn write_state(project: &Path, state: State) {
+    std::fs::write(project.join("src/value.txt"), state.included).unwrap();
+    for (module, value) in [("a", state.module_a), ("b", state.module_b)] {
+        std::fs::write(
+            project.join(format!("src/{module}.rs")),
+            format!("pub fn value() -> &'static str {{ {value:?} }}\n"),
+        )
+        .unwrap();
+    }
+}
+
+fn succeeded(command: &mut Command) -> std::process::Output {
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{command:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+/// Link an observer against the produced library so an rlib's runtime behavior,
+/// rather than its path or incidental binary metadata, is what gets compared.
+fn observe(library: &Path) -> String {
+    let observer = tempfile::tempdir().unwrap();
+    let source = observer.path().join("observe.rs");
+    let executable = observer
+        .path()
+        .join(format!("observe{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&source, "fn main() { print!(\"{}\", fixture::value()); }\n").unwrap();
+    succeeded(
+        Command::new("rustc")
+            .arg(&source)
+            .args(["--edition=2021", "--extern"])
+            .arg(format!("fixture={}", library.display()))
+            .arg("-o")
+            .arg(&executable),
+    );
+    String::from_utf8(succeeded(&mut Command::new(executable)).stdout).unwrap()
+}
+
+fn bare(project: &Path, state: State) -> String {
+    write_state(project, state);
+    let output = tempfile::tempdir().unwrap();
+    let library = output.path().join("libfixture.rlib");
+    let assertion_flags = if state.assertions {
+        ["-Cdebug-assertions=no", "-Cdebug-assertions=yes"]
+    } else {
+        ["-Cdebug-assertions=yes", "-Cdebug-assertions=no"]
+    };
+    succeeded(
+        Command::new("rustc")
+            .current_dir(project)
+            .args([
+                "--crate-type=rlib",
+                "--crate-name=fixture",
+                "--edition=2021",
+                "src/lib.rs",
+                "--cfg",
+                state.cfg,
+                "-o",
+            ])
+            .arg(&library)
+            .args(assertion_flags)
+            .env("ORACLE_VALUE", state.environment),
+    );
+    observe(&library)
+}
+
+fn cached(project: &Path, store: &Path, state: State) -> (String, serde_json::Value) {
+    write_state(project, state);
+    let target = project.join("target");
+    if target.exists() {
+        std::fs::remove_dir_all(&target).unwrap();
+    }
+    let report = tempfile::tempdir().unwrap();
+    let assertion_flags = if state.assertions {
+        ["-Cdebug-assertions=no", "-Cdebug-assertions=yes"]
+    } else {
+        ["-Cdebug-assertions=yes", "-Cdebug-assertions=no"]
+    };
+    let flags = format!(
+        "--cfg {} {} {}",
+        state.cfg, assertion_flags[0], assertion_flags[1]
+    );
+    let encoded_flags = flags.split_whitespace().collect::<Vec<_>>().join("\x1f");
+    let (stats, _) = build_with(
+        project,
+        store,
+        &report.path().join("stats.json"),
+        &[
+            ("MBX_TARGET_VIEWS", "0"),
+            ("MBX_INCREMENTAL", "0"),
+            ("MBX_LEARNED_INCREMENTAL", "0"),
+            ("MBX_VERIFY", "0"),
+            ("MBX_VERIFY_SAMPLE_RATE", "0"),
+            ("RUSTFLAGS", &flags),
+            ("CARGO_ENCODED_RUSTFLAGS", &encoded_flags),
+            ("ORACLE_VALUE", state.environment),
+        ],
+    );
+    (observe(&target.join("debug/libfixture.rlib")), stats)
+}
+
+#[test]
+fn semantic_changes_miss_and_match_bare_rustc() {
+    let cases = [
+        (
+            "cfg value",
+            State {
+                cfg: "oracle_b",
+                ..BASE
+            },
+        ),
+        (
+            "last-wins codegen order",
+            State {
+                assertions: true,
+                ..BASE
+            },
+        ),
+        (
+            "env! value",
+            State {
+                environment: "env-b",
+                ..BASE
+            },
+        ),
+        (
+            "include_str! contents",
+            State {
+                included: "include-b",
+                ..BASE
+            },
+        ),
+        (
+            "module path-to-content mapping",
+            State {
+                module_a: BASE.module_b,
+                module_b: BASE.module_a,
+                ..BASE
+            },
+        ),
+    ];
+    for (name, changed) in cases {
+        let project = tempfile::tempdir().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        write_project(project.path());
+        std::fs::write(
+            project.path().join("src/lib.rs"),
+            r#"
+mod a;
+mod b;
+pub fn value() -> String {
+    format!("{}|{}|{}|{}|{}|{}", cfg!(debug_assertions), if cfg!(oracle_b) { "b" } else { "a" },
+        env!("ORACLE_VALUE"), include_str!("value.txt"), a::value(), b::value())
+}
+"#,
+        )
+        .unwrap();
+        let before = bare(project.path(), BASE);
+        let after = bare(project.path(), changed);
+        assert_ne!(
+            before, after,
+            "{name}: rustc must prove the change affects behavior"
+        );
+
+        let (actual, cold) = cached(project.path(), store.path(), BASE);
+        assert_eq!(actual, before, "{name}: cold build");
+        assert_eq!(count(&cold, "hits"), 0, "{name}: {cold}");
+        let (actual, warm) = cached(project.path(), store.path(), BASE);
+        assert_eq!(actual, before, "{name}: warm build");
+        assert_eq!(
+            count(&warm, "hits"),
+            1,
+            "{name}: unchanged input must hit: {warm}"
+        );
+
+        let (actual, edited) = cached(project.path(), store.path(), changed);
+        assert_eq!(
+            actual, after,
+            "{name}: changed cached build must match bare rustc"
+        );
+        assert_eq!(
+            count(&edited, "hits"),
+            0,
+            "{name}: semantic edit must miss: {edited}"
+        );
+        let (actual, warm) = cached(project.path(), store.path(), changed);
+        assert_eq!(actual, after, "{name}: repeated changed build");
+        assert_eq!(
+            count(&warm, "hits"),
+            1,
+            "{name}: changed input must become cacheable: {warm}"
+        );
+    }
+}


### PR DESCRIPTION
Add a behavioral cache oracle that uses bare rustc to establish the result of each semantic change, then links and executes an observer against the library built through mbx.

Each case proves that the original input becomes a real cache hit, the semantic edit misses and matches bare rustc, and the edited input becomes a hit on repetition. Cases cover cfg values, last-wins codegen argument ordering, `env!`, `include_str!`, and swapping module contents between paths. The fixture has no external dependencies and disables incremental compilation and shadow verification so neither can hide a false hit.

Validation: `mise run ci` passes, including all five real-compiler oracle cases.

Inspired by kunobi-ninja/kache#855.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production cache logic; CI cost may rise slightly due to real `rustc` invocations per case.
> 
> **Overview**
> Adds a **semantic cache oracle** integration test module wired into `build.rs`, using **bare `rustc` plus a linked observer binary** as the behavioral ground truth instead of trusting cache stats alone.
> 
> For each perturbation—`cfg` flags, **last-wins** `-Cdebug-assertions` ordering, `env!`, `include_str!`, and swapping module contents across paths—the test proves unchanged inputs **miss then hit**, semantic edits **miss with output matching bare rustc**, and the edited state **hits on repeat**. Cached runs go through existing `build_with` with incremental compilation, learned incremental, and shadow verification disabled so those paths cannot mask a false hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09c6d8a1292f5be0b91d339cf8e16983f809abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->