### PR TITLE
fix(cc): cache objects that retain literal paths

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -573,6 +573,31 @@ fn equivalent_worktrees_produce_the_same_portable_action_key() {
     assert_eq!(build("one"), build("two"));
 }
 
+#[test]
+fn path_specific_actions_bind_checkout_target_and_source_spelling() {
+    let build = |checkout_name: &str, target_name: &str, source: &str, bound: bool| {
+        let (workspace, _) = checkout(checkout_name);
+        let invocation = CcInvocation::parse(&argv(&["-c", "-o", "out.o", source])).unwrap();
+        let mut context = context(&workspace, &workspace.join(target_name));
+        context.inputs.push(CcActionInput {
+            path: workspace.join("src/a.c"),
+            digest: digest_of("source"),
+        });
+        invocation
+            .action_with_path_binding(context, bound)
+            .unwrap()
+            .digest
+    };
+    let portable = build("one", "target", "src/a.c", false);
+    assert_eq!(portable, build("two", "other-target", "./src/a.c", false));
+    let bound = build("one", "target", "src/a.c", true);
+    assert_ne!(bound, portable);
+    assert_eq!(bound, build("one", "target", "src/a.c", true));
+    assert_ne!(bound, build("two", "target", "src/a.c", true));
+    assert_ne!(bound, build("one", "other-target", "src/a.c", true));
+    assert_ne!(bound, build("one", "target", "./src/a.c", true));
+}
+
 #[cfg(unix)]
 #[test]
 fn action_path_aliases_are_equivalent_and_refreshed_between_actions() {
@@ -892,6 +917,7 @@ fn predicted_system_paths_only_denormalize_under_admitted_roots() {
 #[test]
 fn a_prediction_from_a_future_schema_bypasses() {
     let prediction = CcInputPrediction {
+        path_specific: false,
         version: 2,
         inputs: Vec::new(),
         environment: Vec::new(),

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -678,6 +678,8 @@ struct CcInputDescriptor {
 
 #[derive(Debug, Serialize)]
 struct CcActionDescriptor {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path_binding: Option<CcPathBinding>,
     version: u8,
     kind: &'static str,
     adapter_version: u8,
@@ -714,11 +716,22 @@ struct PreprocessingContext {
     roots: BTreeMap<String, PathBuf>,
 }
 
+/// Literal path spellings retained by an object, unlike portable debug paths.
+#[derive(Debug, Serialize)]
+struct CcPathBinding {
+    working_dir: PathBuf,
+    arguments: Vec<Argument>,
+    roots: BTreeMap<String, PathBuf>,
+}
+
 /// Normalized input names from the last successful execution of one modeled
 /// compile.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CcInputPrediction {
+    /// The output retained literal paths and requires a path-specific action key.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub path_specific: bool,
     /// Prediction schema version.
     pub version: u8,
     /// Normalized input paths, including include-manifest entries.
@@ -739,7 +752,7 @@ fn is_zero(value: &u64) -> bool {
 }
 
 /// One parsed and admitted argument.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 enum Argument {
     /// Keyed verbatim.
     Plain(String),
@@ -970,7 +983,17 @@ impl CcInvocation {
     /// Build the canonical action for this invocation and its discovered
     /// inputs.
     pub fn action(&self, context: CcActionContext) -> Result<CcAction, CcBypassReason> {
-        ActionBuilder::new(self, context).build()
+        self.action_with_path_binding(context, false)
+    }
+
+    /// Build an action tied to literal path spellings when the output retained them.
+    /// Portable actions keep their existing keys.
+    pub fn action_with_path_binding(
+        &self,
+        context: CcActionContext,
+        path_specific: bool,
+    ) -> Result<CcAction, CcBypassReason> {
+        ActionBuilder::new(self, context).build(path_specific)
     }
 
     /// Record the normalized inputs of a successful compile so the next cold
@@ -989,6 +1012,7 @@ impl CcInvocation {
         inputs.sort();
         inputs.dedup();
         Ok(CcInputPrediction {
+            path_specific: false,
             version: 1,
             inputs,
             environment: context.environment.keys().cloned().collect(),
@@ -1220,7 +1244,7 @@ impl<'a> ActionBuilder<'a> {
         }
     }
 
-    fn build(self) -> Result<CcAction, CcBypassReason> {
+    fn build(self, path_specific: bool) -> Result<CcAction, CcBypassReason> {
         self.validate_mappings()?;
         let invocation = self.invocation_descriptor()?;
 
@@ -1251,6 +1275,16 @@ impl<'a> ActionBuilder<'a> {
             .map(|(path, digest)| CcInputDescriptor { path, digest })
             .collect();
         let descriptor = CcActionDescriptor {
+            path_binding: path_specific.then(|| CcPathBinding {
+                working_dir: self.context.working_dir.clone(),
+                arguments: self.invocation.arguments.clone(),
+                roots: self
+                    .context
+                    .path_mappings
+                    .iter()
+                    .map(|mapping| (mapping.placeholder.clone(), mapping.root.clone()))
+                    .collect(),
+            }),
             version: ACTION_SCHEMA_VERSION,
             kind: "cc",
             adapter_version: ADAPTER_VERSION,

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -662,10 +662,17 @@ impl Portable {
             return false;
         };
         !values.iter().any(|value| {
-            memchr::memmem::find(&contents, value.as_bytes()).is_some()
-                || (value.contains('\\')
-                    && memchr::memmem::find(&contents, value.replace('\\', "/").as_bytes())
-                        .is_some())
+            let slashes = value.replace('\\', "/");
+            // Windows canonicalization returns verbatim paths, while compiler
+            // strings usually use ordinary drive or UNC spellings.
+            let plain = if let Some(unc) = slashes.strip_prefix("//?/UNC/") {
+                format!("//{unc}")
+            } else {
+                slashes.strip_prefix("//?/").unwrap_or(&slashes).to_owned()
+            };
+            [value.as_str(), &slashes, &plain, &plain.replace('/', "\\")]
+                .iter()
+                .any(|spelling| memchr::memmem::find(&contents, spelling.as_bytes()).is_some())
         })
     }
 }

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -116,7 +116,9 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     if let Some((prediction, discovered)) = usable {
         let mut candidate = context.clone();
         discovered.clone().apply_to(&mut candidate)?;
-        let action = crate::phase_timing::measure("key", || invocation.action(candidate))?;
+        let action = crate::phase_timing::measure("key", || {
+            invocation.action_with_path_binding(candidate, prediction.path_specific)
+        })?;
         looked_up = true;
         // A restore that fails is a miss, not a bypass. Bypassing would leave
         // the compilation uncached and publish nothing, so a partial or corrupt
@@ -403,20 +405,17 @@ fn publish(
     verify_search_path_unchanged(searchable, before)?;
     discovered.verify()?;
     discovered.apply_to(context)?;
-    // The key says this object does not depend on where the build script put
-    // its headers. Publishing one that names the directory anyway would make
-    // that claim false for every checkout that restored it, so a compilation
-    // whose output kept the value is left uncached rather than shared wrong.
+    // Debug remapping does not change runtime strings such as __FILE__. If
+    // an object retains a path, bind its action to the literal paths instead
+    // of discarding it or restoring another checkout's runtime strings.
     // Addressed absolutely from here on: `-o` may be relative to the compiler's
     // working directory, and the cache agent that stores the object does not
     // share it. OpenSSL's makefiles compile every object that way.
     let object = invocation.output_in(&context.working_dir);
-    if !portable.outputs_are_clean(&object) {
-        return Err(CcBypassReason::UnportableOutput(object).into());
-    }
-    let action = invocation.action(context.clone())?;
+    let mut prediction = invocation.prediction(context, duration_ns)?;
+    prediction.path_specific = !portable.outputs_are_clean(&object);
+    let action = invocation.action_with_path_binding(context.clone(), prediction.path_specific)?;
     publish_result(&action, &object, output, &context.path_mappings)?;
-    let prediction = invocation.prediction(context, duration_ns)?;
     record_prediction(
         task,
         invocation_digest,
@@ -453,7 +452,9 @@ fn restore_flight_prediction(
     )?;
     let mut candidate = context.clone();
     discovered.clone().apply_to(&mut candidate)?;
-    let action = crate::phase_timing::measure("key", || invocation.action(candidate))?;
+    let action = crate::phase_timing::measure("key", || {
+        invocation.action_with_path_binding(candidate, prediction.path_specific)
+    })?;
     if recorded_action.is_some_and(|recorded| recorded != &action.digest) {
         bail!("the action promise no longer matches its predicted inputs");
     }

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -36,6 +36,9 @@ use std::process::{Command, ExitCode, Output};
 use std::time::{Instant, SystemTime};
 
 const ADAPTER: &str = "cc";
+// Keep the extended prediction payload out of older shims' manifests and
+// flights. They reject unknown fields before checking the payload version.
+const PREDICTION_ADAPTER: &str = "cc-path-binding-v1";
 
 /// Compile one C or C++ translation unit, consulting the cache around it.
 ///
@@ -87,7 +90,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     };
 
     drop(setup);
-    let invocation_digest = invocation.invocation_digest(&context)?;
+    let invocation_digest = prediction_invocation(&invocation.invocation_digest(&context)?);
     let _verification = session::verification::select(|| Ok(invocation_digest.clone()))?;
     let verify = session::verify_requested();
     let task = prediction_task(&invocation_digest);
@@ -173,7 +176,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let flight = if verify {
         None
     } else {
-        crate::scheduler::flight(ADAPTER, &invocation_digest.hash)
+        crate::scheduler::flight(PREDICTION_ADAPTER, &invocation_digest.hash)
     };
     if let Some(flight) = &flight
         // Only when the payload can say something this session's own lookup
@@ -212,7 +215,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
     let mut remote_claim = None;
     if flight.is_some() {
         match session::request_agent(&[AgentRequest::JoinActionPromise {
-            adapter: ADAPTER.into(),
+            adapter: PREDICTION_ADAPTER.into(),
             invocation: invocation_digest.clone(),
         }]) {
             Ok(responses) => match responses.into_iter().next() {
@@ -223,7 +226,7 @@ pub fn compile(compiler: &OsStr, arguments: &[OsString], language: CcLanguage) -
                 Some(AgentResponse::ActionPromise {
                     claim: None,
                     prediction: Some(prediction),
-                }) if prediction.adapter == ADAPTER
+                }) if prediction.adapter == PREDICTION_ADAPTER
                     && prediction.invocation == invocation_digest =>
                 {
                     match restore_flight_prediction(
@@ -413,7 +416,7 @@ fn publish(
     // share it. OpenSSL's makefiles compile every object that way.
     let object = invocation.output_in(&context.working_dir);
     let mut prediction = invocation.prediction(context, duration_ns)?;
-    prediction.path_specific = !portable.outputs_are_clean(&object);
+    prediction.path_specific = !portable.outputs_are_clean(&object, &context.path_mappings);
     let action = invocation.action_with_path_binding(context.clone(), prediction.path_specific)?;
     publish_result(&action, &object, output, &context.path_mappings)?;
     record_prediction(
@@ -633,15 +636,32 @@ impl Portable {
     }
 
     /// Whether an output is free of every value the flags normalized away.
-    fn outputs_are_clean(&self, path: &Path) -> bool {
-        if self.values.is_empty() {
+    fn outputs_are_clean(&self, path: &Path, mappings: &[PathMapping]) -> bool {
+        // Keys normalize every mapped root, even when no debug-prefix flag
+        // was injected for it (for example a generated source under target).
+        // Check both logical and canonical spellings, as the key builder does.
+        let values = self
+            .values
+            .iter()
+            .cloned()
+            .chain(mappings.iter().flat_map(|mapping| {
+                [
+                    Some(mapping.root.clone()),
+                    std::fs::canonicalize(&mapping.root).ok(),
+                ]
+                .into_iter()
+                .flatten()
+                .filter_map(|path| path.to_str().map(str::to_owned))
+            }))
+            .collect::<BTreeSet<_>>();
+        if values.is_empty() {
             return true;
         }
         let Ok(contents) = std::fs::read(path) else {
             // Unreadable is not evidence of cleanliness.
             return false;
         };
-        !self.values.iter().any(|value| {
+        !values.iter().any(|value| {
             memchr::memmem::find(&contents, value.as_bytes()).is_some()
                 || (value.contains('\\')
                     && memchr::memmem::find(&contents, value.replace('\\', "/").as_bytes())
@@ -993,6 +1013,11 @@ fn probe_executable(executable: &Path, arguments: &[&str], memo: &Path) -> Resul
     Ok(text)
 }
 
+/// Separate extended predictions from legacy manifests and flight identities.
+fn prediction_invocation(invocation: &CacheDigest) -> CacheDigest {
+    CacheDigest::blake3(format!("{PREDICTION_ADAPTER}\0{}", invocation.hash).as_bytes())
+}
+
 fn find_prediction(task: &str, invocation: &CacheDigest) -> Result<Option<CcInputPrediction>> {
     let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
         task: task.to_string(),
@@ -1004,7 +1029,7 @@ fn find_prediction(task: &str, invocation: &CacheDigest) -> Result<Option<CcInpu
     let Some(prediction) = prediction else {
         return Ok(None);
     };
-    if prediction.adapter != ADAPTER {
+    if prediction.adapter != PREDICTION_ADAPTER {
         return Ok(None);
     }
     let payload: CcInputPrediction = serde_json::from_str(&prediction.payload)?;
@@ -1030,7 +1055,7 @@ fn record_prediction(
     let wire_prediction = ActionPrediction {
         invocation: invocation.clone(),
         action: action.clone(),
-        adapter: ADAPTER.into(),
+        adapter: PREDICTION_ADAPTER.into(),
         payload,
     };
     // Best-effort like the rest of publication, but not silent in a debug

--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -651,7 +651,7 @@ impl Portable {
                 ]
                 .into_iter()
                 .flatten()
-                .filter_map(|path| path.to_str().map(str::to_owned))
+                .flat_map(mapping_root_spellings)
             }))
             .collect::<BTreeSet<_>>();
         if values.is_empty() {
@@ -675,6 +675,28 @@ impl Portable {
                 .any(|spelling| memchr::memmem::find(&contents, spelling.as_bytes()).is_some())
         })
     }
+}
+
+/// Include the logical spellings of macOS's system directory aliases only
+/// when they resolve to the same root. Canonicalization alone loses them.
+fn mapping_root_spellings(path: PathBuf) -> Vec<String> {
+    let mut spellings = Vec::new();
+    if let Some(value) = path.to_str() {
+        spellings.push(value.to_owned());
+    }
+    #[cfg(target_os = "macos")]
+    if let Ok(relative) = path.strip_prefix("/private") {
+        let logical = Path::new("/").join(relative);
+        if let (Ok(physical), Ok(alias)) = (
+            std::fs::canonicalize(&path),
+            std::fs::canonicalize(&logical),
+        ) && physical == alias
+            && let Some(value) = logical.to_str()
+        {
+            spellings.push(value.to_owned());
+        }
+    }
+    spellings
 }
 
 /// The environment values a C or C++ compilation may be made independent of.

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -221,16 +221,16 @@ fn a_portable_compilation_remaps_its_paths_and_refuses_an_output_that_kept_one()
 
     let clean = directory.path().join("clean.o");
     std::fs::write(&clean, b"nothing here names a checkout").unwrap();
-    assert!(portable.outputs_are_clean(&clean));
+    assert!(portable.outputs_are_clean(&clean, &[]));
 
     // A path the source kept as a string survives the remap, and an object
     // carrying one must not be published under a key that normalized it.
     let dirty = directory.path().join("dirty.o");
     std::fs::write(&dirty, format!("built in {out_dir} and says so").as_bytes()).unwrap();
-    assert!(!portable.outputs_are_clean(&dirty));
+    assert!(!portable.outputs_are_clean(&dirty, &[]));
 
     // An unreadable output is not evidence of cleanliness.
-    assert!(!portable.outputs_are_clean(&directory.path().join("absent.o")));
+    assert!(!portable.outputs_are_clean(&directory.path().join("absent.o"), &[]));
 
     // With nothing remapped there is nothing to promise, and every output
     // passes -- which is what a build with OUT_DIR sharing off looks like.
@@ -238,7 +238,7 @@ fn a_portable_compilation_remaps_its_paths_and_refuses_an_output_that_kept_one()
         arguments: Vec::new(),
         values: Vec::new(),
     };
-    assert!(inert.outputs_are_clean(&dirty));
+    assert!(inert.outputs_are_clean(&dirty, &[]));
     assert!(matches!(inert.applied_to(&arguments), Cow::Borrowed(_)));
 }
 
@@ -295,4 +295,30 @@ fn successful_before_snapshots_still_detect_new_headers() {
         error.downcast_ref::<CcBypassReason>(),
         Some(CcBypassReason::SearchPathModifiedDuringCompilation(_))
     ));
+}
+
+/// Extended wire payloads must never replace a legacy prediction or flight.
+#[test]
+fn path_prediction_identity_is_separate_from_legacy() {
+    let legacy = CacheDigest::blake3(b"invocation");
+    let current = prediction_invocation(&legacy);
+    assert_ne!(legacy, current);
+    assert_eq!(current, prediction_invocation(&legacy));
+    assert_ne!(ADAPTER, PREDICTION_ADAPTER);
+}
+
+/// Generated sources can retain a target root without any injected prefix map.
+#[test]
+fn output_scan_covers_roots_without_debug_remaps() {
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("target");
+    std::fs::create_dir(&target).unwrap();
+    let object = directory.path().join("object.o");
+    std::fs::write(&object, target.join("generated.c").to_str().unwrap()).unwrap();
+    let portable = Portable {
+        arguments: Vec::new(),
+        values: Vec::new(),
+    };
+    assert!(portable.outputs_are_clean(&object, &[]));
+    assert!(!portable.outputs_are_clean(&object, &[PathMapping::new(&target, "target")]));
 }

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -347,3 +347,22 @@ fn output_scan_matches_plain_windows_drive_and_unc_paths() {
         assert!(portable.outputs_are_clean(&object, &[]));
     }
 }
+
+/// Non-working-directory mappings can use macOS aliases omitted by canonicalization.
+#[cfg(target_os = "macos")]
+#[test]
+fn output_scan_matches_logical_macos_mapping_roots() {
+    for parent in ["/private/tmp", "/private/var/tmp"] {
+        let directory = tempfile::tempdir_in(parent).unwrap();
+        let physical = std::fs::canonicalize(directory.path()).unwrap();
+        let logical = Path::new("/").join(physical.strip_prefix("/private").unwrap());
+        assert_eq!(std::fs::canonicalize(&logical).unwrap(), physical);
+        let object = directory.path().join("object.o");
+        std::fs::write(&object, logical.join("generated.c").to_str().unwrap()).unwrap();
+        let portable = Portable {
+            arguments: Vec::new(),
+            values: Vec::new(),
+        };
+        assert!(!portable.outputs_are_clean(&object, &[PathMapping::new(&physical, "target")]));
+    }
+}

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -322,3 +322,28 @@ fn output_scan_covers_roots_without_debug_remaps() {
     assert!(portable.outputs_are_clean(&object, &[]));
     assert!(!portable.outputs_are_clean(&object, &[PathMapping::new(&target, "target")]));
 }
+
+/// Canonical Windows roots must match the non-verbatim strings compilers emit.
+#[test]
+fn output_scan_matches_plain_windows_drive_and_unc_paths() {
+    let directory = tempfile::tempdir().unwrap();
+    let object = directory.path().join("object.o");
+    for (root, ordinary) in [
+        (r"\\?\C:\resolved\source", r"C:\resolved\source"),
+        (r"\\?\UNC\server\share\source", r"\\server\share\source"),
+    ] {
+        let portable = Portable {
+            arguments: Vec::new(),
+            values: vec![root.into()],
+        };
+        for spelling in [ordinary.to_owned(), ordinary.replace('\\', "/")] {
+            std::fs::write(&object, format!("{spelling}/generated.c")).unwrap();
+            assert!(
+                !portable.outputs_are_clean(&object, &[]),
+                "{root}: {spelling}"
+            );
+        }
+        std::fs::write(&object, b"no retained path").unwrap();
+        assert!(portable.outputs_are_clean(&object, &[]));
+    }
+}

--- a/test/cc_standalone_exec.bats
+++ b/test/cc_standalone_exec.bats
@@ -323,7 +323,7 @@ SCRIPT
     mkdir -p "$project/out"
     echo 'version = 4' >"$project/Cargo.lock"
     cat >"$project/source.c" <<'SOURCE'
-#include <stdio.h>
+extern int puts(const char *);
 int main(void) { puts(__FILE__); return 0; }
 SOURCE
   done

--- a/test/cc_standalone_exec.bats
+++ b/test/cc_standalone_exec.bats
@@ -354,3 +354,35 @@ SOURCE
   run grep -E '"divergences"[[:space:]]*:[[:space:]]*0' "$first-verify.json"
   assert_success
 }
+
+@test "literal paths under mapped roots outside the working directory stay isolated" {
+  local project="$BATS_TEST_TMPDIR/project"
+  local cargo_home report
+  mkdir -p "$project/out"
+  echo 'version = 4' >"$project/Cargo.lock"
+  # CARGO_HOME roots are modeled independently of the working directory and
+  # are not necessarily included in the injected debug-prefix maps.
+  for cargo_home in "$BATS_TEST_TMPDIR/home-one" "$BATS_TEST_TMPDIR/home-two"; do
+    mkdir -p "$cargo_home/registry"
+    cat >"$cargo_home/registry/generated.c" <<'SOURCE'
+extern int puts(const char *);
+int main(void) { puts(__FILE__); return 0; }
+SOURCE
+  done
+  for cargo_home in "$BATS_TEST_TMPDIR/home-one" "$BATS_TEST_TMPDIR/home-two"; do
+    rm -f "$project/out/source.o"
+    report="$cargo_home-cold.json"
+    (cd "$project" && CARGO_HOME="$cargo_home" MBX_STATS_REPORT="$report" "$MBX_BIN" exec cc -g -c "$cargo_home/registry/generated.c" -o out/source.o)
+    run grep -E '"hits"[[:space:]]*:[[:space:]]*0' "$report"
+    assert_success
+    rm "$project/out/source.o"
+    report="$cargo_home-warm.json"
+    (cd "$project" && CARGO_HOME="$cargo_home" MBX_STATS_REPORT="$report" "$MBX_BIN" exec cc -g -c "$cargo_home/registry/generated.c" -o out/source.o)
+    run grep -E '"hits"[[:space:]]*:[[:space:]]*1' "$report"
+    assert_success
+    cc "$project/out/source.o" -o "$BATS_TEST_TMPDIR/show-path"
+    run "$BATS_TEST_TMPDIR/show-path"
+    assert_success
+    assert_output "$cargo_home/registry/generated.c"
+  done
+}

--- a/test/cc_standalone_exec.bats
+++ b/test/cc_standalone_exec.bats
@@ -314,3 +314,43 @@ SCRIPT
   refute_line 'verified'
   assert_file_exists hello.d
 }
+
+@test "objects retaining absolute source paths cache without leaking another checkout's FILE string" {
+  local first="$BATS_TEST_TMPDIR/first"
+  local second="$BATS_TEST_TMPDIR/second"
+  local project report
+  for project in "$first" "$second"; do
+    mkdir -p "$project/out"
+    echo 'version = 4' >"$project/Cargo.lock"
+    cat >"$project/source.c" <<'SOURCE'
+#include <stdio.h>
+int main(void) { puts(__FILE__); return 0; }
+SOURCE
+  done
+
+  for project in "$first" "$second"; do
+    report="$project-cold.json"
+    (cd "$project" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec cc -g -c "$project/source.c" -o out/source.o)
+    # Identical source and normalized arguments must not reuse the other path.
+    run grep -E '"hits"[[:space:]]*:[[:space:]]*0' "$report"
+    assert_success
+    rm "$project/out/source.o"
+    report="$project-warm.json"
+    (cd "$project" && MBX_STATS_REPORT="$report" "$MBX_BIN" exec cc -g -c "$project/source.c" -o out/source.o)
+    run grep -E '"hits"[[:space:]]*:[[:space:]]*1' "$report"
+    assert_success
+    cc "$project/out/source.o" -o "$project-show-path"
+    run "$project-show-path"
+    assert_success
+    assert_output "$project/source.c"
+  done
+
+  # Returning to the first path still finds its action after the shared
+  # prediction has been refreshed by the second checkout.
+  rm "$first/out/source.o"
+  (cd "$first" && MBX_VERIFY=1 MBX_STATS_REPORT="$first-verify.json" "$MBX_BIN" exec cc -g -c "$first/source.c" -o out/source.o)
+  run grep -E '"verifications"[[:space:]]*:[[:space:]]*1' "$first-verify.json"
+  assert_success
+  run grep -E '"divergences"[[:space:]]*:[[:space:]]*0' "$first-verify.json"
+  assert_success
+}


### PR DESCRIPTION
C compilations containing absolute `__FILE__` strings stopped being cached after #384: the debug-path portability check rejected their objects even on a rebuild at the same path. A Linux reproducer hits with 1.8.1, stores nothing with 1.10.0, and hits with this change. This matches the native-compilation cache loss investigated after #408; a full hk benchmark rerun is still needed to quantify the recovered performance.

Retain these objects under an action key bound to the working directory, literal parsed arguments, and mapping roots. Predictions carry that requirement through normal restores and local/remote flight handoffs. A distinct invocation namespace and adapter isolate the extended payload from older shims. The output scan covers every mapped root, including canonical aliases, rather than just injected debug remaps. Portable objects retain their existing keys, and runtime strings remain unchanged.

Validation:
- 81 mbx-cache-cc tests and 10 mbx C-wrapper unit tests pass.
- All 10 standalone C behavioral tests pass on macOS and Linux, including same-path hits, cross-checkout isolation, exact `__FILE__` output, and shadow verification with zero divergences.
- Clippy passes for both affected crates with all features and targets; formatting and diff checks pass.
- `mise run ci` was attempted but fails in the existing documentation renderer: pinned usage 6.5.0 rejects `unknown_flags`. A subsequent bootstrap-driven broad test attempt also encountered macOS SIGKILL; focused tests above ran directly through Cargo and the built binary.

BREAKING CHANGE: Rust callers constructing `CcInputPrediction` with a struct literal must supply `path_specific` (false for existing portable predictions). Existing serialized portable predictions remain compatible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes C compilation cache keys, prediction wire format, and cross-checkout isolation for path-embedded objects; mistakes could serve wrong `__FILE__` strings or break prediction compatibility despite the new adapter namespace.
> 
> **Overview**
> **C objects that embed literal paths (e.g. `__FILE__`) are cached again** instead of being dropped as unportable. When the post-compile scan finds retained paths, the action key includes a **`path_binding`** (working directory, literal arguments, mapping roots); portable compiles still use the existing normalized keys.
> 
> **Predictions and coordination** carry a new **`path_specific`** flag through lookup, publish, and flight/remote restore. Predictions and flights use a separate **`cc-path-binding-v1`** adapter and **`prediction_invocation`** digest so older shims do not ingest the extended JSON.
> 
> **Output “cleanliness” detection** now considers every **path-mapping root** (with canonical/Windows/macOS spellings), not only injected debug-prefix values, so generated sources under mapped roots are classified correctly.
> 
> **Breaking:** Rust code building `CcInputPrediction` with struct literals must set **`path_specific`** (default `false` for portable behavior on the wire).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4ad7cb56569e67f94fc2423dba1e337a3a4052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->