### PR TITLE
feat(cc): cache named preprocessor outputs

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -251,14 +251,12 @@ fn linking_without_dash_c_is_not_a_compile() {
 }
 
 #[test]
-fn preprocess_and_assembly_modes_bypass_as_non_object_output() {
-    for mode in ["-E", "-S"] {
-        let arguments = argv(&[mode, "-o", "out", "main.c"]);
-        assert_eq!(
-            CcInvocation::parse(&arguments).unwrap_err().kind(),
-            "non-object-output"
-        );
-    }
+fn assembly_modes_bypass_as_non_object_output() {
+    let arguments = argv(&["-S", "-o", "out", "main.c"]);
+    assert_eq!(
+        CcInvocation::parse(&arguments).unwrap_err().kind(),
+        "non-object-output"
+    );
 }
 
 /// `-M` and `-MM` stop after preprocessing, `-MG` changes what a missing
@@ -1221,5 +1219,89 @@ fn debug_dialects_and_levels_have_distinct_action_keys() {
     }
     for flag in ["-ggdb4", "-gfull-extra", "-gmodules", "-gsplit-dwarf"] {
         assert!(CcInvocation::parse(&argv(&[flag, "-c", "-o", "out.o", "src/a.c"])).is_err());
+    }
+}
+
+#[test]
+fn preprocessing_requires_a_named_output_and_unambiguous_dependencies() {
+    for flags in [
+        vec!["-E", "main.c"],
+        vec!["-E", "main.c", "-o", "-"],
+        vec!["-E", "main.c", "-o", "main.i", "-MD"],
+        vec!["-E", "main.c", "-o", "main.i", "-MMD"],
+        vec!["-E", "main.c", "-o", "main.i", "-MD", "-MF", "-"],
+        vec!["-E", "-x", "c", "/", "-o", "main.i", "-MD", "-MF", "main.d"],
+    ] {
+        assert!(CcInvocation::parse(&argv(&flags)).is_err(), "{flags:?}");
+    }
+    let invocation = CcInvocation::parse(&argv(&[
+        "-E", "main.c", "-o", "main.i", "-MD", "-MF", "main.d",
+    ]))
+    .unwrap();
+    assert!(invocation.is_preprocessing());
+    assert_eq!(invocation.output(), Path::new("main.i"));
+    assert_eq!(
+        invocation.caller_depfile().unwrap().path,
+        Path::new("main.d")
+    );
+}
+
+#[test]
+fn preprocessor_keys_retain_checkout_and_argument_spellings() {
+    let (first, first_target) = checkout("first");
+    let (second, second_target) = checkout("second");
+    let invocation = CcInvocation::parse(&argv(&["-E", "main.c", "-o", "main.i"])).unwrap();
+    let digest = invocation
+        .invocation_digest(&context(&first, &first_target))
+        .unwrap();
+    assert_ne!(
+        digest,
+        invocation
+            .invocation_digest(&context(&second, &second_target))
+            .unwrap()
+    );
+    let spelled = CcInvocation::parse(&argv(&["-E", "./main.c", "-o", "main.i"])).unwrap();
+    assert_ne!(
+        digest,
+        spelled
+            .invocation_digest(&context(&first, &first_target))
+            .unwrap()
+    );
+    let compiled = CcInvocation::parse(&argv(&["-c", "main.c", "-o", "main.i"])).unwrap();
+    assert_ne!(
+        digest,
+        compiled
+            .invocation_digest(&context(&first, &first_target))
+            .unwrap()
+    );
+}
+
+#[test]
+fn preprocessing_dependency_targets_follow_the_driver_family() {
+    let arguments = argv(&[
+        "-E",
+        "src/main.c",
+        "-o",
+        "result.i",
+        "-MD",
+        "-MF",
+        "result.d",
+    ]);
+    for (family, expected) in [
+        (CcCompilerFamily::Gcc, "main.o"),
+        (CcCompilerFamily::Clang, "result.i"),
+    ] {
+        let invocation = CcInvocation::parse_for(&arguments, family).unwrap();
+        assert_eq!(
+            invocation.caller_depfile().unwrap().targets[0].name,
+            expected
+        );
+        let mut explicit = arguments.clone();
+        explicit.extend(argv(&["-MT", "custom"]));
+        let invocation = CcInvocation::parse_for(&explicit, family).unwrap();
+        assert_eq!(
+            invocation.caller_depfile().unwrap().targets[0].name,
+            "custom"
+        );
     }
 }

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Cargo build scripts using the `cc` crate compile C and C++ through a
 //! gcc-style driver. This adapter models the narrow shape those build scripts
-//! produce -- one source, one object, `-c` -- and rejects everything else. As
+//! produce -- one source, one object, `-c` -- plus named `-E` output. As
 //! in the rustc adapter, callers should treat [`CcBypassReason`] as a safe
 //! cache bypass: run the real compiler and publish nothing.
 //!
@@ -248,6 +248,7 @@ const SUPPORTED_G_FLAGS: &[&str] = &[
 ];
 
 const SUPPORTED_BARE_FLAGS: &[&str] = &[
+    "-P", // Suppress preprocessor line markers; keyed even without -E.
     "-ansi",
     "-nostdinc",
     "-nostdinc++",
@@ -682,6 +683,8 @@ struct CcActionDescriptor {
     adapter_version: u8,
     #[serde(skip_serializing_if = "Option::is_none")]
     assembly_input_model: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preprocessing: Option<PreprocessingContext>,
     compiler: CcCompilerDescriptor,
     arguments: Vec<String>,
     environment: BTreeMap<String, Option<String>>,
@@ -695,9 +698,20 @@ struct CcInvocationDescriptor {
     adapter_version: u8,
     #[serde(skip_serializing_if = "Option::is_none")]
     assembly_input_model: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preprocessing: Option<PreprocessingContext>,
     compiler: CcCompilerDescriptor,
     arguments: Vec<String>,
     required_inputs: Vec<String>,
+}
+
+/// Preprocessor text embeds literal paths in line markers and macros. Keep
+/// its invocation tied to those spellings instead of rewriting user output.
+#[derive(Debug, Serialize)]
+struct PreprocessingContext {
+    working_dir: PathBuf,
+    arguments: Vec<String>,
+    roots: BTreeMap<String, PathBuf>,
 }
 
 /// Normalized input names from the last successful execution of one modeled
@@ -751,6 +765,7 @@ pub struct CcInvocation {
     required_inputs: Vec<PathBuf>,
     language: CcLanguage,
     preprocessed_assembly: bool,
+    preprocessing_arguments: Option<Vec<String>>,
     sysroot: Option<PathBuf>,
     caller_depfile: Option<CallerDepfile>,
     /// Positions in the parsed command line of the dependency-list flags the
@@ -822,8 +837,8 @@ impl CcInvocation {
             .collect()
     }
 
-    /// Parse a driver command line, admitting only modeled single-object
-    /// compiles.
+    /// Parse a driver command line, admitting modeled single-source compiles
+    /// and preprocessing to a named output.
     pub fn parse(arguments: &[OsString]) -> Result<Self, CcBypassReason> {
         Parser::new(arguments).parse()
     }
@@ -836,7 +851,9 @@ impl CcInvocation {
         if family.is_msvc() {
             MsvcParser::new(arguments).parse()
         } else {
-            Self::parse(arguments)
+            let mut parser = Parser::new(arguments);
+            parser.family = family;
+            parser.parse()
         }
     }
 
@@ -850,7 +867,12 @@ impl CcInvocation {
         &self.source
     }
 
-    /// Object file this invocation produces.
+    /// Whether this invocation writes named preprocessor text.
+    pub fn is_preprocessing(&self) -> bool {
+        self.preprocessing_arguments.is_some()
+    }
+
+    /// Output file this invocation produces.
     pub fn output(&self) -> &Path {
         &self.output
     }
@@ -1176,6 +1198,7 @@ impl<'a> ActionBuilder<'a> {
             kind: "cc",
             adapter_version: ADAPTER_VERSION,
             assembly_input_model: invocation.assembly_input_model,
+            preprocessing: invocation.preprocessing,
             compiler: invocation.compiler,
             arguments: invocation.arguments,
             environment: self.context.environment.clone(),
@@ -1210,6 +1233,19 @@ impl<'a> ActionBuilder<'a> {
             // Version the assembly-only safety model independently so adding
             // support does not invalidate every existing C and C++ entry.
             assembly_input_model: self.invocation.preprocessed_assembly.then_some(1),
+            preprocessing: self
+                .invocation
+                .preprocessing_arguments
+                .as_ref()
+                .map(|arguments| PreprocessingContext {
+                    working_dir: self.context.working_dir.clone(),
+                    arguments: arguments.clone(),
+                    roots: self
+                        .mappings
+                        .iter()
+                        .map(|mapping| (mapping.placeholder.clone(), mapping.root.clone()))
+                        .collect(),
+                }),
             compiler: self.compiler_descriptor(),
             arguments,
             required_inputs,
@@ -1309,6 +1345,7 @@ fn absolute_path(path: &Path, working_dir: &Path) -> PathBuf {
 }
 
 struct Parser<'a> {
+    family: CcCompilerFamily,
     arguments: &'a [OsString],
     index: usize,
     parsed: Vec<Argument>,
@@ -1320,6 +1357,7 @@ struct Parser<'a> {
     explicit_language: Option<CcLanguage>,
     preprocessed_assembly: bool,
     compiling: bool,
+    preprocessing: bool,
     dependency: DependencyRequest,
 }
 
@@ -1340,6 +1378,7 @@ struct DependencyRequest {
 impl<'a> Parser<'a> {
     fn new(arguments: &'a [OsString]) -> Self {
         Self {
+            family: CcCompilerFamily::Gcc,
             arguments,
             index: 0,
             parsed: Vec::new(),
@@ -1351,6 +1390,7 @@ impl<'a> Parser<'a> {
             explicit_language: None,
             preprocessed_assembly: false,
             compiling: false,
+            preprocessing: false,
             dependency: DependencyRequest::default(),
         }
     }
@@ -1372,11 +1412,27 @@ impl<'a> Parser<'a> {
             }
         }
 
-        if !self.compiling {
+        if !self.compiling && !self.preprocessing {
             return Err(CcBypassReason::NotACompile);
         }
         let source = self.source.clone().ok_or(CcBypassReason::MissingInput)?;
         let output = self.output.clone().ok_or(CcBypassReason::MissingOutput)?;
+        if self.preprocessing && output == Path::new("-") {
+            return Err(CcBypassReason::NonObjectOutput("-E -o -".into()));
+        }
+        // GCC interprets -o as the dependency output with -E -MD unless -MF
+        // is explicit. Do not turn that command into a different operation.
+        if self.preprocessing
+            && self.dependency.user_headers_only.is_some()
+            && self.dependency.file.is_none()
+        {
+            return Err(CcBypassReason::CallerDependencyFlags(
+                "-E -MD/-MMD without -MF".into(),
+            ));
+        }
+        if self.preprocessing && self.dependency.file.as_deref() == Some(Path::new("-")) {
+            return Err(CcBypassReason::CallerDependencyFlags("-E -MF -".into()));
+        }
         let language = self.language(&source)?;
         let preprocessed_assembly = self.preprocessed_assembly
             || (self.explicit_language.is_none()
@@ -1390,7 +1446,16 @@ impl<'a> Parser<'a> {
                     .unwrap_or_else(|| output.with_extension("d")),
                 targets: if self.dependency.targets.is_empty() {
                     vec![DepfileTarget {
-                        name: output.to_string_lossy().into_owned(),
+                        // GCC -E ignores -o when choosing the dependency
+                        // target; Clang retains it. Neither uses the depfile.
+                        name: if self.preprocessing && self.family == CcCompilerFamily::Gcc {
+                            Path::new(source.file_name().ok_or(CcBypassReason::MissingInput)?)
+                                .with_extension("o")
+                                .to_string_lossy()
+                                .into_owned()
+                        } else {
+                            output.to_string_lossy().into_owned()
+                        },
                         quoted: true,
                     }]
                 } else {
@@ -1415,6 +1480,12 @@ impl<'a> Parser<'a> {
             required_inputs: self.required_inputs,
             language,
             preprocessed_assembly,
+            preprocessing_arguments: self.preprocessing.then(|| {
+                self.arguments
+                    .iter()
+                    .map(|arg| arg.to_str().expect("arguments were validated").to_owned())
+                    .collect()
+            }),
             sysroot: self.sysroot,
             caller_depfile,
             dependency_argument_indices: self.dependency.indices,
@@ -1525,7 +1596,12 @@ impl<'a> Parser<'a> {
         if COMPILER_QUERY_FLAGS.contains(&value) || value.starts_with("-print") {
             return Err(CcBypassReason::CompilerQuery);
         }
-        if matches!(value, "-E" | "-S") {
+        if value == "-E" {
+            self.preprocessing = true;
+            self.parsed.push(Argument::Plain(value.into()));
+            return Ok(());
+        }
+        if value == "-S" {
             return Err(CcBypassReason::NonObjectOutput(value.into()));
         }
         if let Some(option) = value.strip_prefix("-M") {
@@ -1825,6 +1901,7 @@ impl<'a> MsvcParser<'a> {
             required_inputs: self.required_inputs,
             language,
             preprocessed_assembly: false,
+            preprocessing_arguments: None,
             sysroot: None,
             caller_depfile: None,
             dependency_argument_indices: Vec::new(),

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -48,9 +48,19 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let working_dir = std::env::current_dir()?;
     let mappings = path_mappings(&working_dir);
     let identity = compiler_identity(compiler, language)?;
-    // Appended before anything parses, so the flag is part of the key the same
-    // way the caller's own prefix maps are.
-    let portable = Portable::detect(&mappings, identity.family, &working_dir);
+    // Prefix maps enter the final parse so they are keyed like caller flags.
+    // Named preprocessor output retains its original path spellings instead.
+    let preprocessing = CcInvocation::parse_for(arguments, identity.family)?.is_preprocessing();
+    let portable = if preprocessing {
+        // Preprocessor output retains literal line markers and macro values;
+        // its action identity includes the working directory and path roots.
+        Portable {
+            arguments: Vec::new(),
+            values: Vec::new(),
+        }
+    } else {
+        Portable::detect(&mappings, identity.family, &working_dir)
+    };
     let arguments = portable.applied_to(arguments);
     let arguments = arguments.as_ref();
     let invocation = CcInvocation::parse_for(arguments, identity.family)?;
@@ -58,11 +68,16 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     // one it needs; the caller's is written by the shim once the files this
     // compilation read are known.
     let compiler_arguments = invocation.compiler_arguments(arguments);
-    let environment = environment_inputs_for(
+    let mut environment = environment_inputs_for(
         |name| std::env::var(name).ok(),
         invocation.sysroot(),
         identity.family,
     )?;
+    if preprocessing {
+        // With debug working-directory markers, GCC can honor a logical PWD
+        // alias. It is output text, so it must also be part of the action key.
+        environment.insert("PWD".into(), std::env::var("PWD").ok());
+    }
     let mut context = CcActionContext {
         compiler: identity,
         working_dir: working_dir.clone(),

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -142,10 +142,10 @@ target implies lives in the `cc` crate's own tables, and a wrong guess would
 build the object with the wrong compiler. A value that is a command, such as
 `ccache gcc`, is left alone for the same reason.
 
-Only a plain single-source object compile through a gcc-, clang-, or MSVC-style
-driver is admitted, with preprocessed assembly (`.S`, or `-x
+Single-source object compiles through gcc-, clang-, or MSVC-style drivers
+are admitted, with preprocessed assembly (`.S`, or `-x
 assembler-with-cpp`) counting as C: its includes are what dependency discovery
-reads, and the assembler is part of a GCC identity. Linking, preprocessing,
+reads, and the assembler is part of a GCC identity. Linking, preprocessing to stdout,
 assembly that skips the preprocessor (`.s`), Objective-C, precompiled
 headers, coverage instrumentation, compiler plugins, options forwarded to a
 sub-tool with `-Wp,`/`-Wl,`/`-Xclang`, unmodeled `-Wa,` assembler options, and
@@ -153,6 +153,15 @@ assembler-time `.include`/`.sinclude`/`.incbin` inputs, and response files all
 bypass, as does any flag the adapter does not model. Known
 assembler options that add no inputs, such as `-Wa,--noexecstack`, are keyed
 and admitted. MSVC compiler PDBs, modules, and other extra outputs also bypass.
+GCC/Clang preprocessing with `-E ... -o file` is also cached. The file is
+restored byte-for-byte; line markers and `__FILE__` values are preserved. These
+entries include literal argument paths, the working directory, and mapped
+roots in their keys, so they are not shared across different checkout paths.
+Header discovery and include-directory invalidation still apply. `-E` with
+`-MD`/`-MMD` requires an explicit `-MF`; without it, GCC gives `-o` a different
+meaning, so mbx bypasses that invocation. `-o -` and dependency output to
+stdout with `-MF -` remain bypasses.
+
 A source or header that expands `__DATE__`, `__TIME__`, or `__TIMESTAMP__`
 bypasses too: its object is not a function of its inputs.
 

--- a/test/cc_standalone_exec.bats
+++ b/test/cc_standalone_exec.bats
@@ -190,3 +190,85 @@ EOF
     assert_failure
   done
 }
+
+@test "named preprocessor output restores exact text and tracks changed headers" {
+  local project="$BATS_TEST_TMPDIR/preprocess"
+  local report="$BATS_TEST_TMPDIR/preprocess.json"
+  mkdir -p "$project/include"
+  echo '#define VALUE 7' >"$project/include/value.h"
+  cat >"$project/main.c" <<'SOURCE'
+#include "value.h"
+const char *source = __FILE__;
+int value = VALUE;
+SOURCE
+  # Absolute input/header paths deliberately exercise line markers that must
+  # retain their exact spelling in the cached text.
+  local source="$project/main.c"
+  local include="$project/include"
+  (cd "$project" && cc -E "$source" -I"$include" -o reference.i)
+  (cd "$project" && "$MBX_BIN" exec cc -E "$source" -I"$include" -o result.i)
+  run cmp "$project/reference.i" "$project/result.i"
+  assert_success
+  rm "$project/result.i"
+  (cd "$project" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec cc -E "$source" -I"$include" -o result.i)
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*1' "$report"
+  assert_success
+  run cmp "$project/reference.i" "$project/result.i"
+  assert_success
+
+  # Changing only a header must invalidate a warm prediction.
+  echo '#define VALUE 9' >"$project/include/value.h"
+  (cd "$project" && cc -E "$source" -I"$include" -o reference.i)
+  rm "$project/result.i"
+  (cd "$project" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec cc -E "$source" -I"$include" -o result.i)
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*0' "$report"
+  assert_success
+  run cmp "$project/reference.i" "$project/result.i"
+  assert_success
+
+  # A caller's explicit dependency file is regenerated on a hit. Its target
+  # must match the real driver (GCC and Clang differ under -E).
+  (cd "$project" && cc -E "$source" -I"$include" -o deps.i -MD -MF reference.d)
+  local expected_target
+  expected_target=$(sed -n '1s/:.*//p' "$project/reference.d")
+  rm "$project/deps.i"
+  (cd "$project" && "$MBX_BIN" exec cc -E "$source" -I"$include" -o deps.i -MD -MF deps.d)
+  rm "$project/deps.i" "$project/deps.d"
+  (cd "$project" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec cc -E "$source" -I"$include" -o deps.i -MD -MF deps.d)
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*1' "$report"
+  assert_success
+  run grep 'value.h' "$project/deps.d"
+  assert_success
+  run grep -F "$expected_target:" "$project/deps.d"
+  assert_success
+  run cmp "$project/reference.i" "$project/deps.i"
+  assert_success
+
+  # Stdout still goes through the real compiler transparently.
+  (cd "$project" && cc -E "$source" -I"$include" >stdout.reference)
+  (cd "$project" && "$MBX_BIN" exec cc -E "$source" -I"$include" >stdout.actual)
+  run cmp "$project/stdout.reference" "$project/stdout.actual"
+  assert_success
+}
+
+@test "C++ preprocessing without line markers restores from the cache" {
+  command -v c++ >/dev/null || skip "no C++ compiler is available"
+  local project="$BATS_TEST_TMPDIR/preprocess-cxx"
+  local report="$BATS_TEST_TMPDIR/preprocess-cxx.json"
+  mkdir -p "$project/src"
+  cat >"$project/src/main.cpp" <<'SOURCE'
+#ifdef __cplusplus
+template <typename T> T twice(T value) { return value + value; }
+#else
+#error expected C++ preprocessing
+#endif
+SOURCE
+  (cd "$project" && c++ -E -P src/main.cpp -o expected.ii)
+  (cd "$project" && "$MBX_BIN" exec c++ -E -P src/main.cpp -o result.ii)
+  rm "$project/result.ii"
+  (cd "$project" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec c++ -E -P src/main.cpp -o result.ii)
+  run grep -E '"hits"[[:space:]]*:[[:space:]]*1' "$report"
+  assert_success
+  run cmp "$project/expected.ii" "$project/result.ii"
+  assert_success
+}


### PR DESCRIPTION
Cache GCC/Clang `-E ... -o file` invocations, including C++ and `-P`, so Make/CMake preprocessing steps can restore their named output through `mbx exec`. Output text is stored and restored byte-for-byte. Header content and include-directory changes still invalidate entries.

Preprocessor keys retain literal arguments, working directory, mapped roots, and logical PWD because line markers and macros can embed those paths. Ordinary object keys stay unchanged. Prefix maps are not injected into preprocessing commands.

Caller dependency files are regenerated on cold and warm runs, preserving explicit `-MT`/`-MQ` targets and the GCC/Clang difference in default targets under `-E`. Preprocessing to stdout, dependency output to stdout, and ambiguous `-E -MD/-MMD` invocations without `-MF` bypass the cache.

Validation: `mise run ci` passes. Coverage includes real C/C++ cold and warm preprocessing, exact comparison with the bare compiler, header invalidation, caller dependency regeneration and target comparison, `-P`, stdout transparency, path-sensitive keys, and parser rejection cases.

Inspired by kunobi-ninja/kache#935. Driver target behavior is modeled from [GCC's preprocessor documentation](https://gcc.gnu.org/onlinedocs/cpp/Invocation.html) and [Clang's dependency generation](https://clang.llvm.org/doxygen/Clang_8cpp_source.html).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cached code path with path-sensitive keys and driver-specific dependency semantics; mistakes could serve wrong preprocessor text or stale `.d` files, though ambiguous shapes still bypass.
> 
> **Overview**
> **Extends the C/C++ cache adapter and `mbx exec` shim** so GCC/Clang invocations with **`-E … -o file`** (including **`-P`** and C++) are admitted and restored **byte-for-byte**, instead of treating all `-E` as a bypass.
> 
> Preprocessing uses a separate **`PreprocessingContext`** in action keys: literal argv, working directory, mapped roots, and **`PWD`** when relevant. **Prefix maps are not injected** for `-E`, so line markers and `__FILE__` stay faithful; keys therefore **do not share across checkouts** the way portable object compiles can.
> 
> The parser still **bypasses** `-E` to stdout (`-o -`), ambiguous **`-E -MD/-MMD` without `-MF`**, and **`-MF -`**. With **`-MD -MF`**, caller **`.d` files are regenerated on hits**, with default rule targets matching **GCC vs Clang** under `-E`.
> 
> Docs and **unit/Bats tests** cover rejection cases, key separation, header invalidation, dependency targets, and end-to-end restore behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065c2587c436c1caf2ddea1d555692294fa1c2b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching for named GCC/Clang preprocessing outputs (`-E -o file`).
  * Restored preprocessor results byte-for-byte, including line markers and `__FILE__` values.
  * Regenerated dependency files with appropriate compiler-specific targets.
  * Preserved cache correctness across checkout paths, working directories, and literal command-line paths.
  * Added cache invalidation when headers change.

* **Bug Fixes**
  * Preprocessing now correctly handles C++ output without line markers and transparent stdout output.

* **Documentation**
  * Updated documented preprocessing cache limits and bypass conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->