### PR TITLE
fix: quiet routine compiler environment invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "bytesize",
  "demand",
  "dirs",
+ "env_filter",
  "env_logger",
  "eyre",
  "filetime",

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 [dependencies]
 bytesize = "2"
 demand = "2"
+env_filter = "2"
 env_logger = "0.11"
 dirs = "6"
 eyre = "0.6"

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1048,7 +1048,15 @@ fn reuse_hot_workspace_plan(
             return Ok(LearnedPlan::default());
         };
         let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
-        verify_environment(&dep_info.environment)?;
+        if let Some(name) = environment_mismatch(&dep_info.environment)? {
+            session::report_shim_warning_on_debug(
+                module_path!(),
+                &format!(
+                    "incremental state was not reused: compiler environment input changed: {name}"
+                ),
+            );
+            return Ok(LearnedPlan::default());
+        }
         let discovered = compilation.invocation.discover_inputs_with_mappings(
             &dep_info,
             compilation.working_dir,
@@ -2063,7 +2071,7 @@ fn prediction_task(invocation: &CacheDigest) -> String {
     })
 }
 
-fn verify_environment(environment: &BTreeMap<String, Option<String>>) -> Result<()> {
+fn environment_mismatch(environment: &BTreeMap<String, Option<String>>) -> Result<Option<&str>> {
     for (name, expected) in environment {
         let actual = std::env::var_os(name)
             .map(|value| {
@@ -2073,8 +2081,15 @@ fn verify_environment(environment: &BTreeMap<String, Option<String>>) -> Result<
             })
             .transpose()?;
         if &actual != expected {
-            bail!("compiler environment input changed: {name}");
+            return Ok(Some(name));
         }
+    }
+    Ok(None)
+}
+
+fn verify_environment(environment: &BTreeMap<String, Option<String>>) -> Result<()> {
+    if let Some(name) = environment_mismatch(environment)? {
+        bail!("compiler environment input changed: {name}");
     }
     Ok(())
 }

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -38,7 +38,8 @@ pub(crate) mod verification;
 use client::validate_handshake_response;
 use client::{request_agent_at, request_standalone_agent};
 pub(crate) use diagnostics::{
-    note, report_shim_error, report_shim_warning, reserve_stderr_for_compiler,
+    note, report_shim_error, report_shim_warning, report_shim_warning_on_debug,
+    reserve_stderr_for_compiler,
 };
 #[cfg(unix)]
 pub(crate) use server::create_fifo;

--- a/crates/mbx/src/session/diagnostics.rs
+++ b/crates/mbx/src/session/diagnostics.rs
@@ -1,5 +1,6 @@
 use super::request_agent;
 use mbx_cache_core::{AgentRequest, AgentResponse};
+use std::sync::OnceLock;
 
 /// Write to stderr without failing the build when the pipe is closed.
 pub(crate) fn note(message: &str) {
@@ -31,6 +32,44 @@ pub(crate) fn reserve_stderr_for_compiler() {
 /// probe costs the build its cache keys.
 pub(crate) fn report_shim_warning(message: &str) {
     report_shim_diagnostic(Severity::Warning, message);
+}
+
+/// Report a routine shim warning only when the caller's debug filter requests
+/// it. Rustc shims run before the process-wide logger is initialized, so this
+/// checks the same filter without installing a logger or writing to stderr.
+pub(crate) fn report_shim_warning_on_debug(target: &'static str, message: &str) {
+    let Some(filter) = debug_filter() else {
+        return;
+    };
+    let matches = filter.matches(
+        &log::Record::builder()
+            .args(format_args!("{message}"))
+            .level(log::Level::Debug)
+            .target(target)
+            .build(),
+    );
+    if matches {
+        report_shim_warning(message);
+    }
+}
+
+/// Parse the shim's debug filter once, silently disabling this optional
+/// diagnostic when the filter is malformed. The main mbx process can report a
+/// malformed filter on its own stderr; a rustc shim must never do so because
+/// Cargo treats compiler stderr as part of its fingerprint.
+fn debug_filter() -> Option<&'static env_filter::Filter> {
+    static FILTER: OnceLock<Option<env_filter::Filter>> = OnceLock::new();
+    FILTER
+        .get_or_init(|| {
+            let value = std::env::var("MBX_LOG").unwrap_or_else(|_| "info".to_string());
+            let mut builder = env_filter::Builder::new();
+            if builder.try_parse(&value).is_err() {
+                None
+            } else {
+                Some(builder.build())
+            }
+        })
+        .as_ref()
 }
 
 /// Report a fatal shim diagnostic without losing it when transport fails.

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -17,6 +17,35 @@ fn write_project(directory: &Path) {
     write_named_project(directory, "fixture");
 }
 
+/// Write a binary whose value comes from a compiler environment dependency.
+fn write_environment_project(directory: &Path) {
+    std::fs::create_dir_all(directory.join("src")).unwrap();
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        "[package]\nname = \"environment-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        directory.join("src/main.rs"),
+        "fn main() { println!(\"{}\", option_env!(\"MBX_TEST_BUILD_IDENTITY\").unwrap_or(\"unset\")); }\n",
+    )
+    .unwrap();
+    generate_lockfile(directory);
+}
+
+fn run_environment_project(directory: &Path) -> String {
+    let executable = format!("environment-fixture{}", std::env::consts::EXE_SUFFIX);
+    let output = Command::new(directory.join("target/debug").join(executable))
+        .output()
+        .expect("the environment fixture should run");
+    assert!(
+        output.status.success(),
+        "the environment fixture failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
 /// Write the fixture under `name`.
 ///
 /// The name reaches the lockfile, and the lockfile is what the build identity
@@ -327,24 +356,8 @@ fn a_mid_compilation_input_edit_discards_the_result() {
         "Cargo must not compile a dependent against the stale metadata: {stderr}"
     );
 
-    let mut fingerprint_replays = Vec::new();
-    let fingerprint_root = project.path().join("target/debug/.fingerprint");
-    for unit in std::fs::read_dir(&fingerprint_root).unwrap().flatten() {
-        let Ok(files) = std::fs::read_dir(unit.path()) else {
-            continue;
-        };
-        for file in files.flatten() {
-            let path = file.path();
-            if path
-                .file_name()
-                .is_some_and(|name| name.to_string_lossy().starts_with("output-"))
-                && std::fs::read_to_string(&path)
-                    .is_ok_and(|output| output.contains("compilation result was discarded"))
-            {
-                fingerprint_replays.push(path);
-            }
-        }
-    }
+    let fingerprint_replays =
+        cargo_fingerprints_containing(project.path(), "compilation result was discarded");
     assert!(
         fingerprint_replays.is_empty(),
         "the rejected-result diagnostic must not enter Cargo fingerprints: {fingerprint_replays:?}"
@@ -564,7 +577,9 @@ fn cargo_with(
         .env_remove("MBX_SOCKET")
         .env_remove("RUSTC_WRAPPER")
         .env_remove("RUSTC_WORKSPACE_WRAPPER")
-        .env_remove("CLIPPY_CONF_DIR");
+        .env_remove("CLIPPY_CONF_DIR")
+        .env_remove("MBX_LOG")
+        .env_remove("MBX_TEST_BUILD_IDENTITY");
     for (name, value) in settings {
         command.env(name, value);
     }
@@ -865,6 +880,106 @@ fn corrupt_action_results(store: &Path) -> usize {
         }
     }
     corrupted
+}
+
+fn cargo_fingerprints_containing(project: &Path, message: &str) -> Vec<std::path::PathBuf> {
+    let fingerprint_root = project.join("target/debug/.fingerprint");
+    let mut matches = Vec::new();
+    for unit in std::fs::read_dir(&fingerprint_root).expect("Cargo fingerprint root should exist") {
+        let unit = unit.expect("Cargo fingerprint entry should be readable");
+        if !unit
+            .file_type()
+            .expect("Cargo fingerprint type should be readable")
+            .is_dir()
+        {
+            continue;
+        }
+        for file in std::fs::read_dir(unit.path()).expect("Cargo fingerprint files should exist") {
+            let file = file.expect("Cargo fingerprint file should be readable");
+            let path = file.path();
+            if path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("output-"))
+                && std::fs::read_to_string(&path)
+                    .expect("Cargo fingerprint output should be readable")
+                    .contains(message)
+            {
+                matches.push(path);
+            }
+        }
+    }
+    matches
+}
+
+#[test]
+fn compiler_environment_invalidation_is_quiet_but_debuggable() {
+    let store = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let reports = tempfile::tempdir().unwrap();
+    write_environment_project(project.path());
+    let warning = "incremental state was not reused: compiler environment input changed: MBX_TEST_BUILD_IDENTITY";
+
+    // Each changed value must reach the executable. The same-value runs check
+    // that Cargo has no shim diagnostic to replay without invoking rustc.
+    for (step, value, filter, warned, fresh) in [
+        ("cold", Some("first"), None, false, false),
+        ("default", Some("second"), None, false, false),
+        ("debug", Some("third"), Some("debug"), true, false),
+        ("fresh", Some("third"), Some("info"), false, true),
+        ("removed", None, Some("mbx::rustc=debug"), true, false),
+        ("added", Some("fourth"), Some("info"), false, false),
+        (
+            "module-off",
+            Some("fifth"),
+            Some("debug,mbx::rustc=info"),
+            false,
+            false,
+        ),
+        ("malformed", Some("sixth"), Some("debug/["), false, false),
+        (
+            "fresh-after-malformed",
+            Some("sixth"),
+            Some("info"),
+            false,
+            true,
+        ),
+    ] {
+        let mut settings = Vec::new();
+        if let Some(value) = value {
+            settings.push(("MBX_TEST_BUILD_IDENTITY", value));
+        }
+        if let Some(filter) = filter {
+            settings.push(("MBX_LOG", filter));
+        }
+        let (stats, stderr) = build_with(
+            project.path(),
+            store.path(),
+            &reports.path().join(format!("{step}.json")),
+            &settings,
+        );
+        assert_eq!(
+            run_environment_project(project.path()),
+            value.unwrap_or("unset")
+        );
+        assert_eq!(stderr.contains(warning), warned, "{step}: {stderr}");
+        if fresh {
+            assert!(
+                stats["compiler"].as_object().unwrap().is_empty(),
+                "{step}: {stats}"
+            );
+        }
+        if step == "malformed" {
+            // Only the parent logger may diagnose malformed filters. The shim
+            // must not put the parser's warning into Cargo's fingerprints.
+            assert!(stderr.contains("invalid regex filter"), "{stderr}");
+        } else {
+            assert!(!stderr.contains("invalid regex filter"), "{step}: {stderr}");
+        }
+        for diagnostic in [warning, "invalid regex filter"] {
+            let fingerprints = cargo_fingerprints_containing(project.path(), diagnostic);
+            assert!(fingerprints.is_empty(), "{step}: {fingerprints:?}");
+        }
+    }
 }
 
 #[test]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,9 +108,16 @@ would rather not publish before posting.
 `MBX_LOG` takes an [env_logger](https://docs.rs/env_logger) filter, so
 `debug`, `trace`, or a per-module filter such as `mbx=trace` all work; it
 defaults to `info`. It covers the `mbx` process that drives the build. The
-rustc shim runs without a logger, so per-compilation detail comes from
-`MBX_BYPASS_LOG` instead, or from `mbx explain` for a grouped summary. See
-[Cache results](/cache-results).
+rustc shim runs without a logger, but `MBX_LOG=debug` (or
+`MBX_LOG=mbx::rustc=debug`) also includes its warnings about routine compiler
+environment changes preventing incremental reuse. These are quiet by default:
+a changed value from `env!` or `option_env!` is an ordinary reason to rebuild.
+The warnings travel through the live session so Cargo does not save and replay
+them as compiler diagnostics. Unexpected failures still produce warnings at the
+default log level.
+
+Other per-compilation detail comes from `MBX_BYPASS_LOG`, or from `mbx explain`
+for a grouped summary. See [Cache results](/cache-results).
 
 Report a problem in
 [Q&A discussions](https://github.com/jdx/mr-boxington/discussions/categories/q-a),


### PR DESCRIPTION
Warnings for normal rebuild behavior confuse coding agents, which then spend time troubleshooting an expected condition. Changing an `env!` or `option_env!` input between builds currently prints `incremental state was not reused: compiler environment input changed`, even when compilation succeeds. Treat this expected mismatch as a quiet fallback while preserving warnings for unexpected failures.

`MBX_LOG=debug` or `MBX_LOG=mbx::rustc=debug` retains the original warning through the live session. The shim parses the existing filter syntax without initializing a logger; malformed filters cannot write parser diagnostics into Cargo's compiler fingerprints. Cache decisions and input validation remain unchanged.

Validation covers changed, added, and removed environment values; default and module filters; malformed filters; correct executable output; and fresh Cargo runs without replayed diagnostics.

Local validation: 944 Rust tests passed (2 ignored), along with formatting, generated documentation, the docs build, link checks, and debug Clippy. `mise run ci` passed 50/52 Bats tests; the same two previously reproduced baseline C-cache reuse failures remain in `cc_standalone_exec.bats` (lines 69 and 170, both reporting 0 hits). Release Clippy passed separately because the Bats failure stopped that job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Compiler environment changes now safely invalidate incremental reuse and continue with normal processing instead of causing failures.
  - Strict environment validation still reports errors when required.

- **Diagnostics**
  - Added optional debug-level warnings for routine environment changes that prevent incremental reuse.
  - Warnings are quiet by default and can be enabled with `MBX_LOG=debug` or `MBX_LOG=mbx::rustc=debug`.
  - Invalid log filters no longer produce unwanted stderr output.

- **Documentation**
  - Updated troubleshooting guidance for environment-change warnings and `MBX_LOG` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->