### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "bytesize",
  "demand",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "blake3",
  "eyre",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.22...mbx-cache-cargo-v0.1.23) - 2026-09-08
+
+### Other
+
+- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
+
 ## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.21...mbx-cache-cargo-v0.1.22) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.22"
+version = "0.1.23"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.14.0...mbx-cache-cc-v0.15.0) - 2026-09-08
+
+### Other
+
+- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
+
 ## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.13.1...mbx-cache-cc-v0.14.0) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.14.0"
+version = "0.15.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.14.0...mbx-cache-core-v0.15.0) - 2026-09-08
+
+### Fixed
+
+- keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))
+
+### Other
+
+- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
+
 ## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.13.1...mbx-cache-core-v0.14.0) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.14.0"
+version = "0.15.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.14" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.15" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.14...mbx-cache-protocol-v0.5.15) - 2026-09-08
+
+### Other
+
+- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
+
 ## [0.5.14](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.13...mbx-cache-protocol-v0.5.14) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.14"
+version = "0.5.15"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.14.0...mbx-cache-rustc-v0.15.0) - 2026-09-08
+
+### Other
+
+- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
+
 ## [0.14.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.13.1...mbx-cache-rustc-v0.14.0) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.14.0"
+version = "0.15.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.21...mbx-cache-store-v0.1.22) - 2026-09-08
+
+### Other
+
+- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
+
 ## [0.1.21](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.20...mbx-cache-store-v0.1.21) - 2026-09-06
 
 ### Added

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.21"
+version = "0.1.22"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/jdx/mr-boxington/compare/v1.9.0...v1.10.0) - 2026-09-08
+
+### Added
+
+- add interactive cache removal ([#403](https://github.com/jdx/mr-boxington/pull/403))
+
+### Fixed
+
+- keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))
+- preserve active Cargo targets and check release warnings ([#399](https://github.com/jdx/mr-boxington/pull/399))
+
+### Other
+
+- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
+
 ## [1.9.0](https://github.com/jdx/mr-boxington/compare/v1.8.3...v1.9.0) - 2026-09-06
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.9.0"
+version = "1.10.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -27,11 +27,11 @@ hex = "0.4"
 jiff = { version = "0.2", default-features = false, features = ["std"] }
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.14.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.22", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.14.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.14.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.21", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.23", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.15.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.15.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.22", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.9.0
+**Version:** 1.10.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.14 -> 0.5.15 (✓ API compatible changes)
* `mbx-cache-core`: 0.14.0 -> 0.15.0 (⚠ API breaking changes)
* `mbx-cache-cargo`: 0.1.22 -> 0.1.23 (✓ API compatible changes)
* `mbx-cache-cc`: 0.14.0 -> 0.15.0 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.14.0 -> 0.15.0 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.21 -> 0.1.22 (✓ API compatible changes)
* `mbx`: 1.9.0 -> 1.10.0 (✓ API compatible changes)

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant AgentEvent::ActionDiagnostic 7 -> 8 in /tmp/.tmpydj6md/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:428

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:ErrorRecorded in /tmp/.tmpydj6md/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:561
  variant AgentRequest:RecordError in /tmp/.tmpydj6md/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:307
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.14...mbx-cache-protocol-v0.5.15) - 2026-09-08

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.14.0...mbx-cache-core-v0.15.0) - 2026-09-08

### Fixed

- keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.22...mbx-cache-cargo-v0.1.23) - 2026-09-08

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.14.0...mbx-cache-cc-v0.15.0) - 2026-09-08

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.14.0...mbx-cache-rustc-v0.15.0) - 2026-09-08

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.21...mbx-cache-store-v0.1.22) - 2026-09-08

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>

## `mbx`

<blockquote>

## [1.10.0](https://github.com/jdx/mr-boxington/compare/v1.9.0...v1.10.0) - 2026-09-08

### Added

- add interactive cache removal ([#403](https://github.com/jdx/mr-boxington/pull/403))

### Fixed

- keep rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405))
- preserve active Cargo targets and check release warnings ([#399](https://github.com/jdx/mr-boxington/pull/399))

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The release tags **mbx-cache-core 0.15.0** with semver-breaking public agent wire enums; embedders must upgrade in lockstep even though this PR is only versioning and changelog metadata.
> 
> **Overview**
> This is a **release-plz** publish PR: it bumps crate versions, refreshes `Cargo.lock`, adds dated **CHANGELOG** entries, and updates the generated CLI docs version string to **1.10.0**. There is no new application logic in the diff itself.
> 
> **`mbx` 1.10.0** documents shipped work from earlier merges: interactive cache removal ([#403](https://github.com/jdx/mr-boxington/pull/403)), keeping rustc shim diagnostics out of Cargo fingerprints ([#405](https://github.com/jdx/mr-boxington/pull/405)), preserving active Cargo targets and release warning checks ([#399](https://github.com/jdx/mr-boxington/pull/399)), and adopting native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400)).
> 
> Workspace crates move in step: **`mbx-cache-core` 0.15.0** (with the fingerprint fix in its changelog), plus minor bumps for **`mbx-cache-protocol`**, **`mbx-cache-cargo`**, **`mbx-cache-cc`**, **`mbx-cache-rustc`**, and **`mbx-cache-store`**, with `mbx` dependency pins updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3a969902c3f2b92c5ba3d6ef7204e5e89f766f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->