### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mbx"
-version = "1.10.1"
+version = "1.11.0"
 dependencies = [
  "bytesize",
  "cargo-config2",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cargo"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "dirs",
  "mbx-cache-core",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-cc"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-compression",
  "base64 0.23.1",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-protocol"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "blake3",
  "eyre",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-rustc"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "mbx-cache-core",
  "serde",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "mbx-cache-store"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "eyre",
  "filetime",

--- a/crates/mbx-cache-cargo/CHANGELOG.md
+++ b/crates/mbx-cache-cargo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.24...mbx-cache-cargo-v0.1.25) - 2026-09-11
+
+### Added
+
+- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
+
 ## [0.1.24](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.23...mbx-cache-cargo-v0.1.24) - 2026-09-10
 
 ### Other

--- a/crates/mbx-cache-cargo/Cargo.toml
+++ b/crates/mbx-cache-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cargo"
-version = "0.1.24"
+version = "0.1.25"
 description = "Unstable Cargo invocation integration for mbx cache embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [dependencies]
 dirs = "6"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"

--- a/crates/mbx-cache-cc/CHANGELOG.md
+++ b/crates/mbx-cache-cc/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.16.0...mbx-cache-cc-v0.16.1) - 2026-09-11
+
+### Added
+
+- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
+- *(cache)* control storage of path-specific C objects ([#432](https://github.com/jdx/mr-boxington/pull/432))
+
+### Other
+
+- *(cc)* deduplicate equivalent include manifest roots ([#429](https://github.com/jdx/mr-boxington/pull/429))
+
 ## [0.16.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.15.0...mbx-cache-cc-v0.16.0) - 2026-09-10
 
 ### Fixed

--- a/crates/mbx-cache-cc/Cargo.toml
+++ b/crates/mbx-cache-cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-cc"
-version = "0.16.0"
+version = "0.16.1"
 description = "mbx internals: conservative C and C++ action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-core/CHANGELOG.md
+++ b/crates/mbx-cache-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.16.0...mbx-cache-core-v0.16.1) - 2026-09-11
+
+### Added
+
+- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
+
 ## [0.16.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.15.0...mbx-cache-core-v0.16.0) - 2026-09-10
 
 ### Fixed

--- a/crates/mbx-cache-core/Cargo.toml
+++ b/crates/mbx-cache-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-core"
-version = "0.16.0"
+version = "0.16.1"
 description = "Unstable CAS, transport, and cache-agent primitives for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ fslock = "0.2"
 futures-util = "0.3"
 hex = "0.4"
 log = "0.4"
-mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.15" }
+mbx-cache-protocol = { path = "../mbx-cache-protocol", version = "0.5.16" }
 rand = "0.10"
 reflink-copy = "0.1"
 async-compression = { version = "0.4", default-features = false, features = [

--- a/crates/mbx-cache-protocol/CHANGELOG.md
+++ b/crates/mbx-cache-protocol/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.15...mbx-cache-protocol-v0.5.16) - 2026-09-11
+
+### Added
+
+- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
+
 ## [0.5.15](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.14...mbx-cache-protocol-v0.5.15) - 2026-09-08
 
 ### Other

--- a/crates/mbx-cache-protocol/Cargo.toml
+++ b/crates/mbx-cache-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-protocol"
-version = "0.5.15"
+version = "0.5.16"
 description = "Shared wire contract for mbx remote cache clients and servers"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/mbx-cache-rustc/CHANGELOG.md
+++ b/crates/mbx-cache-rustc/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.16.0...mbx-cache-rustc-v0.16.1) - 2026-09-11
+
+### Added
+
+- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
+
+### Fixed
+
+- *(cache)* cover dependency debug paths in macOS links ([#430](https://github.com/jdx/mr-boxington/pull/430))
+- *(cache)* stabilize macOS proc macro install names ([#427](https://github.com/jdx/mr-boxington/pull/427))
+
 ## [0.15.0](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.14.0...mbx-cache-rustc-v0.15.0) - 2026-09-08
 
 ### Other

--- a/crates/mbx-cache-rustc/Cargo.toml
+++ b/crates/mbx-cache-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-rustc"
-version = "0.16.0"
+version = "0.16.1"
 description = "mbx internals: conservative rustc action analysis and key construction. No API stability -- use the mbx CLI or mbx-cache-protocol."
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ readme.workspace = true
 all-features = true
 
 [dependencies]
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 shlex = "2"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/mbx-cache-store/CHANGELOG.md
+++ b/crates/mbx-cache-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.23...mbx-cache-store-v0.1.24) - 2026-09-11
+
+### Added
+
+- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
+
 ## [0.1.23](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.22...mbx-cache-store-v0.1.23) - 2026-09-10
 
 ### Fixed

--- a/crates/mbx-cache-store/Cargo.toml
+++ b/crates/mbx-cache-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache-store"
-version = "0.1.23"
+version = "0.1.24"
 description = "Unstable shared action-store retention and inspection for mbx embedders"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ readme.workspace = true
 eyre = "0.6"
 fslock = "0.2"
 log = "0.4"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = { version = "0.4", default-features = false }

--- a/crates/mbx/CHANGELOG.md
+++ b/crates/mbx/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0](https://github.com/jdx/mr-boxington/compare/v1.10.1...v1.11.0) - 2026-09-11
+
+### Added
+
+- animate Boxington in build output ([#441](https://github.com/jdx/mr-boxington/pull/441))
+- *(cli)* add append-only progress for agent builds ([#437](https://github.com/jdx/mr-boxington/pull/437))
+- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
+- *(cache)* control storage of path-specific C objects ([#432](https://github.com/jdx/mr-boxington/pull/432))
+
+### Fixed
+
+- end build sessions before launching cargo applications ([#436](https://github.com/jdx/mr-boxington/pull/436))
+- *(cache)* recover C predictions after stderr-only conflicts ([#431](https://github.com/jdx/mr-boxington/pull/431))
+- *(cache)* cover dependency debug paths in macOS links ([#430](https://github.com/jdx/mr-boxington/pull/430))
+- *(cache)* stabilize macOS proc macro install names ([#427](https://github.com/jdx/mr-boxington/pull/427))
+
 ## [1.10.1](https://github.com/jdx/mr-boxington/compare/v1.10.0...v1.10.1) - 2026-09-10
 
 ### Fixed

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx"
-version = "1.10.1"
+version = "1.11.0"
 description = "A build cache for Rust projects"
 edition.workspace = true
 rust-version.workspace = true
@@ -31,11 +31,11 @@ memchr = "2"
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
 portable-pty = "0.9"
-mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.0", default-features = false }
-mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.24", default-features = false }
-mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.16.0", default-features = false }
-mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.16.0", default-features = false }
-mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.23", default-features = false }
+mbx-cache-core = { path = "../mbx-cache-core", version = "0.16.1", default-features = false }
+mbx-cache-cargo = { path = "../mbx-cache-cargo", version = "0.1.25", default-features = false }
+mbx-cache-cc = { path = "../mbx-cache-cc", version = "0.16.1", default-features = false }
+mbx-cache-rustc = { path = "../mbx-cache-rustc", version = "0.16.1", default-features = false }
+mbx-cache-store = { path = "../mbx-cache-store", version = "0.1.24", default-features = false }
 rand = "0.10"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 reflink-copy = "0.1"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 
-**Version:** 1.10.1
+**Version:** 1.11.0
 
 - **Usage:** `mbx [+TOOLCHAIN] <SUBCOMMAND>`
 


### PR DESCRIPTION



## 🤖 New release

* `mbx-cache-protocol`: 0.5.15 -> 0.5.16 (✓ API compatible changes)
* `mbx-cache-core`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `mbx-cache-cargo`: 0.1.24 -> 0.1.25 (✓ API compatible changes)
* `mbx-cache-cc`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `mbx-cache-rustc`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `mbx-cache-store`: 0.1.23 -> 0.1.24 (✓ API compatible changes)
* `mbx`: 1.10.1 -> 1.11.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `mbx-cache-protocol`

<blockquote>

## [0.5.16](https://github.com/jdx/mr-boxington/compare/mbx-cache-protocol-v0.5.15...mbx-cache-protocol-v0.5.16) - 2026-09-11

### Added

- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
</blockquote>

## `mbx-cache-core`

<blockquote>

## [0.16.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-core-v0.16.0...mbx-cache-core-v0.16.1) - 2026-09-11

### Added

- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
</blockquote>

## `mbx-cache-cargo`

<blockquote>

## [0.1.25](https://github.com/jdx/mr-boxington/compare/mbx-cache-cargo-v0.1.24...mbx-cache-cargo-v0.1.25) - 2026-09-11

### Added

- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
</blockquote>

## `mbx-cache-cc`

<blockquote>

## [0.16.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-cc-v0.16.0...mbx-cache-cc-v0.16.1) - 2026-09-11

### Added

- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
- *(cache)* control storage of path-specific C objects ([#432](https://github.com/jdx/mr-boxington/pull/432))

### Other

- *(cc)* deduplicate equivalent include manifest roots ([#429](https://github.com/jdx/mr-boxington/pull/429))
</blockquote>

## `mbx-cache-rustc`

<blockquote>

## [0.16.1](https://github.com/jdx/mr-boxington/compare/mbx-cache-rustc-v0.16.0...mbx-cache-rustc-v0.16.1) - 2026-09-11

### Added

- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))

### Fixed

- *(cache)* cover dependency debug paths in macOS links ([#430](https://github.com/jdx/mr-boxington/pull/430))
- *(cache)* stabilize macOS proc macro install names ([#427](https://github.com/jdx/mr-boxington/pull/427))
</blockquote>

## `mbx-cache-store`

<blockquote>

## [0.1.24](https://github.com/jdx/mr-boxington/compare/mbx-cache-store-v0.1.23...mbx-cache-store-v0.1.24) - 2026-09-11

### Added

- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
</blockquote>

## `mbx`

<blockquote>

## [1.11.0](https://github.com/jdx/mr-boxington/compare/v1.10.1...v1.11.0) - 2026-09-11

### Added

- animate Boxington in build output ([#441](https://github.com/jdx/mr-boxington/pull/441))
- *(cli)* add append-only progress for agent builds ([#437](https://github.com/jdx/mr-boxington/pull/437))
- *(cli)* adapt cargo-pretty with live cache statistics ([#435](https://github.com/jdx/mr-boxington/pull/435))
- *(cache)* control storage of path-specific C objects ([#432](https://github.com/jdx/mr-boxington/pull/432))

### Fixed

- end build sessions before launching cargo applications ([#436](https://github.com/jdx/mr-boxington/pull/436))
- *(cache)* recover C predictions after stderr-only conflicts ([#431](https://github.com/jdx/mr-boxington/pull/431))
- *(cache)* cover dependency debug paths in macOS links ([#430](https://github.com/jdx/mr-boxington/pull/430))
- *(cache)* stabilize macOS proc macro install names ([#427](https://github.com/jdx/mr-boxington/pull/427))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The diff only updates versions, lockfile entries, and changelogs—no runtime code changes in this PR.
> 
> **Overview**
> **Release-only PR** (release-plz): bumps **`mbx` to 1.11.0** and aligned patch versions for `mbx-cache-protocol`, `mbx-cache-core`, `mbx-cache-cargo`, `mbx-cache-cc`, `mbx-cache-rustc`, and `mbx-cache-store`, with matching updates to `Cargo.lock`, workspace `Cargo.toml` dependency pins, per-crate **CHANGELOG** entries, and the generated CLI docs version string.
> 
> No application source changes in the diff; it cuts the release that already landed on main. **1.11.0** changelog highlights: live cache stats in cargo-pretty output, append-only agent build progress, animated Boxington in build output, configurable storage for path-specific C objects, ending build sessions before `cargo run`-style launches, and several cache fixes (C prediction recovery, macOS link debug paths and proc-macro install names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf8102835179476b977334a69f3e6f6195b28d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->