### PR TITLE
fix(verify): identify divergent compilation outputs

### DIFF
--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -320,8 +320,11 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         let divergence = verification_divergence(&cached, &output);
         record_verification(divergence.is_none(), cached.restore);
         if let Some(divergence) = divergence {
-            session::report_shim_warning(&format!(
-                "shadow verification diverged from cached output: {divergence}"
+            session::report_shim_warning(&crate::materialize::verification_warning(
+                "cc",
+                &compilation_name(&invocation),
+                &cached.action,
+                &divergence,
             ));
         }
     }
@@ -1353,11 +1356,17 @@ fn verification_divergence(cached: &CachedCompilation, output: &Output) -> Optio
     if !output.status.success() {
         return Some("the shadow compilation failed".into());
     }
-    if cached.stdout != output.stdout {
-        return Some("standard output differs".into());
-    }
-    if cached.stderr != output.stderr {
-        return Some("standard error differs".into());
+    if let Some(difference) =
+        crate::materialize::stream_divergence("standard output", &cached.stdout, &output.stdout)
+            .or_else(|| {
+                crate::materialize::stream_divergence(
+                    "standard error",
+                    &cached.stderr,
+                    &output.stderr,
+                )
+            })
+    {
+        return Some(difference);
     }
     for expected in &cached.outputs {
         let name = expected.path.display();

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -158,11 +158,11 @@ fn a_divergence_says_which_of_the_things_it_compares_differed() {
     );
     assert_eq!(
         verification_divergence(&cached(b"out", b"", matching.clone()), &compiled(b"", b"")),
-        Some("standard output differs".into())
+        Some("standard output differs at byte 0 (line 1): cached=\"out\", compiled=\"\"".into())
     );
     assert_eq!(
         verification_divergence(&cached(b"", b"warn", matching), &compiled(b"", b"")),
-        Some("standard error differs".into())
+        Some("standard error differs at byte 0 (line 1): cached=\"warn\", compiled=\"\"".into())
     );
 
     // The one that matters: the object itself. This is what every divergence

--- a/crates/mbx/src/materialize.rs
+++ b/crates/mbx/src/materialize.rs
@@ -270,6 +270,49 @@ pub(crate) fn record_action_hit_with_diagnostic(
     }
 }
 
+/// Identify the action before the details, so the session's warning deduplication
+/// cannot merge different compilations that disagree in the same way.
+pub(crate) fn verification_warning(
+    adapter: &str,
+    unit: &str,
+    action: &CacheDigest,
+    divergence: &str,
+) -> String {
+    format!(
+        "shadow verification diverged from cached output: {adapter} action {} ({unit}): {divergence}",
+        action.hash
+    )
+}
+
+/// Describe the first differing byte without emitting terminal controls or an
+/// unbounded compiler diagnostic. Offsets are zero-based; lines are one-based.
+pub(crate) fn stream_divergence(name: &str, cached: &[u8], compiled: &[u8]) -> Option<String> {
+    if cached == compiled {
+        return None;
+    }
+    let offset = cached
+        .iter()
+        .zip(compiled)
+        .position(|(a, b)| a != b)
+        .unwrap_or(cached.len().min(compiled.len()));
+    let line = cached[..offset].iter().filter(|&&b| b == b'\n').count() + 1;
+    let excerpt = |bytes: &[u8]| {
+        let start = offset.saturating_sub(24);
+        let end = bytes.len().min(offset.saturating_add(48));
+        format!(
+            "{}{}{}",
+            if start > 0 { "..." } else { "" },
+            bytes[start..end].escape_ascii(),
+            if end < bytes.len() { "..." } else { "" }
+        )
+    };
+    Some(format!(
+        "{name} differs at byte {offset} (line {line}): cached=\"{}\", compiled=\"{}\"",
+        excerpt(cached),
+        excerpt(compiled)
+    ))
+}
+
 /// Tell the session whether a shadow compilation agreed with the cache.
 pub(crate) fn record_verification(matched: bool, restore: RestoreStats) {
     let responses =
@@ -496,4 +539,58 @@ pub(crate) fn exit_code(status: ExitStatus) -> ExitCode {
     // SAFETY: this process is only a compiler wrapper and must preserve the
     // compiler's full Windows status code, which stable ExitCode cannot hold.
     unsafe { windows_sys::Win32::System::Threading::ExitProcess(status.code().unwrap_or(1) as u32) }
+}
+
+#[cfg(test)]
+mod verification_tests {
+    use super::*;
+
+    #[test]
+    fn stream_comparison_handles_eof_and_reports_the_first_differing_line() {
+        assert_eq!(stream_divergence("stderr", b"same", b"same"), None);
+        let difference = stream_divergence("stderr", b"same\nold", b"same\nnew").unwrap();
+        assert!(difference.contains("byte 5 (line 2)"), "{difference}");
+        assert!(difference.contains(r"same\nold"), "{difference}");
+        for (cached, compiled) in [
+            (b"".as_slice(), b"extra".as_slice()),
+            (b"extra".as_slice(), b"".as_slice()),
+        ] {
+            let difference = stream_divergence("stdout", cached, compiled).unwrap();
+            assert!(difference.contains("byte 0 (line 1)"), "{difference}");
+        }
+    }
+
+    #[test]
+    fn excerpts_are_bounded_and_escape_binary_and_terminal_bytes() {
+        let cached = vec![b'a'; 10_000];
+        let mut compiled = cached.clone();
+        compiled.extend_from_slice(b"\x1b\0\xff\n");
+        let difference = stream_divergence("stderr", &cached, &compiled).unwrap();
+        assert!(difference.contains("byte 10000"), "{difference}");
+        assert!(difference.contains(r"\x1b\x00\xff\n"), "{difference}");
+        assert!(!difference.contains(['\n', '\0', '\x1b']));
+        assert!(difference.len() < 512, "{difference}");
+    }
+
+    #[test]
+    fn different_actions_of_one_unit_keep_distinct_warning_identities() {
+        let first = verification_warning(
+            "rustc",
+            "example",
+            &CacheDigest::blake3(b"lib"),
+            "standard error differs",
+        );
+        let second = verification_warning(
+            "rustc",
+            "example",
+            &CacheDigest::blake3(b"test"),
+            "standard error differs",
+        );
+        assert_ne!(
+            first, second,
+            "session deduplication must preserve both units"
+        );
+        assert!(first.contains("rustc action"));
+        assert!(first.contains("(example)"));
+    }
 }

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -522,8 +522,11 @@ pub(crate) fn compile(
         let divergence = verification_divergence(&cached, &output);
         record_verification(divergence.is_none(), cached.restore);
         if let Some(divergence) = divergence {
-            session::report_shim_warning(&format!(
-                "shadow verification diverged from cached output: {divergence}"
+            session::report_shim_warning(&crate::materialize::verification_warning(
+                "rustc",
+                invocation.crate_name(),
+                &cached.action,
+                &divergence,
             ));
         }
         let _ = replay_output(&output);
@@ -2340,11 +2343,17 @@ fn verification_divergence(cached: &CachedCompilation, output: &Output) -> Optio
     if !output.status.success() {
         return Some("the shadow compilation failed".into());
     }
-    if cached.stdout != output.stdout {
-        return Some("standard output differs".into());
-    }
-    if cached.stderr != output.stderr {
-        return Some("standard error differs".into());
+    if let Some(difference) =
+        crate::materialize::stream_divergence("standard output", &cached.stdout, &output.stdout)
+            .or_else(|| {
+                crate::materialize::stream_divergence(
+                    "standard error",
+                    &cached.stderr,
+                    &output.stderr,
+                )
+            })
+    {
+        return Some(difference);
     }
     for expected in &cached.outputs {
         let name = expected.path.display();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,10 +196,38 @@ The build reports what it found:
 mbx[cache]: qualification: 24 verified, 0 diverged
 ```
 
-Run it in the checkout that filled the cache. Artifacts restored from another
-checkout embed that checkout's paths and would be reported as divergences. Any
-divergence in the same checkout is a modeling bug; please report it.
+The verified count includes divergent compilations. Each compilation contributes
+at most one divergence, reporting its first mismatch. Warnings identify the
+adapter, unit and action; stdout/stderr differences include the first differing
+byte offset, line number and bounded, escaped excerpts of both results. Cached
+diagnostics are rewritten into this checkout's paths before comparison.
+
+Cargo must actually invoke the compiler to verify anything. Run in the checkout
+that filled the cache with a fresh target directory; an unchanged build in an
+existing target can be a Cargo no-op. Keep the original target and shared store.
 `MBX_BYPASS_LOG` and `mbx explain` show what was left out.
+
+For audits across worktrees, populate and verify using the same virtual source
+root. For example, run this from each checkout's workspace root, first with
+`MBX_VERIFY=0` to populate, then with `MBX_VERIFY=1` in the other checkout:
+
+```sh
+RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }--remap-path-prefix=$PWD=/workspace" \
+  CARGO_TARGET_DIR="$PWD/target-audit" MBX_VERIFY=1 mbx build --all-targets --locked
+```
+
+Use a fresh `target-audit` directory each time and the same toolchain, profile,
+and other compiler flags. The source side of `--remap-path-prefix` is keyed
+portably; its virtual destination must agree between checkouts. If using
+`CARGO_ENCODED_RUSTFLAGS`, add the remap there instead: Cargo gives it precedence
+over `RUSTFLAGS`.
+
+Remapping reduces embedded-source-path differences; it does not guarantee
+byte-identical outputs, especially for native links or paths outside the mapped
+root. See [artifact equivalence](/limits#restored-artifacts-are-equivalent-not-always-identical).
+Investigate remaining divergences rather than treating every cross-worktree
+mismatch as harmless. Please report unexplained differences, including the
+identified unit and action.
 
 This is how to qualify a setting whose tier you want to check against your
 own workload, such as


### PR DESCRIPTION
Verification can report multiple divergent compilations as one unnamed stderr warning because the session deduplicates identical messages. Include the adapter, crate/source and action identity in each warning, and show the first differing stdout/stderr byte, line and bounded escaped excerpts. Artifact comparisons and divergence counts remain unchanged.

Document that counts include divergent comparisons, Cargo no-op builds do not verify anything, and cross-worktree audits can use a consistent `--remap-path-prefix` with fresh target directories. Remaining binary differences still need investigation.

Related discussion: https://github.com/jdx/mr-boxington/discussions/419

Validation: focused verification tests cover distinct action identities, first differing lines, EOF, binary/control bytes and bounded excerpts; `mise run ci` passed (workspace tests, debug/release lint, generated docs, built-site links and Bats, including wasm). The run used a command-local shell PATH correction so the pinned usage 6.5.0 was selected instead of an old Homebrew binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to verification warning text and documentation; comparison logic for artifacts is unchanged and new behavior is covered by unit tests.
> 
> **Overview**
> Shadow verification warnings are now **actionable and distinct per compilation** instead of collapsing into one deduplicated message when many units disagree the same way.
> 
> **rustc** and **cc** adapters route divergence reporting through shared helpers in `materialize`: `verification_warning` embeds adapter, unit name, and action digest hash before the detail so session warning dedup cannot merge different compilations; `stream_divergence` replaces generic “stdout/stderr differs” with the first differing byte offset, line number, and bounded ASCII-escaped excerpts for cached vs shadow output. Artifact file checks and verification counting behavior are unchanged.
> 
> **Docs** for verify mode clarify that verified counts include divergent runs, Cargo must actually re-invoke compilers (fresh target dir), and cross-worktree audits can use a consistent `--remap-path-prefix` with dedicated target directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74edc2262a32c1fef446df6b0de661fc65eec0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved verification warnings to identify the affected adapter, compilation, action, and first differing output.
  - Standard-output and standard-error mismatches now include the stream, location, and relevant content excerpts instead of generic messages.
  - Diagnostics handle binary data and end-of-file differences more clearly.

- **Documentation**
  - Updated Verify mode guidance to explain divergent compilation counts, diagnostic details, path rewriting, and cross-worktree audit procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->