### PR TITLE
fix(cache): recover C predictions after stderr-only conflicts

### DIFF
--- a/crates/mbx/src/cc.rs
+++ b/crates/mbx/src/cc.rs
@@ -407,7 +407,7 @@ fn publish(
     discovered.verify_not_modified_since_with_snapshots(compilation_started, input_snapshots)?;
     verify_search_path_unchanged(searchable, before)?;
     discovered.verify()?;
-    discovered.apply_to(context)?;
+    discovered.clone().apply_to(context)?;
     // Debug remapping does not change runtime strings such as __FILE__. If
     // an object retains a path, bind its action to the literal paths instead
     // of discarding it or restoring another checkout's runtime strings.
@@ -418,7 +418,23 @@ fn publish(
     let mut prediction = invocation.prediction(context, duration_ns)?;
     prediction.path_specific = !portable.outputs_are_clean(&object, &context.path_mappings);
     let action = invocation.action_with_path_binding(context.clone(), prediction.path_specific)?;
-    publish_result(&action, &object, output, &context.path_mappings)?;
+    if let Err(error) = publish_result(&action, &object, output, &context.path_mappings) {
+        // GCC can name a random assembler tempfile in stderr. An immutable
+        // result may already exist even though this task has no prediction.
+        // Validate it without replacing this compile's output, and only reuse
+        // its prediction when stdout and the object (including mode) agree.
+        let existing = restore_result(
+            &action,
+            invocation,
+            &discovered,
+            false,
+            &context.path_mappings,
+            &context.working_dir,
+        );
+        if !matches!(existing, Ok(Some(ref cached)) if publication_outputs_match(cached, output)) {
+            return Err(error);
+        }
+    }
     record_prediction(
         task,
         invocation_digest,
@@ -1424,6 +1440,16 @@ fn verification_divergence(cached: &CachedCompilation, output: &Output) -> Optio
     {
         return Some(difference);
     }
+    output_divergence(cached)
+}
+
+/// A stderr-only publication conflict may retain the validated first result.
+/// Verification still compares both streams and reports every byte difference.
+fn publication_outputs_match(cached: &CachedCompilation, output: &Output) -> bool {
+    output.status.success() && cached.stdout == output.stdout && output_divergence(cached).is_none()
+}
+
+fn output_divergence(cached: &CachedCompilation) -> Option<String> {
     for expected in &cached.outputs {
         let name = expected.path.display();
         let Ok(metadata) = std::fs::metadata(&expected.path) else {

--- a/crates/mbx/src/cc_tests.rs
+++ b/crates/mbx/src/cc_tests.rs
@@ -150,6 +150,18 @@ fn a_divergence_says_which_of_the_things_it_compares_differed() {
         stderr: stderr.to_vec(),
     };
     let matching = CacheDigest::blake3(b"compiled");
+    assert!(publication_outputs_match(
+        &cached(b"", b"old", matching.clone()),
+        &compiled(b"", b"new")
+    ));
+    assert!(!publication_outputs_match(
+        &cached(b"old", b"", matching.clone()),
+        &compiled(b"new", b"")
+    ));
+    assert!(!publication_outputs_match(
+        &cached(b"", b"", CacheDigest::blake3(b"different object")),
+        &compiled(b"", b"")
+    ));
 
     assert_eq!(
         verification_divergence(&cached(b"", b"", matching.clone()), &compiled(b"", b"")),

--- a/test/cc_standalone_exec.bats
+++ b/test/cc_standalone_exec.bats
@@ -386,3 +386,52 @@ SOURCE
     assert_output "$cargo_home/registry/generated.c"
   done
 }
+
+@test "a stderr-only C publication conflict records a reusable prediction" {
+  local project="$BATS_TEST_TMPDIR/verify-stream"
+  local compiler="$BATS_TEST_TMPDIR/compiler"
+  local real_cc
+  real_cc="$(command -v cc)"
+  write_project "$project"
+  mkdir -p "$compiler"
+  cat >"$compiler/cc" <<'SCRIPT'
+#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = -c ]; then
+    echo "$MBX_TEST_CC_MESSAGE" >&2
+    break
+  fi
+done
+exec "$MBX_TEST_REAL_CC" "$@"
+SCRIPT
+  chmod +x "$compiler/cc"
+  export MBX_TEST_REAL_CC="$real_cc"
+  export PATH="$compiler:$PATH"
+  cd "$project"
+  run env MBX_TEST_CC_MESSAGE=cached "$MBX_BIN" exec make 'CFLAGS=-O2 -Iinclude -MMD -MF hello.d' hello.o
+  assert_success
+  rm hello.o hello.d
+  # Keep the existing result and blobs but omit prediction indexes, as in a
+  # store whose result was published before its prediction could be recorded.
+  local previous_store="$MBX_CACHE_DIR"
+  export MBX_CACHE_DIR="$BATS_TEST_TMPDIR/result-only-store"
+  mkdir -p "$MBX_CACHE_DIR/actions"
+  cp -R "$previous_store/actions/cas" "$previous_store/actions/action-results" "$MBX_CACHE_DIR/actions/"
+  run env MBX_CACHE_EXPORT_GROUP=verify-audit MBX_TEST_CC_MESSAGE=verified "$MBX_BIN" exec make 'CFLAGS=-O2 -Iinclude -MMD -MF hello.d' hello.o
+  assert_success
+  assert_line 'verified'
+  refute_output --partial 'shadow verification diverged'
+  refute_output --partial 'result was not published'
+  run "$MBX_BIN" cache export --group verify-audit "$BATS_TEST_TMPDIR/audit.tar"
+  assert_success
+  assert_output --partial "exported 1 actions"
+  assert_file_exists "$BATS_TEST_TMPDIR/audit.tar"
+  assert_file_exists hello.d
+  rm hello.o hello.d
+  run env MBX_TEST_CC_MESSAGE=unused "$MBX_BIN" exec make 'CFLAGS=-O2 -Iinclude -MMD -MF hello.d' hello.o
+  assert_success
+  assert_line 'cached'
+  refute_line 'unused'
+  refute_line 'verified'
+  assert_file_exists hello.d
+}


### PR DESCRIPTION
A C action result can exist without a usable prediction. If recompiling produces identical object bytes but different stderr (such as GCC's random assembler tempfile name), immutable publication rejects the result and mbx never records a prediction, repeating the compilation and warning on every build.

After failed publication, validate the existing cached result without materializing over the newly compiled output. Record its prediction only when stdout, object bytes, and file mode match. Preserve the first result and replay the current compiler's output. Different objects or stdout still report the publication failure; verification still compares stderr exactly.

Full `mise run ci` passed on macOS (using the pinned usage binary in the task-shell PATH).

Validation: a regression starts from a store containing results and blobs but no predictions, reproduces the warning with the previous binary, then checks prediction recovery, export, caller depfiles, and replay of the original cached stderr on the next build. Unit coverage rejects object and stdout differences.

Follow-up to https://github.com/jdx/mr-boxington/discussions/419.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches C cache publication and prediction recording on failure paths; logic is narrow (stdout/object agreement) but affects when entries are reused vs rejected.
> 
> **Overview**
> When **immutable C cache publication** fails because a result already exists (often **stderr-only** differences, e.g. GCC naming a random assembler tempfile), the cc shim no longer always aborts before recording a prediction.
> 
> On `publish_result` error it **restores and validates the existing entry** without overwriting the fresh compile (`restore_outputs: false`). If **`publication_outputs_match`**—successful exit, matching stdout, and on-disk object bytes/mode agree—it **keeps the first cached result**, still **records the prediction**, and avoids repeat compiles and publication warnings. Real mismatches on stdout or the object still surface the original error. **`output_divergence`** is shared with shadow verification; verification continues to compare stderr strictly.
> 
> Unit tests cover the match predicate; a **bats** scenario copies a result-only store (no prediction index) and checks recovery, export, depfiles, and replay of the original stderr on the next hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8386f59d737d971e01418ab529c9aed4b52b49b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->