### PR TITLE
fix(cc): recognize the active Xcode developer directory

### DIFF
--- a/crates/mbx-cache-cc/src/cc_cache_tests.rs
+++ b/crates/mbx-cache-cc/src/cc_cache_tests.rs
@@ -1334,3 +1334,42 @@ fn preprocessing_dependency_targets_follow_the_driver_family() {
         );
     }
 }
+
+#[cfg(unix)]
+#[test]
+fn active_developer_roots_cover_beta_and_renamed_xcode() {
+    for selected in [
+        "/Applications/Xcode-beta.app",
+        "/Applications/Xcode-beta.app/Contents/Developer",
+        "/opt/toolchains/Xcode-custom.app",
+    ] {
+        let roots = developer_directory_roots(PathBuf::from(selected));
+        let root = if selected.ends_with(".app") {
+            PathBuf::from(selected).join("Contents/Developer")
+        } else {
+            PathBuf::from(selected)
+        };
+        let sdk = root.join("Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/SDKSettings.json");
+        assert!(roots.iter().any(|root| sdk.starts_with(root)));
+        assert!(
+            !roots
+                .iter()
+                .any(|root| Path::new("/Applications/Other.app/private.h").starts_with(root))
+        );
+    }
+    assert!(developer_directory_roots(PathBuf::from("relative")).is_empty());
+    assert!(developer_directory_roots(PathBuf::from("/")).is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn active_developer_roots_include_resolved_symlinks() {
+    let directory = tempfile::tempdir().unwrap();
+    let real = directory.path().join("developer");
+    std::fs::create_dir(&real).unwrap();
+    let alias = directory.path().join("selected");
+    std::os::unix::fs::symlink(&real, &alias).unwrap();
+    let roots = developer_directory_roots(alias.clone());
+    assert!(roots.contains(&alias));
+    assert!(roots.contains(&std::fs::canonicalize(real).unwrap()));
+}

--- a/crates/mbx-cache-cc/src/lib.rs
+++ b/crates/mbx-cache-cc/src/lib.rs
@@ -1074,6 +1074,60 @@ pub fn is_system_path(path: &Path) -> bool {
     SYSTEM_ROOTS
         .iter()
         .any(|root| path.starts_with(Path::new(root)))
+        || developer_roots().iter().any(|root| path.starts_with(root))
+}
+
+// Xcode may be renamed or installed outside /Applications. Match the active
+// developer directory rather than assuming the application bundle's name.
+// Keep both spellings because compiler depfiles may resolve SDK symlinks.
+#[cfg(target_os = "macos")]
+fn developer_roots() -> &'static [PathBuf] {
+    static ROOTS: std::sync::OnceLock<Vec<PathBuf>> = std::sync::OnceLock::new();
+    ROOTS.get_or_init(|| {
+        let selected = std::env::var_os("DEVELOPER_DIR")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .or_else(|| {
+                let output = std::process::Command::new("/usr/bin/xcode-select")
+                    .arg("--print-path")
+                    .output()
+                    .ok()?;
+                if !output.status.success() {
+                    return None;
+                }
+                Some(PathBuf::from(
+                    std::str::from_utf8(&output.stdout).ok()?.trim(),
+                ))
+            });
+        selected.map(developer_directory_roots).unwrap_or_default()
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn developer_roots() -> &'static [PathBuf] {
+    &[]
+}
+
+#[cfg(any(target_os = "macos", all(test, unix)))]
+fn developer_directory_roots(mut root: PathBuf) -> Vec<PathBuf> {
+    if !root.is_absolute() || root == Path::new("/") {
+        return Vec::new();
+    }
+    // xcrun also accepts DEVELOPER_DIR pointing at the application bundle.
+    if root.extension().is_some_and(|extension| extension == "app") {
+        root = root.join("Contents/Developer");
+    }
+    root = normalize_components(&root);
+    if root == Path::new("/") {
+        return Vec::new();
+    }
+    let mut roots = vec![root.clone()];
+    if let Ok(canonical) = std::fs::canonicalize(&root)
+        && canonical != root
+    {
+        roots.push(canonical);
+    }
+    roots
 }
 
 fn normalize_components(path: &Path) -> PathBuf {

--- a/crates/mbx-cache-cc/tests/developer_directory.rs
+++ b/crates/mbx-cache-cc/tests/developer_directory.rs
@@ -1,0 +1,26 @@
+//! Exercise process-local developer selection without mutating another test's environment.
+#![cfg(target_os = "macos")]
+
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn selected_sdk_is_a_system_path() {
+    const CHILD: &str = "MBX_TEST_DEVELOPER_DIRECTORY_CHILD";
+    if std::env::var_os(CHILD).is_some() {
+        let root = std::env::var("DEVELOPER_DIR").unwrap();
+        let sdk = Path::new(&root).join("Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/SDKSettings.json");
+        assert!(mbx_cache_cc::is_system_path(&sdk));
+        assert!(!mbx_cache_cc::is_system_path(Path::new(
+            "/Applications/Unrelated.app/header.h"
+        )));
+        return;
+    }
+    let status = Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "selected_sdk_is_a_system_path"])
+        .env(CHILD, "1")
+        .env("DEVELOPER_DIR", "/Applications/Xcode-beta.app")
+        .status()
+        .unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
With Xcode-beta selected, its SDK sits outside the fixed `/Applications/Xcode.app` system root. C publication recursively walks SDK include directories as project directories, often exceeds the input budget, and rejects SDKSettings.json as an unmapped absolute input. Jeremy's profiling in #418 attributes the macOS system-CPU spike to those repeated walks.

Recognize the active developer directory from `DEVELOPER_DIR` or `xcode-select --print-path`, once per process. Accept application-bundle overrides and retain the canonical root for symlink-resolved compiler paths. The existing system-path handling then skips recursive SDK manifests while continuing to digest files actually read and key their paths verbatim.

Validation: `mise run ci` passed on macOS; all 82 C-adapter unit tests passed on macOS and Linux (`dev.coder`). A separate macOS subprocess test covers a beta application override without changing the machine's selected developer directory. Tests also cover renamed installations, symlinks, and unrelated paths. Jeremy subsequently confirmed the fix on the affected macOS 27 beta / Xcode-beta host: fresh-worktree Basecamp restores take 15.0s (13.6s with #421), with 428 hits and 14–16s system CPU. The earlier #421-only restore had 195 hits and 385s system CPU; load differed between the series, so wall time is not a controlled before/after comparison. All 161 SDK-path refusals are gone, and the residual 149 unportable outputs, six changing include directories, and one input-limit refusal match the pre-existing macOS baseline. His hey-sdk restore also succeeds in 11.5s with 507 hits.

Affected-host validation: https://github.com/jdx/mr-boxington/discussions/418#discussioncomment-18391466.

Addresses https://github.com/jdx/mr-boxington/discussions/418.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes path classification for all macOS cc cache keys and predictions; incorrect root detection could mis-key SDK inputs, though behavior falls back to empty roots when selection is unavailable.
> 
> **Overview**
> **Extends macOS “system path” handling** so SDK and toolchain files under the *active* Xcode install count as machine-local, not only paths under the fixed `/Applications/Xcode.app` root.
> 
> `is_system_path` now also matches paths under roots derived once per process from `DEVELOPER_DIR` or `xcode-select --print-path`, with support for `.app` bundle overrides and both normalized and canonical roots for symlink-resolved depfile paths. That should stop beta/renamed/custom Xcode layouts from tripping `unmapped-absolute-path` bypasses and from walking large SDK trees as unmapped project directories.
> 
> **Tests** cover root computation (beta paths, custom installs, invalid roots, symlinks), plus a macOS subprocess test that sets `DEVELOPER_DIR` to `Xcode-beta.app` without mutating the host’s global selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2bed57dbaec1c153db9f2854b33550e15abcfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
