### PR TITLE
docs: adopt native mise Rust integration for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ agent and stops it when the build ends; there is no daemon to manage.
 With [mise](https://mise.jdx.dev):
 
 ```sh
-mise use --global --postinstall "mbx setup --yes" mr-boxington
+mise use --global --tool-option mr_boxington=true rust mr-boxington
 ```
 
 Or with Cargo:
@@ -36,8 +36,10 @@ cargo install mbx --locked
 mbx setup
 ```
 
-Open a new shell and check activation with `mbx setup --status`. Then use Cargo
-normally:
+With mise 2026.9.2 or newer, the Rust option enables wrapping without an
+`mbx setup` hook. Open a shell with mise activation or shims on `PATH`,
+[check Cargo's path](https://mr-boxington.jdx.dev/setup#verify-plain-cargo),
+and use Cargo normally:
 
 ```sh
 cargo build
@@ -46,9 +48,10 @@ cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 To try mbx without automatic wrapping, install it and run `mbx build` directly.
-Automatic mise wrapping requires mise 2026.8.16 or newer. Editors, SSH commands,
-and other tools may need the stable shim directory on their `PATH`; the
-[setup guide](https://mr-boxington.jdx.dev/setup) walks through verification.
+For coding agents and other non-interactive tools, use `mise exec -- cargo build`
+or put mise's shims on their `PATH`. The
+[setup guide](https://mr-boxington.jdx.dev/setup) covers desktop applications,
+older mise versions, and standalone shims.
 
 Verified release archives are available for Linux, macOS, and Windows.
 [All installation options →](https://mr-boxington.jdx.dev/installation)

--- a/docs/cookbook/local-development.md
+++ b/docs/cookbook/local-development.md
@@ -6,11 +6,12 @@ description: Set up rust-analyzer, watch loops, laptop budgets, and debugging wi
 mbx can sit underneath the tools already in a Rust development loop. Editors,
 file watchers, terminals, and worktrees may all keep invoking ordinary Cargo;
 their compilations share the same cache and machine-wide scheduler. Start with
-[`mbx setup`](/setup), then use the recipes below for your editor, watch loop,
+[Cargo and editor setup](/setup), then use the recipes below for your editor, watch loop,
 and machine budget.
 
 ## Put editor checks through mbx
 
+The native mise Rust option wraps Cargo but does not configure rust-analyzer.
 Run setup once in the same scope in which mbx is installed:
 
 ```sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,8 +15,11 @@ configuration file is required.
 With [mise](https://mise.jdx.dev):
 
 ```sh
-mise use --global --postinstall "mbx setup --yes" mr-boxington
+mise use --global --tool-option mr_boxington=true rust mr-boxington
 ```
+
+This requires mise 2026.9.2 or newer. Drop `--global` for project-scoped
+wrapping. See [Installation](/installation#mise) for older mise versions.
 
 Or install from crates.io:
 
@@ -50,14 +53,19 @@ cached work.
 
 ## Keep using plain Cargo
 
+The mise command above enables wrapping without running `mbx setup`. Use
+`mise exec -- cargo build`, `mise run` tasks, or plain `cargo` with mise
+activation or shims on `PATH`.
+
+For standalone installations, run:
+
 ```sh
 mbx setup
+mbx setup --status
 ```
 
-If you installed with the mise command above, setup has already run. Open a new
-shell and run `mbx setup --status` to check activation, then use `cargo build`
-and `cargo test` normally. See [Cargo and editor setup](/setup) for project
-scope, rust-analyzer, and tools that do not inherit your interactive shell.
+See [Cargo and editor setup](/setup) to verify Cargo's path, share project
+configuration, configure rust-analyzer, and use mbx from desktop applications.
 
 ## The first build
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,13 +9,31 @@ build; `mbx doctor` checks which tools are active.
 ## mise
 
 ```sh
+mise use --global --tool-option mr_boxington=true rust mr-boxington
+```
+
+Requires mise 2026.9.2 or newer. This installs Rust and mbx and enables Cargo
+wrapping through mise; no `mbx setup` postinstall hook is needed.
+`--tool-option` applies to the following tool, so keep it before `rust`.
+Drop `--global` to enable it only in the current project. Keep an existing
+Rust version pin by [editing its tool entry](/setup#share-setup-with-a-project).
+
+Use `mise exec -- cargo build`, or open a shell with mise activation or shims
+on `PATH` and follow [Verify plain Cargo](/setup#verify-plain-cargo).
+The Rust option does not install a standalone mbx shim or configure
+rust-analyzer; see [editor setup](/setup#rust-analyzer) if you need that too.
+
+### Older mise versions
+
+With mise 2026.8.16 through 2026.9.1:
+
+```sh
 mise use --global --postinstall "mbx setup --yes" mr-boxington
 ```
 
-This installs mbx and sets up automatic Cargo wrapping. Open a new shell, then
-follow [Verify plain Cargo](/setup#verify-plain-cargo). Automatic wrapping
-requires mise 2026.8.16 or newer. Older versions install the standalone shim
-and print an upgrade warning.
+This runs standalone setup and writes an explicit `[wrappers.cargo]` entry.
+Versions older than 2026.8.16 install the standalone shim and print an upgrade
+warning instead of editing mise configuration.
 
 ## Cargo
 
@@ -151,8 +169,10 @@ Upgrade using the same installation method: update the mise version, rerun
 archive. The stable Cargo shim follows upgrades; setup does not need to run
 again.
 
-Before removing the executable, run `mbx setup --uninstall` in each scope you
-enabled. See [Remove automatic wrapping](/setup#remove-automatic-wrapping).
+Before removing the executable, disable `mr_boxington` in each Rust tool entry
+where you enabled it. If you also ran standalone setup, run
+`mbx setup --uninstall` in each scope you enabled. See
+[Remove automatic wrapping](/setup#remove-automatic-wrapping).
 Cached work is disposable; use [cache management](/managed-targets) to inspect
 and reclaim it.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,16 +3,32 @@ description: Make Cargo and rust-analyzer use mbx, choose a setup scope, and ver
 ---
 # Set up Cargo and your editor
 
-Run this after [installing mbx](/installation) to make ordinary `cargo`
-commands use the cache:
+## Native mise integration
+
+With mise 2026.9.2 or newer:
+
+```sh
+mise use --global --tool-option mr_boxington=true rust mr-boxington
+```
+
+This enables ordinary Cargo commands through mise without running `mbx setup`.
+Use `mise exec -- cargo build`, `mise run` tasks, or a shell with mise
+activation or shims on `PATH`. Rust and mbx remain independently versioned.
+Drop `--global` for a project-scoped configuration.
+
+## Standalone setup
+
+After [installing mbx](/installation), run this to install a stable Cargo shim
+and configure rust-analyzer:
 
 ```sh
 mbx setup
 mbx setup --status
 ```
 
-Setup installs a stable Cargo shim and offers mise and rust-analyzer
-integration. To try mbx without changing your setup, run `mbx build` directly.
+Setup offers explicit mise wrapper and rust-analyzer integration. It is useful
+for older mise versions or applications that need an absolute Cargo shim path.
+To try mbx without changing your setup, run `mbx build` directly.
 
 ## Choose a scope
 
@@ -32,32 +48,34 @@ Without an active mise shell, setup prints the exact shell-specific `PATH`
 change and never edits a shell startup file. Setup runs `mise reshim` after
 adding or removing the wrapper.
 
-Automatic mise wrapping requires mise 2026.8.16 or newer.
+The explicit wrapper written by `mbx setup` requires mise 2026.8.16 or newer.
 
 ## Share setup with a project
 
-To keep the wrapper project-scoped and reviewable, commit it directly in the
-project's `mise.toml` instead:
+With mise 2026.9.2 or newer, commit the tool option in the project's `mise.toml`:
 
 ```toml
 [tools]
-mr-boxington = "1"
-
-[wrappers.cargo]
-command = "mbx"
-env = { MBX_CARGO_SHIM_MODE = "1" }
+rust = { version = "stable", mr_boxington = true }
+mr-boxington = "latest"
 ```
 
-Then run `mise install`. This installs mbx but does not activate the wrapper in
-the parent shell. Run project tasks with `mise run`, or activate mise in the
-shell before invoking plain `cargo` commands. This avoids changing the global
-mise configuration, and every contributor who activates the project gets the
-same Cargo wrapper.
+Keep the project's existing Rust version and other options when adding
+`mr_boxington = true`. Both tools must be configured. Run `mise install`, then
+use `mise exec -- cargo build`, project tasks with `mise run`, or plain `cargo`
+with mise activation or shims on `PATH`.
+
+Set `mr_boxington = false` on the project's Rust entry to disable native
+wrapping there. An explicit `[wrappers.cargo]` takes precedence over the Rust
+option, including `false`. When migrating from `mbx setup`, remove the old mbx
+`[wrappers.cargo]` entry and its `postinstall` hook from the applicable config
+so the Rust option controls wrapping. Run `mise reshim` after migrating.
 
 ## Verify plain Cargo
 
 Open a new shell after setup and verify that Cargo resolves to mise's command
-wrapper or the stable mbx shim, depending on how you activated it. On Unix:
+wrapper, a mise shim, or the stable mbx shim, depending on how you activated it.
+On Unix:
 
 ```sh
 command -v cargo
@@ -74,9 +92,23 @@ where.exe cargo
 mise activation supplies the command-wrapper path to shells where mise is active.
 The wrapper invokes `mbx` with Cargo shim mode enabled, then mise removes its
 dispatch directories before mbx delegates to the configured or system Cargo.
-SSH commands, coding agents, editors, and other non-interactive tools may use a
-startup path that does not activate mise. In that case, prepend the directory
-printed by `mbx setup` in a startup file those processes read. For zsh,
+Calling `~/.cargo/bin/cargo` directly bypasses mise's integration.
+
+### Desktop applications and non-interactive commands
+
+For coding agents, SSH commands, and other non-interactive tools, use
+`mise exec -- cargo build` or put mise's shims directory on their `PATH`.
+When using shims, `command -v cargo` resolves to the mise shim rather than the
+command-wrapper directory; both honor the Rust option.
+
+Desktop applications such as Codex may inherit a different `PATH` from an
+interactive terminal. Check `command -v cargo` from a command run by the
+application itself. Configure its command environment to include mise's shims,
+or use `mise exec -- cargo build` for build commands. Restart the application
+after changing its inherited environment.
+
+If you prefer mbx's standalone launcher, run `mbx setup` and prepend the
+directory it prints to the environment those processes use. For zsh,
 `~/.zshenv` applies to interactive and non-interactive shells. For example,
 the default Linux location is:
 
@@ -105,7 +137,8 @@ running setup again.
 
 ## rust-analyzer
 
-Setup also configures rust-analyzer's background check in the matching global
+The native mise option does not configure editor checks. Run `mbx setup` to
+configure rust-analyzer's background check in the matching global
 or project scope. The editor invokes the stable Cargo shim by its absolute path,
 so its build shares mbx's cache and machine-wide compiler pool even when the
 editor did not inherit mise's `PATH`. Its outputs go to
@@ -116,6 +149,13 @@ shared store warms both builds. Existing rust-analyzer check settings are left
 unchanged.
 
 ## Remove automatic wrapping
+
+For native mise integration, remove `mr_boxington` or set it to `false` in each
+Rust tool entry where you enabled it, then run `mise reshim`. Keep the Rust
+version and any unrelated tool options. Do this before removing mr-boxington
+from `[tools]`.
+
+If you ran standalone setup as well:
 
 ```sh
 mbx setup --uninstall

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ cached work.
 
 | Symptom | First check |
 | --- | --- |
-| Plain Cargo does not use mbx | `mbx setup --status`, then [check Cargo's path](/setup#verify-plain-cargo) |
+| Plain Cargo does not use mbx | [Check Cargo's path](/setup#verify-plain-cargo); for standalone setup, also run `mbx setup --status` |
 | A build restores little or nothing | `mbx explain --last`, then [read the results](/cache-results#troubleshooting-a-low-hit-rate) |
 | Cargo waits for a target lock | Give simultaneous builds [separate targets](/scheduling) |
 | Remote requests fail | `mbx doctor`, then [check authentication](/remote-cache#authenticate) |
@@ -36,7 +36,13 @@ Example output (versions, paths, and budgets depend on your machine):
 0 failures, 0 warnings
 ```
 
-Doctor checks that mise's Cargo wrapper is active, or that the installed fallback
+Doctor's setup check currently recognizes explicit mise wrappers and the
+standalone shim installed by `mbx setup`, but not the native Rust tool option.
+Its setup warning alone does not mean native wrapping is inactive;
+[check Cargo's path](/setup#verify-plain-cargo).
+
+For standalone setup, doctor checks that mise's Cargo wrapper is active, or
+that the installed fallback
 shim matches the running mbx and is the first `cargo` on `PATH`. It also checks
 the Cargo and rustc executables, cache write access, the local build-session
 listener, filesystem reflink support, effective remote policy, and remote


### PR DESCRIPTION
Make the native mise Rust option the default installation path, replacing the `mbx setup` postinstall hook with:

```sh
mise use --global --tool-option mr_boxington=true rust mr-boxington
```

Depends on https://github.com/jdx/mise/pull/12908 shipping in mise 2026.9.2 (assumed next release after 2026.9.1). Merge after that release, or adjust the documented minimum if its release number changes.

Update the README, installation and setup guides, local development recipes, and troubleshooting. Cover project configuration, preserving Rust pins, migration from explicit wrappers, disabling native wrapping, and desktop/non-interactive command environments. Retain the older mise installation recipe and standalone/editor setup instructions.

This is a documentation-only change. The guide explicitly notes that the current `mbx doctor` setup check does not recognize the native Rust option; Cargo path verification is the appropriate check for that installation method.

Validation: `mise run ci` passed, including formatting, strict Clippy, Rust tests, all 52 behavioral tests, generated-doc checks, the docs build, and internal link/anchor checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or install behavior changes in this PR.
> 
> **Overview**
> Documentation now treats **mise 2026.9.2+** native Rust wrapping (`--tool-option mr_boxington=true rust mr-boxington`) as the primary install path, replacing the **`mbx setup --yes` postinstall** flow in the README, getting started, and installation guides.
> 
> **Standalone `mbx setup`** is repositioned for Cargo-only installs, older mise (2026.8.16–2026.9.1), rust-analyzer, and apps that need an absolute shim path. New material covers **project `mise.toml`** (`rust = { …, mr_boxington = true }`), **migration** from explicit `[wrappers.cargo]`, **uninstall** (disable the tool option before removing mr-boxington), and **non-interactive/desktop** use (`mise exec`, shims on `PATH`).
> 
> Troubleshooting notes that **`mbx doctor` does not yet detect** native wrapping and points readers to Cargo path verification instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a37dbde8da847741aabbe3ec8e3021ea75e023d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and setup guidance for native Cargo wrapping through mise 2026.9.2+.
  * Added instructions for configuring, verifying, sharing, and disabling project-scoped Cargo wrapping.
  * Clarified standalone setup options for older mise versions and absolute Cargo shim paths.
  * Updated non-interactive tooling and editor guidance, including rust-analyzer limitations.
  * Expanded troubleshooting steps for diagnosing Cargo integration and setup warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->