### PR TITLE
fix: avoid repeated Nix store scans during C builds

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -573,6 +573,35 @@ fn equivalent_worktrees_produce_the_same_portable_action_key() {
     assert_eq!(build("one"), build("two"));
 }
 
+#[cfg(unix)]
+#[test]
+fn action_path_aliases_are_equivalent_and_refreshed_between_actions() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(directory.path()).unwrap();
+    for name in ["one", "two"] {
+        std::fs::create_dir_all(root.join(name).join("src")).unwrap();
+        std::fs::write(root.join(name).join("src/a.c"), "int a;").unwrap();
+    }
+    let alias = root.join("alias");
+    std::os::unix::fs::symlink(root.join("one"), &alias).unwrap();
+    let build = |source: &str| {
+        let invocation = CcInvocation::parse(&argv(&["-c", "-o", "out.o", source])).unwrap();
+        let mut context = context(&root, &root.join("target"));
+        context.inputs.push(CcActionInput {
+            path: root.join(source),
+            digest: digest_of("int a;"),
+        });
+        invocation.action(context).unwrap().digest
+    };
+    let first = build("alias/src/a.c");
+    assert_eq!(first, build("one/src/a.c"));
+    std::fs::remove_file(&alias).unwrap();
+    std::os::unix::fs::symlink(root.join("two"), &alias).unwrap();
+    let second = build("alias/src/a.c");
+    assert_eq!(second, build("two/src/a.c"));
+    assert_ne!(first, second);
+}
+
 #[test]
 fn registry_sources_normalize_under_the_cargo_home_placeholder() {
     // Cargo runs a registry crate's build script with its cwd inside the

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -18,8 +18,8 @@
 #![deny(missing_docs)]
 
 use mbx_cache_core::{
-    CacheDigest, FileDigestCache, PathMapping, PathNormalizationError, canonical_json,
-    normalize_mapped_path,
+    CacheDigest, FileDigestCache, PathAliases, PathMapping, PathNormalizationError, canonical_json,
+    normalize_resolved_mapped_path_with, resolve_path_mappings,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -1150,16 +1150,19 @@ struct ActionBuilder<'a> {
     invocation: &'a CcInvocation,
     context: CcActionContext,
     mappings: Vec<PathMapping>,
+    /// Reuse parent resolution across the inputs of this action only.
+    aliases: PathAliases,
 }
 
 impl<'a> ActionBuilder<'a> {
     fn new(invocation: &'a CcInvocation, mut context: CcActionContext) -> Self {
         context.path_mappings = PathMapping::ordered(&context.path_mappings);
-        let mappings = context.path_mappings.clone();
+        let mappings = resolve_path_mappings(&context.path_mappings);
         Self {
             invocation,
             context,
             mappings,
+            aliases: PathAliases::default(),
         }
     }
 
@@ -1269,7 +1272,7 @@ impl<'a> ActionBuilder<'a> {
         }
         let mut roots = BTreeSet::new();
         let mut placeholders = BTreeSet::new();
-        for mapping in &self.mappings {
+        for mapping in &self.context.path_mappings {
             if !mapping.root.is_absolute() {
                 return Err(CcBypassReason::RelativePathMapping(mapping.root.clone()));
             }
@@ -1307,7 +1310,12 @@ impl<'a> ActionBuilder<'a> {
     /// location is a property of the machine, and its contents are digested
     /// like any other input.
     fn normalize_path(&self, path: &Path) -> Result<String, CcBypassReason> {
-        match normalize_mapped_path(path, &self.context.working_dir, &self.mappings) {
+        match normalize_resolved_mapped_path_with(
+            &self.aliases,
+            path,
+            &self.context.working_dir,
+            &self.mappings,
+        ) {
             Ok(normalized) => Ok(normalized),
             Err(reason) => {
                 let absolute = absolute_path(path, &self.context.working_dir);

--- a/crates/mbx-cache-core/src/path_mapping.rs
+++ b/crates/mbx-cache-core/src/path_mapping.rs
@@ -112,7 +112,13 @@ pub struct PathAliases {
         std::cell::RefCell<std::collections::HashMap<PathBuf, std::rc::Rc<ResolvedDirectory>>>,
 }
 
-/// A directory as `realpath` would name it, and the names it holds, so a
+/// Maximum names remembered per directory. Large stores must not make a
+/// single path lookup proportional to their entire listing. Unlisted names
+/// fall back to `canonicalize`, preserving its case and symlink handling.
+#[cfg(unix)]
+const MAX_DIRECTORY_ENTRIES: usize = 256;
+
+/// A directory as `realpath` would name it, and some names it holds, so a
 /// child can be checked against the listing rather than resolved again.
 #[cfg(unix)]
 #[derive(Debug)]
@@ -203,17 +209,25 @@ impl PathAliases {
         if parent.as_os_str().is_empty() {
             return std::fs::canonicalize(path);
         }
-        // Looked up, then released: resolving the parent below borrows the
-        // memo again, and a `Ref` that lived through the match would panic.
+        // Release the lookup before inserting a newly resolved parent.
         let known = self.directories.borrow().get(parent).cloned();
         let resolved_parent = match known {
             Some(resolved) => resolved,
             None => {
-                let resolved = self.canonicalize(parent)?;
+                // Resolve ancestors with realpath, which looks up their names
+                // without enumerating them. Recursing through this memo would
+                // list /nix/store just to reach a header inside one package.
+                let resolved = std::fs::canonicalize(parent)?;
                 // A listing that cannot be read is an empty one: every child
                 // then takes the full call, which is where it started.
                 let entries = std::fs::read_dir(&resolved)
-                    .map(|listing| listing.flatten().map(|entry| entry.file_name()).collect())
+                    .map(|listing| {
+                        listing
+                            .take(MAX_DIRECTORY_ENTRIES)
+                            .filter_map(Result::ok)
+                            .map(|entry| entry.file_name())
+                            .collect()
+                    })
                     .unwrap_or_default();
                 let resolved = std::rc::Rc::new(ResolvedDirectory {
                     path: resolved,
@@ -229,7 +243,8 @@ impl PathAliases {
         // The name has to be in the listing as written: on a volume that
         // folds case, `realpath` would answer with the name on disk, and a
         // spelling the listing does not contain takes the full call so that
-        // it still does. So does a link, and anything the listing predates.
+        // it still does. So does a link, anything beyond the listing budget,
+        // and anything the listing predates.
         if resolved_parent.entries.contains(name)
             && !std::fs::symlink_metadata(&candidate)?
                 .file_type()
@@ -372,6 +387,49 @@ mod unix_tests {
             )
             .unwrap(),
             "${workspace}/src/late.rs"
+        );
+    }
+
+    #[test]
+    fn large_directory_listings_are_bounded_without_losing_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(directory.path()).unwrap();
+        let store = root.join("store");
+        std::fs::create_dir(&store).unwrap();
+        for index in 0..MAX_DIRECTORY_ENTRIES * 2 {
+            std::fs::write(store.join(format!("header-{index}.h")), "").unwrap();
+        }
+        std::os::unix::fs::symlink(store.join("header-0.h"), store.join("link.h")).unwrap();
+        let aliases = PathAliases::default();
+        let mappings = [PathMapping::new(&store, "store")];
+        for index in 0..MAX_DIRECTORY_ENTRIES * 2 {
+            let name = format!("header-{index}.h");
+            assert_eq!(
+                normalize_resolved_mapped_path_with(&aliases, &store.join(&name), &root, &mappings)
+                    .unwrap(),
+                format!("${{store}}/{name}")
+            );
+        }
+        // Only the immediate parent is listed, never its ancestors.
+        assert_eq!(aliases.directories.borrow().len(), 1);
+        assert_eq!(
+            aliases.directories.borrow()[&store].entries.len(),
+            MAX_DIRECTORY_ENTRIES
+        );
+        assert_eq!(
+            normalize_resolved_mapped_path_with(&aliases, &store.join("link.h"), &root, &mappings)
+                .unwrap(),
+            "${store}/header-0.h"
+        );
+        assert_eq!(
+            normalize_resolved_mapped_path_with(
+                &aliases,
+                &store.join("missing/subdir/header.h"),
+                &root,
+                &mappings
+            )
+            .unwrap(),
+            "${store}/missing/subdir/header.h"
         );
     }
 


### PR DESCRIPTION
C builds with a Nix toolchain can spend minutes enumerating `/nix/store` while normalizing input paths, as reported in [discussion #413](https://github.com/jdx/mr-boxington/discussions/413). The resolver recursively listed every ancestor, and the C adapter discarded its memo after each path.

Resolve each immediate parent with `canonicalize` without listing its ancestors, remember at most 256 names per directory, and reuse resolved mappings and a `PathAliases` memo for each C action. Names outside the remembered subset still use canonicalization, preserving symlink and case handling. The memo expires with the action so subsequent builds observe retargeted aliases.

Validation:

- `mise run ci` passed: workspace tests, debug/release Clippy, generated docs and link checks, and all 52 Bats tests.
- Regression tests cover bounded listings, absence of ancestor enumeration, paths beyond the listing budget, symlinks, missing suffixes, and alias retargeting between C actions.
- Tested in `nixos/nix:latest` (image digest `sha256:7a007c766426c1877758ddc5cb87a965ac131fc78c582ce0083d922d51ae945c`), with Rust 1.95.0 and the Nix Clang 21.1.8 wrapper. Padded `/nix/store` to 71,884 entries with empty fixture directories and built `aws-lc-sys = 0.41.0` using 14 jobs, separate target/cache directories, `MBX_TARGET_VIEWS=0`, and `TARGET_CC`/`TARGET_CXX` so the C shims actually run.

| Cold build | Wall time |
| --- | ---: |
| Raw Cargo | 6.98 s |
| Released mbx 1.8.3 | Timed out at 120 s, unfinished |
| Patched mbx (debug binary) | 10.35 s, successful |

An optimized standalone benchmark using the original and patched resolver modules normalized one real Nix Clang header 100 times: 6.12–7.72 s before, 8.40–8.97 ms with the new resolver alone, and 0.275–0.288 ms with the C adapter's shared memo (three trials). These are path-normalization timings, not full-build speedups. The reporter's macOS/APFS environment remains untested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache-key path normalization for all C/C++ compiles; behavior is intended to match prior semantics with bounded listings and per-action memo lifetime, but incorrect alias handling could cause cache hits or misses.
> 
> **Overview**
> **Speeds up C compile cache-key path normalization** on machines with huge directories (notably Nix `/nix/store`) by changing how symlinks and parents are resolved, and by reusing work within each compile action.
> 
> In **`mbx-cache-core`**, parent directories are now resolved with `canonicalize` instead of walking ancestors through the alias memo (which could **enumerate entire store trees**). Each cached directory listing is **capped at 256 entry names**; paths outside that set still go through full `canonicalize`, so symlinks, case folding, and late-created files stay correct.
> 
> In **`mbx-cache-cc`**, each `ActionBuilder` keeps a **`PathAliases` memo for all inputs in one action**, uses **`resolve_path_mappings` once**, and normalizes via **`normalize_resolved_mapped_path_with`** instead of per-path `normalize_mapped_path`. Mapping validation still reads the raw `path_mappings` from context.
> 
> **Tests** add bounded-listing coverage in core and a Unix integration test that symlink spellings match canonical paths within an action and **diverge after the alias is retargeted** on a later action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b132e3ebcf9961ee1ea6a3b300a6e118753a5701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of symlinked paths so equivalent source paths produce consistent action results.
  * Action results now refresh correctly when a symlink points to a different directory.
  * Improved path resolution in directories with many entries, including paths created after directory scanning.
  * Limited directory scanning to improve reliability and performance in large directories.
* **Tests**
  * Added coverage for symlink changes and large-directory path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->