### PR TITLE
fix(cache): stabilize macOS proc macro install names

### DIFF
--- a/crates/mbx-cache-rustc/src/dep_info.rs
+++ b/crates/mbx-cache-rustc/src/dep_info.rs
@@ -607,6 +607,9 @@ fn render_argument(argument: &Argument) -> Result<OsString, BypassReason> {
         ),
         // Nothing links while emitting dep-info either; replayed verbatim for
         // the same reason as the prefix above.
+        Argument::InstallName(name) => {
+            format!("--codegen=link-arg=-Wl,-install_name,@rpath/{name}")
+        }
         Argument::FuseLd(selection) => format!("--codegen=link-arg=-fuse-ld={selection}"),
     };
     Ok(rendered.into())

--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -334,6 +334,8 @@ enum Argument {
         from: PathBuf,
         to: String,
     },
+    /// A single @rpath filename used as a macOS proc macro install name.
+    InstallName(String),
     /// An `-oso_prefix` handed to ld64, whose path strips checkout-specific
     /// prefixes from the debug map the linker records.
     OsoPrefix {
@@ -438,6 +440,30 @@ impl RustcInvocation {
             self.link_output,
             LinkOutput::NativeExecutable | LinkOutput::NativeProcMacro
         )
+    }
+
+    /// Stable Mach-O identity for a cached macOS proc macro. The compiler loads
+    /// these by filename; embedding the checkout's output path only makes the
+    /// bytes (and dependent action keys) vary between otherwise identical builds.
+    pub fn portable_install_name(&self, outputs: &RustcOutputs) -> Option<String> {
+        if !cfg!(target_os = "macos")
+            || self.link_output != LinkOutput::NativeProcMacro
+            || self
+                .arguments
+                .iter()
+                .any(|arg| matches!(arg, Argument::InstallName(_)))
+        {
+            return None;
+        }
+        let file = outputs
+            .files
+            .iter()
+            .find(|path| path.extension().is_some_and(|ext| ext == "dylib"))?;
+        let name = file.file_name()?.to_str()?;
+        if !safe_install_name(name) {
+            return None;
+        }
+        Some(format!("-Clink-arg=-Wl,-install_name,@rpath/{name}"))
     }
 
     /// Linker selected with `-C linker`, if the invocation overrides rustc's
@@ -1558,6 +1584,15 @@ impl<'a> Parser<'a> {
             }
             return Ok(());
         }
+        // Only a single filename under @rpath is modeled. Other spellings,
+        // combined linker options, and explicit absolute names still bypass.
+        if name == "link-arg"
+            && let Some(option) = value.strip_prefix("link-arg=-Wl,-install_name,@rpath/")
+            && safe_install_name(option)
+        {
+            self.parsed.push(Argument::InstallName(option.to_owned()));
+            return Ok(());
+        }
         // `-oso_prefix` names a checkout-specific path, so it is parsed
         // rather than keyed as text: the path normalizes like every other
         // path in the key, which is what lets two checkouts passing their own
@@ -1677,6 +1712,16 @@ impl<'a> Parser<'a> {
             && let Some(option) = self.first_link_argument()
         {
             return Err(BypassReason::UnmodeledLinkArgument(option.to_owned()));
+        }
+        if self
+            .parsed
+            .iter()
+            .any(|arg| matches!(arg, Argument::InstallName(_)))
+            && !(cfg!(target_os = "macos") && link_output == LinkOutput::NativeProcMacro)
+        {
+            return Err(BypassReason::UnmodeledLinkArgument(
+                "link-arg=-Wl,-install_name".into(),
+            ));
         }
         // `-fuse-ld` is modeled only for native links, where the linker
         // identity probe resolves and pins the linker it names. A wasm or
@@ -1879,6 +1924,13 @@ impl Parser<'_> {
         }
         Ok(())
     }
+}
+
+fn safe_install_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte))
 }
 
 /// Whether a boolean codegen option is asking for its enabled form. Absent a
@@ -2096,6 +2148,9 @@ impl<'a> ActionBuilder<'a> {
                 "--remap-path-prefix={}={}",
                 self.normalize_path(from)?,
                 to
+            )),
+            Argument::InstallName(name) => Ok(format!(
+                "--codegen=link-arg=-Wl,-install_name,@rpath/{name}"
             )),
             Argument::OsoPrefix {
                 path,

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -2134,6 +2134,10 @@ fn portable_proc_macro_install_name_is_keyed_and_preserves_explicit_names() {
     arguments.push("-Clink-arg=-Wl,-install_name,@rpath/custom.dylib".into());
     let explicit = RustcInvocation::parse_with(&arguments, options).unwrap();
     assert_eq!(explicit.portable_install_name(&outputs), None);
+    let command = explicit.dep_info_command(&outputs.dep_info).unwrap();
+    assert!(command.arguments().contains(&OsString::from(
+        "--codegen=link-arg=-Wl,-install_name,@rpath/custom.dylib"
+    )));
     for value in [
         "/absolute/custom.dylib",
         "@rpath/libwidget.dylib,-dead_strip",

--- a/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
+++ b/crates/mbx-cache-rustc/src/rustc_cache_tests.rs
@@ -2081,3 +2081,66 @@ fn linker_plugin_lto_is_keyed_and_a_plugin_path_bypasses() {
         ))
     );
 }
+
+#[test]
+fn install_names_are_only_modeled_for_macos_proc_macros() {
+    for kind in ["bin", "rlib", "proc-macro"] {
+        let parsed = RustcInvocation::parse_with(
+            &args(&[
+                "--crate-name=widget",
+                &format!("--crate-type={kind}"),
+                "--emit=dep-info,link",
+                "--out-dir=target/debug/deps",
+                "-Clink-arg=-Wl,-install_name,@rpath/libwidget.dylib",
+                "src/lib.rs",
+            ]),
+            ParseOptions::caching_native_links(true),
+        );
+        assert_eq!(
+            parsed.is_ok(),
+            cfg!(target_os = "macos") && kind == "proc-macro"
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn portable_proc_macro_install_name_is_keyed_and_preserves_explicit_names() {
+    let mut arguments = args(&[
+        "--crate-name=widget",
+        "--crate-type=proc-macro",
+        "--emit=dep-info,link",
+        "--out-dir=target/debug/deps",
+        "-Cextra-filename=-abc123",
+        "src/lib.rs",
+    ]);
+    let options = ParseOptions::caching_native_links(true);
+    let original = RustcInvocation::parse_with(&arguments, options).unwrap();
+    let context = context(&[("src/lib.rs", "source")]);
+    let outputs = original.outputs(&context.working_dir).unwrap();
+    let flag = original.portable_install_name(&outputs).unwrap();
+    assert_eq!(
+        flag,
+        "-Clink-arg=-Wl,-install_name,@rpath/libwidget-abc123.dylib"
+    );
+    arguments.push(flag.into());
+    let portable = RustcInvocation::parse_with(&arguments, options).unwrap();
+    assert_ne!(
+        original.invocation_digest(&context).unwrap(),
+        portable.invocation_digest(&context).unwrap()
+    );
+    assert_eq!(portable.portable_install_name(&outputs), None);
+    arguments.pop();
+    arguments.push("-Clink-arg=-Wl,-install_name,@rpath/custom.dylib".into());
+    let explicit = RustcInvocation::parse_with(&arguments, options).unwrap();
+    assert_eq!(explicit.portable_install_name(&outputs), None);
+    for value in [
+        "/absolute/custom.dylib",
+        "@rpath/libwidget.dylib,-dead_strip",
+        "@rpath/../custom.dylib",
+    ] {
+        arguments.pop();
+        arguments.push(format!("-Clink-arg=-Wl,-install_name,{value}").into());
+        assert!(RustcInvocation::parse_with(&arguments, options).is_err());
+    }
+}

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -181,7 +181,12 @@ pub(crate) fn compile(
         Some(&initial_outputs.directory),
         initial_invocation.target(),
     );
-    let arguments = portable.applied_to(arguments);
+    let mut arguments = portable.applied_to(arguments);
+    // Include the flag in both parsing/key construction and execution. This
+    // separates old path-bearing artifacts without changing content hashing.
+    if let Some(argument) = initial_invocation.portable_install_name(&initial_outputs) {
+        arguments.push(argument.into());
+    }
     let invocation = RustcInvocation::parse_with(&arguments, options)?;
     let outputs = invocation.outputs(&working_dir)?;
 

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -225,6 +225,8 @@ RUST
   assert_success
   run grep -E '"divergences"[[:space:]]*:[[:space:]]*0' "$report"
   assert_success
+  run grep -E '"misses"[[:space:]]*:[[:space:]]*0' "$report"
+  assert_success
   local dylib_a dylib_b
   dylib_a="$(find -L "$first/target" -name 'libaudit_macro-*.dylib' | head -1)"
   dylib_b="$(find -L "$second/target" -name 'libaudit_macro-*.dylib' | head -1)"

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -179,3 +179,63 @@ test_binary() {
   run grep -E '^unsupported-crate-type' "$bypasses"
   assert_success
 }
+
+@test "macOS proc macros and their consumers verify across checkouts" {
+  [[ "$(uname -s)" == Darwin ]] || skip "Mach-O install names are macOS-specific"
+  local first="$BATS_TEST_TMPDIR/macro-a" second="$BATS_TEST_TMPDIR/macro-b"
+  mkdir -p "$first/macros/src" "$first/src"
+  cat >"$first/Cargo.toml" <<'TOML'
+[package]
+name = "macro-consumer"
+version = "0.1.0"
+edition = "2021"
+[dependencies]
+audit-macro = { path = "macros" }
+[profile.dev]
+debug = false
+TOML
+  cat >"$first/macros/Cargo.toml" <<'TOML'
+[package]
+name = "audit-macro"
+version = "0.1.0"
+edition = "2021"
+[lib]
+proc-macro = true
+TOML
+  cat >"$first/macros/src/lib.rs" <<'RUST'
+extern crate proc_macro;
+use proc_macro::TokenStream;
+#[proc_macro]
+pub fn identity(input: TokenStream) -> TokenStream { input }
+RUST
+  echo 'audit_macro::identity! { fn main() { println!("macro works"); } }' >"$first/src/main.rs"
+  cp -R "$first" "$second"
+  # pwd -P avoids macOS /var versus /private/var aliases in rustc remapping.
+  first="$(cd "$first" && pwd -P)"
+  second="$(cd "$second" && pwd -P)"
+  cd "$first"
+  run env MBX_CACHE_LINKS=1 RUSTFLAGS="--remap-path-prefix=$first=/workspace" "$MBX_BIN" build --offline
+  assert_success
+  cd "$second"
+  local report="$BATS_TEST_TMPDIR/macro-verify.json"
+  run env MBX_CACHE_LINKS=1 MBX_VERIFY=1 MBX_STATS_REPORT="$report" RUSTFLAGS="--remap-path-prefix=$second=/workspace" "$MBX_BIN" build --offline
+  assert_success
+  refute_output --partial 'has different contents'
+  run grep -E '"verifications"[[:space:]]*:[[:space:]]*2' "$report"
+  assert_success
+  run grep -E '"divergences"[[:space:]]*:[[:space:]]*0' "$report"
+  assert_success
+  local dylib_a dylib_b
+  dylib_a="$(find -L "$first/target" -name 'libaudit_macro-*.dylib' | head -1)"
+  dylib_b="$(find -L "$second/target" -name 'libaudit_macro-*.dylib' | head -1)"
+  run cmp "$dylib_a" "$dylib_b"
+  assert_success
+  run codesign --verify "$dylib_b"
+  assert_success
+  run otool -D "$dylib_b"
+  assert_success
+  assert_output --partial "@rpath/$(basename "$dylib_b")"
+  run "$second/target/debug/macro-consumer"
+  assert_success
+  assert_output 'macro works'
+}


### PR DESCRIPTION
macOS proc macros embed their absolute output path in `LC_ID_DYLIB`. A shadow build in another checkout therefore produces different dylib bytes even with source paths remapped, and consumers miss because their `--extern` input hashes change.

Set a stable `@rpath/<output filename>` install name when caching macOS proc macros. The injected linker option participates in both the action key and compilation, separating previous artifacts while keeping verification and dependent input hashing byte-exact. Explicit install names are preserved; unsupported linker arguments continue to bypass caching.

Validation:
- Full `mise run ci` passed (task shell PATH set to the repository-pinned usage 6.5.0 because Homebrew usage 3.5.2 otherwise takes precedence on this machine).
- Rust adapter tests cover key separation, explicit names, platform/artifact scope, and unsupported option spellings.
- A macOS behavioral regression builds a proc macro and consumer in separate checkouts: the previous binary reports one divergence and one downstream miss; the patched binary verifies both with zero divergences. It also compares dylib bytes, verifies the ad-hoc signature, checks the install name, and runs the consumer.

Addresses https://github.com/jdx/mr-boxington/discussions/419#discussioncomment-18391765.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS native proc-macro linking, cache action keys, and restored dylib metadata; incorrect handling could cause cache misses or broken macro loading.
> 
> **Overview**
> Fixes macOS proc-macro dylibs differing across checkouts because **ld64** embeds the build output path in **`LC_ID_DYLIB`**, which breaks cache verification and shifts downstream **`--extern`** input hashes even when sources are remapped.
> 
> For **cached macOS proc-macro** links, the wrapper now injects a stable **`-Wl,-install_name,@rpath/<dylib filename>`** linker flag. That flag is parsed as a first-class **`InstallName`** argument, participates in the action key, and is replayed in dep-info commands. Explicit **`@rpath/...`** install names are left alone; other spellings still bypass caching. **`safe_install_name`** rejects unsafe filenames.
> 
> Unit tests cover platform/crate-type scope, key separation from legacy artifacts, and invalid options. A macOS **bats** test builds a proc macro and consumer in two checkouts and asserts verify stats, matching dylib bytes, codesign, **`otool -D`**, and runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e06db66a68a36af2aa3ac69b375ec10cb49d9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS procedural macro caching across copied or relocated checkouts.
  - Preserved and normalized dynamic-library install names so cached artifacts remain usable when project paths change.
  - Improved cache differentiation for artifacts with custom install-name settings.
  - Added validation to reject unsupported or unsafe install-name formats.

- **Tests**
  - Added coverage for cached procedural macros, code signing, dynamic-library metadata, and successful downstream execution on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->