### PR TITLE
docs: refresh guides and redesign the documentation site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ the commit and pull request, then let release-plz choose the version.
 ## Generated Documentation
 
 `docs/cli/` is generated from the usage declarations in
-`crates/mbx/src/config.rs` and `crates/mbx/src/cli.rs`. Run
+`crates/mbx/src/config.rs` and `crates/mbx/src/cli/`. Run
 `mise run render:docs` after changing a setting and commit the result. Do not
 hand-edit generated CLI documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+Start with [Discussions](https://github.com/jdx/mr-boxington/discussions) for
+questions and proposed changes. For a suspected vulnerability, use the private
+reporting process in [SECURITY.md](SECURITY.md).
+
+## Set up the repository
+
+Install [mise](https://mise.jdx.dev), then run from the repository root:
+
+```sh
+git submodule update --init --recursive
+mise install
+mise exec -- rustup target add wasm32-unknown-unknown
+mise run build
+```
+
+The submodules provide Bats and its assertion helpers. The WebAssembly target
+is required by the end-to-end tests. `mise run build` first builds a bootstrap
+mbx, then uses it to build the workspace.
+
+## Make a change
+
+Keep the change focused and explain the behavior it improves. Use conventional
+commit subjects and pull request titles such as `docs: clarify cache setup` or
+`fix: preserve target paths`. See [AGENTS.md](AGENTS.md) for allowed types and
+repository rules.
+
+Do not bump crate versions or edit changelogs in ordinary pull requests.
+Release-plz generates both. Declare an API break with `!` in the title and
+explain it in a `BREAKING CHANGE:` footer; [RELEASING.md](RELEASING.md) describes
+the release process.
+
+## Check your work
+
+```sh
+mise run format
+mise run ci
+```
+
+`ci` runs formatting and Clippy checks, builds the workspace, verifies generated
+docs and site links, and runs Rust and platform behavioral tests. For a focused
+iteration, use `mise run test:cargo` or `mise run test:e2e`. See
+[test/README.md](test/README.md) for individual Bats cases,
+[benchmarks/README.md](benchmarks/README.md) for performance measurements, and
+[fuzz/README.md](fuzz/README.md) for parser fuzzing.
+
+## Work on documentation
+
+The README introduces the project. `docs/` contains the VitePress website:
+start at `docs/guide.md` for its reading paths and `docs/index.md` for the
+landing page. Navigation is in `docs/.vitepress/config.mts`; components and
+styles are in `docs/.vitepress/theme/`.
+
+```sh
+mise run docs          # generate reference pages and start VitePress
+mise run check:docs    # verify generated pages match their declarations
+mise run check:links   # build the site and check internal pages and anchors
+```
+
+`docs/cli/` is generated. Edit command help in `crates/mbx/src/cli/` or settings
+in `crates/mbx/src/config.rs`, run `mise run render:docs`, and include the result
+in the change. Do not hand-edit generated pages.
+
+Lead guides with the task and a runnable example. Keep command reference,
+conceptual detail, and troubleshooting easy to find without repeating them
+across pages. Preserve published anchors when moving sections, and check the
+site on a narrow screen as well as a desktop.
+
+### Social previews
+
+The documentation build generates a 1200×630 PNG for each page title using
+`docs/.vitepress/social-images.mjs`, the project logo, and the bundled
+[Space Grotesk font](docs/.vitepress/fonts/README.md). Rendering needs no remote
+service or system fonts. Hashed image URLs refresh when titles or artwork
+change. The build tests the renderer and verifies that every page references
+an emitted image.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,27 @@
 <p align="center">
-  <img src="docs/public/logo.svg" alt="Mr Boxington, a friendly cache box wearing a monocle and bow tie" width="220">
+  <img src="docs/public/logo.svg" alt="Mr Boxington, a cache box wearing a monocle and bow tie" width="180">
 </p>
 
 <h1 align="center">mr boxington</h1>
 
 <p align="center">
-  <strong>fix <code>target/</code></strong><br>
-  Keep using cargo. Every build on the machine shares one self-pruning cache, and you can run multiple Cargo builds in parallel.
+  <strong>A shared cache. A tidier <code>target/</code>.</strong><br>
+  Reuse Cargo builds across worktrees, keep disk use in check, and run builds together.
 </p>
 
 <p align="center">
-  <a href="https://mr-boxington.jdx.dev">Documentation</a>
-  ·
+  <a href="https://mr-boxington.jdx.dev/getting-started">Get started</a> ·
+  <a href="https://mr-boxington.jdx.dev/guide">Documentation</a> ·
+  <a href="https://mr-boxington.jdx.dev/benchmarks">Benchmarks</a> ·
   <a href="https://github.com/jdx/mr-boxington/releases">Releases</a>
 </p>
 
-`mbx` puts a content-addressed rustc cache behind ordinary Cargo commands.
-Cargo still resolves dependencies, plans builds, and links outputs. mbx
-restores the compilations it has seen before. Run `mbx setup` once and keep
-using the Cargo commands you already run.
+`mbx` is a build cache for Rust projects. Cargo still resolves dependencies,
+plans builds, and runs your tools. mbx restores matching compiler outputs from
+one shared store and compiles the rest. Each command starts its own cache
+agent and stops it when the build ends; there is no daemon to manage.
 
-```sh
-cargo build                # cached by mbx
-cargo test --all-features  # cached by mbx
-cargo clippy --workspace   # cached by mbx
-mbx tui                    # watch every build's cache activity live
-mbx stats                  # lifetime savings, pruning, and workspace sharing
-mbx gc --dry-run           # preview what cleanup would reclaim
-```
-
-## Why mbx?
-
-- Cache keys contain no checkout-specific paths, so building one worktree
-  warms its siblings, and no two checkouts wait on the same Cargo target lock.
-- Disk use is bounded without a chore. The cache prunes itself to a share of
-  the disk, and a managed `target/` directory is deleted when its checkout is
-  gone, unused for 30 days, or over budget.
-- Several Cargo builds can run at once. They share one machine-wide CPU and
-  memory budget, and a cold compilation already running in one build is
-  compiled once and restored into the others.
-- CI can be warmed safely. GitHub Actions cache can warm fork pull requests
-  from a cache built on `main`, and pull requests never publish remote objects.
-- The summary counts hits, misses, and the compilations mbx could not look up
-  or bypassed on purpose, so a high hit rate cannot hide work that never
-  entered the cache.
-
-## Install
+## Get started
 
 With [mise](https://mise.jdx.dev):
 
@@ -53,130 +29,111 @@ With [mise](https://mise.jdx.dev):
 mise use --global --postinstall "mbx setup --yes" mr-boxington
 ```
 
-> [!NOTE]
-> Automatic Cargo wrapping requires mise 2026.8.16 or newer.
-
-Open a new shell and check that `command -v cargo` resolves to mise's command
-wrapper. `mbx setup` writes a `[wrappers.cargo]` entry and runs `mise reshim`.
-Tools that skip mise activation, such as SSH commands and coding agents, need
-`~/.local/share/mbx/bin` on `PATH` instead. Prefixing a command with `mbx`
-always works.
-
-With Cargo:
+Or with Cargo:
 
 ```sh
 cargo install mbx --locked
 mbx setup
 ```
 
-Release archives for Linux, macOS, and Windows are on the
-[releases page](https://github.com/jdx/mr-boxington/releases), each with a
-`SHA256SUMS` file.
-
-[See all installation options →](https://mr-boxington.jdx.dev/getting-started)
-
-## Automatic pruning
-
-Collection runs after a build, at most once an hour, and needs no
-configuration. The first build prints the budgets it chose for this machine.
-mbx keeps a running total of what collection has reclaimed and prints one line
-about it after a build:
-
-```text
-mbx[savings]: 41.7 GiB of target/ had outlived its checkouts. it has been dealt with.
-```
-
-`savings = "plain"` drops the joke. Inspect or collect the store by hand with:
+Open a new shell and check activation with `mbx setup --status`. Then use Cargo
+normally:
 
 ```sh
-mbx cache stats
-mbx gc --dry-run
-mbx gc
-mbx clean        # this workspace's managed target/ only
+cargo build
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets -- -D warnings
 ```
 
-For a checkout without an existing `target/`, the first build places the
-target directory under the cache root and leaves `target` as a symlink, so
-familiar paths still work and a deleted checkout's outputs get collected. An
-existing `target/` is only replaced if you say yes at the prompt.
+To try mbx without automatic wrapping, install it and run `mbx build` directly.
+Automatic mise wrapping requires mise 2026.8.16 or newer. Editors, SSH commands,
+and other tools may need the stable shim directory on their `PATH`; the
+[setup guide](https://mr-boxington.jdx.dev/setup) walks through verification.
 
-[Learn about managed targets →](https://mr-boxington.jdx.dev/managed-targets)
+Verified release archives are available for Linux, macOS, and Windows.
+[All installation options →](https://mr-boxington.jdx.dev/installation)
 
-## Managed linkers
+## What you get
 
-Choose a different linker for each Cargo profile and target. mbx can use the
-Rust toolchain's bundled LLD or automatically download pinned mold and Wild
-releases, verify their GitHub SHA-256 digest, and reuse the installation
-across builds:
+- **Reuse across worktrees.** Equivalent compilations share cache keys even
+  when checkout paths differ. Building one worktree warms the next.
+- **Automatic cleanup.** The store has a disk budget. Managed targets are
+  collected when their checkout disappears, they go unused, or they exceed
+  their budget. Preview collection with `mbx gc --dry-run`.
+- **Parallel builds with a shared budget.** Independent Cargo commands share
+  CPU and memory permits and deduplicate identical compilations in flight.
+  Give each command its own target directory to avoid Cargo's directory lock.
+- **Faster local edits.** mbx keeps private incremental state for crates you
+  are changing while sharing eligible work across the rest of the build.
+- **CI reuse.** Use GitHub Actions cache, a compatible cache server, or an
+  S3-compatible bucket. Pull request builds restore remote work without
+  publishing new objects through mbx.
+- **An explanation for each result.** Hits, misses, unavailable lookups, and
+  bypasses are counted separately. `mbx explain --last` helps diagnose a build.
 
-```toml
-[linker.profiles.dev]
-x86_64-unknown-linux-gnu = "mold@2.42.0"
-aarch64-unknown-linux-gnu = "wild@0.10.0"
+A cold store needs a build to fill it. Unsupported invocations run normally
+without caching, and restored debug information can retain the original
+checkout's paths. See [how it works](https://mr-boxington.jdx.dev/how-it-works)
+and the [caching limits](https://mr-boxington.jdx.dev/limits).
 
-[linker.profiles.release]
-default = "rust-lld"
+## Use it in GitHub Actions
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mr-boxington-action@v1
+      - run: mbx test --workspace
 ```
 
-Set `MBX_LINKER=system` or another selector for a one-command override.
+Install your chosen Rust toolchain before the cache action. The default backend
+restores a pruned Cargo target and registry archive; pull requests are
+restore-only. See the [GitHub Action guide](https://mr-boxington.jdx.dev/github-action)
+for complete workflows, parallel builds, remote servers, and release policy.
 
-[Configure managed linkers →](https://mr-boxington.jdx.dev/configuration#managed-linkers)
+## Inspect and maintain the cache
 
-## CI
+```sh
+mbx doctor          # check tools, setup, and cache access
+mbx tui             # watch builds across the machine
+mbx stats           # report lifetime savings and workspace sharing
+mbx explain --last  # explain the last recorded build
+mbx cache stats     # inspect storage
+mbx gc --dry-run    # preview collection
+mbx clean           # remove this workspace's managed target
+```
 
-For GitHub-hosted CI, [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
-installs mbx and uses GitHub Actions cache. Trusted environments can point the
-same action at a compatible remote such as the self-hostable
-[cache server](https://mr-boxington.jdx.dev/cache-server).
+On a filesystem that supports reflinks, restored outputs share data blocks
+with the store until modified. Elsewhere, mbx copies bytes. An existing real
+`target/` is only replaced after you accept a prompt.
+[Understand managed targets →](https://mr-boxington.jdx.dev/managed-targets)
 
-Parallel steps that run Clippy and tests together can each get their own
-`CARGO_TARGET_DIR` and share one CPU and memory budget through mbx. mise's
-lint job finished up to 45% sooner this way.
+## Find your next step
 
-[Copy the parallel workflow →](https://mr-boxington.jdx.dev/github-action#parallel-cargo-steps)
+| Task | Guide |
+| --- | --- |
+| Set up editors, watchers, and worktrees | [Local development](https://mr-boxington.jdx.dev/cookbook/local-development) |
+| Change budgets or build policy | [Configuration](https://mr-boxington.jdx.dev/configuration) |
+| Choose mold, Wild, or toolchain LLD | [Managed linkers](https://mr-boxington.jdx.dev/linkers) |
+| Share work across CI runners | [Remote cache](https://mr-boxington.jdx.dev/remote-cache) |
+| Cache make or CMake builds | [Standalone C and C++](https://mr-boxington.jdx.dev/standalone-builds) |
+| Investigate an unexpected result | [Troubleshooting](https://mr-boxington.jdx.dev/troubleshooting) |
+| Look up a command | [CLI reference](https://mr-boxington.jdx.dev/cli/) |
 
-## How it works
+## Contribute
 
-An `mbx` Cargo command starts an in-process cache agent, points Cargo at rustc
-and rustdoc shims, and stops the agent when the build ends. There is no daemon.
-The shims derive action keys, restore cached outputs when they can, and
-otherwise run the real tool and publish a successful result.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, documentation
+checks, tests, and pull request conventions. Ask questions in
+[Discussions](https://github.com/jdx/mr-boxington/discussions); report suspected
+vulnerabilities through the private process in [SECURITY.md](SECURITY.md).
 
-Anything mbx cannot model exactly bypasses the cache. Native links are cached
-on Linux, macOS, and Windows when mbx can put the linker and its system inputs
-into the key, and the workspace crate you are editing is recompiled
-incrementally with state that never enters the shared cache.
-
-[Read the architecture and limits →](https://mr-boxington.jdx.dev/how-it-works)
-
-## Documentation
-
-- [Get started](https://mr-boxington.jdx.dev/getting-started)
-- [Configuration](https://mr-boxington.jdx.dev/configuration)
-- [GitHub Action](https://mr-boxington.jdx.dev/github-action)
-- [Benchmarks](https://mr-boxington.jdx.dev/benchmarks)
-- [Remote cache](https://mr-boxington.jdx.dev/remote-cache)
-- [Protocol compatibility](https://mr-boxington.jdx.dev/protocol-compatibility)
-- [Cache results](https://mr-boxington.jdx.dev/cache-results)
-- [Watching builds](https://mr-boxington.jdx.dev/tui)
-- [CLI reference](https://mr-boxington.jdx.dev/cli)
-- [Current limits](https://mr-boxington.jdx.dev/limits)
-
-### Documentation social previews
-
-The documentation build generates page-specific 1200×630 PNGs for Open Graph
-and Twitter previews. `.vitepress/social-images.mjs` uses the page title, the
-project logo, and a bundled OFL-licensed font; it requires no remote rendering
-service or system fonts. Content hashes in image URLs refresh previews when
-titles or artwork change. `aube run docs:build` from `docs/` tests the renderer
-and verifies that each built page references an emitted PNG.
-
-## Acknowledgements
-
-mbx relies on [Cargo](https://github.com/rust-lang/cargo) and follows earlier
-compiler-cache work in [sccache](https://github.com/mozilla/sccache) and
-[kache](https://github.com/kunobi-ninja/kache), which directly inspired its
-design. [Read the acknowledgements](https://mr-boxington.jdx.dev/acknowledgements).
+mbx builds on Cargo and was informed by sccache and kache, which directly
+inspired its design. [Acknowledgements](https://mr-boxington.jdx.dev/acknowledgements).
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,37 +27,31 @@ bump does not release — only merging a release PR does.
 
 ## Merging the release PR
 
-A release PR is not complete the moment it appears. `release-plz-pr` pushes a
-second commit regenerating `docs/cli`, and that push has nowhere to land once
-the PR is merged — the branch is gone and release-plz never revisits a merged
-PR. Merging early therefore ships a reference that names the previous version,
-and `check:docs` then fails on `main` and on every pull request opened against
-it until someone regenerates by hand.
+Before merging a release PR:
 
-That is not hypothetical: v0.5.4 was merged 37 seconds after its PR opened,
-while the render was still compiling, and `main` went red with a `0.5.3`
-reference. The job now warms the Rust cache and builds `mbx` *before* it asks
-release-plz to open the PR, so the docs commit follows within seconds rather
-than a minute. The window is small, not zero — wait for the second commit, and
-for the PR's own CI, rather than merging on sight.
+1. Wait for the `release-plz-pr` job to finish. It pushes a second commit that
+   regenerates `docs/cli` after release-plz updates versions.
+2. Confirm that the generated reference names the new mbx version.
+3. Wait for the pull request's CI, including the `docs` check, to pass.
 
-Requiring the `docs` check on `main` closes the rest of the gap, since the
-release PR's CI cannot be green until the regenerated reference is on the
-branch. That is a branch-protection setting, not something this repository can
-assert for itself.
+Merging before regeneration removes the branch the second push needs. The
+release then ships stale generated documentation and `check:docs` fails on
+`main`. The job bootstraps mbx before opening the PR to shorten this window,
+but the job must still complete. Requiring the `docs` check in branch protection
+helps enforce the sequence; that setting lives outside the repository.
 
 ## Versions
 
 The crates do not share a version. `mbx` and `mbx-cache-protocol` each have an
 independent one, because each carries a stability promise the other should not
 be able to break: the CLI's surface is its commands and JSON output, and the
-protocol crate's is the remote cache wire contract that `jdx/mbx-cache` depends
+protocol crate's is the remote cache wire contract that `jdx/mr-boxington-cache` depends
 on. `mbx-cache-core`, `mbx-cache-rustc`, and `mbx-cache-cc` are internals;
 they share the `mbx-internals` version group, move together, and stay on `0.x`
-so semver itself says a minor bump may break them. `mbx-cache-cargo` and
+so their APIs may change in a minor release. `mbx-cache-cargo` and
 `mbx-cache-store` release independently on `0.x`.
 
-Nobody edits a version in a feature pull request. release-plz owns every
+Do not edit versions in an ordinary pull request. release-plz owns every
 number, and one written by hand either collides with its calculation or is
 overwritten by it. If an API break is intended, the pull request should say so
 and leave the version alone.
@@ -67,7 +61,7 @@ CHANGE:` footer — so release-plz can choose the appropriate next version.
 
 release-plz computes each line from the commits that touched it and updates the
 path dependencies' version requirements, so a release can move one crate and
-leave the rest alone. When `mbx` reaches `1.0`, the internal crates stay on
+leave the rest alone. The `mbx` CLI is on `1.x`; the internal crates stay on
 `0.x`: the CLI depending on a `0.x` library is normal, and the library target
 inside `mbx` is `#[doc(hidden)]` so none of those types are part of the
 promise. See [protocol compatibility](docs/protocol-compatibility.md) for the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,9 @@
 # Security policy
 
+Report suspected vulnerabilities through [private vulnerability reporting][report].
+For setup questions or ordinary build failures, use
+[Discussions](https://github.com/jdx/mr-boxington/discussions).
+
 ## Supported versions
 
 Security fixes are made on the latest released version and on the `main`
@@ -29,7 +33,8 @@ someone who can contribute build artifacts:
 - Grant remote-cache write access only to trusted CI and maintainers. Pull
   requests, merge requests, local shells, and unprotected branches are forced
   read-only by the client, but the server must still enforce authentication and
-  authorization.
+  authorization. S3 deployments must enforce the same boundary through bucket
+  and credential permissions.
 - A remote namespace prevents accidental key collisions; it is not an access
   control boundary. Use HTTPS, narrowly scoped credentials, and separate
   server-side authorization where projects have different trust domains.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,67 +1,84 @@
 # Performance and correctness measurements
 
+Use the benchmark that matches the question you are investigating. Run these
+commands from the repository root after `mise install`.
+
+| Question | Tool or task | Output |
+| --- | --- | --- |
+| Did mbx startup get more expensive? | `mise run perf` | Instruction counts and wall time from `tak` |
+| How does mbx compare on a real project? | `mise run bench` | One trial of warm, commit, and edit scenarios |
+| How are the website's results refreshed? | `mise run bench:refresh` | Three trials of every scenario in `results.json` |
+| Are cached builds correct in this workspace? | `measure_builds.py --verify` | Versioned reports, logs, and verification results |
+
+## Startup cost
+
 [`tak.toml`](../tak.toml) measures a no-op process-startup control and the
-hermetic `mbx --help` startup path. `tak` gates deterministic instruction counts
-and reports wall time without using noisy shared-runner timing as a hard gate.
-The pinned `mise run perf` task builds the subject and runs both benchmarks;
-`mise run perf:record` appends the result to the local `refs/notes/tak` history.
-PR CI compares against its base once shared history exists. The first merged
-main run seeds that history, so the adoption PR reports measurements without a
-fabricated regression baseline.
+hermetic `mbx --help` path. `tak` gates deterministic instruction counts and
+reports wall time without treating noisy shared-runner timing as a hard gate.
 
-`measure_builds.py` runs this repository's multi-crate workspace with a cold
-target, then recreates that same target and runs from the warmed local cache.
-With `--verify`, a third fresh-target build sets `MBX_VERIFY=1` and fails unless
-at least one result was qualified with zero divergences. The fixed target path
-is intentional: rustc embeds paths in artifacts, so changing the path would
-test the separately documented cross-checkout limitation instead.
+```sh
+mise run perf
+mise run perf:record
+```
 
-`measure_builds.py` writes versioned JSON and Markdown summaries plus mbx
-statistics reports and build logs. The large target and cache working trees
-are temporary and are not retained. CI uploads the correctness measurements
-and a `tak history` snapshot as artifacts; trusted main-branch runs publish the
-shared performance series to `refs/notes/tak`.
+Both tasks build the benchmark subject first. `perf:record` appends results to
+local `refs/notes/tak` history. CI compares against shared history when a
+baseline exists; an initial run seeds that history.
 
-`real_world.py` measures somebody else's project instead of this one. It
-clones a pinned checkout of [jdx/hk](https://github.com/jdx/hk) and runs the
-same `cargo build --locked` under raw cargo, mbx, and kache across the
-timed scenarios CI and developers actually hit: a warm store with a fresh
-target, the next commit on the branch, and a one-line edit rebuilt in place
-with incremental compilation on. That last one runs without `CI` set, since it
-models a developer's machine and mbx turns learned incremental reuse off on a
-runner. It also discards a first edit and times the second: Cargo reaches its first edit with incremental state its own build
-wrote, while mbx has to build a crate's private state on the first edit and
-reuse it after, so timing the first would report a setup cost as though it
-were the loop. Each runs `--trials` times per tool, three in
-CI, from a fresh clone and an empty store every time. The published cell is
-the middle trial and carries every trial's timing, and the site will not name
-a fastest tool when the gap between the top two is inside one tool's own
-range.
+## Cold, warm, and verified builds
 
-The `contention` scenario is the odd one out: it stacks six overlapping check,
-Clippy, and test-compilation jobs on one runner. It measures sequential context,
-native-step parallelism with mbx scheduling, and the same parallel shape with
-`MBX_SCHEDULER=0`, all from cold stores. The parallel commands get separate
-targets so Cargo's target lock cannot serialize them; the sequential reference
-keeps its shared target. The cells are sampled from outside every build: the
-most real compilers alive at once, and the least memory the machine had left.
+`measure_builds.py` builds this workspace with a cold target, recreates the same
+target, and builds from the warmed local cache. Add `--verify` for a third
+fresh-target build with `MBX_VERIFY=1`; it fails unless at least one result was
+qualified with zero divergences.
 
-The comparison is kept fair by fetching the registry once outside every timed
-build, pinning the toolchain (hk does not pin one itself), giving each cell
-its own store and target, clearing any inherited `RUSTC_WRAPPER`, and running
-both caches local-only. Validity gates reject a run whose warm builds restored
-nothing or were no faster than the build that seeded them, whose edit rebuild
-compiled nothing, or whose cargo baseline ran under mbx after all, as it does
-when `cargo` on `PATH` is an mbx shim.
-The contention gates verify that the scheduled batch stays inside its permits
-and the unscheduled one exceeds them, since a bound nothing pushed against
-proves nothing. Wall-time ordering remains a reported benchmark result rather
-than a validity condition because a single shared-runner sample is noisy.
+```sh
+mise run build
+python3 benchmarks/measure_builds.py \
+  --mbx target/mbx-bootstrap/mbx \
+  --workspace . \
+  --output target/build-measurements \
+  --verify
+```
 
-`mise run bench` runs the everyday subset once through; `mise run
-bench:refresh` runs every scenario, three trials of each, and rewrites
-`results.json`, which the documentation site reads.
-kache is used when it is on `PATH` and skipped with a note otherwise. The
-[bench-refresh workflow](../.github/workflows/bench-refresh.yml) runs it
-weekly, only when the published numbers predate the mbx on `main`, and opens a
-pull request rather than publishing directly.
+The fixed target path is intentional. Compiler artifacts can embed source
+paths, so changing the path would test the documented cross-checkout byte
+differences as well as correctness.
+
+The script writes versioned JSON and Markdown summaries, mbx statistics, and
+build logs. Large target and cache working trees are temporary. CI uploads the
+reports and a `tak history` snapshot; trusted main-branch runs publish the
+performance series to `refs/notes/tak`.
+
+## Real-world comparison
+
+`real_world.py` clones a pinned commit of [jdx/hk](https://github.com/jdx/hk) and
+compares plain Cargo, mbx, and kache. kache is included when it is on `PATH` and
+reported as skipped otherwise.
+
+```sh
+mise run bench
+mise run bench:refresh
+```
+
+The scenarios measure a warm store with a fresh target, the next commit, an
+in-place source edit, and six overlapping check, Clippy, and test-compilation
+jobs. The edit scenario runs with `CI` unset and times the second edit, after
+each tool has established its incremental state. The first edit's cost is also
+reported. Parallel jobs receive separate targets so Cargo's target lock does
+not serialize them.
+
+Each trial starts from a fresh clone and empty store. The registry is fetched
+outside timed builds, the toolchain is pinned, inherited wrappers are cleared,
+and caches run locally. Validity checks reject runs that did not exercise the
+intended behavior, such as a warm build with no restores or a Cargo baseline
+that accidentally used an mbx shim. Contention checks verify the permit limit
+was exercised; wall-time ordering remains a reported result.
+
+The website shows the median and the full range of three trials. It marks a
+tool fastest only when its lead exceeds either tool's range. See the
+[benchmark guide](../docs/benchmarks.md) for scenario definitions and limits.
+
+The [refresh workflow](../.github/workflows/bench-refresh.yml) checks weekly,
+reruns when the published results predate mbx on `main`, and opens a pull
+request with updated data. Do not hand-edit timings to match an expected result.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,7 +22,7 @@ const siteUrl = "https://mr-boxington.jdx.dev";
 export default defineConfig({
   title: "mr boxington",
   description:
-    "Put mbx in front of any cargo command. Every build on the machine shares one self-pruning cache, and you can run multiple Cargo builds in parallel.",
+    "Reuse Cargo compiler work across worktrees and CI, manage build storage, and run parallel builds with a shared CPU and memory budget.",
   lang: "en-US",
   lastUpdated: true,
   appearance: "force-dark",
@@ -44,10 +44,24 @@ export default defineConfig({
   themeConfig: {
     logo: "/logo.svg",
     nav: [
-      { text: "Get Started", link: "/getting-started" },
-      { text: "Configuration", link: "/configuration" },
-      { text: "GitHub Action", link: "/github-action" },
-      { text: "CLI", link: "/cli/" },
+      {
+        text: "Docs",
+        link: "/guide",
+        activeMatch:
+          "^/(guide|getting-started|installation|setup|cookbook/local-development|scheduling|incremental|linkers|managed-targets|standalone-builds|tui|stats|troubleshooting|cache-results|how-it-works|limits|compared|faq|acknowledgements)",
+      },
+      {
+        text: "CI & sharing",
+        link: "/github-action",
+        activeMatch:
+          "^/(github-action|remote-cache|cache-server|cookbook/(fork-prs|migrate))",
+      },
+      { text: "Benchmarks", link: "/benchmarks" },
+      {
+        text: "Reference",
+        link: "/cli/",
+        activeMatch: "^/(cli|configuration|protocol-compatibility|stability)",
+      },
       {
         text: `v${latestVersion}`,
         link: "https://github.com/jdx/mr-boxington/releases",
@@ -55,74 +69,89 @@ export default defineConfig({
     ],
     sidebar: [
       {
-        text: "Getting started",
+        text: "Start here",
         items: [
-          { text: "Introduction", link: "/" },
-          { text: "Install and run", link: "/getting-started" },
-          { text: "FAQ", link: "/faq" },
+          { text: "Documentation", link: "/guide" },
+          { text: "Get started", link: "/getting-started" },
+          { text: "Installation", link: "/installation" },
+          { text: "Cargo & editor setup", link: "/setup" },
         ],
       },
       {
-        text: "Use mbx",
-        items: [
-          { text: "Configuration", link: "/configuration" },
-          { text: "GitHub Action", link: "/github-action" },
-          { text: "Remote cache", link: "/remote-cache" },
-          { text: "Cache server", link: "/cache-server" },
-          { text: "Managed targets", link: "/managed-targets" },
-          { text: "Standalone C and C++", link: "/standalone-builds" },
-          { text: "Watching builds", link: "/tui" },
-          { text: "Savings and statistics", link: "/stats" },
-        ],
-      },
-      {
-        text: "Cookbook",
+        text: "Build locally",
         items: [
           { text: "Local development", link: "/cookbook/local-development" },
-          { text: "CI with fork pull requests", link: "/cookbook/fork-prs" },
-          {
-            text: "Migrate from rust-cache or sccache",
-            link: "/cookbook/migrate",
-          },
+          { text: "Managed targets", link: "/managed-targets" },
+          { text: "Parallel builds", link: "/scheduling" },
+          { text: "Incremental builds", link: "/incremental" },
+          { text: "Managed linkers", link: "/linkers" },
+          { text: "Watching builds", link: "/tui" },
+          { text: "Standalone C and C++", link: "/standalone-builds" },
         ],
       },
       {
-        text: "Understand mbx",
+        text: "CI & sharing",
         items: [
-          { text: "How it works", link: "/how-it-works" },
-          { text: "How mbx compares", link: "/compared" },
-          { text: "Acknowledgements", link: "/acknowledgements" },
-          { text: "Benchmarks", link: "/benchmarks" },
-          { text: "Stability", link: "/stability" },
-          { text: "Protocol compatibility", link: "/protocol-compatibility" },
+          { text: "GitHub Action", link: "/github-action" },
+          { text: "Migrate an existing cache", link: "/cookbook/migrate" },
+          { text: "Fork pull requests", link: "/cookbook/fork-prs" },
+          { text: "Remote cache", link: "/remote-cache" },
+          { text: "Cache server", link: "/cache-server" },
+        ],
+      },
+      {
+        text: "Understand & troubleshoot",
+        items: [
+          { text: "Troubleshooting", link: "/troubleshooting" },
           { text: "Cache results", link: "/cache-results" },
-          { text: "Limits", link: "/limits" },
+          { text: "Savings and statistics", link: "/stats" },
+          { text: "How it works", link: "/how-it-works" },
+          { text: "Caching limits", link: "/limits" },
+          { text: "How mbx compares", link: "/compared" },
+          { text: "Benchmarks", link: "/benchmarks" },
+          { text: "FAQ", link: "/faq" },
         ],
       },
       {
         text: "Reference",
         items: [
-          { text: "CLI overview", link: "/cli/" },
-          { text: "doctor", link: "/cli/doctor" },
-          { text: "explain", link: "/cli/explain" },
-          { text: "gc", link: "/cli/gc" },
+          { text: "Configuration", link: "/configuration" },
           {
-            text: "cache",
-            link: "/cli/cache",
+            text: "CLI commands",
+            link: "/cli/",
             collapsed: true,
             items: [
-              { text: "dir", link: "/cli/cache/dir" },
-              { text: "stats", link: "/cli/cache/stats" },
-              { text: "projects", link: "/cli/cache/projects" },
-              { text: "largest", link: "/cli/cache/largest" },
-              { text: "verify", link: "/cli/cache/verify" },
-              { text: "remove", link: "/cli/cache/remove" },
+              { text: "setup", link: "/cli/setup" },
+              { text: "completion", link: "/cli/completion" },
+              { text: "doctor", link: "/cli/doctor" },
+              { text: "explain", link: "/cli/explain" },
+              { text: "clean", link: "/cli/clean" },
+              { text: "gc", link: "/cli/gc" },
+              { text: "tui", link: "/cli/tui" },
+              { text: "stats", link: "/cli/stats" },
+              { text: "prefetch", link: "/cli/prefetch" },
+              { text: "exec", link: "/cli/exec" },
+              {
+                text: "cache",
+                link: "/cli/cache/",
+                collapsed: true,
+                items: [
+                  { text: "dir", link: "/cli/cache/dir" },
+                  { text: "stats", link: "/cli/cache/stats" },
+                  { text: "projects", link: "/cli/cache/projects" },
+                  { text: "largest", link: "/cli/cache/largest" },
+                  { text: "verify", link: "/cli/cache/verify" },
+                  { text: "trace", link: "/cli/cache/trace" },
+                  { text: "export", link: "/cli/cache/export" },
+                  { text: "import", link: "/cli/cache/import" },
+                  { text: "remove", link: "/cli/cache/remove" },
+                ],
+              },
             ],
           },
-          { text: "tui", link: "/cli/tui" },
-          { text: "stats", link: "/cli/stats" },
-          { text: "prefetch", link: "/cli/prefetch" },
-          { text: "Settings", link: "/configuration#settings" },
+          { text: "Stability", link: "/stability" },
+          { text: "Protocol compatibility", link: "/protocol-compatibility" },
+          { text: "Acknowledgements", link: "/acknowledgements" },
         ],
       },
     ],
@@ -132,8 +161,15 @@ export default defineConfig({
       { icon: "discord", link: "https://discord.gg/UBa7pJUN7Z" },
     ],
     editLink: {
-      pattern: ({ filePath }) =>
-        `https://github.com/jdx/mr-boxington/edit/main/docs/${filePath}`,
+      pattern: ({ filePath }) => {
+        const command = filePath.split("/")[1]?.replace(/\.md$/, "");
+        const module =
+          command === "index" || command === "completion" ? "mod" : command;
+        const source = filePath.startsWith("cli/")
+          ? `crates/mbx/src/cli/${module}.rs`
+          : `docs/${filePath}`;
+        return `https://github.com/jdx/mr-boxington/edit/main/${source}`;
+      },
       text: "Edit this page on GitHub",
     },
     search: { provider: "local" },
@@ -162,19 +198,7 @@ gtag('config', 'G-0MDX8ZJYFY');`,
     ],
     ["link", { rel: "apple-touch-icon", href: "/favicon.png" }],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
-    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
-    [
-      "link",
-      { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" },
-    ],
-    [
-      "link",
-      {
-        rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;600&display=swap",
-      },
-    ],
-    ["meta", { name: "theme-color", content: "#d69b42" }],
+    ["meta", { name: "theme-color", content: "#191713" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:site_name", content: "mr boxington" }],
     ["meta", { property: "og:locale", content: "en_US" }],

--- a/docs/.vitepress/fonts/README.md
+++ b/docs/.vitepress/fonts/README.md
@@ -1,5 +1,12 @@
-Space Grotesk is bundled for deterministic social image generation without
-system fonts or network access during the build.
+# Space Grotesk
 
-Source: https://github.com/google/fonts/tree/main/ofl/spacegrotesk
-License: SIL Open Font License 1.1, included in OFL.txt.
+`SpaceGrotesk.ttf` supplies the website's display headings and deterministic
+social preview images. The font is served with the site, so headings do not
+need a third-party font request. Social image generation also works without
+network access or installed system fonts.
+
+- [Upstream source](https://github.com/google/fonts/tree/main/ofl/spacegrotesk)
+- [SIL Open Font License 1.1](OFL.txt), bundled with the font
+
+If replacing the font, keep its license and rerun the documentation build to
+verify the generated previews.

--- a/docs/.vitepress/theme/CacheDashboard.vue
+++ b/docs/.vitepress/theme/CacheDashboard.vue
@@ -172,13 +172,14 @@ function revokeGrant() {
       <header class="topbar">
         <div class="breadcrumb"><span>Acme Engineering</span><i>/</i><b>{{ nav.find((item) => item.id === section)?.label }}</b></div>
         <div class="top-actions">
-          <span class="live"><i></i>Live</span>
+          <span class="live">Demo data</span>
           <button class="icon-button" aria-label="Settings"><Icon name="settings" /></button>
           <button class="avatar">JD</button>
         </div>
       </header>
 
       <div class="content">
+        <p class="demo-disclaimer">Interactive preview with sample data. Changes stay in this page; no cache server is connected. <a href="/cache-server">Read the server guide →</a></p>
         <template v-if="section === 'overview'">
           <div class="page-heading">
             <div><p class="eyebrow">Cache operations</p><h1>Good morning, Jordan.</h1><p>Here’s how your build cache is performing.</p></div>
@@ -310,6 +311,8 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.demo-disclaimer { color: var(--muted); font-size: 12px; line-height: 1.7; margin: 0 0 24px; }
+.demo-disclaimer a { color: var(--amber); text-decoration: underline; }
 * { box-sizing: border-box; }
 button, input, select { font: inherit; }
 button { color: inherit; }

--- a/docs/.vitepress/theme/HomeQuickStart.vue
+++ b/docs/.vitepress/theme/HomeQuickStart.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const command =
+  'mise use --global --postinstall "mbx setup --yes" mr-boxington';
+const status = ref("");
+
+async function copyCommand() {
+  try {
+    await navigator.clipboard.writeText(command);
+    status.value = "Copied";
+  } catch {
+    status.value = "Select the command to copy it.";
+  }
+}
+</script>
+
+<template>
+  <section class="MbxQuickStart" aria-label="Install with mise">
+    <div class="install-command">
+      <code>{{ command }}</code>
+      <button
+        type="button"
+        aria-label="Copy mise installation command"
+        @click="copyCommand"
+      >
+        Copy
+      </button>
+    </div>
+    <p class="install-note">
+      <span>Linux · macOS · Windows</span>
+      <a href="/installation"
+        >More install options <span aria-hidden="true">↗</span></a
+      >
+    </p>
+    <p class="copy-status" role="status">{{ status }}</p>
+  </section>
+</template>
+
+<style scoped>
+.MbxQuickStart {
+  margin-top: 28px;
+  max-width: 580px;
+}
+.install-command {
+  align-items: center;
+  background: var(--vp-code-block-bg);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  display: flex;
+  gap: 12px;
+  padding: 10px 10px 10px 16px;
+  text-align: left;
+}
+code {
+  color: var(--vp-c-text-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  line-height: 1.8;
+  overflow-wrap: anywhere;
+  user-select: all;
+}
+button {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 5px;
+  color: var(--vp-c-brand-1);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 12px;
+  min-height: 44px;
+  padding: 0 12px;
+}
+button:hover {
+  border-color: var(--vp-c-brand-1);
+}
+.install-note {
+  color: var(--vp-c-text-2);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 8px 20px;
+  justify-content: space-between;
+  line-height: 1.6;
+  margin-top: 12px;
+}
+a {
+  color: var(--vp-c-brand-1);
+}
+a:hover {
+  text-decoration: underline;
+}
+.copy-status {
+  color: var(--vp-c-brand-1);
+  font-size: 12px;
+  min-height: 20px;
+  text-align: left;
+}
+@media (max-width: 959px) {
+  .MbxQuickStart {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/HomeShowcase.vue
+++ b/docs/.vitepress/theme/HomeShowcase.vue
@@ -1,355 +1,261 @@
 <template>
   <div class="MbxShowcase">
-    <section class="card" aria-labelledby="mbx-targets-title">
-      <div class="copy">
-        <p class="eyebrow">Every worktree, one store</p>
-        <h2 id="mbx-targets-title">
-          Every worktree starts warm, and cleans up after itself.
-        </h2>
-        <p class="lede">
-          Every checkout draws from one shared store instead of compiling the
-          same crates into its own <code>target/</code>, so build in one
-          worktree and the next starts warm. And those directories prune
-          themselves: one goes away when its checkout is deleted, when it sits
-          unused for a month, or when they outgrow their share of the disk.
-        </p>
-        <div class="links">
-          <a class="primary" href="/how-it-works#portable-keys">
-            How worktrees share
-          </a>
-          <a href="/managed-targets#collection">What gets pruned →</a>
-        </div>
+    <section class="home-section practical" aria-labelledby="practical-title">
+      <div class="section-heading">
+        <p class="home-eyebrow">A little housekeeping goes a long way</p>
+        <h2 id="practical-title">Room for the work<br />you are doing now.</h2>
       </div>
-
-      <div
-        class="diagram"
-        aria-label="Three checkouts sharing one content-addressed store"
-      >
-        <div class="job">
-          <span class="label">~/src/app · compiled here</span>
-          <code>target -> targets/v1/1f9c2ab7</code>
-        </div>
-        <div class="job">
-          <span class="label">~/src/app-hotfix · starts warm</span>
-          <code>target -> targets/v1/8a20d941</code>
-        </div>
-        <div class="job dim last">
-          <span class="label">deleted checkout · collected</span>
-          <code>targets/v1/3c5f0e2b</code>
-        </div>
-        <div class="join" aria-hidden="true">
-          <span></span>
-          <span></span>
-        </div>
-        <div class="pool">
-          <span class="pool-title">one shared store</span>
-          <span>compiled once · reflinked into each target/</span>
-        </div>
-      </div>
-    </section>
-
-    <section class="card reverse" aria-labelledby="mbx-concurrency-title">
-      <div class="copy">
-        <p class="eyebrow">Parallel CI, one machine</p>
-        <h2 id="mbx-concurrency-title">
-          Run multiple Cargo builds at the same time.
-        </h2>
-        <p class="lede">
-          Start several Cargo commands at once — two lint configurations, say,
-          or tests alongside clippy. Left alone, each one tries to fill the
-          machine, and together they overload it. mbx gives them a single
-          shared CPU and memory budget instead, so they run in parallel
-          without oversubscribing the machine. We saw mise's lint job finish
-          up to 45% sooner this way.
-        </p>
-        <div class="links">
-          <a class="primary" href="/github-action#parallel-cargo-steps">
-            Copy the workflow
-          </a>
-          <a href="/configuration#machine-wide-compile-scheduling">
-            Tune the budget →
-          </a>
-        </div>
-      </div>
-
-      <div
-        class="diagram"
-        aria-label="Two Cargo lint builds sharing one CPU and memory budget"
-      >
-        <div class="job">
-          <span class="label">default features</span>
-          <code>mbx clippy</code>
-        </div>
-        <div class="job last">
-          <span class="label">all features + targets</span>
-          <code>mbx clippy --all-features --all-targets</code>
-        </div>
-        <div class="join" aria-hidden="true">
-          <span></span>
-          <span></span>
-        </div>
-        <div class="pool">
-          <span class="pool-title">one shared budget</span>
-          <span>CPU · memory</span>
-        </div>
+      <div class="feature-columns">
+        <article>
+          <span class="feature-number" aria-hidden="true">02</span>
+          <h3>A cache that cleans up.</h3>
+          <p>
+            Managed targets go when their checkout does, or when age and size
+            limits call for it. Preview the cleanup before running it yourself.
+          </p>
+          <code class="feature-command">mbx gc --dry-run</code>
+          <a class="home-text-link" href="/managed-targets"
+            >Understand the disk budget <span aria-hidden="true">→</span></a
+          >
+        </article>
+        <article>
+          <span class="feature-number" aria-hidden="true">03</span>
+          <h3>Builds that share the machine.</h3>
+          <p>
+            Tests, Clippy, and other worktrees draw from one CPU and memory
+            budget. Identical compilations already in flight can finish once and
+            serve both builds.
+          </p>
+          <code class="feature-command"
+            >CARGO_TARGET_DIR=target/clippy mbx clippy</code
+          >
+          <p class="feature-note">
+            Give each command its own target directory.
+          </p>
+          <a class="home-text-link" href="/scheduling"
+            >Set up parallel builds <span aria-hidden="true">→</span></a
+          >
+        </article>
+        <article>
+          <span class="feature-number" aria-hidden="true">04</span>
+          <h3>Something to bring to CI.</h3>
+          <p>
+            Warm runners with GitHub Actions cache, a cache server, or an
+            S3-compatible bucket. Keep remote writers limited to trusted builds.
+          </p>
+          <code class="feature-command">jdx/mr-boxington-action@v1</code>
+          <a class="home-text-link" href="/github-action"
+            >Add the GitHub Action <span aria-hidden="true">→</span></a
+          >
+        </article>
       </div>
     </section>
 
-    <section class="card" aria-labelledby="mbx-remote-title">
-      <div class="copy">
-        <p class="eyebrow">Every runner, one cache</p>
-        <h2 id="mbx-remote-title">CI runners and teammates start warm.</h2>
-        <p class="lede">
-          Point mbx at a cache server or an S3 bucket and your CI runners and
-          teammates all start from the same cache, each build downloading only
-          what it needs. On GitHub Actions there is nothing to host at all.
-          Pull requests from forks are safe to run: they read from the cache
-          without being able to write to it.
+    <section class="home-section proof" aria-labelledby="proof-title">
+      <div>
+        <p class="home-eyebrow">Measured, with the context attached</p>
+        <h2 id="proof-title">See what a warm cache changes.</h2>
+        <p>
+          Compare warm builds, the next commit, local edits, and parallel jobs.
+          The benchmark pages include the workload, trial ranges, and
+          limitations.
         </p>
-        <div class="links">
-          <a class="primary" href="/github-action">Set up the GitHub Action</a>
-          <a href="/remote-cache">Bring a server or a bucket →</a>
-        </div>
       </div>
-
-      <div
-        class="diagram"
-        aria-label="A CI build and a laptop sharing one remote cache"
+      <a class="proof-link" href="/benchmarks"
+        >Explore the benchmarks <span aria-hidden="true">↗</span></a
       >
-        <div class="job">
-          <span class="label">CI runner</span>
-          <code>mbx test --workspace</code>
-        </div>
-        <div class="job last">
-          <span class="label">teammate's laptop</span>
-          <code>mbx build</code>
-        </div>
-        <div class="join" aria-hidden="true">
-          <span></span>
-          <span></span>
-        </div>
-        <div class="pool">
-          <span class="pool-title">one shared cache</span>
-          <span>cache server · S3 bucket · GitHub Actions</span>
-        </div>
+    </section>
+
+    <section class="home-section reading" aria-labelledby="reading-title">
+      <div class="section-heading">
+        <p class="home-eyebrow">Open the manual</p>
+        <h2 id="reading-title">Make it part of your day.</h2>
+      </div>
+      <div class="reading-links">
+        <a href="/cookbook/local-development"
+          ><span>At your desk</span
+          ><strong>Editors, watchers &amp; worktrees</strong
+          ><span aria-hidden="true">↗</span></a
+        >
+        <a href="/configuration"
+          ><span>On your terms</span
+          ><strong>Settings, budgets &amp; build policy</strong
+          ><span aria-hidden="true">↗</span></a
+        >
+        <a href="/troubleshooting"
+          ><span>When you need an answer</span
+          ><strong>Understand a build result</strong
+          ><span aria-hidden="true">↗</span></a
+        >
+      </div>
+      <div class="home-closing">
+        <span>Built on Cargo. Inspired by the caches that came before.</span>
+        <a href="/acknowledgements"
+          >Meet the influences <span aria-hidden="true">→</span></a
+        >
+        <a href="https://jdx.dev/posts/2026-09-05-introducing-mr-boxington/"
+          >Read the announcement <span aria-hidden="true">↗</span></a
+        >
       </div>
     </section>
   </div>
 </template>
 
 <style scoped>
-.MbxShowcase {
+.practical {
+  border-top: 1px solid var(--vp-c-divider);
+  padding-bottom: 72px;
+  padding-top: 64px;
+}
+.section-heading {
+  margin-bottom: 36px;
+}
+.feature-columns {
   display: grid;
-  gap: 24px;
-  margin: 64px auto 24px;
-  max-width: 1152px;
+  gap: 32px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
-
-.card {
-  align-items: center;
-  background:
-    linear-gradient(135deg, rgb(var(--mbx-amber-rgb) / 0.1), transparent 48%),
-    var(--vp-c-bg-soft);
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 18px;
-  display: grid;
-  gap: 48px;
-  overflow: hidden;
-  padding: 40px;
-}
-
-.eyebrow {
-  color: var(--vp-c-brand-1);
-  font-family: var(--vp-font-family-mono);
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  margin: 0 0 12px;
-  text-transform: uppercase;
-}
-
-h2 {
-  color: var(--vp-c-text-1);
-  font-family: var(--mbx-display);
-  font-size: clamp(30px, 4vw, 44px);
-  letter-spacing: -0.035em;
-  line-height: 1.08;
-  margin: 0;
-}
-
-.lede {
-  color: var(--vp-c-text-2);
-  font-size: 17px;
-  line-height: 1.65;
-  margin: 20px 0 28px;
-  max-width: 42rem;
-}
-
-.lede code {
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.9em;
-}
-
-.links {
-  align-items: center;
+article {
+  border-top: 1px solid var(--vp-c-divider);
   display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
+  flex-direction: column;
+  padding-top: 20px;
 }
-
-.links a {
+.feature-number {
   color: var(--vp-c-brand-1);
-  font-weight: 600;
-  text-decoration: none;
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  margin-bottom: 22px;
 }
-
-.links .primary {
-  background: linear-gradient(
-    135deg,
-    var(--mbx-amber-bright),
-    var(--mbx-amber-deep)
-  );
-  border-radius: 9px;
-  color: var(--mbx-ink);
-  padding: 10px 18px;
+h3 {
+  font-family: var(--mbx-display);
+  font-size: 22px;
+  letter-spacing: -0.025em;
+  line-height: 1.3;
+  margin-bottom: 14px;
 }
-
-.diagram {
-  display: grid;
-  grid-template-columns: 1fr;
+article > p {
+  color: var(--vp-c-text-2);
+  font-size: 15px;
+  line-height: 1.8;
 }
-
-.job,
-.pool {
-  background: #100c07;
-  border: 1px solid rgb(var(--mbx-amber-rgb) / 0.24);
-  padding: 17px 18px;
-}
-
-.job:first-child {
-  border-radius: 12px 12px 0 0;
-}
-
-.job.last {
-  border-radius: 0 0 12px 12px;
-}
-
-.job + .job {
-  border-top: 0;
-}
-
-.label,
-.pool span {
-  color: var(--vp-c-text-3);
+.feature-command {
+  color: var(--mbx-paper);
   display: block;
   font-family: var(--vp-font-family-mono);
   font-size: 11px;
-  margin-bottom: 5px;
+  margin: 22px 0;
+  overflow-wrap: anywhere;
 }
-
-.job code {
-  color: var(--mbx-paper);
-  font-family: var(--vp-font-family-mono);
+article .feature-note {
   font-size: 12px;
-  white-space: nowrap;
+  margin: -14px 0 20px;
 }
-
-.job.dim code {
-  color: var(--vp-c-text-3);
-  text-decoration: line-through;
+article > a {
+  margin-top: auto;
 }
-
-.join {
-  height: 56px;
-  margin: 0 auto;
-  position: relative;
-  width: 64%;
-}
-
-.join::after,
-.join span {
-  background: rgb(var(--mbx-amber-rgb) / 0.5);
-  content: "";
-  position: absolute;
-}
-
-.join span {
-  height: 1px;
-  top: 17px;
-  width: 50%;
-}
-
-.join span:first-child {
-  left: 0;
-  transform: rotate(16deg);
-  transform-origin: right;
-}
-
-.join span:last-child {
-  right: 0;
-  transform: rotate(-16deg);
-  transform-origin: left;
-}
-
-.join::after {
-  bottom: 0;
-  height: 29px;
-  left: 50%;
-  width: 1px;
-}
-
-.pool {
-  border-color: rgb(var(--mbx-teal-rgb) / 0.6);
+.proof {
+  align-items: center;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
   border-radius: 12px;
-  box-shadow: 0 18px 38px -24px rgb(var(--mbx-teal-rgb) / 0.7);
-  text-align: center;
+  display: grid;
+  gap: 40px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 36px 40px;
 }
-
-.pool .pool-title {
-  color: var(--mbx-teal-light);
-  font-family: var(--mbx-display);
-  font-size: 18px;
-  font-weight: 700;
-  margin-bottom: 5px;
+.proof h2 {
+  font-size: 30px;
 }
-
-.pool span:last-child {
-  margin: 0;
+.proof p:not(.home-eyebrow) {
+  color: var(--vp-c-text-2);
+  font-size: 15px;
+  line-height: 1.8;
+  margin-top: 16px;
+  max-width: 620px;
 }
-
-@media (min-width: 960px) {
-  .card {
-    grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.75fr);
-    padding: 56px;
-  }
-
-  .card.reverse {
-    grid-template-columns: minmax(340px, 0.75fr) minmax(0, 1.25fr);
-  }
-
-  .card.reverse .copy {
-    order: 2;
-  }
-
-  .card.reverse .diagram {
-    order: 1;
-  }
+.proof-link {
+  border-bottom: 1px solid var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+  font-size: 14px;
+  padding: 12px 0;
 }
-
-@media (max-width: 639px) {
-  .card {
+.proof-link span {
+  margin-left: 12px;
+}
+.reading {
+  padding-bottom: 32px;
+  padding-top: 80px;
+}
+.reading-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.reading-links a {
+  border-bottom: 1px solid var(--vp-c-divider);
+  border-top: 1px solid var(--vp-c-divider);
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr auto;
+  padding: 24px 20px;
+  transition: background 0.2s;
+}
+.reading-links a + a {
+  border-left: 1px solid var(--vp-c-divider);
+}
+.reading-links a:hover {
+  background: var(--vp-c-brand-soft);
+}
+.reading-links a > span:first-child {
+  color: var(--vp-c-text-2);
+  font-size: 12px;
+  grid-column: 1 / -1;
+}
+.reading-links strong {
+  font-size: 15px;
+  font-weight: 500;
+}
+.reading-links a > span:last-child {
+  color: var(--vp-c-brand-1);
+}
+.home-closing {
+  color: var(--vp-c-text-2);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 12px 24px;
+  line-height: 1.8;
+  padding: 32px 0;
+}
+.home-closing > span {
+  flex-basis: 100%;
+}
+.home-closing a {
+  color: var(--vp-c-brand-1);
+}
+.home-closing a:hover {
+  text-decoration: underline;
+}
+@media (max-width: 800px) {
+  .feature-columns,
+  .reading-links {
+    gap: 28px;
+    grid-template-columns: 1fr;
+  }
+  .reading-links {
+    gap: 0;
+  }
+  .reading-links a + a {
     border-left: 0;
-    border-radius: 0;
-    border-right: 0;
-    padding: 36px 24px;
+    border-top: 0;
   }
-
-  .MbxShowcase {
-    margin-top: 48px;
+  .proof {
+    grid-template-columns: 1fr;
+    gap: 20px;
+    padding: 28px;
   }
-
-  .job code {
-    font-size: 10px;
+  .proof-link {
+    justify-self: start;
   }
 }
 </style>

--- a/docs/.vitepress/theme/HomeTerminal.vue
+++ b/docs/.vitepress/theme/HomeTerminal.vue
@@ -1,295 +1,213 @@
-<script setup>
-import { onMounted, ref } from "vue";
+<script setup lang="ts">
+import { ref } from "vue";
 
-// A sample of the savings pool, with numbers consistent with the transcript
-// below (191 hits; the cold build took 3m 41s, the warm one 4.9s). The real
-// line is drawn at random per build. Pick one when the demo mounts and keep it
-// for the lifetime of the page, just like one invocation of mbx would.
-const quips = [
-  "mbx[savings]: served 191 compilations from cache; rustc showed up ready to do 3m 36s of work and was sent home",
-  "mbx[savings]: 6h 14m of compiling skipped across 87 builds. rustc suspects nothing.",
-  "mbx[savings]: 47.0 GiB of build debris binned so far. cargo clean remains unemployed.",
-  "mbx[savings]: your deleted worktrees left 41.0 GiB behind. left. past tense.",
-  "mbx[savings]: every checkout believes it owns 22.0 GiB of outputs. the disk keeps one copy and says nothing.",
-  "mbx[savings]: 4312 compilations on file. the box remembers.",
-  "mbx[savings]: rustc believes it compiled everything. it is down 6h 14m across 87 builds. let it believe.",
-  "mbx[savings]: 22.0 GiB in every checkout, 22.0 GiB on disk. arithmetic declined to comment.",
-];
-// Leave the SSR render empty so hydration agrees, then make the one random
-// choice in the browser. The line arrives with the rest of the transcript.
-const quip = ref("");
-const buildsRun = ref(0);
-
-function runBuild() {
-  if (buildsRun.value < 2) {
-    buildsRun.value += 1;
-  }
-}
-onMounted(() => {
-  quip.value = quips[Math.floor(Math.random() * quips.length)];
-});
+// An illustration of cache behavior, deliberately independent of benchmark data.
+const warm = ref(false);
+const crates = ["libc", "serde", "your-app"];
 </script>
 
 <template>
-  <section class="MbxDemo" aria-label="mbx across two checkouts">
-    <div class="window">
+  <section class="MbxDemo home-section" aria-labelledby="demo-title">
+    <div class="demo-copy">
+      <p class="home-eyebrow">01 / Build here. Reuse there.</p>
+      <h2 id="demo-title">A new worktree.<br />A head start.</h2>
+      <p>
+        One checkout compiles a dependency. The next can restore it, even from a
+        different path. Each keeps its own Cargo target directory while sharing
+        cached work.
+      </p>
+      <a class="home-text-link" href="/how-it-works#portable-keys"
+        >How the cache travels <span aria-hidden="true">→</span></a
+      >
+    </div>
+    <div class="terminal">
       <div class="titlebar">
-        <span aria-hidden="true" class="dot"></span>
-        <span aria-hidden="true" class="dot"></span>
-        <span aria-hidden="true" class="dot"></span>
-        <span class="label">two checkouts · one cache</span>
+        <span class="terminal-dots" aria-hidden="true">● ● ●</span>
+        <span>two worktrees / one store</span>
+        <span class="demo-label">illustration</span>
       </div>
       <div
-        aria-live="polite"
-        class="screen"
-        role="log"
+        class="scenario-controls"
+        role="group"
+        aria-label="Choose a build scenario"
       >
-        <div v-if="buildsRun === 0" class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
-        <template v-if="buildsRun >= 1">
-          <div class="build-output cold-build">
-            <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
-            <div class="line"><span class="verb">   Compiling</span> libc v0.2.174</div>
-            <div class="line"><span class="verb">   Compiling</span> serde v1.0.219</div>
-            <div class="line dim">            … 193 more crates …</div>
-            <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time">3m 41s</span></div>
-            <div aria-hidden="true" class="line gap"></div>
-            <div class="line"><span class="path">~/proj</span> <span class="prompt">$</span> <span class="cmd">git worktree add ../review &amp;&amp; cd ../review</span></div>
-            <div v-if="buildsRun === 1" class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
-          </div>
-        </template>
-        <template v-if="buildsRun >= 2">
-          <div class="build-output warm-build">
-            <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span class="cmd">mbx build</span></div>
-            <div class="line"><span class="verb">    Finished</span> `dev` profile [unoptimized + debuginfo] target(s) in <span class="time fast">4.9s</span></div>
-            <div class="line cache">mbx[cache]: 191 hits, 3 misses, 187 prefetched; 0 B downloaded, 0 B uploaded, 412.6 MiB stored locally</div>
-            <div class="line quip">{{ quip }}</div>
-            <div class="line"><span class="path">~/review</span> <span class="prompt">$</span> <span aria-hidden="true" class="cursor"></span></div>
-          </div>
-        </template>
+        <button type="button" :aria-pressed="!warm" @click="warm = false">
+          First build
+        </button>
+        <button type="button" :aria-pressed="warm" @click="warm = true">
+          New worktree
+        </button>
       </div>
-      <div v-if="buildsRun < 2" class="controls">
-        <button class="run" type="button" @click="runBuild">run cargo build</button>
-        <span class="progress">build {{ buildsRun + 1 }} of 2</span>
+      <div class="screen" role="status" aria-live="polite" aria-atomic="true">
+        <p class="command">
+          <span class="path">{{ warm ? "~/review" : "~/project" }}</span>
+          <span class="prompt">$</span> mbx build
+        </p>
+        <div v-for="crate in crates" :key="crate" class="compiler-row">
+          <span class="outcome" :class="{ restored: warm }">{{
+            warm ? "Restored" : "Compiling"
+          }}</span>
+          <span>{{ crate }}</span>
+          <span class="row-note">{{
+            warm ? "cache hit" : "stored for later"
+          }}</span>
+        </div>
+        <p class="result">
+          {{
+            warm
+              ? "Matching work, ready to use."
+              : "Freshly compiled. Safely tucked away."
+          }}
+        </p>
       </div>
+      <p class="terminal-note">
+        {{
+          warm
+            ? "Matching inputs can reuse outputs. Changed or unsupported work still compiles."
+            : "A cold cache fills as you build. Cargo still skips any work it already considers fresh."
+        }}
+      </p>
     </div>
-    <p class="caption">Whatever one checkout compiles, the next one reuses — locally or in CI.</p>
   </section>
 </template>
 
 <style scoped>
 .MbxDemo {
-  box-sizing: border-box;
-  margin: 0 auto;
-  max-width: 1280px;
-  padding: 16px 24px 8px;
-  width: 100%;
+  align-items: center;
+  display: grid;
+  gap: 48px;
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+  padding-bottom: 72px;
+  padding-top: 56px;
 }
-
-@media (min-width: 640px) {
-  .MbxDemo {
-    padding: 24px 48px 8px;
-  }
+.demo-copy > p:not(.home-eyebrow) {
+  color: var(--vp-c-text-2);
+  font-size: 17px;
+  line-height: 1.8;
+  margin: 20px 0 24px;
+  max-width: 390px;
 }
-
-@media (min-width: 960px) {
-  .MbxDemo {
-    padding: 32px 64px 8px;
-  }
+.terminal {
+  background: #11100d;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  box-shadow: 0 18px 48px -24px #000;
+  min-width: 0;
 }
-
-.window {
-  background: #100c07;
-  border: 1px solid rgb(var(--mbx-amber-rgb) / 0.22);
-  border-radius: 14px;
-  box-shadow:
-    0 30px 70px -30px rgba(0, 0, 0, 0.75),
-    0 20px 60px -30px rgb(var(--mbx-amber-rgb) / 0.2);
-  overflow: hidden;
-}
-
 .titlebar {
   align-items: center;
-  background: rgb(var(--mbx-amber-rgb) / 0.07);
-  border-bottom: 1px solid rgb(var(--mbx-amber-rgb) / 0.14);
+  border-bottom: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
   display: flex;
-  gap: 8px;
-  padding: 10px 14px;
-}
-
-.dot {
-  background: rgb(var(--mbx-amber-rgb) / 0.35);
-  border-radius: 50%;
-  height: 11px;
-  width: 11px;
-}
-
-.label {
-  color: var(--vp-c-text-3);
+  flex-wrap: wrap;
   font-family: var(--vp-font-family-mono);
-  font-size: 12px;
-  letter-spacing: 0.04em;
+  font-size: 10px;
+  gap: 12px;
+  padding: 14px 18px;
+}
+.terminal-dots {
+  color: #766444;
+  letter-spacing: 2px;
+}
+.demo-label {
+  color: var(--mbx-teal-light);
   margin-left: auto;
 }
-
+.scenario-controls {
+  display: flex;
+  gap: 4px;
+  padding: 18px 20px 0;
+}
+.scenario-controls button {
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  font-size: 12px;
+  min-height: 44px;
+  padding: 8px 12px;
+}
+.scenario-controls button[aria-pressed="true"] {
+  background: var(--vp-c-brand-soft);
+  border-color: var(--vp-c-divider);
+  color: var(--vp-c-brand-1);
+}
+.scenario-controls button:hover {
+  color: var(--vp-c-text-1);
+}
 .screen {
   font-family: var(--vp-font-family-mono);
-  font-size: 13px;
-  line-height: 1.75;
-  overflow-x: auto;
-  padding: 18px 20px;
+  font-size: 12px;
+  line-height: 1.8;
+  padding: 22px 24px 16px;
 }
-
-.line {
-  animation: mbx-line-in 0.45s ease both;
-  white-space: pre;
+.command {
+  color: var(--mbx-paper);
+  margin-bottom: 22px;
 }
-
-.build-output .line:nth-child(1) { animation-delay: 0.05s; }
-.build-output .line:nth-child(2) { animation-delay: 0.25s; }
-.build-output .line:nth-child(3) { animation-delay: 0.4s; }
-.build-output .line:nth-child(4) { animation-delay: 0.55s; }
-.build-output .line:nth-child(5) { animation-delay: 0.85s; }
-
-.cold-build .line:nth-child(6) { animation-delay: 0.85s; }
-.cold-build .line:nth-child(7) { animation-delay: 1.05s; }
-.cold-build .line:nth-child(8) { animation-delay: 1.25s; }
-
-.warm-build .line:nth-child(2) { animation-delay: 0.35s; }
-.warm-build .line:nth-child(3) { animation-delay: 0.55s; }
-.warm-build .line:nth-child(4) { animation-delay: 0.75s; }
-.warm-build .line:nth-child(5) { animation-delay: 0.95s; }
-
-.gap {
-  height: 0.9em;
-}
-
 .path {
   color: var(--mbx-teal-light);
 }
-
 .prompt {
   color: var(--vp-c-brand-1);
+  margin: 0 6px;
 }
-
-.cmd {
-  color: var(--mbx-paper);
-  font-weight: 600;
+.compiler-row {
+  align-items: baseline;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 9ch 1fr auto;
+  padding: 7px 0;
 }
-
-.verb {
+.outcome {
+  color: var(--vp-c-brand-1);
+}
+.outcome.restored {
   color: var(--mbx-cargo-green);
-  font-weight: 600;
 }
-
-.dim {
+.row-note {
   color: var(--vp-c-text-3);
+  font-size: 10px;
 }
-
-.time {
+.result {
+  border-top: 1px dashed var(--vp-c-divider);
   color: var(--mbx-paper);
-  font-weight: 600;
+  margin-top: 22px;
+  padding-top: 16px;
 }
-
-.time.fast {
-  background: rgb(var(--mbx-amber-rgb) / 0.18);
-  border-radius: 4px;
-  color: var(--vp-c-brand-1);
-  padding: 1px 5px;
-}
-
-.cache {
-  color: var(--vp-c-brand-1);
-}
-
-.quip {
-  color: rgb(var(--mbx-amber-rgb) / 0.9);
-  min-height: 1.75em;
-}
-
-.cursor {
-  animation: mbx-blink 1.1s steps(1) infinite;
-  background: var(--vp-c-brand-1);
-  display: inline-block;
-  height: 1.1em;
-  vertical-align: text-bottom;
-  width: 0.55em;
-}
-
-.controls {
-  align-items: center;
-  border-top: 1px solid rgb(var(--mbx-amber-rgb) / 0.14);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 18px 20px 20px;
-}
-
-.run {
-  background: linear-gradient(135deg, var(--mbx-amber-bright), var(--mbx-amber-deep));
-  border: 0;
-  border-radius: 9px;
-  box-shadow: 0 12px 28px -12px rgb(var(--mbx-amber-rgb) / 0.75);
-  color: var(--mbx-ink);
-  cursor: pointer;
-  font-family: var(--vp-font-family-mono);
-  font-size: 17px;
-  font-weight: 700;
-  min-height: 48px;
-  padding: 12px 28px;
-  transition: box-shadow 0.2s ease, filter 0.2s ease, transform 0.2s ease;
-}
-
-.run:hover {
-  box-shadow: 0 16px 34px -12px rgb(var(--mbx-amber-rgb) / 0.9);
-  filter: brightness(1.08);
-  transform: translateY(-1px);
-}
-
-.run:active {
-  transform: translateY(1px);
-}
-
-.run:focus-visible {
-  outline: 3px solid var(--mbx-teal-light);
-  outline-offset: 3px;
-}
-
-.progress {
-  color: var(--vp-c-text-3);
-  font-family: var(--vp-font-family-mono);
-  font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.caption {
+.terminal-note {
+  border-top: 1px solid var(--vp-c-divider);
   color: var(--vp-c-text-2);
-  font-size: 14px;
-  margin-top: 14px;
-  text-align: center;
+  font-size: 12px;
+  line-height: 1.7;
+  min-height: 68px;
+  padding: 14px 24px;
 }
-
-@keyframes mbx-line-in {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
+@media (max-width: 800px) {
+  .MbxDemo {
+    gap: 28px;
+    grid-template-columns: 1fr;
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes mbx-blink {
-  50% {
-    opacity: 0;
+  .demo-copy > p:not(.home-eyebrow) {
+    max-width: 540px;
   }
 }
-
-@media (prefers-reduced-motion: reduce) {
-  .line,
-  .cursor {
-    animation: none;
+@media (max-width: 400px) {
+  .screen {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  .row-note {
+    display: none;
+  }
+  .compiler-row {
+    grid-template-columns: 9ch 1fr;
+  }
+  .titlebar {
+    gap: 8px;
+  }
+  .terminal-dots {
+    display: none;
   }
 }
 </style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,317 +1,378 @@
-/* mr boxington — warm cardboard-dark theme */
+/* Shared palette for the docs, landing page, and cache dashboard. */
+@font-face {
+  font-family: "Space Grotesk";
+  font-style: normal;
+  font-weight: 300 700;
+  font-display: swap;
+  src: url("../fonts/SpaceGrotesk.ttf") format("truetype");
+}
 
 :root {
   --mbx-display: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
-
-  /*
-   * The two hues that carry alpha variants are stored as channel triples, so
-   * every translucent use composes from one value: rgb(var(--mbx-amber-rgb) / 0.16).
-   * The rest are opaque one-offs and stay plain hex.
-   */
   --mbx-amber-rgb: 230 173 84;
   --mbx-teal-rgb: 111 142 147;
   --mbx-amber-shade-rgb: 189 125 35;
-
   --mbx-amber: rgb(var(--mbx-amber-rgb));
   --mbx-amber-bright: #f2c479;
   --mbx-amber-deep: #cf8f35;
   --mbx-amber-shade: rgb(var(--mbx-amber-shade-rgb));
-  --mbx-teal-light: #7fa6ad;
-  --mbx-ink: #1c160d;
+  --mbx-teal-light: #9bbbc0;
+  --mbx-ink: #20190e;
   --mbx-paper: #f5ead6;
-  --mbx-cargo-green: #86c07e;
-
-  --vp-font-family-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-
-  --vp-c-brand-1: var(--mbx-amber-shade);
-  --vp-c-brand-2: #9f6518;
-  --vp-c-brand-3: #7e4c0d;
-  --vp-c-brand-soft: rgb(var(--mbx-amber-shade-rgb) / 0.16);
-  --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(
-    120deg,
-    var(--mbx-amber-bright) 15%,
-    var(--mbx-amber) 55%,
-    var(--mbx-teal-light)
-  );
-  --vp-home-hero-image-background-image: radial-gradient(
-    circle,
-    rgb(var(--mbx-amber-rgb) / 0.4),
-    rgb(var(--mbx-teal-rgb) / 0.18) 52%,
-    transparent 72%
-  );
-  --vp-home-hero-image-filter: blur(48px);
+  --mbx-cargo-green: #a1ca92;
+  --vp-font-family-mono:
+    "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --vp-sidebar-width: 280px;
+  --vp-home-hero-name-color: var(--vp-c-brand-1);
+  --vp-home-hero-name-background: none;
+  --vp-home-hero-image-background-image: none;
+  --vp-home-hero-image-filter: none;
 }
 
 .dark {
   --vp-c-brand-1: var(--mbx-amber);
-  --vp-c-brand-2: var(--mbx-amber-deep);
-  --vp-c-brand-3: #b9761c;
-  --vp-c-brand-soft: rgb(var(--mbx-amber-rgb) / 0.16);
-
-  /* warm the neutral greys toward cardboard */
-  --vp-c-bg: #161209;
-  --vp-c-bg-alt: #100d07;
-  --vp-c-bg-elv: #1e1810;
-  --vp-c-bg-soft: #1e1810;
-  --vp-c-divider: rgb(var(--mbx-amber-rgb) / 0.15);
-  --vp-c-gutter: #0c0a05;
-  --vp-code-block-bg: #100d07;
-  --vp-c-text-1: #f1e9da;
-  --vp-c-text-2: #b3a891;
-  --vp-c-text-3: #837a66;
+  --vp-c-brand-2: #f2c479;
+  --vp-c-brand-3: #bd7d23;
+  --vp-c-brand-soft: rgb(var(--mbx-amber-rgb) / 0.12);
+  --vp-c-bg: #191713;
+  --vp-c-bg-alt: #14120f;
+  --vp-c-bg-elv: #24211b;
+  --vp-c-bg-soft: #211e18;
+  --vp-c-divider: #3d362b;
+  --vp-c-gutter: #110f0c;
+  --vp-code-block-bg: #14120f;
+  --vp-c-text-1: #eee8dd;
+  --vp-c-text-2: #c0b7a6;
+  --vp-c-text-3: #a79b86;
 }
 
 ::selection {
-  background: rgb(var(--mbx-amber-rgb) / 0.35);
+  background: rgb(var(--mbx-amber-rgb) / 0.3);
 }
-
-::-webkit-scrollbar {
-  height: 10px;
-  width: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: rgb(var(--mbx-amber-rgb) / 0.22);
-  border: 2px solid transparent;
-  background-clip: padding-box;
-  border-radius: 6px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: rgb(var(--mbx-amber-rgb) / 0.38);
-  background-clip: padding-box;
-}
-
-/* subtle paper grain over everything */
-body::after {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-  content: "";
-  inset: 0;
-  opacity: 0.035;
-  pointer-events: none;
-  position: fixed;
-  z-index: 999;
+a:focus-visible,
+button:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--mbx-teal-light);
+  outline-offset: 4px;
 }
 
 /* The cache dashboard is a full-bleed application surface. */
 .mbx-dashboard-page .VPPage {
   padding: 0;
 }
-
 .mbx-dashboard-page .VPContent {
   padding: 0 !important;
 }
-
 .mbx-dashboard-page .VPLocalNav,
 .mbx-dashboard-page .EndevSponsors,
 .mbx-dashboard-page .EndevFooter {
   display: none;
 }
 
-/* ---------- navbar ---------- */
-
 .VPNavBarTitle .title {
   font-family: var(--mbx-display);
   font-weight: 700;
-  letter-spacing: -0.02em;
-}
-
-/* ---------- home ---------- */
-
-.VPHome {
-  background:
-    radial-gradient(64rem 36rem at 85% -8%, rgb(var(--mbx-amber-rgb) / 0.12), transparent 60%),
-    radial-gradient(52rem 32rem at 0% 18%, rgb(var(--mbx-teal-rgb) / 0.12), transparent 60%);
-}
-
-.VPHero .name {
-  font-family: var(--mbx-display);
   letter-spacing: -0.03em;
 }
-
-.VPHero .text {
-  font-family: var(--vp-font-family-mono);
-  letter-spacing: normal;
+.VPNavBarTitle .logo {
+  height: 30px;
+}
+.VPNavBarMenuLink {
+  font-size: 13px !important;
 }
 
+/* Landing: generous type, restrained surfaces, and one primary action. */
+.VPHome {
+  background: radial-gradient(
+    ellipse 44rem 32rem at 90% 4%,
+    rgb(var(--mbx-amber-rgb) / 0.07),
+    transparent 75%
+  );
+  margin-bottom: 0 !important;
+}
+.VPHero {
+  padding-bottom: 24px !important;
+}
+.VPHero .name {
+  font-family: var(--mbx-display);
+  font-size: 19px;
+  letter-spacing: -0.02em;
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+.VPHero .text {
+  font-family: var(--mbx-display);
+  font-size: clamp(38px, 5.2vw, 66px);
+  font-weight: 600;
+  letter-spacing: -0.055em;
+  line-height: 1.08;
+  max-width: 650px;
+}
 .VPHero .text code {
-  background: none;
-  color: inherit;
+  color: var(--vp-c-brand-1);
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;
+}
+.VPHero .tagline {
+  color: var(--vp-c-text-2);
+  font-size: 18px;
+  line-height: 1.8;
+  max-width: 540px;
+  padding-top: 24px;
+}
+.VPHero .image-src {
+  filter: drop-shadow(0 24px 30px #0005);
+  max-height: 300px;
+  max-width: 300px;
+}
+.VPHero .image-bg {
+  border: 1px dashed rgb(var(--mbx-amber-rgb) / 0.22);
+  border-radius: 50%;
+  height: 350px;
+  width: 350px;
+}
+.VPHero .actions {
+  gap: 12px;
+  padding-top: 28px;
+}
+.VPHero .action {
   padding: 0;
 }
-
-.VPHero .name .clip {
-  position: relative;
-  z-index: 0;
+.VPButton {
+  border-radius: 7px !important;
 }
-
-/* a strip of packing tape behind the name */
-.VPHero .name .clip::after {
-  background: repeating-linear-gradient(
-    -45deg,
-    rgb(var(--mbx-amber-rgb) / 0.18) 0 12px,
-    rgb(var(--mbx-amber-rgb) / 0.09) 12px 24px
-  );
-  border-radius: 3px;
-  bottom: 0.04em;
-  content: "";
-  height: 0.42em;
-  left: -0.25em;
-  position: absolute;
-  right: -0.25em;
-  transform: rotate(-1.2deg);
-  z-index: -1;
-}
-
-.VPHero .tagline {
-  max-width: 34rem;
-}
-
-@media (min-width: 960px) {
-  .VPHero .name {
-    font-size: 64px;
-    line-height: 72px;
-  }
-}
-
-.VPHero .image-src {
-  animation: mbx-float 7s ease-in-out infinite;
-  filter: drop-shadow(0 26px 38px rgba(0, 0, 0, 0.38));
-}
-
-@keyframes mbx-float {
-  0%,
-  100% {
-    transform: translate(-50%, -50%);
-  }
-  50% {
-    transform: translate(-50%, calc(-50% - 12px));
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .VPHero .image-src {
-    animation: none;
-  }
-}
-
-.VPButton.brand {
-  background: linear-gradient(135deg, var(--mbx-amber-bright), var(--mbx-amber-deep));
-  border-color: transparent;
-  box-shadow: 0 10px 28px -10px rgb(var(--mbx-amber-rgb) / 0.55);
+.VPHome .VPButton.brand {
+  background: var(--mbx-amber);
+  border-color: var(--mbx-amber);
   color: var(--mbx-ink);
   font-weight: 700;
-  transition: box-shadow 0.25s ease, filter 0.25s ease, transform 0.25s ease;
 }
-
-.VPButton.brand:hover {
-  background: linear-gradient(135deg, var(--mbx-amber-bright), var(--mbx-amber-deep));
-  box-shadow: 0 14px 34px -10px rgb(var(--mbx-amber-rgb) / 0.7);
+.VPHome .VPButton.brand:hover {
+  background: var(--mbx-amber-bright);
+  border-color: var(--mbx-amber-bright);
   color: var(--mbx-ink);
-  filter: brightness(1.08);
-  transform: translateY(-1px);
 }
-
-.VPButton.alt {
-  border: 1px solid var(--vp-c-divider);
-  transition: border-color 0.25s ease, transform 0.25s ease;
+.VPHome .VPButton.alt {
+  background: transparent;
+  border-color: var(--vp-c-divider);
 }
-
-.VPButton.alt:hover {
+.VPHome .VPButton.alt:hover {
+  background: var(--vp-c-bg-soft);
   border-color: var(--vp-c-brand-1);
-  transform: translateY(-1px);
 }
-
-.VPFeature {
-  background: linear-gradient(180deg, rgb(var(--mbx-amber-rgb) / 0.06), rgb(var(--mbx-amber-rgb) / 0) 45%), var(--vp-c-bg-soft);
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 14px;
-  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+.home-section {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1152px;
+  width: calc(100% - 128px);
 }
-
-.VPFeature:hover {
-  border-color: rgb(var(--mbx-amber-rgb) / 0.55);
-  box-shadow:
-    0 18px 40px -18px rgb(var(--mbx-amber-rgb) / 0.3),
-    0 12px 32px -12px rgba(0, 0, 0, 0.5);
-  transform: translateY(-4px);
+.home-eyebrow {
+  color: var(--vp-c-brand-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+  letter-spacing: 0.09em;
+  line-height: 1.7;
+  margin: 0 0 18px;
+  text-transform: uppercase;
 }
-
-.VPFeature .icon {
-  background: linear-gradient(160deg, rgb(var(--mbx-amber-rgb) / 0.22), rgb(var(--mbx-teal-rgb) / 0.16));
-  border: 1px solid rgb(var(--mbx-amber-rgb) / 0.25);
-  border-radius: 16px;
-  font-size: 26px;
-  height: 88px;
-  width: 88px;
-}
-
-.VPFeature .title {
+.home-section h2 {
+  color: var(--vp-c-text-1);
   font-family: var(--mbx-display);
-  font-size: 17px;
-  letter-spacing: -0.01em;
+  font-size: clamp(30px, 3.5vw, 42px);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1.16;
+}
+.home-text-link {
+  color: var(--vp-c-brand-1);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.7;
+}
+.home-text-link span {
+  display: inline-block;
+  margin-left: 8px;
+}
+.home-text-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 5px;
 }
 
-/* ---------- doc pages ---------- */
-
+/* Long-form docs: readable body copy, calm headings, and usable references. */
+.vp-doc {
+  font-size: 16px;
+  line-height: 1.8;
+}
+.vp-doc p,
+.vp-doc li {
+  line-height: 1.8;
+}
 .vp-doc h1,
 .vp-doc h2,
-.vp-doc h3 {
+.vp-doc h3,
+.vp-doc h4 {
   font-family: var(--mbx-display);
-  letter-spacing: -0.02em;
 }
-
+.vp-doc h1 {
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1.2;
+  margin-bottom: 24px;
+}
+.vp-doc h1 + p {
+  color: var(--vp-c-text-2);
+  font-size: 18px;
+  line-height: 1.8;
+}
 .vp-doc h2 {
-  border-top: none;
-  margin: 56px 0 20px;
-  padding-top: 0;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  margin: 48px 0 20px;
+  padding-top: 24px;
 }
-
-.vp-doc h2::before {
-  background: linear-gradient(90deg, var(--mbx-amber), transparent);
-  border-radius: 2px;
-  content: "";
-  display: block;
-  height: 3px;
-  margin-bottom: 0.8rem;
-  width: 2.25rem;
+.vp-doc h3 {
+  font-size: 21px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  margin-top: 32px;
 }
-
+.vp-doc h3 code {
+  font-size: 0.8em;
+  overflow-wrap: anywhere;
+}
+.vp-doc a {
+  text-underline-offset: 3px;
+}
 .vp-doc div[class*="language-"] {
   border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
 }
-
 .vp-doc [class*="language-"] > span.lang {
-  color: var(--vp-c-brand-1);
+  color: var(--vp-c-text-2);
+}
+.vp-doc [class*="language-"] code {
+  font-size: 13px;
+  line-height: 1.7;
+}
+.vp-doc :not(pre) > code {
+  overflow-wrap: anywhere;
+}
+.vp-doc table {
+  font-size: 14px;
+  line-height: 1.6;
+}
+.vp-doc th {
+  background: var(--vp-c-bg-soft);
+  font-size: 13px;
   font-weight: 600;
+  text-align: left;
 }
-
+.vp-doc td,
+.vp-doc th {
+  padding: 12px 16px;
+}
+.vp-doc tr:nth-child(2n) {
+  background: transparent;
+}
 .vp-doc .custom-block {
-  border-radius: 12px;
+  border-radius: 8px;
+  font-size: 14px;
 }
-
 .vp-doc .custom-block.tip {
   border-left: 3px solid var(--vp-c-tip-1);
 }
-
 .vp-doc .custom-block.warning {
   border-left: 3px solid var(--vp-c-warning-1);
 }
-
 .vp-doc .custom-block.danger {
   border-left: 3px solid var(--vp-c-danger-1);
 }
+.vp-doc img {
+  border-radius: 8px;
+}
+.VPSidebarItem.level-0 > .item > .text {
+  color: var(--vp-c-text-1);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.VPSidebarItem.is-active > .item > .link > .text {
+  color: var(--vp-c-brand-1);
+}
+.VPDocAsideOutline .outline-link {
+  font-size: 12px;
+}
 
-/* ---------- announcement banner ---------- */
+@media (max-width: 959px) {
+  .home-section {
+    width: calc(100% - 96px);
+  }
+  .VPHome .VPHero {
+    margin-top: 0;
+    padding-top: 40px !important;
+  }
+  .VPHero .image {
+    margin: 0 0 24px;
+  }
+  .VPHero .image-container {
+    height: 280px;
+    max-width: 100%;
+  }
+  .VPHero .image-src {
+    max-height: 220px;
+    max-width: 220px;
+  }
+  .VPHero .image-bg {
+    height: 260px;
+    width: 260px;
+  }
+  .VPHero .name {
+    margin-bottom: 12px;
+  }
+}
+@media (max-width: 639px) {
+  .home-section {
+    width: calc(100% - 48px);
+  }
+  .VPHome .VPHero {
+    padding-top: 24px !important;
+  }
+  .VPHero .image {
+    margin: 0 0 20px;
+  }
+  .VPHero .image-container {
+    height: 200px;
+  }
+  .VPHero .image-src {
+    max-height: 175px;
+    max-width: 175px;
+  }
+  .VPHero .image-bg {
+    height: 200px;
+    width: 200px;
+  }
+  .VPHero .tagline {
+    font-size: 16px;
+  }
+  .vp-doc h1 {
+    font-size: 30px;
+  }
+  .vp-doc div[class*="language-"] {
+    border-radius: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+  }
+}
 
+/* Shared announcement and social link integration. */
 .VPSocialLinks {
   align-items: center !important;
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import BenchmarkResults from "./BenchmarkResults.vue";
 import CacheDashboard from "./CacheDashboard.vue";
 import EndevFooter from "./EndevFooter.vue";
 import EndevSponsors from "./EndevSponsors.vue";
+import HomeQuickStart from "./HomeQuickStart.vue";
 import HomeShowcase from "./HomeShowcase.vue";
 import HomeTerminal from "./HomeTerminal.vue";
 import HomeTui from "./HomeTui.vue";
@@ -17,6 +18,7 @@ export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
+      "home-hero-actions-after": () => h(HomeQuickStart),
       "home-hero-after": () => h(HomeTerminal),
       "home-features-after": () => [h(HomeTui), h(HomeShowcase)],
       "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,7 +1,10 @@
+---
+description: The Cargo, sccache, and kache projects that made mbx possible and informed its design.
+---
 # Acknowledgements
 
-mbx relies on Cargo and follows earlier compiler-cache work in sccache and
-kache.
+mbx depends on Cargo and builds on ideas established by earlier compiler
+caches. In particular, kache directly inspired the project's design.
 
 ## Cargo
 
@@ -25,6 +28,8 @@ different tradeoffs.
 inspired its design. It combines a content-addressed `RUSTC_WRAPPER` cache
 with C and C++ compiler shims, remote storage, and executable caching.
 
-The projects do not share code, and they make different tradeoffs. The
+The projects do not share code. Both aim to make compiled work reusable across
+checkouts; they differ in process lifecycle, storage management, and remote
+policy. The
 [comparison with kache](/compared#kache) explains where mbx took a different
 direction and where kache may be the better fit.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,19 +1,20 @@
+---
+description: Compare Cargo, mbx, and kache on a pinned Rust project with documented trials and workload limitations.
+---
 # Benchmarks
 
 mbx is measured against plain Cargo and
 [kache](https://github.com/kunobi-ninja/kache) on [jdx/hk](https://github.com/jdx/hk),
 a mid-size Rust CLI with C dependencies, pinned to one commit and built with
-`cargo build --locked`. Each scenario is a shape CI or a developer actually
-hits. The numbers come from a GitHub Actions run, never a laptop, and the page
+`cargo build --locked`. The scenarios cover work a developer or CI runner may repeat. The numbers come from a GitHub Actions run, never a laptop, and the page
 will not name a fastest tool when the gap is inside run-to-run noise.
 
 <BenchmarkResults />
 
-## Reading the cards
+## Reading the results {#reading-the-cards}
 
 Every timed scenario runs three times per tool from a fresh clone and an
-empty store. The bar is the middle run and the whisker through it spans the
-fastest and slowest. A tool is marked fastest only when its lead over the next
+empty store. The bar shows the median; the whisker spans the fastest and slowest trial. A tool is marked fastest only when its lead over the next
 one is wider than either tool's own whisker; otherwise the card says so and
 names nobody.
 
@@ -44,12 +45,12 @@ A full build, then one line of hk's own source changed and rebuilt in the same
 cache's own bookkeeping is most of what shows up. Two details keep it honest:
 
 - `CI` is unset for every tool. mbx switches
-  [learned incremental reuse](/configuration#learned-incremental-reuse) off
+  [learned incremental reuse](/incremental#learned-incremental-reuse) off
   when it sees that variable, on the reasoning that a fresh runner never edits
   code. With it set, every edit recompiled the crate in full.
 - The first edit after a build is discarded and the second is timed. Cargo's
   own build already wrote its incremental state, while mbx builds an edited
-  crate's [private state](/configuration#learned-incremental-reuse) on the
+  crate's [private state](/incremental#learned-incremental-reuse) on the
   first edit and reuses it afterwards. The card shows what that first edit
   cost, since a developer waits for it once per fresh build.
 
@@ -60,7 +61,7 @@ all-targets/all-features variants of `cargo check`, Clippy, and test
 compilation. The sequential row runs them in turn in one `target/`. The two
 parallel rows give each job its own `target/`, as separate CI steps would,
 and differ only in whether the
-[machine-wide scheduler](/configuration#machine-wide-compile-scheduling) is
+[machine-wide scheduler](/scheduling#machine-wide-compile-scheduling) is
 on. Cargo bounds the compilers it starts itself and knows nothing about the
 Cargo process beside it; the scheduler gives every process one pool of permits
 and holds identical compilations until the first finishes. Peak compilers and
@@ -80,7 +81,7 @@ oversubscribed it.
   inherited `RUSTC_WRAPPER` is cleared, and the run fails if the Cargo
   baseline turns out to be an mbx shim.
 - Both caches run local-only. A remote would measure the network.
-- A run that measured nothing is discarded rather than rendered. That is any
+- Validity checks reject runs that do not exercise the intended cache behavior. That is any
   run where a warm build restored nothing or was no faster than the build that
   seeded it, where the edit rebuild compiled nothing, or where the scheduled
   contention batch went past its permits or the unscheduled one never did.
@@ -104,9 +105,11 @@ directly.
 
 ## What this does not measure
 
-Anything hk does not do. A project with a very different dependency shape,
+These results describe the pinned hk workload. A project with a very different dependency shape,
 such as heavy proc macros, a large C component, or many small leaf crates,
-will see different ratios. The benchmark is Linux-only, and
+will see different ratios. Three trials expose some variation; their ranges
+are not confidence intervals, and a “fastest” label is a display heuristic,
+not a statistical significance test. The benchmark is Linux-only, and
 [limits](/limits) covers what changes on macOS and Windows.
 
 Instruction-counted measurements of mbx's own startup path, and cold and warm

--- a/docs/cache-results.md
+++ b/docs/cache-results.md
@@ -1,7 +1,44 @@
+---
+description: Read cache counters, measure reuse with fresh targets, and diagnose hits, misses, bypasses, and remote failures.
+---
 # Cache results
 
-The short summary separates work mbx handled from work it could not safely
-cache. Set `MBX_SUMMARY=full` for the detailed breakdown described below.
+Use the build summary to see what mbx restored, compiled, or left uncached.
+Counts describe compiler actions observed by mbx; they do not include work
+Cargo skipped because its outputs were already fresh.
+
+```sh
+mbx explain --last          # inspect the most recent recorded build
+MBX_SUMMARY=full mbx build  # print a detailed report for a new build
+```
+
+| Outcome | Cache lookup? | Result stored? |
+| --- | --- | --- |
+| [Hit](#hit) | Found a result | Already stored |
+| [Miss](#miss) | No matching result | After successful compilation |
+| [Not looked up](#could-not-look-up) | No usable input prediction yet | After successful compilation |
+| [Bypass](#bypass) | Skipped | No shared result |
+
+## Measure cache reuse
+
+Running the same command twice in the same target directory often measures
+Cargo's freshness check: no compiler work is needed. To observe mbx reuse,
+build equivalent source with the same toolchain, profile, and features into
+two fresh target directories:
+
+```sh
+mbx build --target-dir target/cache-demo-first
+mbx build --target-dir target/cache-demo-second
+```
+
+Use directory names that do not already contain build outputs. This keeps your
+normal target intact and avoids deleting the shared cache. The second build
+can restore work recorded by the first; unsupported actions still run.
+These explicit targets are not managed, so remove the two example directories
+when you finish. For repeatable timings, use the [benchmark harness](/benchmarks).
+
+Compiler time avoided is summed across actions. It is not elapsed time saved;
+always compare wall-clock build time as well as the counters.
 
 ## Hit
 
@@ -52,7 +89,7 @@ Expected for Cargo probes: source supplied on standard input cannot be rediscove
   - rustc invocation reads source from standard input
 ```
 
-Categories marked expected appear on every build and cost nothing; here the
+Categories marked expected are routine compiler probes, with no output to cache; here the
 `incremental` group is the one the build could act on. The command preserves
 Cargo's exit status after printing the explanation.
 
@@ -69,9 +106,11 @@ not bypass counts, because mbx never observed the compiler invocations.
 
 ## Remote failure
 
-A remote cache request failed and the build carried on without it: unreachable
-host, refused credentials, or a response this client would not accept. mbx never
-fails a build over a remote cache, so these only cost hit rate. The summary
+A remote cache request failed and the build continued without that result:
+an unreachable host, refused credentials, or an invalid response can all reduce
+reuse. Build-time transport failures fall back to local compilation. Invalid
+configuration can still stop startup, and explicit `mbx prefetch` and
+`mbx doctor` commands report connection failures as errors. The summary
 counts them because a remote that is failing every request reports the same
 hits, misses, and bytes as one that was empty. The short summary includes the
 count inline; the full summary explains it:
@@ -116,8 +155,8 @@ mbx explain build --workspace
 The usual causes, roughly in the order they show up:
 
 - The store is cold. A first build has no dep-info to derive keys from, so
-  "could not look up" dominates and everything is stored. Read the hit rate
-  off the second build.
+  "could not look up" can dominate. Compare equivalent builds with fresh
+  targets as described [above](#measure-cache-reuse).
 - Incremental builds are enabled. With `MBX_INCREMENTAL=1`, workspace
   members compile incrementally, those compilations bypass the cache, and the
   changed artifacts make crates above them miss too. See
@@ -139,8 +178,9 @@ The usual causes, roughly in the order they show up:
   `MBX_SHARE_OUT_DIR=0` disables that sharing. See
   [limits](/limits#out-dir-sharing-remaps-generated-source-paths).
 - A build chose its own C compiler, or is cross-compiling. Setting `CC`,
-  `HOST_CC`, or a target-specific variant leaves that build's C and C++
-  compilations uncached, and so does `--target`. Bypass kinds beginning `cc-`
+  `HOST_CC`, `CXX`, or `HOST_CXX` leaves host compilations outside mbx.
+  Cross-compilations are cached when the build explicitly names a supported
+  compiler through `CC_<target>`, `CXX_<target>`, `TARGET_CC`, or `TARGET_CXX`. Bypass kinds beginning `cc-`
   report anything the C adapter declined to model. See
   [limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
 - CI restored nothing. On GitHub Actions, check that the cache step restored
@@ -162,8 +202,8 @@ mbx[cache]: slowest uncached crates: syn 8.90s, regex-syntax 4.90s, serde_derive
 The estimate comes from the duration recorded with the successful compilation
 that populated the action prediction; older predictions without a timing hint
 contribute zero. The five crates with the largest cumulative uncached compiler
-time are listed so optimization work can target wall-clock cost instead of
-action count.
+time are listed so you can identify expensive uncached work. Parallel
+compilations overlap, so this ranking does not directly identify the critical path.
 
 The JSON statistics report exposes the same data in
 `estimated_compiler_duration_avoided_ns`, `compiler`, and

--- a/docs/cache-server.md
+++ b/docs/cache-server.md
@@ -1,3 +1,6 @@
+---
+description: Run the reference mbx cache server with filesystem or S3 storage, namespace grants, and CI authentication.
+---
 # Cache server
 
 [`jdx/mr-boxington-cache`](https://github.com/jdx/mr-boxington-cache) is the
@@ -10,9 +13,12 @@ reference implementation.
 
 ## Run it
 
-The repository's development stack starts the service, PostgreSQL, and MinIO:
+Clone the server repository before starting its development stack. It runs
+the service, PostgreSQL, and MinIO:
 
 ```sh
+git clone https://github.com/jdx/mr-boxington-cache.git
+cd mr-boxington-cache
 docker compose up --build
 ```
 
@@ -26,7 +32,8 @@ mbx-cache \
   --listen 127.0.0.1:8080
 ```
 
-Anonymous access is intended only for a trusted local network. Production
+The standalone example binds to loopback and allows anonymous access for
+local evaluation. Production
 installations should terminate TLS at an ingress or proxy and configure
 tokens. The repository ships a Helm chart for horizontally scaled Kubernetes
 deployments and a Terraform-managed single-host example.
@@ -84,7 +91,10 @@ not through deployment configuration.
 ### OIDC
 
 OIDC lets CI use short-lived identity tokens instead of stored secrets.
-Configure trusted issuers, acceptable audiences, and claim-based grants:
+Configure trusted issuers, acceptable audiences, and claim-based grants.
+This example grants access only to pushes on `acme/backend`'s `main` branch.
+Replace the numeric owner ID and add separate read-only rules for any other
+identities that need access:
 
 ```json
 [
@@ -95,7 +105,9 @@ Configure trusted issuers, acceptable audiences, and claim-based grants:
       {
         "claims": {
           "repository": "acme/backend",
-          "repository_owner_id": "12345"
+          "repository_owner_id": "12345",
+          "ref": "refs/heads/main",
+          "event_name": "push"
         },
         "read": ["acme/backend"],
         "write": ["acme/backend"]
@@ -121,7 +133,7 @@ On the client side, mbx acquires the GitHub Actions job token itself: set
 
 ## Operations
 
-Blob storage is expired by the bucket's own lifecycle rule; the server removes
+For S3-backed storage, expire blobs with the bucket's lifecycle rule; the server removes
 the metadata those objects leave behind and exits without serving:
 
 ```sh

--- a/docs/compared.md
+++ b/docs/compared.md
@@ -1,147 +1,102 @@
+---
+description: Compare mbx with sccache, kache, archive-based CI caching, and Cargo incremental compilation.
+---
 # How mbx compares
+
+Choose a cache around the work you want to reuse: compiler invocations,
+whole CI directories, or edits within one checkout. mbx focuses on Cargo
+workflows, with shared compiler results, managed targets, and a scheduler for
+simultaneous builds.
+
+| Your main need | Start by evaluating |
+| --- | --- |
+| Cargo worktrees, bounded local storage, and concurrent builds | mbx |
+| A broader compiler set or distributed compilation | [sccache](#sccache) |
+| A persistent cache service and hardlinked local outputs | [kache](#kache) |
+| Restore Cargo state between GitHub Actions jobs | [Archive-based caching](#tarball-ci-caches) |
+| Recompile the crate you are editing within one checkout | [Incremental compilation](#cargos-incremental-compilation) |
+
+For measured performance, use [Benchmarks](/benchmarks). Feature comparisons
+do not predict speed on a particular project.
 
 ## sccache
 
-[sccache](https://github.com/mozilla/sccache) is the established compiler
-cache and predates mbx. It aims wider: it caches CUDA alongside Rust, C, and
-C++, and can distribute compilation across machines. mbx caches rustc, the C
-and C++ that cargo build scripts compile, the C and C++ of builds outside
-cargo through [`mbx exec`](/standalone-builds), and native links. mbx spends
-the narrower scope on what it costs to operate, what it does to your disk, and
-what it is safe to let CI write.
+[sccache](https://github.com/mozilla/sccache) is an established compiler cache
+with a broader compiler scope, including CUDA, and support for distributed
+compilation. It can store cached results locally or in remote storage.
 
-- Nothing to restart after a settings change. sccache builds talk to a
-  background server that outlives the build and keeps the configuration it
-  was started with, and a build that cannot reach it fails unless you have
-  opted into falling back. mbx starts an in-process agent for each command
-  and exits with it, so a changed setting applies to the next build.
-- `target/` stops growing. sccache caches compilations, but each checkout's
-  `target/` is still yours to hold and yours to clean. mbx stores outputs once
-  in a content-addressed store, reflinks them into each checkout's `target/`,
-  and collects the directories whose checkout is gone, so a dozen worktrees
-  cost roughly what one does.
-- Several Cargo builds fit on one machine. sccache hands a GNU make jobserver
-  down to the compilers it spawns, which keeps one build from oversubscribing
-  the machine. mbx budgets across builds: Cargo commands started
-  independently, such as clippy beside tests, draw their compilers from a
-  single machine-wide CPU and memory pool, and a compilation identical to one
-  already running anywhere on the machine waits for that one instead of
-  repeating it. See [machine-wide compile
-  scheduling](/configuration#machine-wide-compile-scheduling).
-- A new worktree is warm without configuration. sccache matches on absolute
-  paths until you set `SCCACHE_BASEDIRS` to the directories to strip, and a
-  path you forget to list is a cache miss you never hear about. mbx derives
-  the placeholders itself: workspace, target, registry, toolchain, and
-  sysroot.
-- A disappointing build points at its own cause. Every build reports hits,
-  misses, lookups it could not attempt, and bypasses, instead of moving a
-  global counter.
-- CI can be given a cache it cannot damage. sccache's backends are buckets and
-  services reached with a credential; what holds that credential can write,
-  and usually delete. mbx's remote is a [cache server](/cache-server) with
-  deny-by-default grants, separate read and write namespace patterns,
-  immutable blobs, and no deletion endpoint. A job that should never publish
-  cannot, and one that may publish cannot rewrite or remove what an earlier
-  build wrote.
+mbx's Cargo integration combines several responsibilities:
 
-If you need CUDA or distributed compilation, sccache is the right tool. Both
-wrap rustc through `RUSTC_WRAPPER`, so they cannot be combined for the same
-build.
+- An agent starts and stops with each command, so configuration changes apply
+  to the next build without restarting a persistent service.
+- Portable keys map workspace, target, registry, toolchain, and sysroot roots
+  automatically. Matching work can be restored across checkouts.
+- [Managed targets](/managed-targets) add cleanup policies for checkout outputs
+  as well as a budget for cached objects.
+- [Parallel builds](/scheduling) share compiler permits across independent
+  Cargo processes using the same cache root.
+- [Build reports](/cache-results) separate misses, unavailable lookups, and
+  intentional bypasses for each command.
+
+sccache and mbx both use `RUSTC_WRAPPER`. They cannot cache the same Rust
+invocation together; mbx defers to an existing wrapper. Follow the
+[migration guide](/cookbook/migrate#from-sccache) when switching.
 
 ## kache
 
-[kache](https://github.com/kunobi-ninja/kache) is the closest tool to mbx: it
-predates mbx and directly inspired its design, though the projects share no
-code. mbx began as the Rust cache inside the
-[mise](https://github.com/jdx/mise) task runner and was extracted into its
-own CLI for three things: less to operate, a better day-to-day experience,
-and tight limits on what CI can write to a shared cache, which matters most
-in a public repository that takes fork pull requests. The differences below
-follow from those three goals.
+[kache](https://github.com/kunobi-ninja/kache) directly inspired mbx. Both use
+content-addressed compiler results to share work across checkouts and support
+Rust plus C and C++ workflows. The projects do not share code.
 
-Like mbx, kache is a content-addressed `RUSTC_WRAPPER` cache built for sharing
-compilations across worktrees, with C and C++ compiler shims, S3-compatible
-and filesystem remotes, and executable caching on Linux, macOS, and Windows.
+kache uses hardlinks for local output sharing and offers a persistent service.
+mbx starts an agent per command and tries to reflink outputs into place.
+Reflinks share data blocks until a file is modified; writes to a restored
+output do not modify the cache object. On filesystems without clone support,
+mbx copies the bytes, so the disk savings depend on the filesystem.
 
-- Nothing to install or keep running. `kache init` installs an OS service by
-  default, with a `--no-service` opt-out. mbx starts an in-process agent with
-  each command and exits with it: nothing to bring back after a reboot,
-  nothing to restart, and no state on the machine that outlives the build.
-- Nobody has to remember to prune. kache hardlinks outputs into place, so a
-  checkout's `target/` shares disk with the store but stays where it is until
-  someone runs `kache gc`. mbx owns the directories it creates: outputs live
-  once in the store, appear in each checkout by reflink, and a `target/`
-  whose checkout is gone is collected without being asked. Reflinks are
-  copy-on-write clones that diverge the moment something writes to them, so a
-  build that scribbles into `target/` cannot damage the cache the way a
-  shared inode can. Where the filesystem cannot clone, mbx copies the bytes.
-- Several Cargo builds fit on one machine. Cargo plans one build at a time,
-  so two started together each size themselves to the whole machine and both
-  finish late. kache does not stop you running them, but it does not
-  coordinate them either: it starts each compiler as Cargo asks for it, with
-  no shared budget and nothing that notices two builds compiling the same
-  crate at the same moment. mbx's shims sit in front of every compiler on the
-  machine and hand out permits from one memory-aware pool, so a lint job and
-  a test job run side by side without overloading the box, and a compilation
-  identical to one already running anywhere waits for it. Either way, give
-  each command its own `CARGO_TARGET_DIR`: Cargo's target directory lock
-  serializes them otherwise. See [machine-wide compile
-  scheduling](/configuration#machine-wide-compile-scheduling).
-- A public repository can share one cache. This is the difference that shaped
-  mbx most. kache's remotes are S3-compatible buckets or a filesystem path,
-  and a bucket has one question to ask: does this credential write? Whatever
-  can publish can also overwrite or remove what an earlier build published,
-  and one leaked credential is the whole cache. mbx's remote is a protocol
-  server, which can express finer rules: grants are deny-by-default with
-  separate read and write namespace patterns; CI authenticates with a
-  short-lived OIDC token pinned to a repository and its immutable numeric
-  owner ID, narrowable to a `ref` or `environment`, instead of a stored
-  secret; blobs are immutable and results commit atomically; and there is no
-  deletion endpoint, so a writer adds results and can never rewrite or remove
-  one. Fork pull requests hold no credentials at all and fall back to a
-  read-only platform cache; see [fork PRs](/cookbook/fork-prs). mbx's client
-  also refuses to publish from pull requests, unprotected branches, and tag
-  builds, which catches a misconfigured grant early; the server is what makes
-  the guarantee.
-- A build is cached only when it asks to be. Both tools put C and C++ shims on
-  `PATH` so make, CMake, or anything else that resolves its compiler there
-  gets cached. kache installs them alongside its service, so every build on
-  the machine goes through the cache. mbx puts them on `PATH` for a single
-  [`mbx exec`](/standalone-builds) command and leaves other builds untouched.
-  Both cover Windows; mbx intercepts `cl.exe` there and the plain gcc/clang
-  driver names on Unix.
-- A restored binary matches the machine it runs on. Both tools cache linked
-  binaries on Linux, macOS, and Windows. mbx keys on the resolved linker,
-  startup objects, libc, and SDK as well as dep-info, because a binary linked
-  against a different libc or SDK is a different binary. On a host mbx cannot
-  describe that precisely, it links normally.
+mbx also manages the lifetime of target directories it creates and coordinates
+simultaneous builds through a shared compiler pool. These features address
+worktree cleanup and contention as well as compilation reuse. Explicit
+`CARGO_TARGET_DIR` values remain under your control.
 
-If you want the C and C++ shims installed once instead of wrapping the
-commands that should use them, kache is worth evaluating. Both tools wrap
-rustc through `RUSTC_WRAPPER`, so they cannot be combined for the same build.
+For remote sharing, mbx supports both [S3-compatible buckets](/remote-cache)
+and a [protocol server](/cache-server). The server can enforce separate read
+and write grants by namespace. Bucket deployments need equivalent restrictions
+in their storage permissions. Client-side write policy is an additional guard,
+not an authorization boundary.
+
+Evaluate both with the same source, toolchain, targets, and filesystem. The
+[published benchmark method](/benchmarks#keeping-it-fair) describes how this
+project keeps comparisons consistent.
 
 ## Tarball CI caches
 
-Actions such as `actions/cache` over `target/` (or `Swatinem/rust-cache`)
-save and restore the whole directory as one archive. That is simple and needs
-no extra tooling, but the archive is all-or-nothing: one changed crate still
-uploads and downloads everything, the entry grows until it hits the platform's
-size cap, and stale artifacts accumulate inside it.
+[`actions/cache`](https://github.com/actions/cache) saves selected paths as an
+archive. [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) adds
+Rust-specific keys and pruning. They preserve Cargo's target state so a job
+can reuse outputs without asking a compiler cache for every artifact.
 
-On GitHub-hosted runners,
-[`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
-restores the same pruned target tree those actions do, so its restore and
-build times match rust-cache on Linux and macOS, and it then runs the build
-through mbx: the
-compile scheduler, the toolchain guard, and per-action reuse inside the job.
-The per-action store is what the [cache server](/cache-server) transports,
-where one entry can serve every job and branch instead of one archive per
-job. See [GitHub Actions](/github-action).
+The default [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
+backend also transports a pruned Cargo target and registry archive. The build
+then runs through mbx, gaining its compiler scheduling and per-action reuse
+within the job. This is an archive transport, so it still pays archive restore
+and save costs.
 
-## Cargo's incremental compilation
+The action's `objects` mode transports mbx's recorded action closure instead.
+A configured cache server or S3 bucket transfers individual objects, letting
+builds fetch the work they need across different target layouts. Choose one
+transport for the same cached data; stacking archive actions adds duplicate
+work. See [GitHub Action](/github-action) for the tradeoffs and examples.
 
-Incremental compilation speeds up recompiling the crate you are editing inside
-one checkout. It does nothing across checkouts, worktrees, or CI runners, and
-its artifacts are checkout-specific by design. mbx caches the dependency
-graph everywhere and leaves the inner loop to rustc. The two interact: see
-[incremental builds](/configuration#incremental-builds).
+<span id="cargo-s-incremental-compilation"></span>
+
+## Cargo's incremental compilation {#cargos-incremental-compilation}
+
+Incremental compilation reuses parts of a crate between edits in one checkout.
+A shared compiler cache reuses complete matching results across builds.
+
+mbx uses both: it shares eligible compilations and automatically keeps private
+incremental state for crates whose sources you are changing. That private state
+is never published to the shared cache. Setting `MBX_INCREMENTAL=1` gives Cargo
+control of workspace incremental compilation and can reduce cross-checkout
+reuse. See [Incremental builds](/incremental) before changing the default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,14 @@
+---
+description: Find configuration files, understand precedence, and look up every mbx setting.
+---
 # Configuration
 
-mbx reads configuration from three places; the first value found wins:
+Defaults work without a configuration file. Add only the values you want to
+change. mbx reads configuration from three places; the first value found wins:
 
 1. Environment variables (`MBX_*`).
 2. `.mbx.toml` at the resolved Cargo workspace root, for the
-   [build-policy switches](#workspace-policy) only.
+   [supported workspace settings](#workspace-policy) only.
 3. `mbx/config.toml` in the platform configuration directory:
    - Linux: `~/.config/mbx/config.toml`, honoring `$XDG_CONFIG_HOME`
    - macOS: `~/Library/Application Support/mbx/config.toml`
@@ -12,6 +16,21 @@ mbx reads configuration from three places; the first value found wins:
 
 Anything still unset takes its default. Unknown TOML keys are rejected, so a
 misspelled setting is an error.
+
+## Common adjustments
+
+| Change | Setting or guide |
+| --- | --- |
+| Leave capacity for your editor | `scheduler.reserve_cpus = 2`; [parallel builds](/scheduling) |
+| Keep the action store under a fixed size | `gc.max_size = "20GiB"` |
+| Keep live targets longer | `target.max_age = "60d"`; [managed targets](/managed-targets) |
+| Use factual savings messages | `savings = "plain"` |
+| Print more cache detail | `summary = "full"`; [cache results](/cache-results) |
+| Share results with CI | [Remote cache](/remote-cache) |
+
+Use TOML section headers for dotted settings, as shown in the example below.
+Shell examples that set `NAME=value command` use POSIX syntax; PowerShell users
+can set `$env:NAME` before the command and remove it afterward.
 
 ## Disk-scaled defaults
 
@@ -27,7 +46,12 @@ Setting any of them outright overrides the scaling; `"none"` disables
 
 ## Example
 
-Every value below is optional; these are shown set explicitly.
+This example shows several available controls, not a recommended configuration.
+Copy the sections you need into your global configuration file. Remote settings
+and machine-specific paths do not belong in a checked-in `.mbx.toml`.
+
+<details>
+<summary>Example global configuration</summary>
 
 ```toml
 # <config directory>/mbx/config.toml
@@ -82,50 +106,13 @@ memory = "24GiB"         # default: 85% of physical memory
 priority = "normal"      # or "low"
 ```
 
+</details>
+
 ## Managed linkers
 
-mbx can select a linker by Cargo profile and target triple, install an exact
-version from its official GitHub releases, and route native Rust links through
-it. The built-in selectors are:
-
-- `system`, which leaves Cargo's linker selection alone;
-- `rust-lld` or `lld`, which uses the LLD shipped with the active Rust
-  toolchain;
-- `mold@<version>` or `wild@<version>`, which downloads the
-  matching release asset and verifies GitHub's SHA-256 digest; and
-- `path:<executable>`, which selects a linker mbx does not install.
-
-Managed GitHub linkers require an exact version. Downloads are installed once
-beneath `<cache_dir>/tools`; concurrent builds share the same installation
-lock. `GITHUB_TOKEN` may authenticate GitHub API and download requests.
-
-Within a profile table, an exact target triple wins over `default`. The
-top-level `linker.default` applies when the active profile has no entry. Cargo's
-ordinary profile is `dev`, `--release` selects `release`, `cargo bench` selects
-`bench`, and `--profile <name>` selects that custom profile.
-
-```toml
-[linker]
-default = "system"
-
-[linker.profiles.dev]
-x86_64-unknown-linux-gnu = "mold@2.42.0"
-aarch64-unknown-linux-gnu = "wild@0.10.0"
-
-[linker.profiles.release]
-default = "rust-lld"
-```
-
-`MBX_LINKER` overrides every file for one invocation:
-
-```sh
-MBX_LINKER=mold@2.42.0 cargo build
-MBX_LINKER=system cargo build --release
-```
-
-mold and Wild currently provide managed releases for Linux. Unsupported host
-platforms fail before Cargo starts rather than silently changing the linker.
-The selected executable remains part of mbx's native-link cache identity.
+Select a linker for each Cargo profile and target, or override it for one build
+with `MBX_LINKER`. See [Managed linkers](/linkers) for selectors, prerequisites,
+and complete examples.
 
 ## Workspace policy
 
@@ -184,37 +171,10 @@ To cache C and C++ builds that run outside Cargo, put the build command after
 
 ## Machine-wide compile scheduling
 
-Cargo plans one build at a time: three simultaneous worktree builds each
-believe they own the machine and multiply `-j`. mbx's shims sit in front of
-every real compiler process across all of them, so multiple Cargo builds
-running at the same time share the machine through one permit pool under the
-cache directory (on by default; `MBX_SCHEDULER=0` turns it off). Cache hits
-never wait, Cargo keeps its own dependency scheduling, and permits are released
-by the kernel if a process dies, so a crashed build cannot wedge its siblings.
-
-Builds running at the same time also stop repeating each other: a compilation
-identical to one already running anywhere on the machine waits for that one
-and restores its result. How the pool weighs compilations and links, and what
-happens when a guess is wrong, is described in
-[how it works](/how-it-works#machine-wide-scheduling).
-
-The pool is memory-aware. `scheduler.cpus` permits (default: logical CPUs),
-less `scheduler.reserve_cpus` (default: 0), divide `scheduler.memory` (default:
-85% of physical memory, leaving headroom for everything that is not a compiler;
-`"none"` keeps plain CPU permits). The pool always keeps at least one permit.
-Cargo's `-j`/`--jobs` or `CARGO_BUILD_JOBS` can cap how many weighted permits
-one build holds without shrinking the machine-wide pool available to other
-builds. In a container, physical memory means the cgroup's limit, so a build in
-a 4 GiB container on a large machine is budgeted by the 4 GiB.
-
-`priority = "low"` (`MBX_SCHEDULER_PRIORITY`) is for builds nobody is sitting
-at, such as CI on a shared box or an editor's background check. While a
-normal-priority build is waiting for permits, low-priority builds leave a
-quarter of the pool free for it.
-
-Two limits apply: a single compilation larger than the machine is still too
-large when it runs alone, and crates that have never been measured start at one
-permit until the pool has seen them once.
+Simultaneous mbx builds share CPU and memory permits. Set `scheduler.cpus`,
+`scheduler.reserve_cpus`, `scheduler.memory`, and `scheduler.priority` to tune
+that pool. See [Parallel builds](/scheduling) for examples and the difference
+between a shared budget and Cargo's per-build `-j` limit.
 
 ## Verify mode
 
@@ -274,59 +234,16 @@ suppress the summary for that invocation.
 
 ## Incremental builds
 
-::: tip Smart incremental is already on
-mbx speeds up repeated edits without relying on `CARGO_INCREMENTAL`. It keeps
-incremental state for crates you are actively changing while leaving everything
-else reusable across branches and worktrees.
-
-You probably do not want to turn it on. When policy allows, it makes local
-workspace crates use Cargo's incremental mode. Those checkout-specific builds
-bypass the shared cache and can make crates above them miss it too.
-:::
-
-`MBX_INCREMENTAL=1` stops mbx from forcing `CARGO_INCREMENTAL=0` locally. This
-can help an edit/rebuild loop, but an incremental workspace artifact changes
-the inputs of crates above it and reduces reuse across worktrees. CI always
-disables it because a fresh runner has no incremental state to reuse.
+Leave `MBX_INCREMENTAL` unset for mbx's default combination of shared caching
+and private incremental state. `MBX_INCREMENTAL=1` hands control to Cargo and
+reduces reuse across checkouts. See [Incremental builds](/incremental).
 
 ## Learned incremental reuse
 
-The crate you are editing misses the cache on every build, because its content
-is new every time. On the first source edit to a crate inside the workspace,
-mbx compiles that crate with its own incremental state and keeps the result out
-of the shared cache, since an incremental artifact describes one checkout's
-edit history. A crate outside the workspace switches after three consecutive
-misses with changed sources. The build reports those compilations as
-`incremental` and says how many were held back.
-
-The trigger is the crate's own sources, not its cache key. A miss on unchanged
-sources, such as a wiped `target/` or a first build in a new checkout, compiles
-and publishes normally, and so do the crates above a dependency that was
-rebuilt and published. The crates above a dependency that took private state
-are the exception. Their results would be keyed on an artifact no other
-checkout can hold, so they keep private state too instead of paying for a full
-compilation and a publication nothing can restore. The whole cone publishes
-again once the edited crate settles. Once a crate is known to be hot, later
-edits go straight to its private incremental state instead of rebuilding and
-looking up a shared action the edit cannot hit. The record and state are
-private to each checkout and live under `incremental/` in mbx's cache directory,
-so `cargo clean` does not discard the next edit's speedup. Normal garbage
-collection removes state for deleted or expired checkouts.
-
-Each crate's state is discarded, with a warning naming the crate, once it
-passes `learned_incremental_max_size` (`MBX_LEARNED_INCREMENTAL_MAX_SIZE`,
-default 8 GiB; `"none"` lifts the limit). rustc keeps about one session's worth
-of state per crate and removes the sessions it has superseded, so the state is
-proportional to the crate rather than to how long it has been edited, and the
-budget is a backstop rather than a size ordinary crates reach. A large binary
-built with debug info keeps a few GiB. Set the budget below that and every edit
-compiles from scratch while still being reported as incremental, so raise it
-rather than lower it when the warning appears.
-
-CI never does this, because a fresh runner has no earlier state to build on.
-`MBX_LEARNED_INCREMENTAL=0` turns it off. `MBX_INCREMENTAL=1` supersedes it by
-handing incremental compilation back to cargo, and `MBX_VERIFY=1` disables it
-for the build being verified.
+mbx recognizes source edits and retains private state for the affected crates.
+`learned_incremental_max_size` bounds that state per crate; its default is
+`8GiB`. See [Learned incremental reuse](/incremental#learned-incremental-reuse)
+for triggers, cleanup, and overrides.
 
 ## Sizes and durations
 
@@ -335,8 +252,8 @@ accept values such as `30s`, `15m`, and `1h`.
 
 ## Settings
 
-Every setting, generated from the same usage-rs declaration mbx uses at
-runtime.
+The complete setting reference is generated from mbx's runtime declarations.
+Environment-only settings are labeled in the entries below.
 
 <!-- The line range skips the generated header and file-precedence preamble;
      the top of this page describes precedence more completely. -->

--- a/docs/cookbook/fork-prs.md
+++ b/docs/cookbook/fork-prs.md
@@ -1,3 +1,6 @@
+---
+description: Route trusted CI builds to a private cache server and fork pull requests to GitHub Actions cache.
+---
 # CI with fork pull requests
 
 Open-source repositories take pull requests from forks, and forks change what
@@ -7,8 +10,12 @@ fork-triggered runs, so a fork's job cannot authenticate to a
 already keeps every pull request read-only. The remaining question is which
 backend each run should use.
 
-The recipe: trusted runs talk to the cache server, and fork pull requests fall
-back to GitHub Actions cache, which needs no credentials.
+If all jobs can use GitHub Actions cache, the [default action setup](/github-action)
+already supports fork pull requests. Use this recipe when trusted runs also
+need a private cache server: fork pull requests use the GitHub backend instead.
+
+Protect `main` before expecting remote writes. Configure the server's read and
+write grants separately; client-side policy does not authorize access.
 
 ```yaml
 name: ci
@@ -68,7 +75,7 @@ jobs:
   pushes saves the store after the build (action steps clean up in reverse
   order, so the mirror's save runs last), and fork PRs restore that entry.
 
-## Hardening
+## Separate trust levels {#hardening}
 
 The single-workflow recipe above trusts the platform to withhold fork
 credentials. To make the trust boundary structural, split it in two: a router
@@ -76,7 +83,7 @@ workflow whose `trusted` and `untrusted` jobs are mutually exclusive, each
 calling a shared `workflow_call` implementation with different permissions and
 inputs.
 [tak's ci.yml](https://github.com/jdx/tak/blob/main/.github/workflows/ci.yml)
-is a living example. What the split buys:
+is a living example. This structure lets you enforce the following boundaries:
 
 - An untrusted run never declares `id-token: write` at all, and its first step
   can assert `ACTIONS_ID_TOKEN_REQUEST_URL` is absent.

--- a/docs/cookbook/local-development.md
+++ b/docs/cookbook/local-development.md
@@ -1,8 +1,13 @@
+---
+description: Set up rust-analyzer, watch loops, laptop budgets, and debugging with mbx.
+---
 # Local development
 
 mbx can sit underneath the tools already in a Rust development loop. Editors,
 file watchers, terminals, and worktrees may all keep invoking ordinary Cargo;
-their compilations share the same cache and machine-wide scheduler.
+their compilations share the same cache and machine-wide scheduler. Start with
+[`mbx setup`](/setup), then use the recipes below for your editor, watch loop,
+and machine budget.
 
 ## Put editor checks through mbx
 
@@ -34,7 +39,7 @@ mbx doctor
 ```
 
 On Windows, use `(Get-Command cargo).Path` instead of `command -v cargo`.
-See [Install and run](/getting-started#verify-plain-cargo) for the shell and
+See [Cargo and editor setup](/setup#verify-plain-cargo) for the shell and
 non-interactive `PATH` setup.
 
 ## Run a watch loop
@@ -93,8 +98,9 @@ CPU setting limits concurrent real compiler work across every terminal and
 worktree; cache hits do not consume permits. The memory setting prevents known
 large compilations from filling all CPU permits at once.
 
-For a temporary low-power watch session, set the same values in its
-environment. Child Cargo processes inherit them:
+For a watch session with a smaller shared budget, set the same values in its
+environment. Child Cargo processes inherit them. These are scheduler settings,
+so consider the other builds sharing that pool:
 
 ```sh
 MBX_SCHEDULER_CPUS=2 MBX_SCHEDULER_MEMORY=4GiB \

--- a/docs/cookbook/migrate.md
+++ b/docs/cookbook/migrate.md
@@ -1,11 +1,17 @@
+---
+description: Replace rust-cache or sccache in a workflow and verify the resulting mbx cache behavior.
+---
 # Migrate from rust-cache or sccache
+
+Move one development or CI workflow at a time, verify activation, then compare
+a representative warm build. Keep production release jobs subject to the
+[release policy](/github-action#production-releases).
 
 ## From rust-cache or `actions/cache` over `target/`
 
-A tarball cache and mbx solve the same problem, so replace the step instead of
-stacking them. An archived `target/` restored over a managed one is the stale,
-ever-growing entry mbx replaces (see
-[tarball CI caches](/compared#tarball-ci-caches)).
+Replace the existing cache action with `jdx/mr-boxington-action`. Both actions
+can transport Cargo's target state, so using both for the same paths adds
+duplicate restore/save work. See [archive caching](/compared#tarball-ci-caches).
 
 Before:
 
@@ -26,14 +32,12 @@ steps:
 ```
 
 The action's default entry carries Cargo's target directory and its download
-caches under `~/.cargo`, so nothing rust-cache restored is lost in the swap.
-The `github-cache-mode: objects` payload omits the download caches; pair it
-with the [manual GitHub cache setup](/github-action#manual-github-cache-setup)
-to keep them.
+caches under `~/.cargo`, so the workflow can retain dependency artifacts and Cargo downloads.
+The `github-cache-mode: objects` payload omits the download caches; use a separate Cargo-download cache if you need those files too.
 
-Leave release jobs out of the migration: a production release should not
-restore any compiler cache, mbx's or the one being removed. See the
-[release warning](/github-action#s3-compatible-bucket).
+Production release jobs may use a trusted local cache, but should not restore
+compiler outputs from a remote or an Actions archive. See
+[Production releases](/github-action#production-releases).
 
 ## From sccache
 
@@ -53,10 +57,12 @@ Then check the result:
 mbx doctor
 ```
 
-## The first build measures nothing
+<span id="the-first-build-measures-nothing"></span>
 
-However you arrive, the first mbx build has an empty store: it restores
-nothing, stores everything, and the summary's
-[could not look up](/cache-results#could-not-look-up) count dominates. Compare
-the second build, and
-[`mbx explain`](/cache-results#bypass) says what any remaining gap is made of.
+## Verify the migration
+
+Run `mbx doctor`, then your usual build. A cold object store needs work to fill
+it; a restored Cargo target may already be fresh and require no compilations.
+Neither result proves cross-target cache reuse. Follow
+[Measure cache reuse](/cache-results#measure-cache-reuse) for a controlled
+comparison, and use `mbx explain --last` to understand any remaining bypasses.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,12 +1,16 @@
 ---
-title: Cache dashboard
-description: Observe namespaces, cache hit rates, missing actions, and access grants.
+title: Cache dashboard demo
+description: Explore an illustrative cache-server dashboard with sample namespaces, cache activity, and grants.
 layout: page
 navbar: false
 sidebar: false
 aside: false
 footer: false
 pageClass: mbx-dashboard-page
+head:
+  - - meta
+    - name: robots
+      content: noindex
 ---
 
 <CacheDashboard />

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,25 +1,33 @@
+---
+description: Answers to common questions about mbx storage, cache reuse, toolchains, and the project name.
+---
 # FAQ
 
-Short answers, with the page that owns each one.
+Common questions about reuse, storage, and compatibility. For a specific
+build problem, start with [Troubleshooting](/troubleshooting).
 
 ## Is deleting the cache safe?
 
-Always. The store is a cache of work mbx can redo: the worst case is a colder
-build, never a wrong one. See [stability](/stability#the-store-is-disposable).
+The shared compiler outputs can be rebuilt. Prefer `mbx gc --dry-run` and
+`mbx gc` to reclaim space under the configured policy. Deleting the whole cache
+root also removes managed targets and private incremental state; stop running
+builds first. See [stability](/stability#the-store-is-disposable).
 
 ## Why wasn't my first build faster?
 
-A first build has an empty store. There is nothing to hit, so it can only
-cost time, and the summary's "could not look up" line dominates. Time the
-second build instead. See
+A cold store has no results to restore. The first compilation records inputs
+and outputs for later reuse. A second command in the same target may simply
+be fresh according to Cargo; use [fresh targets](/cache-results#measure-cache-reuse)
+to measure the shared cache. See
 [cache results](/cache-results#troubleshooting-a-low-hit-rate), and the
-[warm scenario](/benchmarks#warm) for what that second build gets.
+[warm scenario](/benchmarks#warm-build) for what that second build gets.
 
 ## Why does a fully warm build still take time?
 
-Links mbx cannot describe always run, so a large binary re-links even when
-every compilation hit. Host binaries and tests are restored on Linux, macOS,
-and Windows, and self-contained WebAssembly targets everywhere. The rest is
+Cargo still plans the build, mbx validates inputs and materializes outputs,
+and any unsupported actions run normally. Eligible host binaries and tests
+can be restored on Linux, macOS, and Windows; links with unmodeled inputs still
+run. See the
 [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
 
 ## The cache stopped hitting after a Rust update. Is it broken?
@@ -57,18 +65,18 @@ Every feature has its own switch:
 
 | Switch | Turns off |
 | --- | --- |
-| `MBX_SCHEDULER=0` | [machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling) |
+| `MBX_SCHEDULER=0` | [machine-wide compile scheduling](/scheduling#machine-wide-compile-scheduling) |
 | `MBX_CC=0` | [build-script and `mbx exec` C and C++ caching](/configuration#build-script-c-and-c) |
 | `MBX_TARGET_VIEWS=0` | [managed target directories](/managed-targets#disable-managed-targets) |
 | `MBX_CACHE_LINKS=0` | [native link caching](/limits#native-linking-is-cached-only-where-the-linker-can-be-described) |
-| `MBX_LEARNED_INCREMENTAL=0` | [learned incremental reuse](/configuration#learned-incremental-reuse) |
+| `MBX_LEARNED_INCREMENTAL=0` | [learned incremental reuse](/incremental#learned-incremental-reuse) |
 | `MBX_EVENTS=0` | [per-compilation event streams](/tui#recording) |
 | `MBX_SAVINGS=off` | [the savings line](/configuration#the-savings-line) |
 
 ## Something looks wrong. What should a report include?
 
 `mbx doctor --json`, a run with `MBX_LOG=debug`, and `MBX_BYPASS_LOG`. See
-[reporting a problem](/getting-started#reporting-a-problem).
+[reporting a problem](/troubleshooting#reporting-a-problem).
 
 ## Why is it called Mr. Boxington?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,428 +1,142 @@
+---
+description: Install mbx, run your first cached Cargo build, and learn what to expect from the result.
+---
 # Get started
+
+mbx reuses compiler work across Rust workspaces, checkouts, and CI runs. Cargo
+still resolves dependencies and decides what needs building. mbx restores
+matching compilations and runs the compiler for everything else.
+
+You need an existing Rust toolchain and a Cargo project. No cache server or
+configuration file is required.
 
 ## Install
 
-### mise
+With [mise](https://mise.jdx.dev):
 
 ```sh
 mise use --global --postinstall "mbx setup --yes" mr-boxington
 ```
 
-::: info Requires mise 2026.8.16 or newer
-Automatic Cargo wrapping uses mise's `[wrappers]` configuration, available in
-mise 2026.8.16 and newer. With an older mise, setup installs the standalone
-shim but only prints an upgrade warning instead of editing mise configuration.
-:::
-
-With `--global`, mise activates mbx in its global configuration. Drop
-`--global` to activate it only in the current project's configuration.
-
-To keep the wrapper project-scoped and reviewable, commit it directly in the
-project's `mise.toml` instead:
-
-```toml
-[tools]
-mr-boxington = "1.3.0"
-
-[wrappers.cargo]
-command = "mbx"
-env = { MBX_CARGO_SHIM_MODE = "1" }
-```
-
-Then run `mise install`. This installs mbx but does not activate the wrapper in
-the parent shell. Run project tasks with `mise run`, or activate mise in the
-shell before invoking plain `cargo` commands. This avoids changing the global
-mise configuration, and every contributor who activates the project gets the
-same Cargo wrapper.
-
-### Release archive
-
-:::tabs
-== Linux x86-64
-
-```sh
-mkdir -p ~/.local/bin
-archive=mbx-x86_64-unknown-linux-gnu.tar.gz
-release=https://github.com/jdx/mr-boxington/releases/latest/download
-curl -fsSLO "$release/$archive"
-curl -fsSLO "$release/SHA256SUMS"
-grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
-tar -xzf "$archive" -C ~/.local/bin
-```
-
-== Linux ARM64
-
-```sh
-mkdir -p ~/.local/bin
-archive=mbx-aarch64-unknown-linux-gnu.tar.gz
-release=https://github.com/jdx/mr-boxington/releases/latest/download
-curl -fsSLO "$release/$archive"
-curl -fsSLO "$release/SHA256SUMS"
-grep "  $archive$" SHA256SUMS | sha256sum --check --strict -
-tar -xzf "$archive" -C ~/.local/bin
-```
-
-== macOS
-
-```sh
-mkdir -p ~/.local/bin
-archive=mbx-aarch64-apple-darwin.tar.gz
-release=https://github.com/jdx/mr-boxington/releases/latest/download
-curl -fsSLO "$release/$archive"
-curl -fsSLO "$release/SHA256SUMS"
-grep "  $archive$" SHA256SUMS | shasum -a 256 --check --strict -
-tar -xzf "$archive" -C ~/.local/bin
-```
-
-== Windows x86-64
-
-```powershell
-$archive = "mbx-x86_64-pc-windows-msvc.zip"
-$release = "https://github.com/jdx/mr-boxington/releases/latest/download"
-Invoke-WebRequest "$release/$archive" -OutFile $archive
-Invoke-WebRequest "$release/SHA256SUMS" -OutFile SHA256SUMS
-$expected = (Select-String -Path SHA256SUMS -Pattern $archive).Line.Split(" ")[0]
-if ((Get-FileHash $archive -Algorithm SHA256).Hash -ne $expected.ToUpper()) {
-  throw "checksum mismatch"
-}
-Expand-Archive $archive -DestinationPath "$env:LOCALAPPDATA\Programs\mbx"
-```
-
-Add `%LOCALAPPDATA%\Programs\mbx` to `PATH`.
-
-== Windows ARM64
-
-```powershell
-$archive = "mbx-aarch64-pc-windows-msvc.zip"
-$release = "https://github.com/jdx/mr-boxington/releases/latest/download"
-Invoke-WebRequest "$release/$archive" -OutFile $archive
-Invoke-WebRequest "$release/SHA256SUMS" -OutFile SHA256SUMS
-$expected = (Select-String -Path SHA256SUMS -Pattern $archive).Line.Split(" ")[0]
-if ((Get-FileHash $archive -Algorithm SHA256).Hash -ne $expected.ToUpper()) {
-  throw "checksum mismatch"
-}
-Expand-Archive $archive -DestinationPath "$env:LOCALAPPDATA\Programs\mbx"
-```
-
-Add `%LOCALAPPDATA%\Programs\mbx` to `PATH`.
-
-:::
-
-Every release publishes its archives and `SHA256SUMS` on
-[GitHub Releases](https://github.com/jdx/mr-boxington/releases).
-Linux also has `-musl` archives for a static binary that does not depend on a
-host glibc.
-
-### Cargo
+Or install from crates.io:
 
 ```sh
 cargo install mbx --locked
-mbx setup
 ```
 
-During `mise use --postinstall`, `mbx setup --yes` adds a `[wrappers.cargo]`
-entry to the configuration
-named by `MISE_CONFIG_FILE`. Otherwise, setup only integrates with mise when
-mise is activated in the current shell. It recommends the config that defines
-`mr-boxington`, then the nearest project config, and finally the global config.
-`mbx setup` prompts before using that recommendation; `--yes` accepts it.
-Without an active mise shell, setup prints the exact shell-specific `PATH`
-change and never edits a shell startup file. Setup runs `mise reshim` after
-adding or removing the wrapper.
-
-### Verify plain Cargo
-
-Open a new shell after setup and verify that Cargo resolves to mise's command
-wrapper. On Unix:
-
-```sh
-command -v cargo
-# ~/.local/share/mise/command-wrappers/bin/cargo on Linux
-```
-
-On Windows, use PowerShell or `where.exe`:
-
-```powershell
-(Get-Command cargo).Path
-where.exe cargo
-```
-
-mise activation supplies the command-wrapper path to shells where mise is active.
-The wrapper invokes `mbx` with Cargo shim mode enabled, then mise removes its
-dispatch directories before mbx delegates to the configured or system Cargo.
-SSH commands, coding agents, editors, and other non-interactive tools may use a
-startup path that does not activate mise. In that case, prepend the directory
-printed by `mbx setup` in a startup file those processes read. For zsh,
-`~/.zshenv` applies to interactive and non-interactive shells:
-
-```sh
-export PATH="$HOME/.local/share/mbx/bin:$PATH"
-```
-
-Start a new process and run `command -v cargo` again. Once it resolves to the
-shim, ordinary `cargo build`, `cargo test`, and `cargo check` commands use mbx
-automatically. Prefixing a Cargo command with `mbx`, as in `mbx build`, still
-works.
-
-Outside mise activation, the stable `cargo` launcher uses the setup-time mbx
-while it exists, then resolves the active `mbx` from `PATH` after an upgrade
-removes that path. Windows `cargo.exe` resolves the active mbx from `PATH`, with
-the setup-time path as a fallback. Upgrading a mise-managed mbx does not require
-running setup again.
-
-Setup also configures rust-analyzer's background check in the matching global
-or project scope. The editor invokes the stable Cargo shim by its absolute path,
-so its build shares mbx's cache and machine-wide compiler pool even when the
-editor did not inherit mise's `PATH`. Its outputs go to
-`target/rust-analyzer`, separate from terminal builds so the two Cargo processes
-do not contend on the target-directory lock. When `target` is managed, the
-editor directory lives inside that view and is collected with it, while the
-shared store warms both builds. Existing rust-analyzer check settings are left
-unchanged.
-
-After installing from a release archive, run `$HOME/.local/bin/mbx setup` on
-Unix. On Windows, run
-`& "$env:LOCALAPPDATA\Programs\mbx\mbx.exe" setup` in PowerShell.
-
-## Supported platforms
-
-Release binaries cover:
-
-- Linux x86-64 and ARM64 (GNU and static musl builds)
-- macOS on Apple Silicon
-- Windows x86-64 and ARM64
-
-Other platforms with a Rust toolchain can build from source with
-`cargo install mbx --locked`. mbx wraps whichever Cargo and rustc are active,
-including rustup-managed toolchains. `mbx doctor` reports the pair it found.
-
-Reflinked output restoration needs a filesystem with copy-on-write file
-cloning: APFS on macOS, btrfs or XFS on Linux, ReFS (Dev Drive) on Windows.
-mbx probes the cache and target locations and copies bytes where cloning is
-unavailable. Caching still works on ext4 or NTFS but spends the disk twice.
-
-### Windows
-
-Windows is a supported release platform. The differences from Linux and macOS:
-
-- Reflinks need ReFS, which usually means a Dev Drive; on NTFS mbx copies
-  bytes instead.
-- The managed `target` link needs Developer Mode or a privileged process;
-  where Windows refuses to create it, Cargo keeps its ordinary target
-  directory. See [managed target directories](/managed-targets).
-- rustc compilations and native host links are cached; native-link keys bind
-  the selected MSVC/LLVM linker, Windows SDK, and CRT. See
-  [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
-- MSVC C and C++ compiles from build scripts and `mbx exec` are cached through
-  a conservative `cl.exe` adapter. See
-  [limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
+Linux, macOS, and Windows binaries are also available. See
+[Installation](/installation) for verified downloads and platform requirements.
 
 ## Run a build
 
-After setup, use Cargo normally:
-
-```sh
-cargo build
-cargo test --workspace --all-features
-cargo clippy --workspace --all-targets
-```
-
-The command and its arguments are passed to Cargo unchanged. Cargo still owns
-dependency resolution, feature unification, build planning, and linking. Cargo
-aliases, installed subcommands, and toolchain selection are preserved:
-
-```sh
-cargo +1.91 check --workspace
-```
-
-`MBX_DISABLE=1 cargo …` bypasses mbx for one invocation in a POSIX shell. In
-PowerShell, set `$env:MBX_DISABLE = "1"`, run Cargo, then remove it with
-`Remove-Item Env:MBX_DISABLE`.
-
-::: tip Use mbx without setup
-Run `mbx +1.91 check` directly for zero-config use. Only commands prefixed with
-`mbx` use caching in this mode.
-:::
-
-mbx's own `tui`, `cache`, `gc`, `doctor`, and diagnostic commands stay under
-`mbx`.
-
-## Choose a linker
-
-On Linux, pinned mold is the recommended performance-oriented starting point.
-Try the current supported release for one build first:
-
-```sh
-MBX_LINKER=mold@2.42.0 cargo build
-```
-
-To keep it enabled, add this to your platform
-[configuration file](/configuration):
-
-```toml
-[linker]
-default = "mold@2.42.0"
-```
-
-Managed linker selection currently requires `clang` on `PATH`. macOS and
-Windows should keep the default `system` selection for now. On Linux or macOS,
-`rust-lld` is the no-download alternative: it ships with the active Rust
-toolchain, and a `cargo +toolchain` command automatically selects that
-toolchain's LLD. Wild is also available on Linux. See
-[managed linkers](/configuration#managed-linkers) for selectors and
-profile- and target-specific examples.
-
-## Run multiple Cargo builds at the same time
-
-Any task runner can start multiple mbx commands at the same time. For example,
-mise runs these two lint configurations together:
-
-```toml
-# mise.toml
-[tasks."lint:default"]
-run = "mbx clippy --workspace -- -D warnings"
-env.CARGO_TARGET_DIR = "target/clippy-default"
-
-[tasks."lint:all"]
-run = "mbx clippy --workspace --all-features --all-targets -- -D warnings"
-env.CARGO_TARGET_DIR = "target/clippy-all"
-```
-
-```sh
-mise run lint:default ::: lint:all
-```
-
-Separate target directories keep Cargo's directory lock from serializing the
-commands. mbx shares one machine-wide compiler pool and deduplicates identical
-work in flight without further configuration. See
-[how it works](/how-it-works#machine-wide-scheduling) for the mechanism and
-the same shape [inside GitHub Actions](/github-action#parallel-cargo-steps).
-
-## The first build
-
-The first build on a machine prints what it set up:
-
-```text
-mbx[setup]: first build on this machine
-mbx[setup]:   cache is /home/you/.cache/mbx, shared by every checkout and worktree, pruned to 50.0 GiB
-mbx[setup]:   this filesystem supports reflinks, so target/ shares disk with the cache instead of copying
-mbx[setup]:   target/ is managed: deleted when its checkout is gone, unused for 30 days, or over 100.0 GiB total
-mbx[setup]:   `mbx gc --dry-run` previews cleanup; every limit is configurable
-```
-
-The budgets are a share of the disk holding the cache, so the numbers above
-depend on the machine, and the reflink line appears only where a probe just
-proved the filesystem supports it. See [managed target
-directories](/managed-targets) for what collection removes and how to change
-or disable each limit.
-
-## Diagnose the installation
+From your Rust workspace:
 
 ```sh
 mbx doctor
+mbx build
 ```
 
-```text
-  ok  cargo        cargo 1.98.0 (797e8a9bc 2026-08-05)
-  ok  rustc        rustc 1.98.0 (88d9e12ae 2026-08-18)
-  ok  cache        /home/you/.cache/mbx is writable
-  ok  session      Unix-domain listeners are available
-  ok  config       50.0 GiB budget, automatic gc enabled, managed targets enabled at /home/you/.cache/mbx/targets
-  ok  reflink      supported by the cache filesystem
-  ok  setup        mise Cargo wrapper is active and the fallback shim is current at /home/you/.local/share/mbx/bin/cargo
-  ok  remote       not configured; using the local cache
+Pass Cargo arguments as usual:
 
-0 failures, 0 warnings
+```sh
+mbx test --workspace --all-features
+mbx clippy --workspace --all-targets -- -D warnings
+mbx +stable check --workspace
 ```
 
-Doctor checks that mise's Cargo wrapper is active, or that the installed fallback
-shim matches the running mbx and is the first `cargo` on `PATH`. It also checks
-the Cargo and rustc executables, cache write access, the local build-session
-listener, filesystem reflink support, effective remote policy, and remote
-protocol connectivity. Warnings describe setup problems, optional features, or
-fallbacks; failures make the command exit
-unsuccessfully.
+Cargo aliases, installed subcommands, and toolchain selection are preserved.
+Use the same toolchain, features, and profile across builds to reuse the same
+cached work.
 
-Build sessions normally communicate over a Unix-domain socket. When a sandbox
-blocks Unix socket listeners but permits filesystem FIFOs, mbx automatically
-uses FIFO transport and keeps caching enabled. If neither transport is
-available, mbx warns and runs Cargo without caching instead of preventing the
-build from starting.
+## Keep using plain Cargo
+
+```sh
+mbx setup
+```
+
+If you installed with the mise command above, setup has already run. Open a new
+shell and run `mbx setup --status` to check activation, then use `cargo build`
+and `cargo test` normally. See [Cargo and editor setup](/setup) for project
+scope, rust-analyzer, and tools that do not inherit your interactive shell.
+
+## The first build
+
+A new local store has no compilations to restore. The first build fills it;
+later builds and equivalent worktrees can reuse that work. If Cargo already
+has up-to-date outputs in `target/`, it skips those compilations entirely.
+That is normal and will not appear as mbx cache hits.
+
+For a checkout without an existing `target/`, mbx creates a managed target and
+leaves a `target` symlink in the workspace. An existing directory is replaced
+only after you accept the interactive prompt. See
+[Managed target directories](/managed-targets) for placement and cleanup.
+
+The first build also prints the cache location and disk budgets chosen for your
+machine. Automatic collection runs after builds, at most once an hour.
 
 ## Read the result
 
-After a build that used the cache, mbx prints a one-line summary to stderr:
+An illustrative summary looks like this:
 
 ```text
 mbx[cache]: 139 hits, 8 misses, 4 not looked up, 147 prefetched, 7 bypassed; 312.4 MiB downloaded, 0 B uploaded, 280.1 MiB stored locally
 ```
 
-A miss means mbx looked up an action and found nothing. “Not looked up” means
-it had no key yet. A bypass means mbx declined to cache the action. See
-[Cache results](/cache-results).
-Set `MBX_SUMMARY=full` for the detailed breakdown, `MBX_SUMMARY=off` for none,
-or use Cargo's `-q`/`--quiet` for a quiet invocation.
+| Result | What happened |
+| --- | --- |
+| Hit | mbx restored a matching compilation |
+| Miss | mbx looked up a key, then compiled and stored a new result |
+| Not looked up | mbx needed a first compilation to learn the inputs |
+| Bypassed | The invocation ran without shared caching |
+
+[Cache results](/cache-results) explains all counters and how to measure reuse.
+Use `mbx explain --last` to inspect the last recorded build or `mbx tui` to
+[watch builds live](/tui).
 
 ## Inspect the store
 
 ```sh
-mbx cache dir       # where the store lives
-mbx cache stats     # size and contents of the store
-mbx cache projects  # cache use attributed to recorded workspaces
-mbx cache largest   # the largest objects and action results
-mbx cache verify    # check local objects against their digests
-mbx gc
-mbx gc --dry-run
-mbx gc --max-size 20GiB
+mbx cache stats     # size and contents
+mbx gc --dry-run    # preview cleanup
 ```
 
-Automatic collection is on by default and scales its budgets to the disk; see
-[managed target directories](/managed-targets).
-
-Every inspection command also supports stable, versioned JSON for scripts and
-CI integrations:
-
-```sh
-mbx doctor --json
-mbx cache dir --json
-mbx cache stats --json
-mbx gc --json
-```
-
-## Reporting a problem
-
-Three things describe almost any mbx problem:
-
-```sh
-mbx doctor --json           # environment, store, and setup state
-MBX_LOG=debug cargo build     # mbx's own diagnostics for the run
-MBX_BYPASS_LOG=bypass.log cargo build   # why each compilation was not cached
-```
-
-All three describe your machine: `mbx doctor --json` reports absolute cache
-paths and the URL and namespace of any configured remote, and the logs name
-the crates you build. Credentials are never printed. Remove anything else you
-would rather not publish before posting.
-
-`MBX_LOG` takes an [env_logger](https://docs.rs/env_logger) filter, so
-`debug`, `trace`, or a per-module filter such as `mbx=trace` all work; it
-defaults to `info`. It covers the `mbx` process that drives the build. The
-rustc shim runs without a logger, so per-compilation detail comes from
-`MBX_BYPASS_LOG` instead, or from `mbx explain` for a grouped summary. See
-[Cache results](/cache-results).
-
-Report a problem in
-[Q&A discussions](https://github.com/jdx/mr-boxington/discussions/categories/q-a),
-and propose a change in
-[Ideas](https://github.com/jdx/mr-boxington/discussions/categories/ideas).
-A suspected vulnerability goes through
-[private advisory reporting](https://github.com/jdx/mr-boxington/security/advisories/new);
-see [SECURITY.md](https://github.com/jdx/mr-boxington/blob/main/SECURITY.md).
+A cache can always be rebuilt. Use the [management guide](/managed-targets)
+to understand what each cleanup command removes.
 
 ## Next steps
 
-- Tune local behavior in [Configuration](/configuration).
-- Warm pull requests with [GitHub Actions cache](/github-action).
-- Run independent tasks together through
-  [mise or GitHub Actions](#run-multiple-cargo-builds-at-the-same-time).
-- Learn what enters a key in [How it works](/how-it-works).
+| I want to… | Read |
+| --- | --- |
+| Set up an editor or watch loop | [Local development](/cookbook/local-development) |
+| Cache a GitHub Actions job | [GitHub Action](/github-action) |
+| Run independent builds together | [Parallel builds](/scheduling) |
+| Tune disk, output, or build policy | [Configuration](/configuration) |
+| Understand an unexpected result | [Troubleshooting](/troubleshooting) |
+
+<details>
+<summary>Looking for a section that moved?</summary>
+
+<span id="verify-plain-cargo"></span>
+[Verify plain Cargo](/setup#verify-plain-cargo) now lives in the setup guide.
+
+<span id="supported-platforms"></span>
+[Supported platforms](/installation#supported-platforms) now lives in Installation.
+
+<span id="mise"></span>
+<span id="cargo"></span>
+<span id="release-archive"></span>
+<span id="windows"></span>
+[Installation methods and Windows notes](/installation) have moved there too.
+
+<span id="choose-a-linker"></span>
+[Choose a linker](/linkers) has its own guide.
+
+<span id="run-multiple-cargo-builds-at-the-same-time"></span>
+[Parallel builds](/scheduling) covers separate targets and shared budgets.
+
+<span id="diagnose-the-installation"></span>
+<span id="reporting-a-problem"></span>
+[Installation checks](/troubleshooting#diagnose-the-installation) and
+[Reporting a problem](/troubleshooting#reporting-a-problem) now live in Troubleshooting.
+
+</details>

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,9 +1,44 @@
+---
+description: Add mbx to GitHub Actions, choose a cache transport, run parallel builds, and handle release jobs.
+---
 # GitHub Action
 
 [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action)
-installs mbx and connects it to either GitHub Actions cache or an mbx-compatible
-server. The examples below show the inputs that matter for each backend; the
-action's repository documents the complete list.
+installs or reuses mbx and configures caching for the job. Start with the default
+GitHub backend; use a server when you need object sharing across runners.
+The [action repository](https://github.com/jdx/mr-boxington-action) owns the
+complete input reference.
+
+## Start with a complete workflow
+
+Save this as `.github/workflows/ci.yml`. It uses the runner's Rust toolchain;
+add your toolchain installation step before the cache action if you pin one.
+
+```yaml
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mr-boxington-action@v1
+      - run: mbx test --workspace
+```
+
+The push to `main` fills the archive for later runs. Pull requests restore it
+without saving new entries. Most examples below are snippets for an existing
+job's `steps` list.
+
+## Read the CI summary
 
 mbx automatically uses its explanatory CI build summary in GitHub Actions and
 skips local first-run onboarding. The summary describes mbx's **object cache**;
@@ -14,17 +49,15 @@ archive restore/save results separately. Use `MBX_SUMMARY=short`, `full`, or
 
 ## GitHub Actions cache
 
-The default backend restores Cargo's pruned target directory and its registry
-from the previous compatible cache entry, the same shape of entry
-[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) restores, so a
-job that changes a few files recompiles only those crates. Paired measurements
-on GitHub-hosted Linux and macOS runners put restore-plus-build within noise
-of rust-cache, ahead on build and test jobs, with a cache entry of the same
-size; Windows runners still restore more slowly. A new
-immutable entry is saved after a push to the repository's default branch, and
-after a trusted `workflow_dispatch` run when the action's
-`save-on-workflow-dispatch` input is enabled. Pull requests, including pull
-requests from forks, are restore-only.
+The default backend restores a pruned Cargo target directory and registry from
+a compatible archive. Cargo can then reuse its own fresh outputs. A new
+immutable entry is saved after a push to the default branch, or a trusted
+`workflow_dispatch` run when `save-on-workflow-dispatch` is enabled. Pull
+requests, including forks, are restore-only.
+
+The action manages target placement for this archive mode. Local defaults for
+managed targets and link caching may be overridden by the transport; inspect
+the action's inputs before assuming a local configuration applies unchanged.
 
 ```yaml
 permissions:
@@ -36,33 +69,42 @@ steps:
   - run: mbx test --workspace
 ```
 
-The earlier payload, mbx's own object store exported as the closure of every
-`mbx` command the job completed, remains available as
-`github-cache-mode: objects`. It suits builds that must share one entry across
-differing target directories or checkout layouts; it omits the Cargo registry,
-which Cargo then downloads again during the build, and measured about ten
-seconds slower per job. The action assigns `MBX_CACHE_EXPORT_GROUP` for that
-mode itself. Change `cache-generation` when a cache format or policy change
-should start fresh:
+Use `github-cache-mode: objects` when several target directories or checkout
+layouts need to share one entry. This mode exports the actions used or produced
+by the job and omits the Cargo registry. Cargo may need to download crates
+again unless you cache those downloads separately.
 
 ```yaml
 - uses: jdx/mr-boxington-action@v1
   with:
-    version: 0.3.0
+    github-cache-mode: objects
+```
+
+Change `cache-generation` when a format or policy change should start a new
+archive series:
+
+```yaml
+- uses: jdx/mr-boxington-action@v1
+  with:
     cache-generation: v2
 ```
+
+### Match the toolchain
 
 Generated keys cover the operating system, the architecture, and the identity
 of the `rustc` on `PATH`, because a store built by one compiler matches nothing
 under another. Install the toolchain before the action, and name it in the
 action's `toolchain` input when the build selects its own, as `mbx +1.91 check`
 does. Advanced workflows can provide complete `cache-key` and `restore-keys`
-inputs.
+inputs. The `toolchain` input scopes the key; it does not install or select
+the toolchain for the build.
 
 ## Parallel Cargo steps
 
 Run multiple Cargo builds at the same time by starting independent lint or
-test configurations together. mbx gives every compiler they launch one
+test configurations together using GitHub's
+[`parallel` step group](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel).
+mbx gives every compiler they launch one
 machine-wide CPU and memory budget:
 
 ```yaml
@@ -85,11 +127,10 @@ directory lock serializes the parallel steps. The mbx store and scheduler stay
 shared, so the steps run side by side on one CPU and memory budget instead of
 each Cargo process filling the runner on its own.
 
-We saw mise's own lint job finish up to 45% sooner this way. Tuning and
-failure behavior are covered under
-[machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling).
+Measure the complete job on your workload. See [Parallel builds](/scheduling)
+for tuning and [Benchmarks](/benchmarks#six-parallel-jobs) for a measured batch.
 
-### Docker builds
+## Docker builds
 
 Mount the mbx store and Cargo registry into the container at stable locations.
 The registry may either be mounted directly at `$CARGO_HOME/registry` or
@@ -109,7 +150,7 @@ mbx maps the registry separately from the rest of `CARGO_HOME`, so cached
 compiler inputs remain portable when that child symlink resolves outside the
 Cargo home directory.
 
-### Closure bundles for action transports
+## Closure bundles for action transports
 
 An action can transport only the cache entries produced or used by its builds,
 instead of archiving the whole local store. Every completed `mbx` command
@@ -168,8 +209,8 @@ custom save policies need to share the same entry:
   if: always()
 ```
 
-Use `actions/cache/restore` instead of `actions/cache` in pull requests so they
-cannot create entries.
+Use `actions/cache/restore` instead of `actions/cache` in pull requests so the restore action does not also save an entry. Storage permissions and
+workflow trust still determine what code in the job can access.
 
 ::: tip Pin actions in production
 The examples use major tags for readability. Pin third-party actions to full
@@ -242,11 +283,15 @@ authorize anything, so make IAM agree: scope the role's trust policy to the
 branches allowed to assume it, and give pull request jobs a role that can only
 read. See [remote cache](/remote-cache#who-may-publish).
 
-::: warning Do not use remote caches for production releases
+## Production releases
+
+::: warning Keep published artifacts independent of remote compiler caches
 A production release may still use `mbx` and its local cache, but should not use
 a remote cache so a cache-poisoning attack cannot influence published artifacts.
-Release jobs should also avoid restoring or saving the mbx store through
-`actions/cache`.
+Release jobs should also avoid restoring or saving compiler outputs through
+`actions/cache` or the GitHub backend. The client's tag/release write restriction
+does not disable remote reads automatically: remove remote configuration and
+archive restore steps explicitly.
 :::
 
 For a repository that combines both backends, the server for trusted runs and

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,60 @@
+---
+description: Find the right guide for installing mbx, local development, CI caching, configuration, and troubleshooting.
+---
+# Documentation
+
+mbx adds a shared compiler cache and automatic storage management to Cargo.
+Start with a local build, then add the integrations your workflow needs.
+
+## Start here
+
+[Get started](/getting-started) takes you from installation to your first
+cached build. For platform-specific downloads, see [Installation](/installation).
+For automatic Cargo wrapping and rust-analyzer, see [Cargo and editor setup](/setup).
+
+## Work locally
+
+| Task | Guide |
+| --- | --- |
+| Use editors, watch loops, or a debugger | [Local development](/cookbook/local-development) |
+| Run tests and Clippy at the same time | [Parallel builds](/scheduling) |
+| Understand what is stored or deleted | [Managed target directories](/managed-targets) |
+| Tune repeated source edits | [Incremental builds](/incremental) |
+| Select a linker by profile and target | [Managed linkers](/linkers) |
+| Watch compiler and cache activity | [Watching builds](/tui) |
+| Cache make or CMake compiler calls | [Standalone C and C++](/standalone-builds) |
+
+## Set up CI and sharing
+
+| Task | Guide |
+| --- | --- |
+| Add caching to a GitHub Actions job | [GitHub Action](/github-action) |
+| Replace an existing caching step | [Migrate from rust-cache or sccache](/cookbook/migrate) |
+| Support pull requests from forks | [CI with fork pull requests](/cookbook/fork-prs) |
+| Connect a server or S3-compatible bucket | [Remote cache](/remote-cache) |
+| Operate the reference server | [Cache server](/cache-server) |
+
+## Understand a result
+
+Start with [Troubleshooting](/troubleshooting) for an unexpected build. Read
+[Cache results](/cache-results) to interpret the counters, [How it works](/how-it-works)
+for the architecture, and [Caching limits](/limits) for invocations mbx bypasses.
+
+Use [Savings and statistics](/stats) for lifetime totals and workspace sharing,
+or [Watching builds](/tui) to explore live activity and per-build insights.
+
+[Benchmarks](/benchmarks) includes measured results and the method behind them.
+[How mbx compares](/compared) explains the tradeoffs with other caches and
+Cargo's incremental compilation.
+
+## Look something up
+
+- [Configuration](/configuration): file locations, precedence, and every setting.
+- [CLI reference](/cli/): command syntax, flags, and arguments.
+- [Stability](/stability): upgrade behavior and supported output formats.
+- [Protocol compatibility](/protocol-compatibility): local, remote, and Rust API contracts.
+- [FAQ](/faq): common questions and the story behind the name.
+
+To improve these docs or contribute code, read
+[Contributing](https://github.com/jdx/mr-boxington/blob/main/CONTRIBUTING.md).
+The [acknowledgements](/acknowledgements) recognize the projects mbx builds on.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,7 +1,17 @@
+---
+description: Follow a Cargo build through compiler shims, portable action keys, output restoration, and shared scheduling.
+---
 # How it works
 
-mbx is a Cargo wrapper. Run Cargo subcommands directly through it: `cargo
-build`, `cargo test`, `cargo clippy`, or any installed Cargo subcommand.
+mbx works at the compiler boundary. Cargo decides which tools need to run;
+mbx decides whether each eligible invocation can be restored from cached work.
+An **action** is one modeled invocation and its inputs. The **content-addressed
+store** (CAS) holds outputs under digests of their content.
+
+Run `mbx build` directly, or use ordinary `cargo build` after [`mbx setup`](/setup).
+Both follow the same build lifecycle.
+
+## From command to result
 
 1. mbx resolves the workspace and target roots through Cargo metadata.
 2. It starts an in-process cache agent and creates shims for the build.
@@ -21,10 +31,10 @@ in-flight-work registry, so those builds do not multiply the machine's CPU and
 memory budgets or repeat an identical cold compilation.
 [Machine-wide scheduling](#machine-wide-scheduling) below describes the
 mechanism, and the
-[mise task example](/getting-started#run-multiple-cargo-builds-at-the-same-time)
+[mise task example](/scheduling#run-independent-tasks)
 and
 [parallel GitHub Actions example](/github-action#parallel-cargo-steps) are
-copyable shapes.
+ready-to-use recipes.
 
 ## Build-script C and C++
 
@@ -33,9 +43,10 @@ themselves, resolved to the platform compilers when the session starts. They
 are set as `HOST_CC` and `HOST_CXX` rather than `CC` and `CXX`: the `cc` crate
 consults the host pair only when it is not cross-compiling, and these shims
 wrap the host compiler, so a `cargo build --target` keeps the cross compiler it
-would have found on its own. A build that already chose a compiler through any
-of those variables is left alone, and `MBX_CC=0` turns the shims off
-entirely.
+would have found on its own. An explicit host compiler in `CC`, `CXX`, `HOST_CC`, or `HOST_CXX` is left
+alone. Explicit target compilers can be wrapped; see the
+[C and C++ limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
+`MBX_CC=0` turns this caching off.
 
 Unlike rustc, a C compile leaves no dependency record behind for a later build
 to read, and publishing one would add a file the uncached build never produced.
@@ -86,10 +97,10 @@ Hashing those files is shared too. The agent keeps a ledger of every file a
 shim has hashed, keyed by the file's length, modification time, and change
 time, so a dependency's rlib is read once however many crates link it. The
 ledger is saved with the checkout's private state when the build finishes and
-loaded by its next build, so the crate being edited does not read its unchanged
-dependencies again before it can look anything up. An entry answers only while
-the file on disk still has the identity it was recorded with; anything else is
-hashed as if never seen.
+loaded by its next build, avoiding repeated reads of unchanged dependencies.
+Reuse depends on the file-identity checks supported by that filesystem; network
+filesystems receive additional content validation. If an entry cannot be
+validated, mbx hashes the file again.
 
 ## Rustdoc actions
 
@@ -152,13 +163,20 @@ history for the links in front of it. A compilation the Linux OOM killer stops
 is recorded heavier than it measured, so its retry runs with more room.
 
 The pool size, memory budget, and priority are settings; see
-[machine-wide compile scheduling](/configuration#machine-wide-compile-scheduling).
+[machine-wide compile scheduling](/scheduling#machine-wide-compile-scheduling).
+
+## What remains local
+
+Cargo's target state belongs to a workspace. Learned incremental state belongs
+to a checkout and never enters the shared cache. A configured remote receives
+eligible shared actions according to the [write policy](/remote-cache#read-and-write-policy).
+[Managed targets](/managed-targets) and garbage collection control local retention.
 
 ## Correctness first
 
 Unsupported crate types, unmodeled search paths, and incremental compilations
 bypass the shared action cache. That includes the private incremental state of
-[learned incremental reuse](/configuration#learned-incremental-reuse), which is
+[learned incremental reuse](/incremental#learned-incremental-reuse), which is
 never published. A compilation that links nothing is cached whatever its crate
 type: `cargo check` and clippy compile every binary and test target that way.
 A native link is admitted only when its linker can be described: host binaries,

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -1,0 +1,77 @@
+---
+description: Understand how mbx combines shared compiler caching with private incremental state for local edits.
+---
+# Incremental builds
+
+mbx automatically keeps private incremental state for crates you edit. Unchanged
+work remains eligible for the shared cache. Leave the defaults in place for a
+normal edit/build loop.
+
+| Mode | What is reused | Scope |
+| --- | --- | --- |
+| Shared action cache | Complete matching compiler outputs | Across equivalent builds and checkouts |
+| Learned incremental reuse | Intermediate work from earlier source edits | Private to one checkout |
+| Cargo incremental mode | Cargo-managed incremental state | Private to Cargo's target directory |
+
+## Learned incremental reuse
+
+An edited crate has new source content, so its old shared result cannot match.
+On the first source edit to a workspace crate, mbx compiles it with private
+incremental state. A crate outside the workspace switches after three
+consecutive misses with changed sources. The build reports this work as
+`incremental`; the result never enters the shared cache.
+
+The trigger is a source change. An unchanged crate in a fresh target or a new
+checkout still compiles and publishes normally when it misses the cache.
+Dependents of a crate using private incremental state also keep private state:
+their inputs contain an artifact other checkouts cannot share. That part of the
+build can publish again once the edited crate settles. Later edits to a known
+active crate go directly to its private state.
+
+### Where state lives
+
+State and its records live under `incremental/` in the mbx cache directory,
+separately for each checkout. `cargo clean` does not remove this state.
+Garbage collection removes it for deleted or expired checkouts.
+
+### Bound the storage
+
+`learned_incremental_max_size` limits each crate to `8GiB` by default. Once a
+crate exceeds that limit, mbx warns and discards its state before the next
+compilation. Set it in your global configuration:
+
+```toml
+learned_incremental_max_size = "12GiB"
+```
+
+The environment equivalent is `MBX_LEARNED_INCREMENTAL_MAX_SIZE`; `"none"`
+disables the limit. rustc normally removes superseded sessions, so the budget
+is a backstop. A large debug build can need several GiB. If the warning appears
+on every edit, the limit may be too small to retain useful state: raising it
+can prevent repeated full recompilations.
+
+## Cargo incremental mode
+
+By default, mbx sets `CARGO_INCREMENTAL=0` and uses learned incremental reuse
+for changing crates. `MBX_INCREMENTAL=1` stops it from forcing Cargo's setting
+off locally:
+
+```sh
+MBX_INCREMENTAL=1 mbx build
+```
+
+This lets Cargo manage incremental workspace compilation. Those artifacts
+remain checkout-specific and bypass the shared cache; their dependents may
+also miss. Use it only when you want that tradeoff.
+
+## Overrides and CI
+
+- `MBX_LEARNED_INCREMENTAL=0` disables learned incremental reuse.
+- `MBX_INCREMENTAL=1` supersedes it by handing incremental control to Cargo.
+- `MBX_VERIFY=1` disables it for the build being verified.
+- CI disables both incremental policies because a fresh runner has no earlier
+  edit state to reuse.
+
+Use [Cache results](/cache-results) to distinguish private incremental work
+from ordinary misses. The [local-edit benchmark](/benchmarks#local-edit) reports
+both the initial state-building cost and a later edit.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,28 +1,20 @@
 ---
 layout: home
-title: Shared, self-pruning Cargo build cache
+title: A shared cache for Cargo builds
+description: Reuse compiler work across Rust worktrees and CI, prune build storage automatically, and run Cargo builds with a shared CPU and memory budget.
 
 hero:
   name: "mr boxington"
-  text: "fix <code>target/</code>"
-  tagline: Put mbx in front of any cargo command. Every build on the machine shares one self-pruning cache, and you can run multiple Cargo builds in parallel.
+  text: "A shared cache.<br>A tidier <code>target/</code>."
+  tagline: Keep using Cargo. Reuse compiler work across worktrees, give parallel builds one shared budget, and let the cache clean up after itself.
   image:
     src: /logo.svg
-    alt: Mr Boxington, a friendly cache box
+    alt: Mr Boxington, a cardboard cache box wearing a monocle and bow tie
   actions:
     - theme: brand
-      text: Read the announcement
-      link: https://jdx.dev/posts/2026-09-05-introducing-mr-boxington/
-    - theme: alt
       text: Get started
       link: /getting-started
     - theme: alt
-      text: How it works
-      link: /how-it-works
-    - theme: alt
-      text: GitHub Action
-      link: /github-action
-    - theme: alt
-      text: Benchmarks
-      link: /benchmarks
+      text: Explore the docs
+      link: /guide
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,159 @@
+---
+description: Install mbx with mise, Cargo, or verified release archives on Linux, macOS, and Windows.
+---
+# Installation
+
+mbx uses your existing Rust toolchain. Install Cargo and rustc before running a
+build; `mbx doctor` checks which tools are active.
+
+## mise
+
+```sh
+mise use --global --postinstall "mbx setup --yes" mr-boxington
+```
+
+This installs mbx and sets up automatic Cargo wrapping. Open a new shell, then
+follow [Verify plain Cargo](/setup#verify-plain-cargo). Automatic wrapping
+requires mise 2026.8.16 or newer. Older versions install the standalone shim
+and print an upgrade warning.
+
+## Cargo
+
+```sh
+cargo install mbx --locked
+mbx --version
+```
+
+You can now run `mbx build` in a Rust workspace. To make plain `cargo` commands
+use mbx too, run [`mbx setup`](/setup).
+
+## Release archives
+
+:::tabs
+== Linux x86-64
+
+```sh
+mkdir -p ~/.local/bin
+archive=mbx-x86_64-unknown-linux-gnu.tar.gz
+release=https://github.com/jdx/mr-boxington/releases/latest/download
+curl -fsSLO "$release/$archive" &&
+  curl -fsSLO "$release/SHA256SUMS" &&
+  grep "  $archive$" SHA256SUMS | sha256sum --check --strict - &&
+  tar -xzf "$archive" -C ~/.local/bin
+```
+
+== Linux ARM64
+
+```sh
+mkdir -p ~/.local/bin
+archive=mbx-aarch64-unknown-linux-gnu.tar.gz
+release=https://github.com/jdx/mr-boxington/releases/latest/download
+curl -fsSLO "$release/$archive" &&
+  curl -fsSLO "$release/SHA256SUMS" &&
+  grep "  $archive$" SHA256SUMS | sha256sum --check --strict - &&
+  tar -xzf "$archive" -C ~/.local/bin
+```
+
+== macOS Apple Silicon
+
+```sh
+mkdir -p ~/.local/bin
+archive=mbx-aarch64-apple-darwin.tar.gz
+release=https://github.com/jdx/mr-boxington/releases/latest/download
+curl -fsSLO "$release/$archive" &&
+  curl -fsSLO "$release/SHA256SUMS" &&
+  grep "  $archive$" SHA256SUMS | shasum -a 256 --check --strict - &&
+  tar -xzf "$archive" -C ~/.local/bin
+```
+
+== Windows x86-64
+
+```powershell
+$ErrorActionPreference = "Stop"
+$archive = "mbx-x86_64-pc-windows-msvc.zip"
+$release = "https://github.com/jdx/mr-boxington/releases/latest/download"
+Invoke-WebRequest "$release/$archive" -OutFile $archive
+Invoke-WebRequest "$release/SHA256SUMS" -OutFile SHA256SUMS
+$expected = (Select-String -Path SHA256SUMS -Pattern $archive).Line.Split(" ")[0]
+if ((Get-FileHash $archive -Algorithm SHA256).Hash -ne $expected.ToUpper()) {
+  throw "checksum mismatch"
+}
+Expand-Archive $archive -DestinationPath "$env:LOCALAPPDATA\Programs\mbx"
+```
+
+Add `%LOCALAPPDATA%\Programs\mbx` to `PATH`.
+
+== Windows ARM64
+
+```powershell
+$ErrorActionPreference = "Stop"
+$archive = "mbx-aarch64-pc-windows-msvc.zip"
+$release = "https://github.com/jdx/mr-boxington/releases/latest/download"
+Invoke-WebRequest "$release/$archive" -OutFile $archive
+Invoke-WebRequest "$release/SHA256SUMS" -OutFile SHA256SUMS
+$expected = (Select-String -Path SHA256SUMS -Pattern $archive).Line.Split(" ")[0]
+if ((Get-FileHash $archive -Algorithm SHA256).Hash -ne $expected.ToUpper()) {
+  throw "checksum mismatch"
+}
+Expand-Archive $archive -DestinationPath "$env:LOCALAPPDATA\Programs\mbx"
+```
+
+Add `%LOCALAPPDATA%\Programs\mbx` to `PATH`.
+
+:::
+
+Every release publishes its archives and `SHA256SUMS` on
+[GitHub Releases](https://github.com/jdx/mr-boxington/releases).
+Linux also has `-musl` archives for a static binary that does not depend on a
+host glibc.
+
+After extracting an archive, put its directory on `PATH`, then run
+`mbx --version` and `mbx doctor`. Run `mbx setup` to enable
+[automatic Cargo wrapping](/setup).
+
+## Supported platforms
+
+Release binaries cover:
+
+- Linux x86-64 and ARM64 (GNU and static musl builds)
+- macOS on Apple Silicon
+- Windows x86-64 and ARM64
+
+Other platforms with a Rust toolchain can build from source with
+`cargo install mbx --locked`. mbx wraps whichever Cargo and rustc are active,
+including rustup-managed toolchains. `mbx doctor` reports the pair it found.
+
+Reflinked output restoration needs a filesystem with copy-on-write file
+cloning: APFS on macOS, btrfs or XFS on Linux, ReFS (Dev Drive) on Windows.
+mbx probes the cache and target locations and copies bytes where cloning is
+unavailable. Caching still works on ext4 or NTFS but spends the disk twice.
+
+### Windows
+
+Windows is a supported release platform. The differences from Linux and macOS:
+
+- Reflinks need ReFS, which usually means a Dev Drive; on NTFS mbx copies
+  bytes instead.
+- The managed `target` link needs Developer Mode or a privileged process;
+  where Windows refuses to create it, Cargo keeps its ordinary target
+  directory. See [managed target directories](/managed-targets).
+- rustc compilations and native host links are cached; native-link keys bind
+  the selected MSVC/LLVM linker, Windows SDK, and CRT. See
+  [limits](/limits#native-linking-is-cached-only-where-the-linker-can-be-described).
+- MSVC C and C++ compiles from build scripts and `mbx exec` are cached through
+  a conservative `cl.exe` adapter. See
+  [limits](/limits#c-and-c-caching-covers-the-host-compiles-mbx-drives).
+
+## Upgrade or uninstall
+
+Upgrade using the same installation method: update the mise version, rerun
+`cargo install mbx --locked`, or replace the binary with a verified release
+archive. The stable Cargo shim follows upgrades; setup does not need to run
+again.
+
+Before removing the executable, run `mbx setup --uninstall` in each scope you
+enabled. See [Remove automatic wrapping](/setup#remove-automatic-wrapping).
+Cached work is disposable; use [cache management](/managed-targets) to inspect
+and reclaim it.
+
+Continue with [your first build](/getting-started#run-a-build).

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1,7 +1,24 @@
-# Limits
+---
+description: Find out which Rust, native-link, build-script, and C/C++ invocations mbx can safely cache.
+---
+# Caching limits {#limits}
 
 When mbx cannot model a compilation exactly, it runs the compiler and does not
-cache the result. This page lists those cases.
+cache the result. A bypass preserves the build; it reduces reuse. Run
+`mbx explain --last` to identify the reason for a particular action.
+
+| Work | Cache behavior |
+| --- | --- |
+| Rust compilations without a link | Eligible when inputs can be modeled |
+| Native executables, tests, and proc macros | Eligible on described Linux, macOS, and Windows hosts |
+| Built-in self-contained WebAssembly links | Eligible for the targets listed below |
+| Build-script execution | Eligible using Cargo's declared freshness inputs |
+| C and C++ object compilation | Eligible through supported compiler wrappers |
+| Incremental state | Private to the checkout; never shared |
+| Unknown flags, inputs, or extra outputs | Runs without shared caching |
+
+The sections below spell out the boundaries. For an unexpected result, start
+with [Troubleshooting](/troubleshooting).
 
 ## Build-script execution follows Cargo's freshness inputs
 
@@ -39,9 +56,9 @@ build.
 
 By default mbx forces `CARGO_INCREMENTAL=0` and instead gives a crate whose
 sources keep changing its own private incremental state; see [learned
-incremental reuse](/configuration#learned-incremental-reuse). Those
+incremental reuse](/incremental#learned-incremental-reuse). Those
 compilations are never published to the shared cache. See [incremental
-builds](/configuration#incremental-builds) for the trade `MBX_INCREMENTAL=1`
+builds](/incremental) for the trade `MBX_INCREMENTAL=1`
 makes.
 
 ## Native linking is cached only where the linker can be described
@@ -95,7 +112,7 @@ without one links for the host, and that is the only linker mbx identifies.
 ## Restored artifacts are equivalent, not always identical
 
 A restore writes this checkout's spelling of the outputs that describe where a
-compilation ran, its dep-info and its diagnostics, so the files cargo reads
+compilation ran, its dep-info and its diagnostics, so the files Cargo reads
 name the directory it is building into.
 
 The compiled artifacts are reused as they were produced, and a few things can
@@ -125,11 +142,11 @@ can be told apart.
 
 ## C and C++ caching covers the host compiles mbx drives
 
-mbx caches the C and C++ a cargo build script compiles for the host through
+mbx caches the C and C++ a Cargo build script compiles for the host through
 the `cc` crate, and the C and C++ of a command run under
 [`mbx exec`](/standalone-builds), which puts shims for the plain driver names
 on `PATH` for that command alone. A compile outside both paths is not reached.
-Neither are cross compilations the build did not name a compiler for: a cargo
+Neither are cross compilations the build did not name a compiler for: a Cargo
 build installs the shims as `HOST_CC` and `HOST_CXX`, which the `cc` crate
 consults only when host and target agree, and `mbx exec` shims only `cc`,
 `c++`, `gcc`, `g++`, `clang`, and `clang++` on Unix, plus `cl.exe` on Windows,
@@ -223,6 +240,7 @@ Object eviction prefers abandoned checkout data and then older access times.
 Filesystems using `relatime` coarsen that order; `noatime` removes it. A poor
 choice costs a recompile, not correctness.
 
-The configured size budget covers action objects and results. Prediction data,
-checkout records, temporary downloads, and managed target directories make the
-whole cache directory somewhat larger.
+The action-store budget covers action objects and results. Prediction data,
+checkout records, and temporary downloads add overhead. Managed targets have
+their own budget and can account for substantial space; use the optional
+combined budget to bound both. See [Managed target directories](/managed-targets).

--- a/docs/linkers.md
+++ b/docs/linkers.md
@@ -1,0 +1,75 @@
+---
+description: Select system, toolchain LLD, mold, or Wild linkers by Cargo profile and target.
+---
+# Managed linkers
+
+The default `system` selection preserves Cargo's linker. Change it when you
+want to try another linker or share a pinned choice across a workspace.
+Managed selections require `clang` on `PATH`. Keep `system` on Windows;
+managed `rust-lld` selection is not supported there.
+
+## Try a linker
+
+On Linux, try a pinned mold release for one build:
+
+```sh
+MBX_LINKER=mold@2.42.0 mbx build
+```
+
+This is an example version, not an automatically updated recommendation. On
+Linux or macOS, `rust-lld` uses the active Rust toolchain's bundled LLD without
+a download:
+
+```sh
+MBX_LINKER=rust-lld mbx build
+```
+
+## Selectors
+
+mbx can select a linker by Cargo profile and target triple, install an exact
+version from its official GitHub releases, and route native Rust links through
+it. The built-in selectors are:
+
+- `system`, which leaves Cargo's linker selection alone;
+- `rust-lld` or `lld`, which uses the LLD shipped with the active Rust
+  toolchain;
+- `mold@<version>` or `wild@<version>`, which downloads the
+  matching release asset and verifies GitHub's SHA-256 digest; and
+- `path:<executable>`, which selects a linker mbx does not install.
+
+Managed GitHub linkers require an exact version. Downloads are installed once
+beneath `<cache_dir>/tools`; concurrent builds share the same installation
+lock. `GITHUB_TOKEN` may authenticate GitHub API and download requests.
+
+Within a profile table, an exact target triple wins over `default`. The
+top-level `linker.default` applies when the active profile has no entry. Cargo's
+ordinary profile is `dev`, `--release` selects `release`, `cargo bench` selects
+`bench`, and `--profile <name>` selects that custom profile.
+
+```toml
+[linker]
+default = "system"
+
+[linker.profiles.dev]
+x86_64-unknown-linux-gnu = "mold@2.42.0"
+aarch64-unknown-linux-gnu = "wild@0.10.0"
+
+[linker.profiles.release]
+default = "rust-lld"
+```
+
+`MBX_LINKER` overrides every file for one invocation:
+
+```sh
+MBX_LINKER=mold@2.42.0 cargo build
+MBX_LINKER=system cargo build --release
+```
+
+mold and Wild currently provide managed releases for Linux. Unsupported host
+platforms fail before Cargo starts rather than silently changing the linker.
+The selected executable remains part of mbx's native-link cache identity.
+
+Store persistent selections in your [global configuration](/configuration) or
+in the [workspace policy](/configuration#workspace-policy). The `path:` selector
+is accepted only outside repository-owned policy. A linker change can
+change cache keys; compare equivalent builds when measuring it.

--- a/docs/managed-targets.md
+++ b/docs/managed-targets.md
@@ -1,3 +1,6 @@
+---
+description: Understand target placement, disk budgets, automatic collection, and cleanup commands.
+---
 # Managed target directories
 
 Cargo normally writes build outputs to `<workspace>/target`. Deleting a
@@ -33,8 +36,8 @@ directory is removed when any of these is true:
 
 - Its checkout is gone. This happens regardless of the limits below.
 - It has gone unused for `target.max_age`, 30 days by default. The next build
-  in that checkout restores from the shared store, so this costs a re-link
-  rather than a rebuild.
+  in that checkout can restore matching cached outputs. Evicted or unsupported
+  work must compile again.
 - The managed directories together exceed `target.max_size`. The least
   recently used go first. The most recently used directory is never collected
   for being over budget; if the budget cannot be met without it, mbx says so
@@ -44,8 +47,9 @@ Cached compilations shared with a live checkout remain protected throughout.
 
 ### Budgets scale with the disk
 
-Both budgets default to a share of the disk holding the cache, so a laptop and
-a build server do not need the same configuration:
+Both budgets scale with the disk that holds the data. By default, targets and
+the action store share the cache disk. A custom `target.root` uses its own
+volume for the target budget:
 
 | Budget | Default | Bounds |
 | --- | --- | --- |
@@ -70,8 +74,7 @@ max_total_size = "50GiB"
 ```
 
 `"none"` turns off `target.max_size`, `target.max_age`, or
-`gc.max_total_size`. A value that is neither a size nor `"none"` is an error,
-so a typo cannot disable collection. `gc.max_size` has no `"none"`; the action
+`gc.max_total_size`. Invalid sizes and durations are errors, so a typo cannot disable collection. `gc.max_size` has no `"none"`; the action
 store is always bounded. `MBX_TARGET_VIEWS=0` opts out of managed target
 directories altogether. A directory that is still reached through an existing
 `target` symlink keeps counting as in use, so turning placement off does not
@@ -110,6 +113,19 @@ fails, mbx restores the original directory.
 
 mbx does not offer removal for an explicitly configured target directory or a
 symlink it does not own.
+
+## Inspect and clean up
+
+| Command | Effect |
+| --- | --- |
+| `mbx cache stats` | Inspect the shared store |
+| `mbx gc --dry-run` | Preview collection under the configured budgets |
+| `mbx gc` | Collect eligible targets and cached objects |
+| `mbx clean` | Remove this workspace's managed target and link |
+| `mbx cache remove /path/to/workspace` | Remove the target and forget that workspace's cache claims |
+
+`mbx clean` does not clear the shared cache. Cargo's `cargo clean` is a
+separate command and follows Cargo's own target-directory behavior.
 
 ## Disable managed targets
 

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -1,6 +1,18 @@
+---
+description: Compatibility rules for the local agent protocol, remote cache HTTP contract, and published Rust crates.
+---
 # Protocol compatibility
 
-mr-boxington has two versioned protocols with different compatibility rules.
+mbx has two wire protocols and a separately versioned Rust API surface.
+
+| Integration | Compatibility rule |
+| --- | --- |
+| Local compiler shim and agent | Exact protocol and application-version match |
+| Remote cache client and server | Versioned HTTP contract with negotiated extensions |
+| Published Rust subcrates | Independent crate versions; embedding APIs remain on `0.x` |
+
+For CLI and JSON output guarantees, see [Stability](/stability). Most mbx users
+do not need to interact with these protocols directly.
 
 ## Shim/agent protocol
 
@@ -116,7 +128,7 @@ does not currently enforce API compatibility. Wire format changes still require
 the protocol-version steps above.
 
 A breaking API change is declared, not numbered by hand: the commit carries
-`feat!:` or a `BREAKING CHANGE:` footer, and release-plz prices it into the
+`feat!:` or a `BREAKING CHANGE:` footer, and release-plz uses it to choose the
 version when it opens the release PR.
 [RELEASING.md](https://github.com/jdx/mr-boxington/blob/main/RELEASING.md)
 covers what that means for contributors.

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -1,6 +1,9 @@
+---
+description: Connect mbx to a cache server or S3-compatible bucket and understand authentication and write policy.
+---
 # Remote cache
 
-A remote cache lets ephemeral runners and teammates restore only the rustc
+A remote cache lets ephemeral runners and teammates restore the compiler
 actions a build needs. The local content-addressed store remains the working
 cache; remote objects are downloaded into it and newly completed actions may be
 uploaded from trusted CI.
@@ -8,7 +11,18 @@ uploaded from trusted CI.
 mbx reaches a remote in one of two ways. A **cache server** speaks the mbx
 protocol and answers with the extensions built on top of it. An
 **S3-compatible bucket** stores the same objects with nothing to run. The URL's
-scheme chooses; everything else on this page applies to both.
+scheme chooses the backend.
+
+| Backend | Use it when | Credentials |
+| --- | --- | --- |
+| [Cache server](#configure-a-server) | You want server-side grants and negotiated transfer extensions | Bearer token or GitHub OIDC |
+| [S3-compatible bucket](#configure-an-s3-compatible-bucket) | You already operate object storage | Exported AWS credentials |
+| [GitHub Actions cache](/github-action) | You want managed archive storage for GitHub jobs | Handled by the action |
+
+Put `[remote]` settings in your [global configuration](/configuration), or use
+`MBX_REMOTE_*` environment variables in CI. They are not accepted from a
+repository's `.mbx.toml`. A configured `read-write` mode is still subject to
+[the environment's write policy](#read-and-write-policy).
 
 ## Configure a server
 
@@ -49,7 +63,8 @@ one bucket between projects. Keys are laid out under
 `<prefix>/<namespace>/v1/`, so a bucket policy can scope a writer to its own
 prefix.
 
-An IAM policy needs `s3:GetObject` and `s3:PutObject` on that prefix. Add
+Readers need `s3:GetObject` on that prefix. Trusted writers also need
+`s3:PutObject`. Add
 `s3:ListBucket` on the bucket as well. mbx never lists anything, but without
 that permission AWS answers `403` instead of `404` for an absent object, so a
 miss cannot be told apart from a refusal.
@@ -100,8 +115,9 @@ each other's predictions, which costs prefetch coverage on later builds.
 
 ### Who may publish
 
-A cache server authenticates and authorizes every request. A bucket does not:
-whatever the credentials may write, mbx may write. The client-side [write
+A cache server enforces namespace grants; a bucket enforces its object-storage
+permissions. Whatever a bucket credential can write is within reach of code
+holding that credential. The client-side [write
 policy](#read-and-write-policy) still applies, so pull requests never publish,
 but with a bucket that policy is the only thing between an untrusted build and
 your cache unless IAM agrees.
@@ -164,6 +180,7 @@ The OIDC flow is GitHub-specific, so authenticate GitLab jobs with a bearer
 token in a masked, protected CI/CD variable:
 
 ```yaml
+# Install mbx and a Rust toolchain in the job image first.
 build:
   variables:
     MBX_REMOTE_URL: https://cache.example.com
@@ -235,7 +252,7 @@ the server offers batched lookups it asks for them together instead of once per
 action. `remote_action_lookups` counts requests, not actions, so the same build
 reports far fewer of them against a server with the extension.
 
-Both extensions are negotiated. A server without them, or one that advertises an
+Batch lookups and packed uploads are negotiated. A server without them, or one that advertises an
 endpoint it does not serve, gets the single-object requests every version of mbx
 has made. Nothing needs configuring either way.
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,73 @@
+---
+description: Run concurrent Cargo builds with separate target directories and one shared compiler budget.
+---
+# Parallel builds
+
+Give independent Cargo commands their own target directories. mbx coordinates
+their real compiler processes through a shared CPU and memory budget; Cargo
+continues to plan dependencies within each build.
+
+## Run independent tasks
+
+Any task runner can start multiple mbx commands at the same time. For example,
+mise runs these two lint configurations together:
+
+```toml
+# mise.toml
+[tasks."lint:default"]
+run = "mbx clippy --workspace -- -D warnings"
+env.CARGO_TARGET_DIR = "target/clippy-default"
+
+[tasks."lint:all"]
+run = "mbx clippy --workspace --all-features --all-targets -- -D warnings"
+env.CARGO_TARGET_DIR = "target/clippy-all"
+```
+
+```sh
+mise run lint:default ::: lint:all
+```
+
+Separate target directories keep Cargo's directory lock from serializing the
+commands. mbx shares one machine-wide compiler pool and deduplicates identical
+work in flight without further configuration. See
+[how it works](/how-it-works#machine-wide-scheduling) for the mechanism and
+the same shape [inside GitHub Actions](/github-action#parallel-cargo-steps).
+
+## Machine-wide compile scheduling
+
+Each Cargo process sets its own concurrency. Without coordination, several
+builds can collectively start more compiler processes than the machine can
+comfortably run. mbx coordinates them through a shared pool under the cache
+directory. Scheduling is on by default; `MBX_SCHEDULER=0` disables it.
+
+A permit represents a share of the pool's CPU and memory budget. The pool has
+`scheduler.cpus` permits (default: logical CPUs), minus
+`scheduler.reserve_cpus` (default: 0), with at least one permit remaining.
+`scheduler.memory` defaults to 85% of physical memory. In a Linux container,
+the cgroup's memory limit constrains that budget.
+
+Compiler processes take permits according to their estimated memory use.
+Unmeasured compilations start at one permit; native links start at two and can
+use estimates from earlier links. Measurements refine later admissions.
+Set `scheduler.memory = "none"` to use CPU permits without memory weighting.
+
+Cache hits do not need compiler permits. If a process dies, the kernel releases
+its permits. For the weighting and recovery details, see
+[how it works](/how-it-works#machine-wide-scheduling).
+
+Use `scheduler.priority = "low"` (`MBX_SCHEDULER_PRIORITY=low`) for an editor's
+background check or CI on a shared machine. While normal-priority work is
+waiting, low-priority builds leave a quarter of the pool available for it.
+
+## Choose the scope of a limit
+
+| Limit | Affects |
+| --- | --- |
+| `scheduler.cpus`, `scheduler.memory` | The shared compiler pool |
+| `scheduler.reserve_cpus` | Capacity left outside that pool |
+| Cargo `-j` or `CARGO_BUILD_JOBS` | How much of the pool one build may hold |
+| `scheduler.priority = "low"` | Whether a build yields to waiting normal-priority work |
+
+A memory budget schedules work using measurements; it is not an operating-system
+memory limit. A compiler process can still exceed its estimate. For laptop
+settings, see [Keep a laptop responsive](/cookbook/local-development#keep-a-laptop-responsive).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,141 @@
+---
+description: Make Cargo and rust-analyzer use mbx, choose a setup scope, and verify shell activation.
+---
+# Set up Cargo and your editor
+
+Run this after [installing mbx](/installation) to make ordinary `cargo`
+commands use the cache:
+
+```sh
+mbx setup
+mbx setup --status
+```
+
+Setup installs a stable Cargo shim and offers mise and rust-analyzer
+integration. To try mbx without changing your setup, run `mbx build` directly.
+
+## Choose a scope
+
+| Command | Scope |
+| --- | --- |
+| `mbx setup` | Prompt for the recommended configuration |
+| `mbx setup --yes` | Accept the recommendation |
+| `mbx setup --global` | Global mise configuration |
+| `mbx setup --local` | Current project's mise configuration |
+
+During `mise use --postinstall`, `mbx setup --yes` adds a `[wrappers.cargo]`
+entry to the configuration named by `MISE_CONFIG_FILE`. Otherwise, setup only integrates with mise when
+mise is activated in the current shell. It recommends the config that defines
+`mr-boxington`, then the nearest project config, and finally the global config.
+`mbx setup` prompts before using that recommendation; `--yes` accepts it.
+Without an active mise shell, setup prints the exact shell-specific `PATH`
+change and never edits a shell startup file. Setup runs `mise reshim` after
+adding or removing the wrapper.
+
+Automatic mise wrapping requires mise 2026.8.16 or newer.
+
+## Share setup with a project
+
+To keep the wrapper project-scoped and reviewable, commit it directly in the
+project's `mise.toml` instead:
+
+```toml
+[tools]
+mr-boxington = "1"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
+```
+
+Then run `mise install`. This installs mbx but does not activate the wrapper in
+the parent shell. Run project tasks with `mise run`, or activate mise in the
+shell before invoking plain `cargo` commands. This avoids changing the global
+mise configuration, and every contributor who activates the project gets the
+same Cargo wrapper.
+
+## Verify plain Cargo
+
+Open a new shell after setup and verify that Cargo resolves to mise's command
+wrapper or the stable mbx shim, depending on how you activated it. On Unix:
+
+```sh
+command -v cargo
+# ~/.local/share/mise/command-wrappers/bin/cargo on Linux
+```
+
+On Windows, use PowerShell or `where.exe`:
+
+```powershell
+(Get-Command cargo).Path
+where.exe cargo
+```
+
+mise activation supplies the command-wrapper path to shells where mise is active.
+The wrapper invokes `mbx` with Cargo shim mode enabled, then mise removes its
+dispatch directories before mbx delegates to the configured or system Cargo.
+SSH commands, coding agents, editors, and other non-interactive tools may use a
+startup path that does not activate mise. In that case, prepend the directory
+printed by `mbx setup` in a startup file those processes read. For zsh,
+`~/.zshenv` applies to interactive and non-interactive shells. For example,
+the default Linux location is:
+
+```sh
+export PATH="$HOME/.local/share/mbx/bin:$PATH"
+```
+
+On macOS, the default is different:
+
+```sh
+export PATH="$HOME/Library/Application Support/mbx/bin:$PATH"
+```
+
+Use the path setup prints if your data directory is customized.
+
+Start a new process and run `command -v cargo` again. Once it resolves to the
+shim, ordinary `cargo build`, `cargo test`, and `cargo check` commands use mbx
+automatically. Prefixing a Cargo command with `mbx`, as in `mbx build`, still
+works.
+
+Outside mise activation, the stable `cargo` launcher uses the setup-time mbx
+while it exists, then resolves the active `mbx` from `PATH` after an upgrade
+removes that path. Windows `cargo.exe` resolves the active mbx from `PATH`, with
+the setup-time path as a fallback. Upgrading a mise-managed mbx does not require
+running setup again.
+
+## rust-analyzer
+
+Setup also configures rust-analyzer's background check in the matching global
+or project scope. The editor invokes the stable Cargo shim by its absolute path,
+so its build shares mbx's cache and machine-wide compiler pool even when the
+editor did not inherit mise's `PATH`. Its outputs go to
+`target/rust-analyzer`, separate from terminal builds so the two Cargo processes
+do not contend on the target-directory lock. When `target` is managed, the
+editor directory lives inside that view and is collected with it, while the
+shared store warms both builds. Existing rust-analyzer check settings are left
+unchanged.
+
+## Remove automatic wrapping
+
+```sh
+mbx setup --uninstall
+```
+
+Use `--global` or `--local` to select a mise scope explicitly. Repeat for each
+scope you enabled, and remove any mbx `PATH` entry you added manually. Open a
+new shell and check Cargo's path again. Uninstalling activation does not remove
+the mbx executable or clear the cache.
+
+## Shell completions
+
+Generate a completion script for `bash`, `zsh`, `fish`, or `powershell`:
+
+```sh
+mbx completion zsh > _mbx
+```
+
+Install the generated file in your shell's completion directory. The script
+is self-contained. See the [completion reference](/cli/completion).
+
+For watch loops, debugger paths, and laptop budgets, continue to
+[Local development](/cookbook/local-development).

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,13 +1,20 @@
+---
+description: Understand compatibility guarantees for upgrades, CLI JSON output, local storage, and Rust APIs.
+---
 # Stability
 
-What an mbx upgrade can and cannot break.
+The CLI, machine-readable reports, local cache, and embedding APIs have
+different compatibility rules. Use this page when planning an upgrade or
+building tooling around mbx.
 
 ## The store is disposable
 
 The local store is a cache of work mbx can redo. Correctness never depends on
 its format: an entry a new version cannot read is a miss, and the compilation
 runs again. The worst case for any upgrade is a colder build, not a wrong one,
-and deleting the cache directory is always safe.
+and cached compilations can be regenerated. Stop builds before manually
+deleting the whole root: it also contains managed targets and private state.
+Prefer [`mbx gc`](/managed-targets#inspect-and-clean-up) for routine cleanup.
 
 Managed target directories live under a versioned root (`targets/v1/…`), and
 the `target` symlink in each checkout keeps working across upgrades.
@@ -20,7 +27,7 @@ shape change bumps the version. Scripts should read the version field and
 parse the JSON. The `mbx[...]` stderr lines are written for people and may be
 reworded at any time.
 
-### Session event streams are not
+### Session event streams are not a public API {#session-event-streams-are-not}
 
 The per-compilation streams under `sessions/v1/` that back
 [`mbx tui`](/tui) are an implementation detail of that command. Their records

--- a/docs/standalone-builds.md
+++ b/docs/standalone-builds.md
@@ -1,3 +1,6 @@
+---
+description: Cache C and C++ compiler calls from make, CMake, and other build tools with mbx exec.
+---
 # Cache C and C++ builds outside Cargo
 
 Use `mbx exec` to cache compiler calls made by make, CMake, and other build
@@ -15,8 +18,9 @@ mbx exec cmake -S . -B build
 mbx exec cmake --build build
 ```
 
-Only the command after `mbx exec` is affected. There is no daemon to start and
-nothing is installed globally.
+Only the command after `mbx exec` uses these compiler wrappers. There is no
+daemon or global compiler setup. For C and C++ compiled by Cargo build scripts,
+use `mbx build`; that integration is [enabled by default](/configuration#build-script-c-and-c).
 
 ## What `mbx exec` does
 
@@ -44,7 +48,11 @@ CMake writes it to `CMakeCache.txt`; autoconf may write it into generated
 makefiles. If configuration happens outside `mbx exec`, the saved path points
 straight to the compiler and later `mbx exec` builds cannot intercept it.
 
-Configure once through `mbx exec` so the build system records mbx's wrapper.
+For an existing CMake build configured with a direct compiler path, configure
+a fresh build directory through `mbx exec`. Changing `PATH` during a later
+build does not replace the compiler saved in `CMakeCache.txt`.
+
+Configure through `mbx exec` so the build system records mbx's wrapper.
 That path remains valid across later commands. You should still use `mbx exec`
 for each build you want cached:
 
@@ -99,6 +107,5 @@ MBX_CC=0 mbx exec make
 ```
 
 C and C++ compilation is the only work `mbx exec` caches, so this runs the
-command as if it were invoked directly. Production release builds may use the
-local cache but should not use a remote cache, which keeps remote cache
-poisoning away from published artifacts.
+command without compiler caching. For published artifacts, follow the
+[production release policy](/github-action#production-releases).

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -1,3 +1,6 @@
+---
+description: Read lifetime compiler savings, pruning totals, and estimated workspace sharing with mbx stats.
+---
 # Savings and statistics
 
 `mbx stats` shows what sharing builds has saved on this machine, with the date

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,115 @@
+---
+description: Diagnose setup, low cache reuse, remote failures, and unexpected build behavior.
+---
+# Troubleshooting
+
+Start with the symptom, then inspect a specific build before clearing any
+cached work.
+
+| Symptom | First check |
+| --- | --- |
+| Plain Cargo does not use mbx | `mbx setup --status`, then [check Cargo's path](/setup#verify-plain-cargo) |
+| A build restores little or nothing | `mbx explain --last`, then [read the results](/cache-results#troubleshooting-a-low-hit-rate) |
+| Cargo waits for a target lock | Give simultaneous builds [separate targets](/scheduling) |
+| Remote requests fail | `mbx doctor`, then [check authentication](/remote-cache#authenticate) |
+| Build storage is larger than expected | `mbx cache stats` and `mbx gc --dry-run`; review [budgets](/managed-targets#budgets-scale-with-the-disk) |
+| Breakpoints point at an old checkout | Use the [debugger recipe](/cookbook/local-development#debug-a-binary-restored-from-another-checkout) |
+
+## Diagnose the installation
+
+```sh
+mbx doctor
+```
+
+Example output (versions, paths, and budgets depend on your machine):
+
+```text
+  ok  cargo        cargo 1.98.0 (797e8a9bc 2026-08-05)
+  ok  rustc        rustc 1.98.0 (88d9e12ae 2026-08-18)
+  ok  cache        /home/you/.cache/mbx is writable
+  ok  session      Unix-domain listeners are available
+  ok  config       50.0 GiB budget, automatic gc enabled, managed targets enabled at /home/you/.cache/mbx/targets
+  ok  reflink      supported by the cache filesystem
+  ok  setup        mise Cargo wrapper is active and the fallback shim is current at /home/you/.local/share/mbx/bin/cargo
+  ok  remote       not configured; using the local cache
+
+0 failures, 0 warnings
+```
+
+Doctor checks that mise's Cargo wrapper is active, or that the installed fallback
+shim matches the running mbx and is the first `cargo` on `PATH`. It also checks
+the Cargo and rustc executables, cache write access, the local build-session
+listener, filesystem reflink support, effective remote policy, and remote
+protocol connectivity. Warnings describe setup problems, optional features, or
+fallbacks; failures make the command exit
+unsuccessfully.
+
+Build sessions normally communicate over a Unix-domain socket. When a sandbox
+blocks Unix socket listeners but permits filesystem FIFOs, mbx automatically
+uses FIFO transport and keeps caching enabled. If neither transport is
+available, mbx warns and runs Cargo without caching instead of preventing the
+build from starting.
+
+## Inspect a build
+
+```sh
+mbx explain --last                 # read the last recorded session
+mbx explain build --workspace      # run a build with diagnostics
+```
+
+The first command does not run Cargo. The second preserves Cargo's exit status.
+If Cargo considers every output fresh, there may be no compiler invocations to
+explain. See [Measure cache reuse](/cache-results#measure-cache-reuse) for a
+controlled comparison with fresh targets.
+
+## Bypass mbx for one command
+
+In a POSIX shell:
+
+```sh
+MBX_DISABLE=1 cargo build
+```
+
+In PowerShell:
+
+```powershell
+$env:MBX_DISABLE = "1"
+try { cargo build } finally { Remove-Item Env:MBX_DISABLE }
+```
+
+This keeps Cargo's existing outputs. To investigate an artifact that may have
+been restored earlier, use a separate target directory as shown in the
+[debugger recipe](/cookbook/local-development#debug-a-binary-restored-from-another-checkout).
+
+## Reporting a problem
+
+Three things describe almost any mbx problem:
+
+```sh
+mbx doctor --json
+MBX_LOG=debug mbx build
+MBX_BYPASS_LOG=bypass.log mbx build
+```
+
+The doctor report describes the environment; `MBX_LOG` records build diagnostics
+and `MBX_BYPASS_LOG` records per-compilation bypass reasons.
+
+All three describe your machine: `mbx doctor --json` reports absolute cache
+paths and the URL and namespace of any configured remote, and the logs name
+the crates you build. Credentials are never printed. Remove anything else you
+would rather not publish before posting.
+
+`MBX_LOG` takes an [env_logger](https://docs.rs/env_logger) filter, so
+`debug`, `trace`, or a per-module filter such as `mbx=trace` all work; it
+defaults to `info`. It covers the `mbx` process that drives the build. The
+rustc shim runs without a logger, so per-compilation detail comes from
+`MBX_BYPASS_LOG` instead, or from `mbx explain` for a grouped summary. See
+[Cache results](/cache-results).
+
+Report a problem in
+[Q&A discussions](https://github.com/jdx/mr-boxington/discussions/categories/q-a),
+and propose a change in
+[Ideas](https://github.com/jdx/mr-boxington/discussions/categories/ideas).
+A suspected vulnerability goes through
+[private advisory reporting](https://github.com/jdx/mr-boxington/security/advisories/new);
+see [SECURITY.md](https://github.com/jdx/mr-boxington/blob/main/SECURITY.md).

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -1,3 +1,6 @@
+---
+description: Watch live cache activity, inspect completed sessions, and read a plain-text build snapshot.
+---
 # Watching builds
 
 `mbx tui` shows what every build on this machine is doing to the cache, as it
@@ -11,20 +14,18 @@ mbx tui
 
 *Live, with example build data. Open any screenshot at full size to read the details.*
 
-The end-of-build summary tells you what a build did once it is over, and
-[cache results](/cache-results) explains how to read it. It cannot tell you what
-a build is doing right now, or which crate any of its numbers belonged to.
-`mbx tui` shows one row per compilation, named, with the outcome mbx chose for
-it.
+`mbx tui` shows one row per compilation, with its crate name and cache outcome.
+Open it in a second terminal while your normal build continues. For the
+end-of-build summary, see [Cache results](/cache-results).
 
-mbx has no daemon, so `mbx tui` is not talking to anything. Each build appends
+The TUI reads local session files; it does not need a daemon or cache server. Each build appends
 its decisions to a stream under the cache, and the dashboard reads those
 streams. It shows builds in other terminals, builds that started before you
 opened it, and any number of builds at once.
 
 ## Screens
 
-**Live** lists the builds it knows about and, for the selected one, the
+**Live** lists recorded builds and, for the selected one, the
 compilations as they are decided. Outcomes are colored: green for a hit, red for
 a miss, grey for a compilation no lookup was possible for, yellow for one mbx
 bypassed, cyan for a shadow verification that matched, and magenta for one that
@@ -194,8 +195,10 @@ adding rows after 16 MiB, though its totals are still recorded. A stream a build
 is still writing is never collected. `mbx gc --dry-run` reports what it would
 drop alongside everything else.
 
-Streams are history, not cache content. Nothing keys on them, they are never
-weighed against the store's size budget, and deleting them costs a row in a list.
+Session history does not affect cache keys or count against the action-store
+size budget. Deleting finished session files removes their rows from the TUI
+and the history available to `mbx explain --last`, without removing compiled
+artifacts.
 
 ::: warning Not a stable format
 The event files are an implementation detail of `mbx tui` and may change in any

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -8,7 +8,14 @@ These targets exercise repository-owned parsers with arbitrary local input:
 - `dep_info`: rustc's Makefile-style dependency metadata;
 - `rustc_paths`: compiler argument parsing and mapped-path normalization.
 
-Run all targets briefly with:
+Install the fuzzing prerequisites once:
+
+```sh
+rustup toolchain install nightly
+cargo install cargo-fuzz --locked
+```
+
+From the repository root, run each target for a 30-second smoke check:
 
 ```console
 cargo +nightly fuzz run blob_pack -- -max_total_time=30
@@ -19,5 +26,5 @@ cargo +nightly fuzz run rustc_paths -- -max_total_time=30
 ```
 
 The inputs are capped at 1 MiB so CI smoke runs and local campaigns stay
-bounded. Crashes are written under `fuzz/artifacts/`; commit minimized
+bounded. Increase `-max_total_time` for a longer campaign. Crashes are written under `fuzz/artifacts/`; commit minimized
 regressions to the matching corpus directory after reviewing them.

--- a/test/README.md
+++ b/test/README.md
@@ -1,14 +1,20 @@
 # Behavioral tests
 
 The command-line and end-to-end suite uses
-[Bats](https://github.com/bats-core/bats-core), following the same layout as
-fnox and hk. Bats and its assertion helpers are pinned as Git submodules so a
+[Bats](https://github.com/bats-core/bats-core), with isolated homes and cache directories for each test. Bats and its assertion helpers are pinned as Git submodules so a
 checkout has the exact test runner used by CI.
 
 Initialize the runner once after cloning:
 
 ```bash
 git submodule update --init --recursive
+```
+
+Install the pinned toolchain with `mise install`, then add the target used by
+the WebAssembly test:
+
+```sh
+mise exec -- rustup target add wasm32-unknown-unknown
 ```
 
 Run every Rust and behavioral test:
@@ -21,9 +27,13 @@ Run only Bats tests, one file, or one named case:
 
 ```bash
 mise run test:bats
-test/bats/bin/bats test/cli.bats
-test/bats/bin/bats --filter "isolated store" test/cli.bats
+MBX_BIN="$PWD/target/mbx-bootstrap/mbx" test/bats/bin/bats test/cli.bats
+MBX_BIN="$PWD/target/mbx-bootstrap/mbx" test/bats/bin/bats --filter "isolated store" test/cli.bats
 ```
+
+The individual commands use the bootstrap binary produced by `mise run build`.
+`mise run test:e2e` selects Bats on Unix and the PowerShell suite in `e2e-win/`
+on Windows.
 
 Every test loads `test/test_helper/common_setup.bash`, which selects the debug
 binary and gives the test an isolated home, config, data, and cache directory.


### PR DESCRIPTION
The README and onboarding guide mixed first-run steps with setup details, tuning, and reference material. This refresh gives new users a shorter path to their first build and organizes the website around local development, CI and sharing, troubleshooting, and reference.

- Add focused installation, Cargo/editor setup, troubleshooting, parallel-build, incremental-build, and linker guides, plus a documentation hub and contributor guide.
- Revise prose and examples across the authored Markdown files, correct stale behavior descriptions, and preserve published section links.
- Redesign the landing page with a copyable install command, an interactive cache illustration, clearer typography, locally served fonts, improved contrast, and responsive layouts. Preserve the TUI screenshot selector and connect the new statistics and trace commands to the navigation.

Validation:

- `mise run ci` passes, including formatting, Clippy, generated documentation, site/link checks, Rust tests, and Bats suites. The optional alternate-linker case is skipped because no alternate linker is installed.
- The site builds all 52 documentation pages with social metadata and no broken internal links.
- All 165 existing guide section anchors remain present.
- Browser checks cover narrow mobile layouts, documentation search, the install copy button, cache illustration, and TUI screenshot selector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and site theme changes only; no mbx runtime or cache behavior changes in the diff.
> 
> **Overview**
> This PR **restructures onboarding and reference** so the README and **Get started** stay short, while deeper setup, tuning, and troubleshooting move into dedicated guides (`/guide`, installation, setup, scheduling, incremental, linkers, troubleshooting, and related cookbook pages). **CONTRIBUTING.md** is added; **RELEASING**, **SECURITY**, and benchmark contributor docs are tightened to match.
> 
> **VitePress** gets a new nav/sidebar (Docs, CI & sharing, Benchmarks, Reference), richer CLI sidebar entries, and **Edit on GitHub** links that point at `crates/mbx/src/cli/*.rs` for generated command pages. The **landing page** is redesigned: copyable mise install (`HomeQuickStart`), a toggle-based cache illustration (`HomeTerminal`), refreshed feature sections, bundled **Space Grotesk** (no Google Fonts), updated theme/contrast, and a **demo disclaimer** on the cache dashboard (`noindex`).
> 
> Across authored pages, prose is revised (cache results, remote policy, comparisons, GitHub Action workflows), long **configuration** sections are split out with cross-links, and **getting-started** anchors are preserved via moved-section stubs. **AGENTS.md** now documents CLI help under `crates/mbx/src/cli/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b46799a8e5a7775b9157c54f422979ef4394492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guides for installation, setup, scheduling, linkers, incremental builds, troubleshooting, remote caching, and contribution workflows.
  - Reorganized navigation and refreshed guidance for getting started, GitHub Actions, cache management, benchmarks, security, and releases.
  - Added clearer command examples, compatibility information, and cache-result explanations.

- **Website**
  - Redesigned the homepage with a quick-start installation action, updated feature sections, and a simplified build demonstration.
  - Updated visual styling, responsive layouts, typography, and accessibility-focused behavior.
  - Clarified that the dashboard displays sample data and is not connected to a cache server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->