### PR TITLE
fix: recognize nightly Cargo build-script names

### DIFF
--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1052,11 +1052,13 @@ pub fn is_build_script_shim() -> bool {
     let Some(invoked) = build_script_invocation_path() else {
         return false;
     };
-    invoked
-        .file_stem()
-        .and_then(OsStr::to_str)
-        .is_some_and(|stem| stem == "build-script-build")
-        && find_build_script_real_path(&invoked).is_some()
+    is_build_script_executable(&invoked) && find_build_script_real_path(&invoked).is_some()
+}
+
+fn is_build_script_executable(path: &Path) -> bool {
+    path.file_stem().is_some_and(|stem| {
+        stem == OsStr::new("build-script-build") || stem == OsStr::new("build_script_build")
+    })
 }
 
 pub(crate) fn build_script_invocation_path() -> Option<PathBuf> {

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -51,6 +51,13 @@ fn ambiguous_build_script_sidecars_are_refused() {
     assert_eq!(find_build_script_real_path(&invoked), None);
 }
 
+#[test]
+fn cargo_build_script_executable_names_are_recognized() {
+    assert!(is_build_script_executable(Path::new("build-script-build")));
+    assert!(is_build_script_executable(Path::new("build_script_build")));
+    assert!(!is_build_script_executable(Path::new("build-script")));
+}
+
 fn test_config(cache_dir: &Path) -> Config {
     Config {
         cache_dir: cache_dir.to_path_buf(),


### PR DESCRIPTION
## What changed

Recognize both Cargo build-script launcher names:

- `build-script-build`, emitted by Cargo 1.97.1
- `build_script_build`, emitted by Cargo 1.100.0-nightly from 2026-09-02

Without the underscore form, mbx runs its pinned launcher as the top-level CLI. The build script prints mbx usage and exits 2.

## Reproduction

A dependency-free crate with `build = "build.rs"` produced this result with a fresh cache:

| Toolchain | mbx 1.8.3 | This change |
|---|---:|---:|
| Cargo 1.97.1 | pass | pass |
| Cargo 1.100.0-nightly | exit 101 | pass |

The patched nightly run completed from a cold target in 3.22 seconds. After deleting the target, the cache-backed rerun completed successfully in 0.00 seconds.

## Verification

- `mise run ci`
- Unit coverage for both launcher names and a non-build-script control
- The original nightly reproduction with a fresh mbx cache
- A real nightly project build that previously failed at every dependency build script


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build script detection to recognize both hyphenated and underscored executable naming conventions.
  - Build processes using either supported naming format are now handled correctly, reducing failures when identifying build script executables.

- **Tests**
  - Added coverage verifying recognition of supported build script names and rejection of unsupported names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->