### PR TITLE
chore: refresh real-world benchmarks for mbx v1.10.0

### DIFF
--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -4,14 +4,14 @@
   "revision": "fc29ead1456ba7c1f62826c284126410a4014b00",
   "toolchain": "1.97.1",
   "platform": "Linux-7.1.4-x86_64-with-glibc2.39",
-  "runner": "nsc-runner-5cp8sbbeio8po",
-  "workflow_run": "33965148646",
-  "commit": "3fb60e2a50928d26eee5712d35d83e3ab957a9d9",
+  "runner": "nsc-runner-i5g14cdhc6ovc",
+  "workflow_run": "34188214905",
+  "commit": "2d16b9a82b1dd97a3994791fcd4e28552cc332b4",
   "versions": {
-    "mbx": "1.8.1",
+    "mbx": "1.10.0",
     "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
     "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
-    "kache": "kache 0.16.0"
+    "kache": "kache 0.17.0"
   },
   "passed": true,
   "failures": [],
@@ -23,31 +23,31 @@
       "results": [
         {
           "tool": "mbx",
-          "wall_duration_ns": 6839758355,
+          "wall_duration_ns": 10522022903,
           "trials": 3,
           "wall_durations_ns": [
-            6745851196,
-            7100419379,
-            6839758355
+            11320541280,
+            10464037838,
+            10522022903
           ],
           "stats": {
-            "lookups": 722,
-            "hits": 721,
+            "lookups": 544,
+            "hits": 543,
             "misses": 1,
-            "unconsulted": 6,
-            "predictions_loaded": 927,
-            "restored_output_files": 1559,
-            "restored_output_bytes": 1392845011
+            "unconsulted": 184,
+            "predictions_loaded": 749,
+            "restored_output_files": 1381,
+            "restored_output_bytes": 1385937899
           }
         },
         {
           "tool": "kache",
-          "wall_duration_ns": 7819176192,
+          "wall_duration_ns": 8894735276,
           "trials": 3,
           "wall_durations_ns": [
-            7819176192,
-            7772398974,
-            7926953105
+            8894735276,
+            9042043194,
+            8010892648
           ]
         }
       ],
@@ -60,41 +60,41 @@
       "results": [
         {
           "tool": "cargo",
-          "wall_duration_ns": 19502527937,
+          "wall_duration_ns": 28111040598,
           "trials": 3,
           "wall_durations_ns": [
-            19607006745,
-            19502527937,
-            18660376260
+            26881670678,
+            29589135842,
+            28111040598
           ]
         },
         {
           "tool": "mbx",
-          "wall_duration_ns": 14600330702,
+          "wall_duration_ns": 21861287101,
           "trials": 3,
           "wall_durations_ns": [
-            14416131347,
-            14600330702,
-            14886178228
+            20803963277,
+            21861287101,
+            24311065861
           ],
           "stats": {
-            "lookups": 723,
-            "hits": 720,
+            "lookups": 545,
+            "hits": 542,
             "misses": 3,
-            "unconsulted": 6,
-            "predictions_loaded": 927,
-            "restored_output_files": 1557,
-            "restored_output_bytes": 1206318875
+            "unconsulted": 184,
+            "predictions_loaded": 749,
+            "restored_output_files": 1379,
+            "restored_output_bytes": 1199424811
           }
         },
         {
           "tool": "kache",
-          "wall_duration_ns": 15316054700,
+          "wall_duration_ns": 23963528643,
           "trials": 3,
           "wall_durations_ns": [
-            15228936947,
-            15389930599,
-            15316054700
+            22651790711,
+            23963762479,
+            23963528643
           ]
         }
       ],
@@ -108,45 +108,45 @@
       "results": [
         {
           "tool": "cargo",
-          "wall_duration_ns": 2990686571,
+          "wall_duration_ns": 4241950422,
           "trials": 3,
           "wall_durations_ns": [
-            2990686571,
-            2996549860,
-            2934647785
+            4539619473,
+            3888718907,
+            4241950422
           ],
-          "warmup_wall_duration_ns": 2965220787
+          "warmup_wall_duration_ns": 4487258029
         },
         {
           "tool": "mbx",
-          "wall_duration_ns": 2960046224,
+          "wall_duration_ns": 4144321957,
           "trials": 3,
           "wall_durations_ns": [
-            2949615516,
-            3008158129,
-            2960046224
+            4100674609,
+            4144321957,
+            4172823778
           ],
-          "warmup_wall_duration_ns": 9322088198,
+          "warmup_wall_duration_ns": 13872613641,
           "stats": {
             "lookups": 1,
             "hits": 1,
             "misses": 0,
             "unconsulted": 0,
-            "predictions_loaded": 927,
+            "predictions_loaded": 749,
             "restored_output_files": 2,
             "restored_output_bytes": 10242953
           }
         },
         {
           "tool": "kache",
-          "wall_duration_ns": 2856428370,
+          "wall_duration_ns": 4155146879,
           "trials": 3,
           "wall_durations_ns": [
-            2807849460,
-            2856428370,
-            2947946171
+            4155146879,
+            4450373599,
+            3877456153
           ],
-          "warmup_wall_duration_ns": 9493082274
+          "warmup_wall_duration_ns": 15573782319
         }
       ],
       "skipped": [],
@@ -159,15 +159,15 @@
       "results": [
         {
           "tool": "mbx-sequential",
-          "wall_duration_ns": 47752684033,
+          "wall_duration_ns": 82681063438,
           "peak_compilers": 32,
-          "min_available_bytes": 62826651648,
+          "min_available_bytes": 63118213120,
           "permits": null,
           "trials": 3,
           "wall_durations_ns": [
-            47752684033,
-            47552622205,
-            48121037386
+            82681063438,
+            75163232155,
+            87548670521
           ],
           "stats": {
             "hits": 8
@@ -175,15 +175,15 @@
         },
         {
           "tool": "mbx-unscheduled",
-          "wall_duration_ns": 39673460753,
-          "peak_compilers": 155,
-          "min_available_bytes": 54652903424,
+          "wall_duration_ns": 156243084560,
+          "peak_compilers": 152,
+          "min_available_bytes": 54991122432,
           "permits": null,
           "trials": 3,
           "wall_durations_ns": [
-            41543218091,
-            39673460753,
-            39474533965
+            152272746739,
+            156243084560,
+            156398184835
           ],
           "stats": {
             "hits": 12
@@ -191,18 +191,18 @@
         },
         {
           "tool": "mbx",
-          "wall_duration_ns": 32501410646,
-          "peak_compilers": 32,
-          "min_available_bytes": 61672169472,
+          "wall_duration_ns": 92539578905,
+          "peak_compilers": 31,
+          "min_available_bytes": 61851455488,
           "permits": 32,
           "trials": 3,
           "wall_durations_ns": [
-            33456166599,
-            32501410646,
-            29582219926
+            103501708908,
+            92539578905,
+            84891707404
           ],
           "stats": {
-            "hits": 4280
+            "hits": 3390
           }
         }
       ],


### PR DESCRIPTION
## Refreshed real-world benchmarks

`benchmarks/results.json` was measured with `1.8.1`; the latest release is now `mbx 1.10.0`. Re-ran the benchmark with that release on the fixed Namespace Linux xlarge profile: a pinned checkout of jdx/hk built under raw cargo, mbx, and kache across the warm, next-commit, edit-loop, and six-job contention scenarios, three trials of each.

**Read the numbers before merging.** They publish to https://mr-boxington.jdx.dev/benchmarks on merge. Look into a scenario that swapped places, or a trial range wide enough to explain the gap beside it, before it goes on the site.

## Real-world benchmark: hk

jdx/hk, a mid-size Rust CLI with C dependencies, `cargo build --locked` on Rust 1.97.1.

### warm

warm store, fresh target -- CI restoring the same commit; plain Cargo has no cache to restore

| Tool | Median wall time | Trials | Hits | Restored files |
| :--- | ---: | ---: | ---: | ---: |
| mbx | 10.5 s | 3 (10.5-11.3 s) | 543 | 1381 |
| kache | 8.9 s | 3 (8.0-9.0 s) | - | - |

### commit

cache tools warmed at the parent commit, build the child -- Cargo is the uncached push-to-push baseline

| Tool | Median wall time | Trials | Hits | Restored files |
| :--- | ---: | ---: | ---: | ---: |
| cargo | 28.1 s | 3 (26.9-29.6 s) | - | - |
| mbx | 21.9 s | 3 (20.8-24.3 s) | 542 | 1379 |
| kache | 24.0 s | 3 (22.7-24.0 s) | - | - |

### edit

one line changed and rebuilt in place, incremental on -- the local edit loop in its steady state, where Cargo is the thing to beat

| Tool | Median wall time | Trials | Hits | Restored files |
| :--- | ---: | ---: | ---: | ---: |
| cargo | 4.2 s | 3 (3.9-4.5 s) | - | - |
| mbx | 4.1 s | 3 (4.1-4.2 s) | 1 | 2 |
| kache | 4.2 s | 3 (3.9-4.5 s) | - | - |

### contention

six overlapping check, Clippy, and test jobs -- sequential for context, then parallel with and without mbx's machine-wide compiler limit

| Tool | Batch wall time | Peak compilers | Lowest free memory | Hits |
| :--- | ---: | ---: | ---: | ---: |
| mbx-sequential | 82.7 s | 32 | 63.1 GB | 8 |
| mbx-unscheduled | 156.2 s | 152 | 55.0 GB | 12 |
| mbx | 92.5 s | 31 / 32 permits | 61.9 GB | 3390 |

---
The [run](https://github.com/jdx/mr-boxington/actions/runs/34188214905) has the per-build logs. Generated by the `bench-refresh` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark artifact and CI metadata only; no runtime, auth, or build-tool logic changes.
> 
> **Overview**
> **Refreshes published real-world benchmark data** in `benchmarks/results.json` after re-running the full `bench:refresh` matrix (jdx/hk on the pinned Namespace Linux xlarge profile, three trials per scenario).
> 
> Metadata now points at **mbx `1.10.0`** (was `1.8.1`), **kache `0.17.0`**, workflow run `34188214905`, and commit `2d16b9a`. All scenario timings, trial arrays, and mbx cache stats (lookups, hits, `unconsulted`, `predictions_loaded`, restored files/bytes) are replaced with the new run—wall times are broadly higher than the previous snapshot, including contention where **mbx-unscheduled** is much slower than before while **mbx** with compiler permits remains the middle option versus sequential.
> 
> No application or benchmark harness code changes; merge updates what ships to the public benchmarks page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73dc3f35a2dd7b9cb33484cd87142f143f531dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Benchmarks**
  - Updated benchmark metadata and measured results for the latest runner and workflow.
  - Refreshed timing and cache performance statistics across warm, commit, edit, and contention scenarios.
  - Added warmup timing measurements for selected edit scenarios.
  - Updated benchmarked tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->