### PR TITLE
fix(cache): model rustc embedded metadata selection

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -1441,7 +1441,8 @@ impl<'a> Parser<'a> {
         if let Some(attached) = value.strip_prefix("-Z") {
             let option = self.take_value("-Z", (!attached.is_empty()).then_some(attached))?;
             match option.as_str() {
-                "shell-argfiles" | "unstable-options" => {
+                "embed-metadata=no" | "embed-metadata=yes" | "shell-argfiles"
+                | "unstable-options" => {
                     self.parsed.push(Argument::Plain(format!("-Z{option}")));
                     return Ok(());
                 }

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1077,6 +1077,30 @@ fn models_parallel_frontend_options_in_the_action_key() {
 }
 
 #[test]
+fn models_embedded_metadata_selection_in_the_action_key() {
+    let invocation = |selection: &[&str]| {
+        let mut arguments = vec![
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+        ];
+        arguments.extend_from_slice(selection);
+        arguments.push("src/lib.rs");
+        RustcInvocation::parse(&args(&arguments)).unwrap()
+    };
+    let key = |invocation: RustcInvocation| {
+        invocation
+            .action(context(&[("src/lib.rs", "source")]))
+            .unwrap()
+            .digest
+    };
+
+    let disabled = invocation(&["-Zembed-metadata=no"]);
+    assert_eq!(disabled, invocation(&["-Z", "embed-metadata=no"]));
+    assert_ne!(key(disabled), key(invocation(&["-Zembed-metadata=yes"])));
+}
+
+#[test]
 fn parallel_frontend_options_require_values() {
     for arguments in [
         vec!["-Zthreads", "src/lib.rs"],

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -1098,6 +1098,18 @@ fn models_embedded_metadata_selection_in_the_action_key() {
     let disabled = invocation(&["-Zembed-metadata=no"]);
     assert_eq!(disabled, invocation(&["-Z", "embed-metadata=no"]));
     assert_ne!(key(disabled), key(invocation(&["-Zembed-metadata=yes"])));
+
+    // Only the two documented spellings are admitted. Any other value keeps
+    // bypassing, so a selection this adapter cannot describe never reaches a
+    // key that claims to describe it.
+    for value in ["off", "true", ""] {
+        let flag = format!("-Zembed-metadata={value}");
+        assert_eq!(
+            RustcInvocation::parse(&args(&[&flag, "src/lib.rs"])),
+            Err(BypassReason::UnknownFlag(flag.clone())),
+            "{flag} should bypass"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What changed

Model `-Zembed-metadata` in the rustc cache adapter, so a nightly Cargo build reaches the cache instead of bypassing it.

Cargo passes `-Z embed-metadata=no` to rustc whenever both the Cargo and rustc channels are nightly, for every unit that benefits from it. The adapter doesn't recognize the flag, so each of those compilations bypasses with:

```
mbx[warning]: rustc cache bypassed: rustc flag is not modeled by the cache adapter: -Zembed-metadata=no
```

On a nightly toolchain that covers most of the dependency graph, so almost nothing is stored and nothing can be restored.

The flag joins `-Zshell-argfiles` and `-Zunstable-options` as admitted key material. It's keyed as text like the other admitted `-Z` options, which is what the selection needs: `=no` keeps full metadata out of the rlib and leaves it in the `.rmeta`, so two invocations that differ only in this flag produce different bytes and must not share a key.

Only the `yes` and `no` spellings are admitted. Any other value still bypasses, so a future spelling can't be keyed with semantics the adapter doesn't model.

## Measurement

A dependency-free library crate, built in two separate checkouts against one fresh cache, on `nightly-2026-09-05` (Cargo 1.100.0-nightly, b2e9d5f9d 2026-09-02):

| | checkout A | checkout B |
|---|---|---|
| mbx 1.8.3 | 0 hits, 0 misses, 1 bypassed, 0 B stored | 0 hits, 0 misses, 1 bypassed |
| This change | 0 hits, 0 misses, 1 not looked up, 8.5 KiB stored | **1 hit** |

Stock mbx stores nothing on the first checkout, so the second can never hit. With the change, the first checkout stores the result and the second restores it.

## Verification

- `mise run ci`
- A unit test asserting that the attached and separate spellings parse identically, that `=no` and `=yes` produce different action keys, and that `off`, `true` and an empty value each still bypass
- That bypass assertion falsified by widening the exact match into a prefix match locally, which turns the test red
- The two-checkout probe above, with its stock-binary control
- A real nightly build of a large project, where the warning previously appeared once per crate

This is independent of #396. Both surface on nightly toolchains, and they sit in different crates with no overlap.
