### PR TITLE
fix(cache): retain predictions from every exported command

### DIFF
--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -399,7 +399,26 @@ fn export_receipts(
     archive: &Path,
     additions: ExportAdditions,
 ) -> Result<TransferOutcome> {
-    receipts.sort_by_key(|receipt| receipt.completed_nanos);
+    receipts.sort_by(|left, right| {
+        left.completed_nanos
+            .cmp(&right.completed_nanos)
+            .then_with(|| {
+                // Concurrent commands may complete on the same clock tick. Use
+                // their persisted predictions to break ties, not directory order.
+                fn key(prediction: &ActionPrediction) -> (&CacheDigest, &CacheDigest, &str, &str) {
+                    (
+                        &prediction.invocation,
+                        &prediction.action,
+                        &prediction.adapter,
+                        &prediction.payload,
+                    )
+                }
+                left.predictions
+                    .iter()
+                    .map(key)
+                    .cmp(right.predictions.iter().map(key))
+            })
+    });
     let mut actions = BTreeSet::new();
     let mut tasks = BTreeMap::new();
     for receipt in receipts {

--- a/crates/mbx-cache-store/src/lib.rs
+++ b/crates/mbx-cache-store/src/lib.rs
@@ -409,19 +409,27 @@ fn export_receipts(
                 .iter()
                 .map(|prediction| prediction.action.clone()),
         );
-        // One task manifest can carry only one action per invocation. The
-        // newest run of the same task is the useful prediction set to import;
-        // every older action remains in `actions` and therefore in the bundle.
-        tasks.insert(
-            receipt.identity.clone(),
-            TaskActionManifest {
-                version: 1,
-                task: receipt.identity,
-                predictions: receipt.predictions,
-            },
+        // Keep predictions from every command in the job. When commands
+        // share an invocation, the most recently completed command wins.
+        let predictions = tasks.entry(receipt.identity).or_insert_with(BTreeMap::new);
+        predictions.extend(
+            receipt
+                .predictions
+                .into_iter()
+                .map(|prediction| (prediction.invocation.clone(), prediction)),
         );
     }
-    let tasks = tasks.into_values().collect::<Vec<_>>();
+    let tasks = tasks
+        .into_iter()
+        .map(|(task, predictions)| TaskActionManifest {
+            version: 1,
+            task,
+            predictions: predictions.into_values().collect(),
+        })
+        .collect::<Vec<_>>();
+    if tasks.iter().any(|task| !task.validate()) {
+        eyre::bail!("combined export predictions exceed task manifest limits");
+    }
     validate_export_additions(&additions)?;
     let (mut objects, result_paths) = strict_closure(store, &actions)?;
     let cas = LocalCas::new(store);

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -708,6 +708,39 @@ fn grouped_export_keeps_each_commands_predictions_and_newest_conflicts() {
 }
 
 #[test]
+fn equal_timestamp_exports_ignore_receipt_enumeration_order() {
+    let source = tempfile::tempdir().unwrap();
+    let identity = "e".repeat(64);
+    let receipts = ["first", "second"].map(|name| BuildReceipt {
+        version: 1,
+        workspace_root: source.path().to_path_buf(),
+        identity: identity.clone(),
+        completed_nanos: 1,
+        group: Some("job".into()),
+        predictions: vec![ActionPrediction {
+            invocation: CacheDigest::blake3(b"shared invocation"),
+            action: store_result(source.path(), name, &[]),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        }],
+    });
+    let mut predictions = Vec::new();
+    for order in [receipts.to_vec(), receipts.into_iter().rev().collect()] {
+        let destination = tempfile::tempdir().unwrap();
+        let archive = destination.path().join("job.tar");
+        export_receipts(source.path(), order, &archive, ExportAdditions::default()).unwrap();
+        import_archive(destination.path(), &archive).unwrap();
+        let manifest: TaskActionManifest = serde_json::from_slice(
+            &std::fs::read(task_manifest_path(destination.path(), &identity)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(manifest.predictions.len(), 1);
+        predictions.push(manifest.predictions);
+    }
+    assert_eq!(predictions[0], predictions[1]);
+}
+
+#[test]
 fn collection_preserves_grouped_receipts_replaced_in_the_task_manifest() {
     let source = tempfile::tempdir().unwrap();
     let destination = tempfile::tempdir().unwrap();

--- a/crates/mbx-cache-store/src/store_tests.rs
+++ b/crates/mbx-cache-store/src/store_tests.rs
@@ -650,6 +650,64 @@ fn grouped_export_unions_parallel_build_receipts() {
 }
 
 #[test]
+fn grouped_export_keeps_each_commands_predictions_and_newest_conflicts() {
+    let source = tempfile::tempdir().unwrap();
+    let destination = tempfile::tempdir().unwrap();
+    let identity = "e".repeat(64);
+    let prediction = |invocation: &str, action: &str| ActionPrediction {
+        invocation: CacheDigest::blake3(invocation.as_bytes()),
+        action: store_result(source.path(), action, &[]),
+        adapter: "rustc".into(),
+        payload: "{}".into(),
+    };
+    let clippy = prediction("clippy", "clippy result");
+    let test = prediction("test", "test result");
+    let old_shared = prediction("shared", "old shared result");
+    let new_shared = prediction("shared", "new shared result");
+    let receipt = |completed_nanos, predictions| BuildReceipt {
+        version: 1,
+        workspace_root: source.path().join("workspace"),
+        identity: identity.clone(),
+        completed_nanos,
+        group: Some("job".into()),
+        predictions,
+    };
+    let archive = source.path().join("job.tar");
+    // Deliberately supply reverse completion order.
+    let exported = export_receipts(
+        source.path(),
+        vec![
+            receipt(2, vec![test.clone(), new_shared.clone()]),
+            receipt(1, vec![clippy.clone(), old_shared.clone()]),
+        ],
+        &archive,
+        ExportAdditions::default(),
+    )
+    .unwrap();
+    import_archive(destination.path(), &archive).unwrap();
+    let manifest: TaskActionManifest = serde_json::from_slice(
+        &std::fs::read(task_manifest_path(destination.path(), &identity)).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(manifest.predictions.len(), 3);
+    for expected in [clippy, test, new_shared] {
+        let actual = manifest
+            .predictions
+            .iter()
+            .find(|p| p.invocation == expected.invocation)
+            .unwrap();
+        assert_eq!(actual.action, expected.action);
+    }
+    assert_eq!(exported.actions, 4);
+    assert!(
+        LocalActionCache::new(destination.path())
+            .find(&old_shared.action)
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
 fn collection_preserves_grouped_receipts_replaced_in_the_task_manifest() {
     let source = tempfile::tempdir().unwrap();
     let destination = tempfile::tempdir().unwrap();


### PR DESCRIPTION
A grouped object-cache export currently replaces a task's entire prediction manifest with its last command's receipt. For a job running clippy and then tests under the same Cargo.lock identity, the archive contains both commands' actions but loses clippy-only predictions, so the next job cannot look those actions up.

Merge predictions by invocation across all receipts for each task, with the newest completed receipt winning conflicts. Equal completion timestamps use a deterministic tie-breaker from the persisted predictions. Keep every referenced action in the archive and reject an oversized combined manifest before publishing the export.

Validation: `mise run ci` passed on macOS. All 51 `mbx-cache-store` tests passed on Linux (`dev.coder`). The new export/import regression fails against the old implementation and covers distinct commands, overlapping invocations, reverse receipt order, and retention of superseded actions. A second regression covers reversed enumeration of equal-timestamp receipts.

Addresses https://github.com/jdx/mr-boxington/discussions/422.
