### PR TITLE
fix(cache): cover dependency debug paths in macOS links

### DIFF
--- a/crates/mbx-cache-rustc/src/lib.rs
+++ b/crates/mbx-cache-rustc/src/lib.rs
@@ -1827,7 +1827,12 @@ impl Parser<'_> {
             let Argument::OsoPrefix { path, .. } = argument else {
                 return false;
             };
-            path.is_absolute() && directory.starts_with(normalize_components(path))
+            path.is_absolute()
+                && (directory.starts_with(normalize_components(path))
+                    || std::fs::canonicalize(&directory)
+                        .ok()
+                        .zip(std::fs::canonicalize(path).ok())
+                        .is_some_and(|(directory, prefix)| directory.starts_with(prefix)))
         })
     }
 

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -2866,11 +2866,17 @@ fn path_mappings_with_env(
 /// same shape below a target-triple directory). Mapping the profile parent,
 /// rather than only `deps`, also covers generated inputs below `build/`.
 fn standalone_target_root(output: &Path, target: Option<&str>) -> PathBuf {
-    if matches!(
+    let profile = if matches!(
         output.file_name().and_then(OsStr::to_str),
         Some("deps" | "examples")
-    ) && let Some(profile_root) = output.parent().and_then(Path::parent)
-    {
+    ) {
+        output.parent()
+    } else if output.parent().and_then(Path::file_name) == Some(OsStr::new("build")) {
+        output.parent().and_then(Path::parent)
+    } else {
+        None
+    };
+    if let Some(profile_root) = profile.and_then(Path::parent) {
         let target_component = target.and_then(|target| Path::new(target).file_stem());
         if target_component.is_some_and(|target| profile_root.file_name() == Some(target))
             && let Some(root) = profile_root.parent()

--- a/crates/mbx/src/rustc.rs
+++ b/crates/mbx/src/rustc.rs
@@ -1778,8 +1778,8 @@ fn selected_clippy_config(working_dir: &Path) -> Option<PathBuf> {
 ///
 /// On macOS a linked binary records the absolute path and timestamp of every
 /// object behind it, which is what makes a debug-info link unportable across
-/// checkouts. The output directory is where all of them live, and only the
-/// shim sees its managed, hashed spelling on every invocation -- so when
+/// checkouts. The target root covers both the executable's output directory
+/// and its dependencies, including sibling directories for examples. When
 /// native links are being cached on this platform, the shim appends the
 /// prefix itself rather than asking anyone to discover it. An invocation that
 /// already carries one keeps what its caller chose, and an invocation without
@@ -1816,8 +1816,48 @@ fn with_oso_prefix(arguments: &[OsString], cache_links: bool) -> Cow<'_, [OsStri
     let Some(out_dir) = out_dir.filter(|out_dir| out_dir.is_absolute()) else {
         return Cow::Borrowed(arguments);
     };
+    // Examples link rlibs from the sibling deps directory, and build scripts
+    // can live further below build/. Strip the shared target root rather than
+    // only the directory receiving this particular executable.
+    let prefix = std::env::var_os(session::TARGET_DIR_ENV)
+        .map(PathBuf::from)
+        .filter(|root| root.is_absolute() && out_dir.starts_with(root))
+        .unwrap_or_else(|| standalone_target_root(&out_dir, None));
+    // ld64 resolves archive paths through Cargo's target symlink before
+    // recording them, so the prefix must use the same physical spelling.
+    let prefix = std::fs::canonicalize(&prefix).unwrap_or(prefix);
     let mut extended = arguments.to_vec();
-    extended.push(format!("-Clink-arg=-Wl,-oso_prefix,{}/", out_dir.display()).into());
+    // Direct object paths use rustc's output spelling while archive paths are
+    // canonicalized by ld64. Give both the same spelling so one prefix covers
+    // them. This still writes through Cargo's target symlink to the same files.
+    let native_output = arguments.iter().enumerate().any(|(index, argument)| {
+        argument == "--test"
+            || matches!(
+                argument.to_str(),
+                Some("--crate-type=bin" | "--crate-type=proc-macro")
+            )
+            || (argument == "--crate-type"
+                && arguments
+                    .get(index + 1)
+                    .is_some_and(|value| matches!(value.to_str(), Some("bin" | "proc-macro"))))
+    });
+    if native_output && let Ok(output) = std::fs::canonicalize(&out_dir) {
+        for index in 0..extended.len() {
+            if extended[index] == "--out-dir" {
+                if let Some(value) = extended.get_mut(index + 1) {
+                    *value = output.as_os_str().to_owned();
+                }
+            } else if extended[index]
+                .to_str()
+                .is_some_and(|arg| arg.starts_with("--out-dir="))
+            {
+                let mut value = OsString::from("--out-dir=");
+                value.push(&output);
+                extended[index] = value;
+            }
+        }
+    }
+    extended.push(format!("-Clink-arg=-Wl,-oso_prefix,{}/", prefix.display()).into());
     Cow::Owned(extended)
 }
 
@@ -2737,7 +2777,19 @@ fn path_mappings_with_env(
     // working directory -- the session passes both in.
     let configured_target = environment(session::TARGET_DIR_ENV)
         .map(PathBuf::from)
-        .filter(|root| root.is_absolute());
+        .filter(|root| root.is_absolute())
+        .map(|root| {
+            // Match the spelling emitted by rustc when a macOS link uses the
+            // physical target directory to share ld64's single OSO prefix.
+            let physical = std::fs::canonicalize(&root).ok();
+            physical
+                .filter(|physical| {
+                    target_output.is_some_and(|output| {
+                        output.starts_with(physical) && !output.starts_with(&root)
+                    })
+                })
+                .unwrap_or(root)
+        });
     if let Some(root) = configured_target.or_else(|| {
         target_output
             .filter(|root| root.is_absolute())
@@ -2814,8 +2866,10 @@ fn path_mappings_with_env(
 /// same shape below a target-triple directory). Mapping the profile parent,
 /// rather than only `deps`, also covers generated inputs below `build/`.
 fn standalone_target_root(output: &Path, target: Option<&str>) -> PathBuf {
-    if output.file_name() == Some(OsStr::new("deps"))
-        && let Some(profile_root) = output.parent().and_then(Path::parent)
+    if matches!(
+        output.file_name().and_then(OsStr::to_str),
+        Some("deps" | "examples")
+    ) && let Some(profile_root) = output.parent().and_then(Path::parent)
     {
         let target_component = target.and_then(|target| Path::new(target).file_stem());
         if target_component.is_some_and(|target| profile_root.file_name() == Some(target))

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -969,6 +969,17 @@ fn a_root_written_with_a_trailing_separator_still_rewrites() {
 #[cfg(target_os = "macos")]
 #[test]
 fn the_shim_appends_an_oso_prefix_for_cached_links() {
+    // Test the standalone fallback in a subprocess without racing other tests' environment.
+    if std::env::var_os("MBX_TEST_OSO_FALLBACK").is_none() {
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("the_shim_appends_an_oso_prefix_for_cached_links")
+            .env("MBX_TEST_OSO_FALLBACK", "1")
+            .env_remove(session::TARGET_DIR_ENV)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        return;
+    }
     let arguments = |values: &[&str]| values.iter().map(OsString::from).collect::<Vec<_>>();
     let base = arguments(&[
         "--crate-name=app",
@@ -985,6 +996,11 @@ fn the_shim_appends_an_oso_prefix_for_cached_links() {
     );
     let example = arguments(&["--out-dir=/work/target/debug/examples", "examples/app.rs"]);
     assert_eq!(with_oso_prefix(&example, true).last(), extended.last());
+    let build_script = arguments(&[
+        "--out-dir=/work/target/debug/build/package-hash",
+        "build.rs",
+    ]);
+    assert_eq!(with_oso_prefix(&build_script, true).last(), extended.last());
     // Off when links are not cached, when the caller chose a prefix, and when
     // there is no output directory to cover.
     assert_eq!(with_oso_prefix(&base, false).len(), base.len());

--- a/crates/mbx/src/rustc_tests.rs
+++ b/crates/mbx/src/rustc_tests.rs
@@ -981,8 +981,10 @@ fn the_shim_appends_an_oso_prefix_for_cached_links() {
     let extended = with_oso_prefix(&base, true);
     assert_eq!(
         extended.last().unwrap(),
-        &OsString::from("-Clink-arg=-Wl,-oso_prefix,/work/target/debug/deps/"),
+        &OsString::from("-Clink-arg=-Wl,-oso_prefix,/work/target/"),
     );
+    let example = arguments(&["--out-dir=/work/target/debug/examples", "examples/app.rs"]);
+    assert_eq!(with_oso_prefix(&example, true).last(), extended.last());
     // Off when links are not cached, when the caller chose a prefix, and when
     // there is no output directory to cover.
     assert_eq!(with_oso_prefix(&base, false).len(), base.len());
@@ -1017,7 +1019,7 @@ fn the_shim_appends_an_oso_prefix_for_cached_links() {
     let split = arguments(&["--out-dir=/work/target/debug/deps", "src/main.rs"]);
     assert_eq!(
         with_oso_prefix(&split, true).last().unwrap(),
-        &OsString::from("-Clink-arg=-Wl,-oso_prefix,/work/target/debug/deps/"),
+        &OsString::from("-Clink-arg=-Wl,-oso_prefix,/work/target/"),
     );
 }
 

--- a/test/native_link_cache.bats
+++ b/test/native_link_cache.bats
@@ -241,3 +241,49 @@ RUST
   assert_success
   assert_output 'macro works'
 }
+
+@test "macOS examples verify debug maps for sibling dependency directories" {
+  [[ "$(uname -s)" == Darwin ]] || skip "Mach-O debug maps are macOS-specific"
+  local views
+  for views in true false; do
+    export MBX_TARGET_VIEWS="$views"
+    export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/store-$views"
+    local first="$BATS_TEST_TMPDIR/$views/example-a" second="$BATS_TEST_TMPDIR/$views/example-b"
+    mkdir -p "$first/src" "$first/examples"
+    cat >"$first/Cargo.toml" <<'TOML'
+[package]
+name = "example-debug-map"
+version = "0.1.0"
+edition = "2021"
+[profile.dev]
+debug = 2
+split-debuginfo = "unpacked"
+TOML
+    echo '#[inline(never)] pub fn answer() -> u32 { 42 }' >"$first/src/lib.rs"
+    echo 'fn main() { println!("{}", example_debug_map::answer()); }' >"$first/examples/answer.rs"
+    cp -R "$first" "$second"
+    first="$(cd "$first" && pwd -P)"
+    second="$(cd "$second" && pwd -P)"
+    cd "$first"
+    run env MBX_CACHE_LINKS=1 RUSTFLAGS="--remap-path-prefix=$first=/workspace" "$MBX_BIN" build --examples --offline
+    assert_success
+    cd "$second"
+    local report="$BATS_TEST_TMPDIR/example-verify.json"
+    run env MBX_CACHE_LINKS=1 MBX_VERIFY=1 MBX_STATS_REPORT="$report" RUSTFLAGS="--remap-path-prefix=$second=/workspace" "$MBX_BIN" build --examples --offline
+    assert_success
+    refute_output --partial 'shadow verification diverged'
+    run grep -E '"verifications"[[:space:]]*:[[:space:]]*2' "$report"
+    assert_success
+    run grep -E '"divergences"[[:space:]]*:[[:space:]]*0' "$report"
+    assert_success
+    run grep -E '"misses"[[:space:]]*:[[:space:]]*0' "$report"
+    assert_success
+    run cmp "$first/target/debug/examples/answer" "$second/target/debug/examples/answer"
+    assert_success
+    run codesign --verify "$second/target/debug/examples/answer"
+    assert_success
+    run "$second/target/debug/examples/answer"
+    assert_success
+    assert_output '42'
+  done
+}


### PR DESCRIPTION
macOS example executables link rlibs from the sibling `deps/` directory. The injected `-oso_prefix` previously covered only the executable's output directory, leaving checkout paths in the Mach-O debug map and causing cross-checkout verification failures.

Use the shared target root for the prefix. For managed targets, give rustc's linked outputs the physical directory spelling that ld64 uses for archive paths, and use the matching spelling when normalizing diagnostics. Non-linked libraries retain their output paths so incremental dependency tracking is unchanged. Explicit prefixes and explicit cross targets retain their existing behavior.

Full `mise run ci` passed on macOS (using the pinned usage binary in the task-shell PATH).

Validation: the regression reproduces a divergence with the previous binary, then verifies both a library and its example with zero misses or divergences across checkouts, with managed targets both enabled and disabled. It also compares executable bytes, verifies the ad-hoc signature, and runs the example. The existing incremental-dependency regression passes.

Follow-up to https://github.com/jdx/mr-boxington/discussions/419.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS linker argument injection and cache key path normalization for native links; wrong prefix or canonicalization could still cause verification divergences or bypass behavior, but scope is platform-specific and heavily tested.
> 
> **Overview**
> Fixes macOS native-link cache misses when **example** (and similar) builds leave sibling `deps/` paths in the Mach-O debug map.
> 
> **Linker shim (`with_oso_prefix`)** now strips the shared **target root** instead of only `--out-dir`, canonicalizes that prefix to match ld64’s symlink-resolved archive paths, and for host **bin/proc-macro/test** links rewrites `--out-dir` to the physical directory so one `-oso_prefix` covers both object and rlib spellings. **`standalone_target_root`** and target **path mappings** were widened (`examples`, `build/`) and aligned with that physical spelling when the configured target is a symlink.
> 
> **Parser** treats an existing `OsoPrefix` as satisfied when canonicalized paths match, not only string prefix checks.
> 
> **Tests:** unit expectations + subprocess env isolation; new Bats case verifying cross-checkout example builds with zero verification divergences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d412e0659803f24895a0c1203ec4460f314e2315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS build caching when projects use symlinked or relocated target directories.
  - Fixed linker debug-map handling for example builds and sibling checkout directories.
  - Improved reliability of cached native links while preserving valid code signing and executable behavior.

- **Tests**
  - Added coverage for cached links across multiple target-directory configurations, including verification of identical binaries and successful execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->