### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.9.0"
+version = "2.0.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.22...mbx-cache-cargo-v0.1.23) - 2026-09-08
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.21...mbx-cache-cargo-v0.1.22) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.22"
+version = "0.1.23"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.14.0"
+version = "0.15.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.14.0...mbx-cache-core-v0.15.0) - 2026-09-08
+
+### Fixed
+
+- [**breaking**] keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))
+
 ## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.13.1...mbx-cache-core-v0.14.0) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.14.0"
+version = "0.15.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-core/src/agent.rs
+++ b/crates/mbx-cache-core/src/agent.rs
@@ -53,14 +53,30 @@ const MAX_EXECUTABLE_IDENTITY_BYTES: usize = 256 * 1024;
 const TASK_ACTION_MANIFEST_VERSION: u8 = 1;
 const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
 /// Longest shim diagnostic the agent accepts, in bytes.
-const MAX_WARNING_BYTES: usize = 4 * 1024;
+const MAX_DIAGNOSTIC_BYTES: usize = 4 * 1024;
 /// Most distinct shim diagnostics one session surfaces before going quiet.
 ///
 /// A failure mode that repeats across a build tends to repeat with the same
 /// message, which deduplication already collapses; the cap only guards
 /// against a message that embeds something unique per compilation.
-const MAX_WARNINGS: usize = 128;
+const MAX_DIAGNOSTICS: usize = 128;
 const ACTION_DIAGNOSTIC_PREFIX: &str = "@mbx-action-diagnostic\t";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum DiagnosticLevel {
+    Warning,
+    Error,
+}
+
+impl DiagnosticLevel {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Warning => "warning",
+            Self::Error => "error",
+        }
+    }
+}
+
 /// Most file identities one digest lookup or record may carry.
 const MAX_FILE_DIGEST_BATCH: usize = 16 * 1024;
 /// Most recorded file digests one session retains across every scope.
@@ -313,9 +329,11 @@ pub struct CacheAgent {
     remote_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_transfers: Arc<tokio::sync::Semaphore>,
     prefetch_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
-    /// Distinct shim diagnostics already surfaced, so a warning that fires
-    /// once per compilation is printed once per session.
-    warnings: Arc<Mutex<BTreeSet<String>>>,
+    /// Distinct shim diagnostics already surfaced, so a diagnostic that fires
+    /// once per compilation is printed once per session. The severity is part
+    /// of each key: a fatal reason must still be surfaced after the same text
+    /// appeared as a warning.
+    diagnostics: Arc<Mutex<BTreeSet<(DiagnosticLevel, String)>>>,
     /// Digests of files shims hashed or wrote this session, keyed by scope and
     /// path, each entry standing while its recorded identity matches the disk.
     file_digests: Arc<Mutex<BTreeMap<(FileDigestScope, PathBuf), RecordedFileDigest>>>,
@@ -598,7 +616,7 @@ impl CacheAgent {
             remote_transfers,
             prefetch_transfers: Arc::new(tokio::sync::Semaphore::new(MAX_PREFETCH_TRANSFERS)),
             prefetch_tasks: Arc::new(Mutex::new(Vec::new())),
-            warnings: Arc::new(Mutex::new(BTreeSet::new())),
+            diagnostics: Arc::new(Mutex::new(BTreeSet::new())),
             file_digests: Arc::new(Mutex::new(BTreeMap::new())),
             file_digest_locks: Arc::new(Mutex::new(BTreeMap::new())),
             file_digest_permits: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_FILE_DIGESTS)),
@@ -1482,8 +1500,11 @@ impl CacheAgent {
                     Ok(AgentResponse::WarningRecorded)
                 }
                 Some(Err(error)) => Err(error),
-                None => self.record_warning(message),
+                None => self.record_diagnostic(DiagnosticLevel::Warning, message),
             },
+            AgentRequest::RecordError { message } => {
+                self.record_diagnostic(DiagnosticLevel::Error, message)
+            }
             AgentRequest::FindFileDigests { scope, files } => self.find_file_digests(scope, files),
             AgentRequest::JoinActionPromise {
                 adapter,
@@ -1979,23 +2000,40 @@ impl CacheAgent {
     /// compilation the shim stands in for -- which build scripts read as part
     /// of the compiler's answer. Deduplicated because one cause tends to fire
     /// once per compilation, and capped so a message unique per compilation
-    /// cannot scroll the build away.
-    fn record_warning(&self, message: String) -> Result<AgentResponse> {
+    /// cannot scroll the build away. The level is part of the deduplication
+    /// key, so a fatal reason is never hidden by an earlier warning with the
+    /// same text.
+    fn record_diagnostic(&self, level: DiagnosticLevel, message: String) -> Result<AgentResponse> {
         if message.is_empty()
-            || message.len() > MAX_WARNING_BYTES
+            || message.len() > MAX_DIAGNOSTIC_BYTES
             || message.contains(['\n', '\r', '\0'])
         {
-            bail!("invalid shim warning");
+            bail!("invalid shim {}", level.label());
         }
-        let mut warnings = self.warnings.lock().unwrap();
-        if !warnings.contains(&message) && warnings.len() < MAX_WARNINGS {
-            eprintln!("mbx[warning]: {message}");
-            self.emit(|| AgentEvent::Warning {
-                message: message.clone(),
+        let mut diagnostics = self.diagnostics.lock().unwrap();
+        let key = (level, message.clone());
+        if !diagnostics.contains(&key) {
+            // An acknowledgement promises the diagnostic was surfaced. A
+            // fatal shim error must be able to fall back locally when this
+            // channel can no longer display it.
+            if diagnostics.len() >= MAX_DIAGNOSTICS {
+                bail!("shim diagnostic limit reached");
+            }
+            eprintln!("mbx[{}]: {message}", level.label());
+            self.emit(|| match level {
+                DiagnosticLevel::Warning => AgentEvent::Warning {
+                    message: message.clone(),
+                },
+                DiagnosticLevel::Error => AgentEvent::Error {
+                    message: message.clone(),
+                },
             });
-            warnings.insert(message);
+            diagnostics.insert(key);
         }
-        Ok(AgentResponse::WarningRecorded)
+        Ok(match level {
+            DiagnosticLevel::Warning => AgentResponse::WarningRecorded,
+            DiagnosticLevel::Error => AgentResponse::ErrorRecorded,
+        })
     }
 
     /// Answer file-digest lookups from the session ledger.

--- a/crates/mbx-cache-core/src/agent/wire.rs
+++ b/crates/mbx-cache-core/src/agent/wire.rs
@@ -253,7 +253,7 @@ pub enum AgentRequest {
     /// Appended rather than grouped with the other `Record*` requests it
     /// belongs beside: these variants carry no `repr`, so inserting one moves
     /// the discriminant of every variant after it, and a break nobody asked
-    /// for is worth less than the grouping. New variants go here.
+    /// for is worth less than the grouping.
     RecordWarning {
         /// Human-readable single-line diagnostic.
         message: String,
@@ -298,6 +298,15 @@ pub enum AgentRequest {
     RecordWrapperTiming {
         /// Completed invocation timings.
         timing: WrapperTiming,
+    },
+    /// Surface a fatal shim diagnostic through the session that owns the build.
+    ///
+    /// This is appended to preserve every existing request variant and wire
+    /// shape while allowing a caller to distinguish fatal acknowledgement from
+    /// [`Self::RecordWarning`] and fall back locally when it is not accepted.
+    RecordError {
+        /// Human-readable single-line diagnostic.
+        message: String,
     },
 }
 
@@ -410,6 +419,11 @@ pub enum AgentEvent {
         /// Human-readable single-line diagnostic.
         message: String,
     },
+    /// A shim reported a fatal diagnostic for the session to surface.
+    Error {
+        /// Human-readable single-line diagnostic.
+        message: String,
+    },
     /// Cache-key material for the action event immediately following it.
     ActionDiagnostic {
         /// Outcome of the action this describes.
@@ -514,9 +528,8 @@ pub enum AgentResponse {
     },
     /// A shim diagnostic was accepted for the session to surface.
     ///
-    /// Sits past `Error` for the reason [`AgentRequest::RecordWarning`] sits
-    /// last: anywhere earlier renumbers the variants below it. New variants go
-    /// here.
+    /// Kept after `Error` so this acknowledgement remains alongside the
+    /// existing diagnostic response without changing earlier variants.
     WarningRecorded,
     /// Digests recorded earlier for the requested file identities.
     FileDigests {
@@ -541,4 +554,9 @@ pub enum AgentResponse {
     },
     /// Wrapper phase timings were recorded.
     WrapperTimingRecorded,
+    /// A fatal shim diagnostic was accepted for the session to surface.
+    ///
+    /// This is appended to preserve every existing response variant and wire
+    /// shape while giving fatal diagnostics their own acknowledgement.
+    ErrorRecorded,
 }

--- a/crates/mbx-cache-core/src/agent_tests.rs
+++ b/crates/mbx-cache-core/src/agent_tests.rs
@@ -125,13 +125,16 @@ async fn records_compiler_time_by_outcome_and_crate() {
 }
 
 #[tokio::test]
-async fn surfaces_each_shim_warning_once() {
-    struct Collected(Mutex<Vec<String>>);
+async fn surfaces_each_shim_diagnostic_once_per_severity() {
+    struct Collected(Mutex<Vec<(DiagnosticLevel, String)>>);
     impl AgentEventObserver for Collected {
         fn event(&self, event: AgentEvent) {
-            if let AgentEvent::Warning { message } = event {
-                self.0.lock().unwrap().push(message);
-            }
+            let diagnostic = match event {
+                AgentEvent::Warning { message } => (DiagnosticLevel::Warning, message),
+                AgentEvent::Error { message } => (DiagnosticLevel::Error, message),
+                _ => return,
+            };
+            self.0.lock().unwrap().push(diagnostic);
         }
     }
     let directory = tempfile::tempdir().unwrap();
@@ -142,12 +145,20 @@ async fn surfaces_each_shim_warning_once() {
     for _ in 0..3 {
         let response = agent
             .respond(AgentRequest::RecordWarning {
-                message: "cc result was not restored: blob missing".into(),
+                message: "same diagnostic text".into(),
             })
             .await;
         assert!(matches!(response, AgentResponse::WarningRecorded));
     }
-    // A different message is its own diagnostic, not a repeat.
+    for _ in 0..3 {
+        let response = agent
+            .respond(AgentRequest::RecordError {
+                message: "same diagnostic text".into(),
+            })
+            .await;
+        assert!(matches!(response, AgentResponse::ErrorRecorded));
+    }
+    // A different message is its own warning diagnostic, not a repeat.
     agent
         .respond(AgentRequest::RecordWarning {
             message: "verification was not recorded".into(),
@@ -157,24 +168,80 @@ async fn surfaces_each_shim_warning_once() {
     assert_eq!(
         *observer.0.lock().unwrap(),
         vec![
-            "cc result was not restored: blob missing".to_string(),
-            "verification was not recorded".to_string(),
+            (DiagnosticLevel::Warning, "same diagnostic text".to_string()),
+            (DiagnosticLevel::Error, "same diagnostic text".to_string()),
+            (
+                DiagnosticLevel::Warning,
+                "verification was not recorded".to_string()
+            ),
         ]
     );
 }
 
 #[tokio::test]
-async fn rejects_malformed_shim_warnings() {
+async fn rejects_malformed_shim_diagnostics() {
     let directory = tempfile::tempdir().unwrap();
     let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
     for message in [
         String::new(),
         "two\nlines".into(),
-        "wide".repeat(MAX_WARNING_BYTES),
+        "wide".repeat(MAX_DIAGNOSTIC_BYTES),
     ] {
         let response = agent.respond(AgentRequest::RecordWarning { message }).await;
         assert!(matches!(response, AgentResponse::Error { .. }));
     }
+    for message in [
+        String::new(),
+        "two\nlines".into(),
+        "wide".repeat(MAX_DIAGNOSTIC_BYTES),
+    ] {
+        let response = agent.respond(AgentRequest::RecordError { message }).await;
+        assert!(matches!(response, AgentResponse::Error { .. }));
+    }
+}
+
+#[tokio::test]
+async fn a_fatal_diagnostic_over_the_shared_cap_is_rejected() {
+    struct Counter(AtomicU64);
+    impl AgentEventObserver for Counter {
+        fn event(&self, event: AgentEvent) {
+            if matches!(event, AgentEvent::Warning { .. } | AgentEvent::Error { .. }) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+    let directory = tempfile::tempdir().unwrap();
+    let observer = Arc::new(Counter(AtomicU64::new(0)));
+    let agent = CacheAgent::new(directory.path().join("cache"), "test-version")
+        .with_observer(observer.clone());
+
+    for index in 0..MAX_DIAGNOSTICS {
+        let response = agent
+            .respond(AgentRequest::RecordWarning {
+                message: format!("unique warning {index}"),
+            })
+            .await;
+        assert!(matches!(response, AgentResponse::WarningRecorded));
+    }
+    // A duplicate warning remains acknowledged after the cap, while a new
+    // fatal reason receives an error response so its caller can print it.
+    let response = agent
+        .respond(AgentRequest::RecordWarning {
+            message: "unique warning 0".into(),
+        })
+        .await;
+    assert!(matches!(response, AgentResponse::WarningRecorded));
+    let response = agent
+        .respond(AgentRequest::RecordError {
+            message: "fatal reason after cap".into(),
+        })
+        .await;
+    assert!(matches!(response, AgentResponse::Error { .. }));
+
+    assert_eq!(
+        observer.0.load(Ordering::Relaxed),
+        u64::try_from(MAX_DIAGNOSTICS).unwrap()
+    );
 }
 
 #[tokio::test]
@@ -192,17 +259,30 @@ async fn stops_surfacing_shim_warnings_at_the_cap() {
     let agent = CacheAgent::new(directory.path().join("cache"), "test-version")
         .with_observer(observer.clone());
 
-    for index in 0..MAX_WARNINGS + 10 {
-        agent
+    for index in 0..MAX_DIAGNOSTICS + 10 {
+        let response = agent
             .respond(AgentRequest::RecordWarning {
                 message: format!("unique failure {index}"),
             })
             .await;
+        if index < MAX_DIAGNOSTICS {
+            assert!(matches!(response, AgentResponse::WarningRecorded));
+        } else {
+            assert!(matches!(response, AgentResponse::Error { .. }));
+        }
     }
+
+    // A message already surfaced remains acknowledged even after the cap.
+    let response = agent
+        .respond(AgentRequest::RecordWarning {
+            message: "unique failure 0".into(),
+        })
+        .await;
+    assert!(matches!(response, AgentResponse::WarningRecorded));
 
     assert_eq!(
         observer.0.load(Ordering::Relaxed),
-        u64::try_from(MAX_WARNINGS).unwrap()
+        u64::try_from(MAX_DIAGNOSTICS).unwrap()
     );
 }
 

--- a/crates/mbx-cache-core/tests/agent_protocol.rs
+++ b/crates/mbx-cache-core/tests/agent_protocol.rs
@@ -181,6 +181,12 @@ fn requests() -> Vec<(&'static str, AgentRequest)> {
             },
         ),
         (
+            "request.record_error",
+            AgentRequest::RecordError {
+                message: "compilation result was discarded".into(),
+            },
+        ),
+        (
             "request.record_compiler_invocation",
             AgentRequest::RecordCompilerInvocation {
                 outcome: "miss".into(),
@@ -344,6 +350,7 @@ fn responses() -> Vec<(&'static str, AgentResponse)> {
             AgentResponse::UnconsultedRecorded,
         ),
         ("response.warning_recorded", AgentResponse::WarningRecorded),
+        ("response.error_recorded", AgentResponse::ErrorRecorded),
         (
             "response.compiler_invocation_recorded",
             AgentResponse::CompilerInvocationRecorded,
@@ -579,6 +586,7 @@ define_variant_coverage!(request_variant_name, EXPECTED_REQUEST_VARIANTS, AgentR
     AgentRequest::RecordBypass { .. } => "record_bypass",
     AgentRequest::RecordUnconsulted => "record_unconsulted",
     AgentRequest::RecordWarning { .. } => "record_warning",
+    AgentRequest::RecordError { .. } => "record_error",
     AgentRequest::RecordCompilerInvocation { .. } => "record_compiler_invocation",
     AgentRequest::RecordActionVerification { .. } => "record_action_verification",
     AgentRequest::StoreActionResult { .. } => "store_action_result",
@@ -607,6 +615,7 @@ define_variant_coverage!(response_variant_name, EXPECTED_RESPONSE_VARIANTS, Agen
     AgentResponse::BypassRecorded => "bypass_recorded",
     AgentResponse::UnconsultedRecorded => "unconsulted_recorded",
     AgentResponse::WarningRecorded => "warning_recorded",
+    AgentResponse::ErrorRecorded => "error_recorded",
     AgentResponse::CompilerInvocationRecorded => "compiler_invocation_recorded",
     AgentResponse::ActionStored { .. } => "action_stored",
     AgentResponse::ActionPrediction { .. } => "action_prediction",

--- a/crates/mbx-cache-core/tests/fixtures/agent-protocol-v8.jsonl
+++ b/crates/mbx-cache-core/tests/fixtures/agent-protocol-v8.jsonl
@@ -9,6 +9,7 @@ request.record_action_hit	{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaa
 request.record_bypass	{"kind":"compiler-query","type":"record_bypass"}
 request.record_unconsulted	{"type":"record_unconsulted"}
 request.record_warning	{"message":"cc result was not restored: blob missing","type":"record_warning"}
+request.record_error	{"message":"compilation result was discarded","type":"record_error"}
 request.record_compiler_invocation	{"crate_name":"fixture","duration_ns":19,"outcome":"miss","type":"record_compiler_invocation"}
 request.record_action_verification	{"matched":true,"restore":{"avoided_compiler_duration_ns":10,"copied_output_bytes":17,"copied_output_files":16,"duration_ns":11,"output_bytes":13,"output_files":12,"reflinked_output_bytes":15,"reflinked_output_files":14,"reused_output_bytes":19,"reused_output_files":18},"type":"record_action_verification"}
 request.store_action_result	{"result":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"metadata":null,"output_root":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"version":1},"type":"store_action_result"}
@@ -35,6 +36,7 @@ response.action_verification_recorded	{"type":"action_verification_recorded"}
 response.bypass_recorded	{"type":"bypass_recorded"}
 response.unconsulted_recorded	{"type":"unconsulted_recorded"}
 response.warning_recorded	{"type":"warning_recorded"}
+response.error_recorded	{"type":"error_recorded"}
 response.compiler_invocation_recorded	{"type":"compiler_invocation_recorded"}
 response.action_stored	{"path":"cache/action","type":"action_stored"}
 response.action_prediction	{"prediction":{"action":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"adapter":"rustc","invocation":{"algorithm":"blake3","hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":7},"payload":"{}"},"type":"action_prediction"}

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.14.0"
+version = "0.15.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.21...mbx-cache-store-v0.1.22) - 2026-09-08
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.21](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.20...mbx-cache-store-v0.1.21) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.21"
+version = "0.1.22"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/jdx/mr-boxington/compare/v1.9.0...v2.0.0) - 2026-09-08
+
+### Added
+
+- add interactive cache removal ([#403](https://github.com/jdx/mr-boxington/pull/403))
+
+### Fixed
+
+- [**breaking**] keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))
+- preserve active Cargo targets and check release warnings ([#399](https://github.com/jdx/mr-boxington/pull/399))
+
 ## [1.9.0](https://github.com/jdx/mr-boxington/compare/v1.8.3...v1.9.0) - 2026-09-06
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.9.0"
+version = "2.0.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -27,11 +27,11 @@ hex = "0.4"
 jiff = { version = "0.2", default-features = false, features = ["std"] }
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.22", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.14.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.14.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.21", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.23", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.15.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.15.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.22", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -85,7 +85,9 @@ impl LearnedPlan {
             return;
         };
         if let Err(error) = write_churn_state(path, sources, self.streak) {
-            eprintln!("mbx[warning]: churn was not recorded for this crate: {error:#}");
+            session::report_shim_warning(&format!(
+                "churn was not recorded for this crate: {error:#}"
+            ));
         }
     }
 
@@ -249,7 +251,9 @@ pub(crate) fn compile(
                         cached.restore.avoided_compiler_duration_ns = timing.duration_ns;
                     }
                     Err(error) => {
-                        eprintln!("mbx[warning]: compiler timing was not refreshed: {error:#}");
+                        session::report_shim_warning(&format!(
+                            "compiler timing was not refreshed: {error:#}"
+                        ));
                     }
                 }
                 if learned_enabled && source_is_in_workspace(&compilation) {
@@ -279,7 +283,7 @@ pub(crate) fn compile(
                 learned = plan_learned_reuse(&compilation, &discovered, learned_enabled);
             }
             Err(error) => {
-                eprintln!("mbx[warning]: result was not restored: {error:#}");
+                session::report_shim_warning(&format!("result was not restored: {error:#}"));
             }
         }
     }
@@ -307,7 +311,7 @@ pub(crate) fn compile(
                 prediction_missing = !action_lookup_attempted;
             }
             Err(error) => {
-                eprintln!("mbx[warning]: prediction was not restored: {error:#}");
+                session::report_shim_warning(&format!("prediction was not restored: {error:#}"));
             }
         }
     }
@@ -348,7 +352,9 @@ pub(crate) fn compile(
             }
             Ok(None) => {}
             Err(error) => {
-                eprintln!("mbx[warning]: a flight prediction was not restored: {error:#}");
+                session::report_shim_warning(&format!(
+                    "a flight prediction was not restored: {error:#}"
+                ));
             }
         }
     }
@@ -403,19 +409,23 @@ pub(crate) fn compile(
                             return Ok(ExitCode::SUCCESS);
                         }
                         Ok(None) => {}
-                        Err(error) => eprintln!(
-                            "mbx[warning]: a remote flight prediction was not restored: {error:#}"
-                        ),
+                        Err(error) => session::report_shim_warning(&format!(
+                            "a remote flight prediction was not restored: {error:#}"
+                        )),
                     }
                 }
                 Some(AgentResponse::ActionPromise { .. }) => {}
                 Some(AgentResponse::Error { message }) => {
-                    eprintln!("mbx[warning]: remote flight coordination failed: {message}")
+                    session::report_shim_warning(&format!(
+                        "remote flight coordination failed: {message}"
+                    ));
                 }
                 _ => {}
             },
             Err(error) => {
-                eprintln!("mbx[warning]: remote flight coordination failed: {error:#}")
+                session::report_shim_warning(&format!(
+                    "remote flight coordination failed: {error:#}"
+                ));
             }
         }
     }
@@ -456,7 +466,9 @@ pub(crate) fn compile(
         if let Some(root) = incremental_root()
             && let Err(error) = record_private_artifacts(&root, &outputs)
         {
-            eprintln!("mbx[warning]: private artifacts were not recorded: {error:#}");
+            session::report_shim_warning(&format!(
+                "private artifacts were not recorded: {error:#}"
+            ));
         }
     }
     let output = crate::phase_timing::measure("compiler", || command.output())
@@ -503,14 +515,16 @@ pub(crate) fn compile(
                 let _ = replay_bytes(&[], &output.stderr);
                 return Ok(ExitCode::FAILURE);
             }
-            eprintln!("mbx[warning]: verification inputs were not validated: {error:#}");
+            session::report_shim_warning(&format!(
+                "verification inputs were not validated: {error:#}"
+            ));
         }
         let divergence = verification_divergence(&cached, &output);
         record_verification(divergence.is_none(), cached.restore);
         if let Some(divergence) = divergence {
-            eprintln!(
-                "mbx[warning]: shadow verification diverged from cached output: {divergence}"
-            );
+            session::report_shim_warning(&format!(
+                "shadow verification diverged from cached output: {divergence}"
+            ));
         }
         let _ = replay_output(&output);
         return Ok(exit_code(output.status));
@@ -604,7 +618,9 @@ pub(crate) fn compile(
             Err(error) if discard_modified_compiler_result(&outputs, &input_snapshots, &error) => {
                 compiler_input_invalid = true;
             }
-            Err(error) => eprintln!("mbx[warning]: result was not stored: {error:#}"),
+            Err(error) => {
+                session::report_shim_warning(&format!("result was not stored: {error:#}"));
+            }
         }
     }
     session::record_compiler_invocation_with_diagnostic(
@@ -659,11 +675,11 @@ fn discard_modified_compiler_result(
         return false;
     }
     if let Err(discard_error) = discard_compiler_outputs(outputs) {
-        eprintln!(
-            "mbx[warning]: some invalid compiler outputs could not be removed: {discard_error:#}"
-        );
+        session::report_shim_warning(&format!(
+            "some invalid compiler outputs could not be removed: {discard_error:#}"
+        ));
     }
-    eprintln!("mbx[error]: compilation result was discarded: {error:#}");
+    session::report_shim_error(&format!("compilation result was discarded: {error:#}"));
     true
 }
 
@@ -754,7 +770,9 @@ fn compile_execution_only_build_script(
             let _ = replay_bytes(&[], &output.stderr);
             return Ok(ExitCode::FAILURE);
         }
-        eprintln!("mbx[warning]: build-script inputs were not validated: {error:#}");
+        session::report_shim_warning(&format!(
+            "build-script inputs were not validated: {error:#}"
+        ));
     }
     if output.status.success()
         && let Some(executable) = outputs.build_script_executable(invocation.crate_name())
@@ -892,15 +910,15 @@ fn incremental_directory(invocation: &CacheDigest, crate_name: &str) -> Option<P
                 // as incremental, and a crate whose state is discarded on
                 // every edit is indistinguishable from the outside from
                 // incremental compilation that simply does not help.
-                eprintln!(
-                    "mbx[warning]: discarded {} of incremental state for {crate_name}: it passed learned_incremental_max_size, which can be raised to keep it",
+                session::report_shim_warning(&format!(
+                    "discarded {} of incremental state for {crate_name}: it passed learned_incremental_max_size, which can be raised to keep it",
                     bytesize::ByteSize::b(bytes).display().iec()
-                );
+                ));
             }
             Some(directory)
         }
         Err(error) => {
-            eprintln!("mbx[warning]: incremental state was not prepared: {error:#}");
+            session::report_shim_warning(&format!("incremental state was not prepared: {error:#}"));
             None
         }
     }
@@ -992,7 +1010,9 @@ fn plan_learned_reuse(
     match planned {
         Ok(plan) => plan,
         Err(error) => {
-            eprintln!("mbx[warning]: churn was not tracked for this crate: {error:#}");
+            session::report_shim_warning(&format!(
+                "churn was not tracked for this crate: {error:#}"
+            ));
             LearnedPlan::default()
         }
     }
@@ -1063,7 +1083,7 @@ fn reuse_hot_workspace_plan(
     match planned {
         Ok(plan) => plan,
         Err(error) => {
-            eprintln!("mbx[warning]: incremental state was not reused: {error:#}");
+            session::report_shim_warning(&format!("incremental state was not reused: {error:#}"));
             LearnedPlan::default()
         }
     }
@@ -1155,7 +1175,7 @@ fn record_learned_baseline(compilation: &Compilation<'_>, discovered: &Discovere
         write_churn_state(&path, &sources, 0)
     })();
     if let Err(error) = recorded {
-        eprintln!("mbx[warning]: initial churn state was not recorded: {error:#}");
+        session::report_shim_warning(&format!("initial churn state was not recorded: {error:#}"));
     }
 }
 
@@ -1224,10 +1244,10 @@ fn forget_private_artifacts(root: &Path, outputs: &RustcOutputs) {
             && let Err(error) = std::fs::remove_file(&path)
             && error.kind() != std::io::ErrorKind::NotFound
         {
-            eprintln!(
-                "mbx[warning]: a private artifact marker was not removed for {}: {error}",
+            session::report_shim_warning(&format!(
+                "a private artifact marker was not removed for {}: {error}",
                 artifact.display()
-            );
+            ));
         }
     }
 }
@@ -2026,7 +2046,9 @@ fn record_prediction_value(
 /// that one compilation out of thousands failed to record, which is not enough
 /// to reproduce or to tell whether the same crate fails on every build.
 fn warn_prediction_not_recorded(crate_name: &str, error: &eyre::Report) {
-    eprintln!("mbx[warning]: action prediction for {crate_name} was not recorded: {error:#}");
+    session::report_shim_warning(&format!(
+        "action prediction for {crate_name} was not recorded: {error:#}"
+    ));
 }
 
 /// Select the session run, or a bounded persistent-manifest shard when this

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -37,7 +37,9 @@ pub(crate) mod verification;
 #[cfg(test)]
 use client::validate_handshake_response;
 use client::{request_agent_at, request_standalone_agent};
-pub(crate) use diagnostics::{note, report_shim_warning, reserve_stderr_for_compiler};
+pub(crate) use diagnostics::{
+    note, report_shim_error, report_shim_warning, reserve_stderr_for_compiler,
+};
 #[cfg(unix)]
 pub(crate) use server::create_fifo;
 pub(crate) use server::listener_unavailable;
@@ -1324,9 +1326,12 @@ fn run_transparent_cc(compiler: OsString, arguments: Vec<OsString>) -> ExitCode 
 /// from or publish through the cache; anything else is a transparent compiler
 /// call.
 pub fn run_rustc_shim() -> ExitCode {
+    // Cargo captures the wrapper's stderr as compiler output. Keep mbx's own
+    // diagnostics out of that stream; the session agent owns their display.
+    reserve_stderr_for_compiler();
     let mut arguments = std::env::args_os().skip(1);
     let Some(rustc) = arguments.next() else {
-        eprintln!("mbx[error]: the rustc shim expected the rustc executable as its first argument");
+        report_shim_error("the rustc shim expected the rustc executable as its first argument");
         return ExitCode::from(1);
     };
     let mut arguments = arguments.collect::<Vec<_>>();
@@ -1356,7 +1361,7 @@ pub fn run_rustc_shim() -> ExitCode {
             Err(error) => {
                 record_bypass(&error);
                 #[cfg(debug_assertions)]
-                eprintln!("mbx[warning]: rustc cache bypassed: {error:#}");
+                report_shim_warning(&format!("rustc cache bypassed: {error:#}"));
             }
         }
     }
@@ -1463,7 +1468,7 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
 
         if permit.is_none() {
             let error = command.exec();
-            eprintln!("mbx[error]: the rustc shim failed to execute rustc: {error}");
+            report_shim_error(&format!("the rustc shim failed to execute rustc: {error}"));
             return ExitCode::from(1);
         }
         // A held permit must be released when the compiler finishes, and its
@@ -1483,7 +1488,7 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
                 crate::materialize::exit_code(status)
             }
             Err(error) => {
-                eprintln!("mbx[error]: the rustc shim failed to execute rustc: {error}");
+                report_shim_error(&format!("the rustc shim failed to execute rustc: {error}"));
                 ExitCode::from(1)
             }
         }
@@ -1521,7 +1526,7 @@ fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode 
                 unsafe { windows_sys::Win32::System::Threading::ExitProcess(exit_code) }
             }
             Err(error) => {
-                eprintln!("mbx[error]: the rustc shim failed to execute rustc: {error}");
+                report_shim_error(&format!("the rustc shim failed to execute rustc: {error}"));
                 ExitCode::from(1)
             }
         }

--- a/crates/mbx/src/session/diagnostics.rs
+++ b/crates/mbx/src/session/diagnostics.rs
@@ -9,11 +9,11 @@ pub(crate) fn note(message: &str) {
 
 /// Whether this process's stderr belongs to the compiler it stands in for.
 ///
-/// Set once at cc-shim entry. Build scripts read an intercepted compiler's
-/// stderr as part of its answer -- cc-rs marks a probed flag unsupported the
-/// moment anything lands there -- so one printed warning changes the flags of
-/// every compilation the build script produces afterwards, and with them
-/// every action key, orphaning the whole build's predictions.
+/// Set once at cc- or rustc-shim entry. Build scripts read an intercepted
+/// compiler's stderr as part of its answer: cc-rs marks a probed flag unsupported
+/// the moment anything lands there. Cargo also saves rustc stderr in its
+/// fingerprints and replays it even when no compiler runs. Shim diagnostics
+/// must therefore travel through the live session instead.
 static STDERR_RESERVED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Declare that this process replays compiler output on stderr and must not
@@ -30,6 +30,25 @@ pub(crate) fn reserve_stderr_for_compiler() {
 /// losing a diagnostic costs a little visibility, while poisoning a configure
 /// probe costs the build its cache keys.
 pub(crate) fn report_shim_warning(message: &str) {
+    report_shim_diagnostic(Severity::Warning, message);
+}
+
+/// Report a fatal shim diagnostic without losing it when transport fails.
+///
+/// The session retains the error's severity when it displays and emits it.
+/// The local fallback keeps the fatal reason visible when delivery fails,
+/// including when an older agent does not understand the error request.
+pub(crate) fn report_shim_error(message: &str) {
+    report_shim_diagnostic(Severity::Error, message);
+}
+
+#[derive(Clone, Copy)]
+enum Severity {
+    Warning,
+    Error,
+}
+
+fn report_shim_diagnostic(severity: Severity, message: &str) {
     let mut message = message.replace(['\n', '\r'], "; ");
     // Stay under the agent's acceptance limit rather than losing the whole
     // diagnostic to it; the start of an error chain names the failure.
@@ -38,14 +57,32 @@ pub(crate) fn report_shim_warning(message: &str) {
         message.truncate(end.unwrap_or_default());
         message.push_str("...");
     }
+    let (label, request) = match severity {
+        Severity::Warning => (
+            "warning",
+            AgentRequest::RecordWarning {
+                message: message.clone(),
+            },
+        ),
+        Severity::Error => (
+            "error",
+            AgentRequest::RecordError {
+                message: message.clone(),
+            },
+        ),
+    };
+    let response = request_agent(&[request])
+        .ok()
+        .and_then(|responses| responses.into_iter().next());
     let delivered = matches!(
-        request_agent(&[AgentRequest::RecordWarning {
-            message: message.clone(),
-        }])
-        .map(|responses| responses.into_iter().next()),
-        Ok(Some(AgentResponse::WarningRecorded))
+        (severity, response),
+        (Severity::Warning, Some(AgentResponse::WarningRecorded))
+            | (Severity::Error, Some(AgentResponse::ErrorRecorded))
     );
-    if !delivered && !STDERR_RESERVED.load(std::sync::atomic::Ordering::Relaxed) {
-        note(&format!("mbx[warning]: {message}"));
+    if !delivered
+        && (matches!(severity, Severity::Error)
+            || !STDERR_RESERVED.load(std::sync::atomic::Ordering::Relaxed))
+    {
+        note(&format!("mbx[{label}]: {message}"));
     }
 }

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -125,6 +125,30 @@ fn generate_lockfile(directory: &Path) {
 
 #[cfg(unix)]
 #[test]
+fn a_fatal_rustc_shim_error_survives_an_unavailable_agent() {
+    let directory = tempfile::tempdir().unwrap();
+    let shim = mbx::session::install_shim(
+        Path::new(env!("CARGO_BIN_EXE_mbx")),
+        directory.path(),
+        mbx::session::ShimLink::Tracking,
+    )
+    .unwrap();
+    let output = Command::new(shim)
+        .arg(directory.path().join("missing-rustc"))
+        .env("MBX_SOCKET", directory.path().join("missing-agent.sock"))
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "a missing compiler must fail");
+    assert!(
+        stderr.contains("mbx[error]: the rustc shim failed to execute rustc:"),
+        "the fatal reason must survive a failed delivery: {stderr}"
+    );
+    assert!(!stderr.contains("mbx[warning]"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
 fn transparent_rustc_replaces_the_shim_process() {
     let directory = tempfile::tempdir().unwrap();
     let shim = mbx::session::install_shim(
@@ -290,12 +314,40 @@ fn a_mid_compilation_input_edit_discards_the_result() {
         "the invalid compilation must fail"
     );
     assert!(
-        stderr.contains("compilation result was discarded: compiler input was modified"),
-        "the mutation should be diagnosed: {stderr}"
+        stderr
+            .contains("mbx[error]: compilation result was discarded: compiler input was modified"),
+        "the mutation should be diagnosed as an error: {stderr}"
+    );
+    assert!(
+        !stderr.contains("mbx[warning]: compilation result was discarded"),
+        "a fatal rejection must retain its severity: {stderr}"
     );
     assert!(
         !stderr.contains("Checking above"),
         "Cargo must not compile a dependent against the stale metadata: {stderr}"
+    );
+
+    let mut fingerprint_replays = Vec::new();
+    let fingerprint_root = project.path().join("target/debug/.fingerprint");
+    for unit in std::fs::read_dir(&fingerprint_root).unwrap().flatten() {
+        let Ok(files) = std::fs::read_dir(unit.path()) else {
+            continue;
+        };
+        for file in files.flatten() {
+            let path = file.path();
+            if path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("output-"))
+                && std::fs::read_to_string(&path)
+                    .is_ok_and(|output| output.contains("compilation result was discarded"))
+            {
+                fingerprint_replays.push(path);
+            }
+        }
+    }
+    assert!(
+        fingerprint_replays.is_empty(),
+        "the rejected-result diagnostic must not enter Cargo fingerprints: {fingerprint_replays:?}"
     );
 
     let deps = project.path().join("target/debug/deps");
@@ -311,6 +363,36 @@ fn a_mid_compilation_input_edit_discards_the_result() {
     assert!(
         stale_outputs.is_empty(),
         "the stale compiler outputs should be removed: {stale_outputs:?}"
+    );
+
+    // A shim diagnostic is delivered by the live session rather than through
+    // the compiler stream. Cargo must therefore have no rejected-result
+    // message to replay when the same source is compiled successfully.
+    let retry = Command::new(env!("CARGO_BIN_EXE_mbx"))
+        .current_dir(project.path())
+        .args(["check", "--offline"])
+        .env("MBX_CACHE_DIR", store.path())
+        .env("MBX_TARGET_VIEWS", "0")
+        .env("MBX_LEARNED_INCREMENTAL", "0")
+        .env("CARGO_INCREMENTAL", "0")
+        .env("RUSTC", &wrapper)
+        .env("TEST_REAL_RUSTC", which::which("rustc").unwrap())
+        .env("TEST_COMPILER_FINISHED", &compiled)
+        .env("TEST_RELEASE_COMPILER", &release)
+        .env_remove("MBX_SOCKET")
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .output()
+        .unwrap();
+    let retry_stderr = String::from_utf8_lossy(&retry.stderr);
+    assert!(
+        retry.status.success(),
+        "the unchanged retry should succeed: {retry_stderr}"
+    );
+    assert!(
+        !retry_stderr.contains("compilation result was discarded"),
+        "Cargo must not replay the rejected-result diagnostic: {retry_stderr}"
     );
 }
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.9.0
+**Version:** 2.0.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.14.0 -> 0.15.0 (⚠ API breaking changes)
* `mbx-cache-cc`: 0.14.0 -> 0.15.0
* `mbx-cache-rustc`: 0.14.0 -> 0.15.0
* `mbx`: 1.9.0 -> 2.0.0 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.22 -> 0.1.23
* `mbx-cache-store`: 0.1.21 -> 0.1.22

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant AgentEvent::ActionDiagnostic 7 -> 8 in /tmp/.tmplWJ4Fx/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:428

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:ErrorRecorded in /tmp/.tmplWJ4Fx/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:561
  variant AgentRequest:RecordError in /tmp/.tmplWJ4Fx/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:307
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.14.0...mbx-cache-core-v0.15.0) - 2026-09-08

### Fixed

- [**breaking**] keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.13.1...mbx-cache-cc-v0.14.0) - 2026-09-06

### Added

- *(cc)* cache named preprocessor outputs ([#394](https://github.com/jdx/mr-boxington/pull/394))
- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Fixed

- *(cc)* cache gdb and full debug compilations portably ([#384](https://github.com/jdx/mr-boxington/pull/384))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- *(cc)* reuse unchanged include directory manifests ([#388](https://github.com/jdx/mr-boxington/pull/388))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.13.1...mbx-cache-rustc-v0.14.0) - 2026-09-06

### Added

- *(tui)* add cache insights and lifetime statistics ([#389](https://github.com/jdx/mr-boxington/pull/389))

### Other

- refresh guides and redesign the documentation site ([#395](https://github.com/jdx/mr-boxington/pull/395))
- generate page-specific social preview images ([#374](https://github.com/jdx/mr-boxington/pull/374))
</blockquote>

## `mbx`

<blockquote>

## [2.0.0](https://github.com/jdx/mr-boxington/compare/v1.9.0...v2.0.0) - 2026-09-08

### Added

- add interactive cache removal ([#403](https://github.com/jdx/mr-boxington/pull/403))

### Fixed

- [**breaking**] keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))
- preserve active Cargo targets and check release warnings ([#399](https://github.com/jdx/mr-boxington/pull/399))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.22...mbx-cache-cargo-v0.1.23) - 2026-09-08

### Other

- updated the following local packages: mbx-cache-core
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.21...mbx-cache-store-v0.1.22) - 2026-09-08

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The diff is mostly versioning and docs, but the release includes breaking `mbx-cache-core` wire enums and behavior that affects Cargo fingerprinting and cache keys—important for embedders and build reproducibility.
> 
> **Overview**
> This **release-plz** PR cuts a coordinated workspace release by bumping crate versions, refreshing `Cargo.lock`, updating changelogs, and setting the generated CLI docs version to **2.0.0**.
> 
> **`mbx` 1.9.0 → 2.0.0** ships **interactive cache removal** ([#403](https://github.com/jdx/mr-boxington/pull/403)), a fix to **preserve active Cargo targets** and release warning checks ([#399](https://github.com/jdx/mr-boxington/pull/399)), and the fingerprint-related rustc shim behavior below.
> 
> **`mbx-cache-core` 0.14.0 → 0.15.0** (and matching bumps for **`mbx-cache-cc`**, **`mbx-cache-rustc`**, plus dependency-only releases for **`mbx-cache-cargo`** and **`mbx-cache-store`**) documents a **breaking** fix to **keep rustc shim diagnostics out of Cargo fingerprints** ([#405](https://github.com/jdx/mr-boxington/pull/405)). That change extends the agent wire protocol (`RecordError` / `ErrorRecorded`) and shifts the `AgentEvent::ActionDiagnostic` discriminant—embedders on `mbx-cache-core` must upgrade in lockstep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0740c8bfb2048b2bae2847689f2c9bcdf6242ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->