### PR TITLE
perf(cc): deduplicate equivalent include manifest roots

### DIFF
--- a/crates/mbx-cache-cc/src/depfile.rs
+++ b/crates/mbx-cache-cc/src/depfile.rs
@@ -514,24 +514,35 @@ fn minimal_manifest_directories(directories: BTreeSet<PathBuf>) -> Vec<PathBuf> 
     let mut directories = directories
         .into_iter()
         .map(|directory| {
-            let normalized = normalize_components(&directory);
+            let normalized = manifest_directory_identity(&directory);
             (directory, normalized)
         })
         .collect::<Vec<_>>();
     directories.sort_by(|(left, left_normalized), (right, right_normalized)| {
         left_normalized
+            .as_deref()
+            .unwrap_or(left)
             .components()
             .count()
-            .cmp(&right_normalized.components().count())
+            .cmp(
+                &right_normalized
+                    .as_deref()
+                    .unwrap_or(right)
+                    .components()
+                    .count(),
+            )
             .then_with(|| left_normalized.cmp(right_normalized))
             .then_with(|| left.cmp(right))
     });
 
-    let mut minimal = Vec::<(PathBuf, PathBuf)>::new();
+    let mut minimal = Vec::<(PathBuf, Option<PathBuf>)>::new();
     for (directory, normalized) in directories {
         if !minimal
             .iter()
-            .any(|(_, ancestor)| manifest_covers(ancestor, &normalized))
+            .any(|(_, ancestor)| match (ancestor, &normalized) {
+                (Some(ancestor), Some(normalized)) => manifest_covers(ancestor, normalized),
+                _ => false,
+            })
         {
             minimal.push((directory, normalized));
         }
@@ -540,6 +551,27 @@ fn minimal_manifest_directories(directories: BTreeSet<PathBuf>) -> Vec<PathBuf> 
         .into_iter()
         .map(|(directory, _)| directory)
         .collect()
+}
+
+/// Lexical parent removal is safe only when the removed directory exists and
+/// is not a symlink: `link/..` can name a completely different physical tree.
+/// An unprovable path keeps its own manifest instead of joining another root.
+fn manifest_directory_identity(directory: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in directory.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                let metadata = std::fs::symlink_metadata(&normalized).ok()?;
+                if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                    return None;
+                }
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    Some(normalized)
 }
 
 /// Whether walking `ancestor` recursively is guaranteed to visit `descendant`.
@@ -553,7 +585,7 @@ fn manifest_covers(ancestor: &Path, descendant: &Path) -> bool {
         return false;
     };
     if relative.as_os_str().is_empty() {
-        return false;
+        return true;
     }
     let mut current = ancestor.to_path_buf();
     for component in relative.components() {

--- a/crates/mbx-cache-cc/src/depfile_tests.rs
+++ b/crates/mbx-cache-cc/src/depfile_tests.rs
@@ -107,6 +107,76 @@ fn a_parent_manifest_does_not_claim_a_directory_reached_through_a_symlink() {
     );
 }
 
+/// Amalgamated sources name one tree through many parent-directory spellings.
+#[test]
+fn equivalent_parent_paths_share_one_manifest_budget_and_track_new_headers() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path().join("include");
+    let source = write(&root, "source.c", "int value;\n");
+    for index in 0..1024 {
+        write(&root, &format!("header-{index}.h"), "");
+    }
+    let mut directories = BTreeSet::from([root.clone()]);
+    for index in 0..20 {
+        let child = root.join(format!("part-{index}"));
+        std::fs::create_dir(&child).unwrap();
+        directories.insert(child.join(".."));
+    }
+    assert_eq!(
+        minimal_manifest_directories(directories.clone()).as_slice(),
+        std::slice::from_ref(&root)
+    );
+    let collect = || {
+        CcDiscoveredInputs::collect(
+            workspace.path(),
+            BTreeSet::from([source.clone()]),
+            directories.clone(),
+            &NoFileDigestCache,
+        )
+        .unwrap()
+    };
+    let before = collect();
+    assert_eq!(before.inputs.len(), 2);
+    write(&root, "new-shadow.h", "");
+    let after = collect();
+    assert_ne!(before.inputs, after.inputs);
+}
+
+/// Failed path resolution must not be mistaken for an equivalent root.
+#[test]
+fn nonexistent_parent_traversals_keep_their_own_manifest() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path().join("include");
+    std::fs::create_dir(&root).unwrap();
+    let missing = root.join("missing/..");
+    let minimal = minimal_manifest_directories(BTreeSet::from([root.clone(), missing.clone()]));
+    assert_eq!(minimal.len(), 2);
+    assert!(minimal.contains(&root) && minimal.contains(&missing));
+}
+
+/// A lexical `..` may escape through a link, including after an earlier scan.
+#[cfg(unix)]
+#[test]
+fn replacing_a_parent_traversal_with_a_symlink_stops_deduplication() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path().join("include");
+    let child = root.join("child");
+    let external = workspace.path().join("external/nested");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::create_dir_all(&external).unwrap();
+    let alias = child.join("..");
+    let directories = BTreeSet::from([root.clone(), alias.clone()]);
+    assert_eq!(
+        minimal_manifest_directories(directories.clone()).as_slice(),
+        std::slice::from_ref(&root)
+    );
+    std::fs::remove_dir(&child).unwrap();
+    std::os::unix::fs::symlink(&external, &child).unwrap();
+    let minimal = minimal_manifest_directories(directories);
+    assert_eq!(minimal.len(), 2);
+    assert!(minimal.contains(&root) && minimal.contains(&alias));
+}
+
 #[test]
 fn timestamp_macro_tokens_in_any_read_file_bypass() {
     let directory = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Equivalent include-directory spellings such as `crypto/fipsmodule/aes/../..` were each charged against the 16,384-entry manifest budget. On aws-lc's amalgamated `bcm.c`, repeated scans exhausted that budget and prevented the result from being cached, leaving a costly compile in otherwise warm builds.

Deduplicate equivalent roots only when every removed `..` component traverses an existing ordinary directory. Paths with missing components or symlink traversals retain separate manifests. Ancestor manifests still track newly introduced headers that could shadow previous inputs.

Validation:
- 86 cache-library tests pass on macOS; 84 pass in the Linux reproduction checkout. New regressions cover duplicate-root budget exhaustion, added headers, missing paths, and a directory replaced by a symlink.
- A Linux shadow-verification build checked 385 cached compilations with zero divergences.
- Clippy with all targets/features, formatting, and diff checks pass.
- On an isolated aws-lc-sys 0.44.0 workload with debug mbx binaries, three alternating warm trials improved from 4.63s median (4.59–4.98s) to 3.30s (3.13–3.45s), about 29%. A fresh cache seeded by the safe implementation restores bcm.c successfully. This is not a full hk benchmark.
- `mise run ci` was attempted and stops at the existing pinned usage 6.5.0 documentation-rendering error for `unknown_flags`. Generated deletions were discarded.

The full hk benchmark will run after this change is merged and released.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache-key computation for CC include manifests; incorrect deduplication could miss shadowing headers, but guards for symlinks, missing paths, and unprovable `..` limit that risk.
> 
> **Overview**
> **Include-directory manifest deduplication** now treats paths as the same root only when `..` segments traverse existing, non-symlink directories via new `manifest_directory_identity`; lexical-only normalization is replaced so missing segments or symlink escapes keep separate manifests and do not collapse onto another tree.
> 
> `minimal_manifest_directories` sorts and compares using these optional identities, and `manifest_covers` treats an ancestor as covering an equivalent descendant (empty relative path). New tests cover amalgamated duplicate `child/..` spellings (single manifest budget, new headers still invalidate keys), nonexistent `missing/..`, and directory→symlink replacement undoing deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa752d91ec20007f7dd344a3ed5a09ef4497037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved include-directory handling when paths use parent-directory segments such as `..`.
  - Prevented directories from being incorrectly merged when path resolution is unsafe, unavailable, or affected by symlinks.
  - Correctly recognizes identical ancestor and descendant paths as covered.
  - Ensured newly added headers remain tracked after equivalent directory paths are consolidated.

- **Tests**
  - Added coverage for normalized parent-directory aliases, unresolved paths, and symlink-based directory changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->