### PR TITLE
fix(doctor): point cross-device reflink warnings at MBX_CACHE_DIR

### DIFF
--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -353,16 +353,22 @@ fn reflink_check_with(
     match probe() {
         Ok(()) => Check::pass("reflink", format!("{layout}: cloning is supported")),
         Err(error) => {
-            let reason = match error.kind() {
-                std::io::ErrorKind::CrossesDevices => "different filesystems",
-                std::io::ErrorKind::PermissionDenied => "permission denied",
-                std::io::ErrorKind::Unsupported => "cloning unsupported",
-                _ => "clone probe failed",
+            let (reason, hint) = match error.kind() {
+                std::io::ErrorKind::CrossesDevices => (
+                    "different filesystems",
+                    " Containerized CI runners often mount an overlay filesystem for the \
+                     workspace while the cache directory defaults elsewhere; point \
+                     MBX_CACHE_DIR at a path on the same filesystem as the target \
+                     directory (for example, inside the job workspace) to restore cloning.",
+                ),
+                std::io::ErrorKind::PermissionDenied => ("permission denied", ""),
+                std::io::ErrorKind::Unsupported => ("cloning unsupported", ""),
+                _ => ("clone probe failed", ""),
             };
             Check::warn(
                 "reflink",
                 format!(
-                    "{layout}: {reason} ({error}); restores to this location may require copying"
+                    "{layout}: {reason} ({error}); restores to this location may require copying.{hint}"
                 ),
             )
         }
@@ -851,6 +857,21 @@ mod layout_tests {
             assert!(result.detail.contains(&target.path().display().to_string()));
         }
         assert_eq!(std::fs::read_dir(target.path()).unwrap().count(), 0);
+    }
+
+    /// Containerized CI runners commonly split an overlay-mounted workspace
+    /// from the cache directory's underlying filesystem, so every restore
+    /// falls back to a full copy. The warning should point directly at the
+    /// fix rather than leaving the reader to rediscover MBX_CACHE_DIR.
+    #[test]
+    fn cross_device_failure_suggests_aligning_cache_dir() {
+        let cache = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let result = reflink_check_with(cache.path(), target.path(), |_, _| {
+            Err(std::io::ErrorKind::CrossesDevices.into())
+        });
+        assert_eq!(result.severity, Severity::Warn);
+        assert!(result.detail.contains("MBX_CACHE_DIR"));
     }
 
     #[cfg(unix)]

--- a/crates/mbx/src/doctor.rs
+++ b/crates/mbx/src/doctor.rs
@@ -362,7 +362,16 @@ fn reflink_check_with(
                      directory (for example, inside the job workspace) to restore cloning.",
                 ),
                 std::io::ErrorKind::PermissionDenied => ("permission denied", ""),
-                std::io::ErrorKind::Unsupported => ("cloning unsupported", ""),
+                std::io::ErrorKind::Unsupported => (
+                    "cloning unsupported",
+                    " The filesystem driver here has no clone operation at all, regardless of \
+                     which directory is used: this is common when a container's root \
+                     filesystem uses a storage driver such as Docker's overlay2 without a \
+                     reflink-capable backing filesystem. The backing filesystem itself needs to \
+                     support clones, such as Btrfs or XFS formatted with reflink=1; ask \
+                     whoever manages the runner or container host to check the storage driver \
+                     and backing filesystem, or accept that restores here will always copy.",
+                ),
                 _ => ("clone probe failed", ""),
             };
             Check::warn(
@@ -872,6 +881,24 @@ mod layout_tests {
         });
         assert_eq!(result.severity, Severity::Warn);
         assert!(result.detail.contains("MBX_CACHE_DIR"));
+    }
+
+    /// `Unsupported` means the filesystem driver has no clone operation at
+    /// all, commonly a container storage driver such as overlay2 without a
+    /// reflink-capable backing filesystem. Unlike `CrossesDevices`, no path
+    /// choice fixes this, so the warning must not repeat the MBX_CACHE_DIR
+    /// hint and should instead name the storage-driver/backing-filesystem
+    /// cause.
+    #[test]
+    fn unsupported_failure_names_the_storage_driver_not_the_cache_dir() {
+        let cache = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let result = reflink_check_with(cache.path(), target.path(), |_, _| {
+            Err(std::io::ErrorKind::Unsupported.into())
+        });
+        assert_eq!(result.severity, Severity::Warn);
+        assert!(result.detail.contains("storage driver"));
+        assert!(!result.detail.contains("MBX_CACHE_DIR"));
     }
 
     #[cfg(unix)]

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -193,6 +193,11 @@ build:
 Set `MBX_REMOTE_TOKEN` in the project's CI/CD variables, masked and limited to
 protected branches, not in the YAML.
 
+GitLab's Docker and Kubernetes executors commonly mount the job workspace on
+an overlay filesystem separate from the default cache directory, which
+disables local reflink restores regardless of the remote backend. See
+[restores are slow in containerized CI](/troubleshooting#restores-are-slow-in-containerized-ci).
+
 ## Prefetch
 
 After a command has published its action manifest, another machine can warm

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,6 +87,27 @@ with your CI's own cache mechanism (for example, GitLab's `cache:` key) the
 same way you would persist `~/.cache/mbx` otherwise, or the cache starts cold
 on every job.
 
+### The warning says "cloning unsupported" instead
+
+A different `mbx doctor` warning names the failure "cloning unsupported"
+rather than "different filesystems":
+
+```text
+warn  reflink      /root/.cache/mbx -> /builds/acme/backend/target: cloning unsupported (Operation not supported (os error 95)); restores to this location may require copying. The filesystem driver here has no clone operation at all, regardless of which directory is used...
+```
+
+`MBX_CACHE_DIR` does not fix this one. "Different filesystems" means the two
+paths are on separate mounts, which choosing a co-located directory solves.
+"Cloning unsupported" means the filesystem driver itself has no clone
+operation, so every directory on that filesystem is equally unable to
+reflink. This is common when a container's root filesystem uses a storage
+driver such as Docker's `overlay2` without a reflink-capable backing
+filesystem; reflinks need the backing filesystem itself to support them, such
+as Btrfs or XFS formatted with `reflink=1`. Ask whoever manages the runner or
+container host to check the storage driver and backing filesystem. Until
+that changes, restores on that host copy bytes instead of cloning them, and
+`MBX_CACHE_DIR` placement has no effect either way.
+
 ## Inspect a build
 
 ```sh

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,6 +14,7 @@ cached work.
 | Remote requests fail | `mbx doctor`, then [check authentication](/remote-cache#authenticate) |
 | Build storage is larger than expected | `mbx cache stats` and `mbx gc --dry-run`; review [budgets](/managed-targets#budgets-scale-with-the-disk) |
 | Breakpoints point at an old checkout | Use the [debugger recipe](/cookbook/local-development#debug-a-binary-restored-from-another-checkout) |
+| Restores are slow in CI | `mbx doctor`, then [align the cache and target filesystems](#restores-are-slow-in-containerized-ci) |
 
 ## Diagnose the installation
 
@@ -55,6 +56,36 @@ blocks Unix socket listeners but permits filesystem FIFOs, mbx automatically
 uses FIFO transport and keeps caching enabled. If neither transport is
 available, mbx warns and runs Cargo without caching instead of preventing the
 build from starting.
+
+## Restores are slow in containerized CI
+
+[Copy-on-write output restoration](/how-it-works#copy-on-write-output-restoration)
+needs the cache directory and the target directory on the same filesystem.
+Many containerized CI runners (GitLab's Docker and Kubernetes executors,
+Kubernetes-based GitHub Actions runners, and similar setups) mount the job
+workspace on an overlay filesystem while the default cache directory resolves
+to a different mount, such as an emptyDir volume or the image's own layer.
+Reflinking then fails with "different filesystems" on every restore, and mbx
+falls back to a full byte copy for every cached output:
+
+```text
+warn  reflink      /root/.cache/mbx -> /builds/acme/backend/target: different filesystems (CrossesDevices); restores to this location may require copying. Containerized CI runners often mount an overlay filesystem for the workspace while the cache directory defaults elsewhere; point MBX_CACHE_DIR at a path on the same filesystem as the target directory (for example, inside the job workspace) to restore cloning.
+```
+
+Point `MBX_CACHE_DIR` at a path on the same filesystem as the target directory,
+typically somewhere under the job's own workspace:
+
+```yaml
+# GitLab CI
+variables:
+  MBX_CACHE_DIR: $CI_PROJECT_DIR/.mbx-cache
+```
+
+Re-run `mbx doctor` after the change; the `reflink` check should report
+`cloning is supported` for that layout. Persist `MBX_CACHE_DIR` across jobs
+with your CI's own cache mechanism (for example, GitLab's `cache:` key) the
+same way you would persist `~/.cache/mbx` otherwise, or the cache starts cold
+on every job.
 
 ## Inspect a build
 


### PR DESCRIPTION
Containerized CI runners (GitLab Docker/Kubernetes executors, k8s-based GH Actions runners) commonly mount the job workspace on an overlay filesystem while the default cache directory resolves elsewhere, so every restore falls back to a full copy with no clear diagnostic pointing at the fix. This makes the doctor warning actionable and documents the MBX_CACHE_DIR alignment fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reflink diagnostic warnings now provide an actionable `MBX_CACHE_DIR` hint for cross-filesystem failures.
  - Unsupported reflink errors now identify storage-driver or backing-filesystem limitations and clarify when `MBX_CACHE_DIR` cannot resolve the issue.

- **Documentation**
  - Added guidance for diagnosing slow restores in containerized CI environments.
  - Documented cache configuration, validation with `mbx doctor`, and persisting caches across jobs.
  - Expanded GitLab CI guidance for Docker and Kubernetes executors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->