### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "bytesize",
  "demand",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.23...mbx-cache-cargo-v0.1.24) - 2026-09-10
+
+### Other
+
+- updated the following local packages: mbx-cache-core
+
 ## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.22...mbx-cache-cargo-v0.1.23) - 2026-09-08
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.23"
+version = "0.1.24"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.15.0...mbx-cache-cc-v0.16.0) - 2026-09-10
+
+### Fixed
+
+- *(cc)* recognize the active Xcode developer directory ([#425](https://github.com/jdx/mr-boxington/pull/425))
+- avoid repeated Nix store scans during C builds ([#414](https://github.com/jdx/mr-boxington/pull/414))
+
 ## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.14.0...mbx-cache-cc-v0.15.0) - 2026-09-08
 
 ### Other

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.15.0"
+version = "0.16.0"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.15.0...mbx-cache-core-v0.16.0) - 2026-09-10
+
+### Fixed
+
+- forward routine shim diagnostics as debug logs ([#417](https://github.com/jdx/mr-boxington/pull/417))
+- avoid repeated Nix store scans during C builds ([#414](https://github.com/jdx/mr-boxington/pull/414))
+
 ## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.14.0...mbx-cache-core-v0.15.0) - 2026-09-08
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.15.0"
+version = "0.16.0"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.15.0"
+version = "0.16.0"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.22...mbx-cache-store-v0.1.23) - 2026-09-10
+
+### Fixed
+
+- *(cache)* retain predictions from every exported command ([#424](https://github.com/jdx/mr-boxington/pull/424))
+
 ## [0.1.22](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.21...mbx-cache-store-v0.1.22) - 2026-09-08
 
 ### Other

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.22"
+version = "0.1.23"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1](https://github.com/jdx/mr-boxington/compare/v1.10.0...v1.10.1) - 2026-09-10
+
+### Fixed
+
+- *(cc)* report publication failures and require valid snapshots ([#421](https://github.com/jdx/mr-boxington/pull/421))
+- *(verify)* identify divergent compilation outputs ([#420](https://github.com/jdx/mr-boxington/pull/420))
+- forward routine shim diagnostics as debug logs ([#417](https://github.com/jdx/mr-boxington/pull/417))
+
 ## [1.10.0](https://github.com/jdx/mr-boxington/compare/v1.9.0...v1.10.0) - 2026-09-08
 
 ### Added

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.10.0"
+version = "1.10.1"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -27,11 +27,11 @@ hex = "0.4"
 jiff = { version = "0.2", default-features = false, features = ["std"] }
 log = "0.4"
 memchr = "2"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.15.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.23", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.15.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.15.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.22", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.24", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.16.0", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.16.0", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.23", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.10.0
+**Version:** 1.10.1
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-core`: 0.15.0 -> 0.16.0 (⚠ API breaking changes)
* `mbx-cache-cc`: 0.15.0 -> 0.16.0 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.15.0 -> 0.16.0
* `mbx-cache-store`: 0.1.22 -> 0.1.23 (✓ API compatible changes)
* `mbx`: 1.10.0 -> 1.10.1 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.23 -> 0.1.24

### ⚠ `mbx-cache-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentResponse:DebugRecorded in /tmp/.tmpDKHD78/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:572
  variant AgentRequest:RecordDebug in /tmp/.tmpDKHD78/mr-boxington/crates/mbx-cache-core/src/agent/wire.rs:314
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-core`

<blockquote>

## [0.16.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.15.0...mbx-cache-core-v0.16.0) - 2026-09-10

### Fixed

- forward routine shim diagnostics as debug logs ([#417](https://github.com/jdx/mr-boxington/pull/417))
- avoid repeated Nix store scans during C builds ([#414](https://github.com/jdx/mr-boxington/pull/414))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.16.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.15.0...mbx-cache-cc-v0.16.0) - 2026-09-10

### Fixed

- *(cc)* recognize the active Xcode developer directory ([#425](https://github.com/jdx/mr-boxington/pull/425))
- avoid repeated Nix store scans during C builds ([#414](https://github.com/jdx/mr-boxington/pull/414))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.14.0...mbx-cache-rustc-v0.15.0) - 2026-09-08

### Other

- adopt native mise Rust integration for setup ([#400](https://github.com/jdx/mr-boxington/pull/400))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.22...mbx-cache-store-v0.1.23) - 2026-09-10

### Fixed

- *(cache)* retain predictions from every exported command ([#424](https://github.com/jdx/mr-boxington/pull/424))
</blockquote>

## `mbx`

<blockquote>

## [1.10.1](https://github.com/jdx/mr-boxington/compare/v1.10.0...v1.10.1) - 2026-09-10

### Fixed

- *(cc)* report publication failures and require valid snapshots ([#421](https://github.com/jdx/mr-boxington/pull/421))
- *(verify)* identify divergent compilation outputs ([#420](https://github.com/jdx/mr-boxington/pull/420))
- forward routine shim diagnostics as debug logs ([#417](https://github.com/jdx/mr-boxington/pull/417))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.24](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.23...mbx-cache-cargo-v0.1.24) - 2026-09-10

### Other

- updated the following local packages: mbx-cache-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical versioning, but the release ships cache-keying and prediction behavior fixes plus a semver-breaking agent wire enum extension in mbx-cache-core for embedders.
> 
> **Overview**
> This is a **release-plz** cut that bumps crate versions, refreshes **Cargo.lock**, and adds dated **CHANGELOG** entries—no application source changes in the diff itself.
> 
> **mbx** goes **1.10.0 → 1.10.1** (patch), with changelog fixes for CC publication/snapshot handling, clearer **verify** output for divergent compilations, and shim diagnostics routed to debug logs. **mbx-cache-core**, **mbx-cache-cc**, and **mbx-cache-rustc** move **0.15.0 → 0.16.0**; **mbx-cache-store** **0.1.22 → 0.1.23**; **mbx-cache-cargo** **0.1.23 → 0.1.24**. Workspace **Cargo.toml** dependency pins and the generated CLI docs **Version** line are updated to match.
> 
> Notable packaged fixes (from changelogs): **mbx-cache-core** / **mbx-cache-cc** avoid repeated Nix store scans during C builds; **mbx-cache-cc** recognizes the active Xcode developer directory; **mbx-cache-store** retains predictions from every exported command. **mbx-cache-core 0.16.0** is flagged as an API break for exhaustive matches on agent wire enums (**RecordDebug** / **DebugRecorded**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812c84bfefc331336678397899ea5740ef423b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->