### PR TITLE
fix(cc): report publication failures and require valid snapshots

### DIFF
--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -137,18 +137,18 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
             }
         };
         if let Some(cached) = restored {
+            record_prediction(
+                &task,
+                &invocation_digest,
+                &action.digest,
+                &prediction,
+                None,
+                None,
+            );
             if !verify {
                 write_caller_depfile(
                     &invocation,
                     discovered.files().map(|input| input.path.as_path()),
-                );
-                record_prediction(
-                    &task,
-                    &invocation_digest,
-                    &action.digest,
-                    &prediction,
-                    None,
-                    None,
                 );
                 replay_bytes(&cached.stdout, &cached.stderr)?;
                 record_action_hit(
@@ -316,6 +316,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         duration_ns,
     );
 
+    let verified = verification.is_some();
     if let Some(cached) = verification {
         let divergence = verification_divergence(&cached, &output);
         record_verification(divergence.is_none(), cached.restore);
@@ -333,23 +334,27 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     if !output.status.success() {
         return Ok(exit_code(output.status));
     }
+    // Shadow verification audits an existing result; it must not try to
+    // replace it with the fresh result, especially when they differ.
     // A failure to publish must not fail a compilation that already succeeded.
-    if let Err(error) = publish(
-        &invocation,
-        &mut context,
-        &depfile,
-        &output,
-        compilation_started,
-        &input_snapshots,
-        &task,
-        &invocation_digest,
-        duration_ns,
-        &searchable,
-        before,
-        flight.as_ref(),
-        remote_claim.as_deref(),
-        &portable,
-    ) {
+    if !verified
+        && let Err(error) = publish(
+            &invocation,
+            &mut context,
+            &depfile,
+            &output,
+            compilation_started,
+            &input_snapshots,
+            &task,
+            &invocation_digest,
+            duration_ns,
+            &searchable,
+            before,
+            flight.as_ref(),
+            remote_claim.as_deref(),
+            &portable,
+        )
+    {
         session::report_cc_publication_failure(&compilation_name(&invocation), &error);
     }
     // Owed whether or not the object was published: the build that asked for

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -281,7 +281,8 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     // computed afterwards, and comparing the two is what stops a header that
     // appeared mid-compile from being recorded as one the compiler had seen.
     let searchable = searchable_directories(&invocation, &working_dir);
-    let before = manifest_snapshot(&searchable).ok();
+    let before =
+        crate::phase_timing::measure("include_scan", || manifest_snapshot(&searchable)).ok();
     // The machine-wide permit is taken after every chance to hit the cache,
     // and the timer starts afterwards: time spent waiting for the machine is
     // not time this compilation cost.
@@ -347,10 +348,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
         remote_claim.as_deref(),
         &portable,
     ) {
-        #[cfg(debug_assertions)]
-        session::report_shim_warning(&format!("cc result was not published: {error:#}"));
-        #[cfg(not(debug_assertions))]
-        let _ = error;
+        session::report_cc_publication_failure(&compilation_name(&invocation), &error);
     }
     // Owed whether or not the object was published: the build that asked for
     // the list reads it next. Written after publication, because the list
@@ -389,6 +387,7 @@ fn publish(
     remote_claim: Option<&str>,
     portable: &Portable,
 ) -> Result<()> {
+    let _phase = crate::phase_timing::phase("store");
     let input_snapshots = input_snapshots
         .as_ref()
         .map_err(|error| eyre::eyre!(error.to_string()))?;
@@ -707,7 +706,7 @@ fn verify_search_path_unchanged(
     let Some(before) = before else {
         return Ok(());
     };
-    let after = manifest_snapshot(searchable)?;
+    let after = crate::phase_timing::measure("include_scan", || manifest_snapshot(searchable))?;
     for (directory, digest) in &before {
         if after.get(directory) != Some(digest) {
             return Err(

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -281,8 +281,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     // computed afterwards, and comparing the two is what stops a header that
     // appeared mid-compile from being recorded as one the compiler had seen.
     let searchable = searchable_directories(&invocation, &working_dir);
-    let before =
-        crate::phase_timing::measure("include_scan", || manifest_snapshot(&searchable)).ok();
+    let before = crate::phase_timing::measure("include_scan", || manifest_snapshot(&searchable));
     // The machine-wide permit is taken after every chance to hit the cache,
     // and the timer starts afterwards: time spent waiting for the machine is
     // not time this compilation cost.
@@ -385,7 +384,7 @@ fn publish(
     invocation_digest: &CacheDigest,
     duration_ns: u64,
     searchable: &BTreeSet<PathBuf>,
-    before: Option<BTreeMap<PathBuf, CacheDigest>>,
+    before: Result<BTreeMap<PathBuf, CacheDigest>, CcBypassReason>,
     flight: Option<&crate::scheduler::Flight>,
     remote_claim: Option<&str>,
     portable: &Portable,
@@ -702,13 +701,11 @@ fn searchable_directories(invocation: &CcInvocation, working_dir: &Path) -> BTre
 /// Reject a compilation whose include search path shifted underneath it.
 fn verify_search_path_unchanged(
     searchable: &BTreeSet<PathBuf>,
-    before: Option<BTreeMap<PathBuf, CacheDigest>>,
+    before: Result<BTreeMap<PathBuf, CacheDigest>, CcBypassReason>,
 ) -> Result<()> {
-    // A snapshot that could not be taken is not evidence of a change; the
-    // directory walk failing is already reported when discovery repeats it.
-    let Some(before) = before else {
-        return Ok(());
-    };
+    // A later successful walk cannot establish what the compiler saw when
+    // the pre-compilation snapshot failed. Compile normally, but do not cache.
+    let before = before?;
     let after = crate::phase_timing::measure("include_scan", || manifest_snapshot(searchable))?;
     for (directory, digest) in &before {
         if after.get(directory) != Some(digest) {

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -266,3 +266,33 @@ fn duplicate_portable_paths_do_not_change_compiler_arguments() {
         assert_eq!(repeated.values, unique.values);
     }
 }
+
+#[test]
+fn a_failed_before_snapshot_cannot_be_replaced_by_a_successful_later_walk() {
+    let root = tempfile::tempdir().unwrap();
+    let include = root.path().join("include");
+    // A file where an include directory should be makes the first walk fail.
+    std::fs::write(&include, b"not a directory").unwrap();
+    let searchable = BTreeSet::from([include.clone()]);
+    let before = manifest_snapshot(&searchable);
+    assert!(before.is_err());
+    std::fs::remove_file(&include).unwrap();
+    std::fs::create_dir(&include).unwrap();
+    assert!(manifest_snapshot(&searchable).is_ok());
+    assert!(verify_search_path_unchanged(&searchable, before).is_err());
+}
+
+#[test]
+fn successful_before_snapshots_still_detect_new_headers() {
+    let root = tempfile::tempdir().unwrap();
+    let searchable = BTreeSet::from([root.path().to_path_buf()]);
+    let before = manifest_snapshot(&searchable);
+    verify_search_path_unchanged(&searchable, before).unwrap();
+    let before = manifest_snapshot(&searchable);
+    std::fs::write(root.path().join("new.h"), b"header").unwrap();
+    let error = verify_search_path_unchanged(&searchable, before).unwrap_err();
+    assert!(matches!(
+        error.downcast_ref::<CcBypassReason>(),
+        Some(CcBypassReason::SearchPathModifiedDuringCompilation(_))
+    ));
+}

--- a/crates/mbx/src/materialize.rs
+++ b/crates/mbx/src/materialize.rs
@@ -279,8 +279,9 @@ pub(crate) fn verification_warning(
     divergence: &str,
 ) -> String {
     format!(
-        "shadow verification diverged from cached output: {adapter} action {} ({unit}): {divergence}",
-        action.hash
+        "shadow verification diverged from cached output: {adapter} action {} ({}): {divergence}",
+        action.hash,
+        unit.escape_default()
     )
 }
 
@@ -570,6 +571,19 @@ mod verification_tests {
         assert!(difference.contains(r"\x1b\x00\xff\n"), "{difference}");
         assert!(!difference.contains(['\n', '\0', '\x1b']));
         assert!(difference.len() < 512, "{difference}");
+    }
+
+    #[test]
+    fn verification_unit_names_escape_terminal_controls() {
+        let warning = verification_warning(
+            "cc",
+            "cc:bad\x1b[2J\n\0.c",
+            &CacheDigest::blake3(b"action"),
+            "standard error differs",
+        );
+        assert!(!warning.chars().any(char::is_control), "{warning:?}");
+        assert!(warning.contains(r"cc:bad\u{1b}[2J\n\u{0}.c"), "{warning}");
+        assert!(warning.ends_with("standard error differs"));
     }
 
     #[test]

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1783,6 +1783,26 @@ fn record_cc_bypass(error: &eyre::Report) {
     let _ = request_agent(&[AgentRequest::RecordBypass { kind }, diagnostic]);
 }
 
+/// A compiler succeeded but its result could not be cached. Do not count a
+/// second outcome: this invocation already recorded its compilation outcome.
+pub(crate) fn report_cc_publication_failure(unit: &str, error: &eyre::Report) {
+    let reason = error.downcast_ref::<mbx_cache_cc::CcBypassReason>();
+    let kind = reason.map_or_else(
+        || "cc-other".to_string(),
+        |reason| format!("cc-{}", reason.kind()),
+    );
+    append_bypass_log(
+        &kind,
+        error,
+        reason.and_then(mbx_cache_cc::CcBypassReason::remediation),
+    );
+    let diagnostic = bypass_diagnostic(
+        expected_cc_bypass(reason),
+        &format!("cc result was not published for {unit}: {error:#}"),
+    );
+    let _ = request_agent(&[diagnostic]);
+}
+
 /// Only known routine decisions are downgraded: adapter errors also include
 /// failed reads and invalid state, which must retain warning severity.
 fn expected_rustc_bypass(reason: Option<&mbx_cache_rustc::BypassReason>) -> bool {

--- a/crates/mbx/src/session.rs
+++ b/crates/mbx/src/session.rs
@@ -1748,6 +1748,7 @@ fn record_bypass(error: &eyre::Report) {
     let reason = error.downcast_ref::<mbx_cache_rustc::BypassReason>();
     let kind = reason.map_or("other", mbx_cache_rustc::BypassReason::kind);
     append_bypass_log(
+        None,
         kind,
         error,
         reason.and_then(mbx_cache_rustc::BypassReason::remediation),
@@ -1771,6 +1772,7 @@ fn record_cc_bypass(error: &eyre::Report) {
         |reason| format!("cc-{}", reason.kind()),
     );
     append_bypass_log(
+        None,
         &kind,
         error,
         reason.and_then(mbx_cache_cc::CcBypassReason::remediation),
@@ -1792,13 +1794,17 @@ pub(crate) fn report_cc_publication_failure(unit: &str, error: &eyre::Report) {
         |reason| format!("cc-{}", reason.kind()),
     );
     append_bypass_log(
+        Some(unit),
         &kind,
         error,
         reason.and_then(mbx_cache_cc::CcBypassReason::remediation),
     );
     let diagnostic = bypass_diagnostic(
         expected_cc_bypass(reason),
-        &format!("cc result was not published for {unit}: {error:#}"),
+        &format!(
+            "cc result was not published for {}: {error:#}",
+            unit.escape_default()
+        ),
     );
     let _ = request_agent(&[diagnostic]);
 }
@@ -1853,6 +1859,7 @@ fn expected_cc_bypass(reason: Option<&mbx_cache_cc::CcBypassReason>) -> bool {
                 | ToolPassthrough(_)
                 | Plugin(_)
                 | UnportableOutput(_)
+                | SearchPathModifiedDuringCompilation(_)
                 | LocalCpuTarget(_)
                 | UnsupportedCompilerDriver(_)
                 | UnsupportedEnvironment(_)
@@ -1948,7 +1955,12 @@ pub(crate) fn action_diagnostic_request(
 /// or path caused each one. It exists because stderr cannot be relied on:
 /// cargo swallows the output of its own probe invocations, so some bypasses are
 /// invisible there.
-fn append_bypass_log(kind: &str, error: &eyre::Report, remediation: Option<&str>) {
+fn append_bypass_log(
+    unit: Option<&str>,
+    kind: &str,
+    error: &eyre::Report,
+    remediation: Option<&str>,
+) {
     let Some(path) = std::env::var_os(BYPASS_LOG_ENV).filter(|path| !path.is_empty()) else {
         return;
     };
@@ -1957,7 +1969,10 @@ fn append_bypass_log(kind: &str, error: &eyre::Report, remediation: Option<&str>
     // Records are a single short line for that reason: a write the kernel had
     // to break up could still interleave, and nothing here can prevent it.
     let suffix = remediation.map_or_else(String::new, |text| format!("\t{text}"));
-    let line = format!("{kind}\t{error:#}{suffix}\n");
+    let unit = unit.map_or_else(String::new, |unit| {
+        format!("\tunit={}", unit.escape_default())
+    });
+    let line = format!("{kind}\t{error:#}{suffix}{unit}\n");
     if let Err(problem) = append_line(&path, &line) {
         // Say so once. This runs per compilation and a destination that cannot
         // be written now will fail for every later record too, so warning each

--- a/crates/mbx/src/session_tests.rs
+++ b/crates/mbx/src/session_tests.rs
@@ -1342,6 +1342,9 @@ fn routine_bypasses_are_debug_but_failed_cache_paths_are_warnings() {
     )));
     assert!(!super::expected_rustc_bypass(None));
     assert!(!super::expected_cc_bypass(None));
+    assert!(super::expected_cc_bypass(Some(
+        &mbx_cache_cc::CcBypassReason::SearchPathModifiedDuringCompilation("include".into())
+    )));
     assert!(
         matches!(super::bypass_diagnostic(true, "routine"), AgentRequest::RecordDebug { target, .. } if target == "mbx::session")
     );

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -3728,6 +3728,7 @@ fn cc_publication_failures_are_visible_without_counting_a_second_outcome() {
         );
         let log = std::fs::read_to_string(log).unwrap();
         assert!(log.contains("input expands a timestamp macro:"), "{log}");
+        assert!(log.contains("unit=cc:hello.c"), "{log}");
         assert!(
             stats["bypasses"]
                 .get("cc-embedded-timestamp-macro")

--- a/crates/mbx/tests/build.rs
+++ b/crates/mbx/tests/build.rs
@@ -3682,3 +3682,64 @@ fn routine_shim_logs_stay_off_compiler_stderr_when_delivery_fails() {
     assert_eq!(output.stdout, b"compiler stdout\n");
     assert_eq!(output.stderr, b"compiler stderr\n");
 }
+
+/// Publication can refuse a successful compile. The reason must remain
+/// available in release builds without contaminating the compiler's stderr.
+#[cfg(unix)]
+#[test]
+fn cc_publication_failures_are_visible_without_counting_a_second_outcome() {
+    if !has_c_compiler() {
+        return;
+    }
+    for (filter, visible) in [("off", false), ("debug", true)] {
+        let project = tempfile::tempdir().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        let reports = tempfile::tempdir().unwrap();
+        write_c_project(project.path());
+        std::fs::write(
+            project.path().join("src/hello.c"),
+            "const char *build_date(void) { return __DATE__; }\n",
+        )
+        .unwrap();
+        let script = project.path().join("build.rs");
+        let source = std::fs::read_to_string(&script).unwrap()
+            .replace(".status()", ".output()")
+            .replace("status.success()", "status.status.success()")
+            .replace("// The tests disable", "assert!(status.stderr.is_empty(), \"compiler stderr was polluted: {:?}\", status.stderr);\n    // The tests disable");
+        std::fs::write(script, source).unwrap();
+        let log = reports.path().join("bypass.log");
+        let (stats, stderr) = build_with(
+            project.path(),
+            store.path(),
+            &reports.path().join("stats.json"),
+            &[
+                ("MBX_LOG", filter),
+                ("MBX_BYPASS_LOG", log.to_str().unwrap()),
+            ],
+        );
+        let diagnostics: Vec<_> = stderr
+            .lines()
+            .filter(|line| line.contains("cc result was not published for cc:hello.c"))
+            .collect();
+        assert_eq!(!diagnostics.is_empty(), visible, "{stderr}");
+        assert!(
+            diagnostics.iter().all(|line| line.contains("DEBUG")),
+            "{stderr}"
+        );
+        let log = std::fs::read_to_string(log).unwrap();
+        assert!(log.contains("input expands a timestamp macro:"), "{log}");
+        assert!(
+            stats["bypasses"]
+                .get("cc-embedded-timestamp-macro")
+                .is_none(),
+            "publication must not double-count the compilation: {stats}"
+        );
+        assert!(
+            stats["wrapper_phases_ns"]["include_scan"]
+                .as_u64()
+                .unwrap_or(0)
+                > 0,
+            "{stats}"
+        );
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -23,13 +23,17 @@ run_windows = "./target/mbx-bootstrap/mbx.exe build --workspace --all-targets"
 [tasks.test]
 alias = "t"
 description = "Run Rust and behavioral tests"
-depends = ["test:cargo", "test:e2e"]
+depends = ["test:cargo", "test:e2e", "test:release-diagnostics"]
 
 [tasks."test:cargo"]
 description = "Run Rust tests"
 depends = ["bootstrap"]
 run = "./target/mbx-bootstrap/mbx test --workspace"
 run_windows = "./target/mbx-bootstrap/mbx.exe test --workspace"
+
+[tasks."test:release-diagnostics"]
+description = "Check publication diagnostics in the release-built wrapper"
+run = "cargo test --release -p mbx --test build cc_publication_failures_are_visible_without_counting_a_second_outcome"
 
 [tasks."test:e2e"]
 description = "Run platform behavioral tests"

--- a/test/cc_standalone_exec.bats
+++ b/test/cc_standalone_exec.bats
@@ -272,3 +272,45 @@ SOURCE
   run cmp "$project/expected.ii" "$project/result.ii"
   assert_success
 }
+
+@test "a divergent C verification preserves its cached result and writes caller dependencies" {
+  local project="$BATS_TEST_TMPDIR/verify-stream"
+  local compiler="$BATS_TEST_TMPDIR/compiler"
+  local real_cc
+  real_cc="$(command -v cc)"
+  write_project "$project"
+  mkdir -p "$compiler"
+  cat >"$compiler/cc" <<'SCRIPT'
+#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = -c ]; then
+    echo "$MBX_TEST_CC_MESSAGE" >&2
+    break
+  fi
+done
+exec "$MBX_TEST_REAL_CC" "$@"
+SCRIPT
+  chmod +x "$compiler/cc"
+  export MBX_TEST_REAL_CC="$real_cc"
+  export PATH="$compiler:$PATH"
+  cd "$project"
+  run env MBX_TEST_CC_MESSAGE=cached "$MBX_BIN" exec make 'CFLAGS=-O2 -Iinclude -MMD -MF hello.d' hello.o
+  assert_success
+  rm hello.o hello.d
+  run env MBX_CACHE_EXPORT_GROUP=verify-audit MBX_TEST_CC_MESSAGE=verified MBX_VERIFY=1 "$MBX_BIN" exec make 'CFLAGS=-O2 -Iinclude -MMD -MF hello.d' hello.o
+  assert_success
+  assert_output --partial 'shadow verification diverged'
+  refute_output --partial 'result was not published'
+  run "$MBX_BIN" cache export --group verify-audit "$BATS_TEST_TMPDIR/audit.tar"
+  assert_success
+  assert_output --partial "exported 1 actions"
+  assert_file_exists "$BATS_TEST_TMPDIR/audit.tar"
+  assert_file_exists hello.d
+  rm hello.o hello.d
+  run env MBX_TEST_CC_MESSAGE=unused "$MBX_BIN" exec make 'CFLAGS=-O2 -Iinclude -MMD -MF hello.d' hello.o
+  assert_success
+  assert_line 'cached'
+  refute_line 'unused'
+  refute_line 'verified'
+  assert_file_exists hello.d
+}


### PR DESCRIPTION
C compilations can succeed while cache publication is refused. Release builds currently hide those failures, and a failed pre-compile include snapshot is discarded, allowing publication without establishing the directory state seen by the compiler.

Report publication failures with the C unit and reason through session diagnostics and `MBX_BYPASS_LOG`, without counting a second compilation outcome or contaminating compiler stderr. Preserve failed snapshots and refuse publication when the pre-compile state cannot be established. Attribute publication work to `store` and directory snapshots to `include_scan`; keep expected refusals at debug severity.

Shadow verification now records the audited prediction and preserves the cached result instead of trying to republish the fresh output. A differing compiler diagnostic therefore produces the verification warning without a second conflicting-result publication warning. The caller's dependency file is still written. Unit names are escaped in verification and publication diagnostics.

Validation: `mise run ci` passes, including release-built publication diagnostics and the Bats regression for divergent C verification, dependency output, retained cached stderr, and grouped export of the audited action. The verification regression reproduces the extra publication warning with the previous binary.

Addresses diagnostics and verification follow-ups in https://github.com/jdx/mr-boxington/discussions/418 and https://github.com/jdx/mr-boxington/discussions/419. The Xcode-beta SDK root fix is separate in #425; this PR supplies the diagnostics used to identify it.
