### PR TITLE
fix: end build sessions before launching cargo applications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
 
 [[package]]
+name = "cargo-config2"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "855d1b74d8faf6c56e02ddbb8a60f6eae479bba5ee6ee29cddee73fe9484f261"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1426,7 @@ name = "mbx"
 version = "1.10.1"
 dependencies = [
  "bytesize",
+ "cargo-config2",
  "demand",
  "dirs",
  "env_logger",

--- a/crates/mbx/Cargo.toml
+++ b/crates/mbx/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [dependencies]
 bytesize = "2"
+cargo-config2 = "0.1.45"
 demand = "2"
 env_logger = "0.11"
 dirs = "6"

--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -285,14 +285,19 @@ fn cargo_with_settings_bypass_log_and_roots(
         };
         Ok((status, stats))
     });
-    let status = account_session(config, settings, session_outcome, removed_target_bytes)?;
-    if status == ExitCode::SUCCESS
-        && let Some(launch) = launch.filter(|launch| launch.was_captured())
-    {
-        launch.run()
-    } else {
-        Ok(status)
-    }
+    // Finish the build session before the application takes over stderr, but
+    // keep the automatic target sweep after it exits: collection must not
+    // remove the executable Cargo just selected before we have started it.
+    let session_outcome = match session_outcome {
+        Ok((Ok(status), stats))
+            if status == ExitCode::SUCCESS
+                && launch.as_ref().is_some_and(|launch| launch.was_captured()) =>
+        {
+            Ok((launch.unwrap().run(), stats))
+        }
+        other => other,
+    };
+    account_session(config, settings, session_outcome, removed_target_bytes)
 }
 
 pub(super) struct TargetViewPlacement {

--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -78,6 +78,9 @@ fn cargo_with_settings_bypass_log_and_roots(
         settings.summary
     };
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    if super::launch::needs_plain_launch(arguments) {
+        return super::launch::plain_launch(&cargo, arguments);
+    }
     // Only where mbx can identify the linker precisely enough to key what it
     // produced. Said out loud only to somebody who asked for it: this is on
     // by default now, and a platform that cannot do it would otherwise warn
@@ -166,6 +169,7 @@ fn cargo_with_settings_bypass_log_and_roots(
     }
 
     let session_dir = tempfile::Builder::new().prefix("mbx-session-").tempdir()?;
+    let launch = super::launch::Launch::prepare(arguments, session_dir.path())?;
     let cargo_jobs = cargo_job_limit(arguments);
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -193,6 +197,7 @@ fn cargo_with_settings_bypass_log_and_roots(
             Err(error) => return Err(error),
         };
         let mut environment = inherited_environment(|name| std::env::var(name).ok(), &working_dir);
+        let _lease = super::launch::lease(session_dir.path(), &mut environment)?;
         if let Some(path) = bypass_log {
             let path = if path.is_absolute() {
                 path.to_path_buf()
@@ -253,6 +258,10 @@ fn cargo_with_settings_bypass_log_and_roots(
             if cache_links { "1" } else { "0" }.into(),
         );
 
+        if let Some(launch) = &launch {
+            launch.environment(&mut environment)?;
+        }
+        super::launch::record_overlay(&mut environment)?;
         let status = run_cargo(&cargo, arguments, environment);
         // The shim records a prediction only after a compilation has either
         // been restored or published successfully. Preserve that completed
@@ -276,7 +285,14 @@ fn cargo_with_settings_bypass_log_and_roots(
         };
         Ok((status, stats))
     });
-    account_session(config, settings, session_outcome, removed_target_bytes)
+    let status = account_session(config, settings, session_outcome, removed_target_bytes)?;
+    if status == ExitCode::SUCCESS
+        && let Some(launch) = launch.filter(|launch| launch.was_captured())
+    {
+        launch.run()
+    } else {
+        Ok(status)
+    }
 }
 
 pub(super) struct TargetViewPlacement {

--- a/crates/mbx/src/cli/launch.rs
+++ b/crates/mbx/src/cli/launch.rs
@@ -10,6 +10,7 @@ const SHIM: &str = "mbx-launch";
 const CAPTURE: &str = "MBX_LAUNCH_CAPTURE";
 const RESTORE: &str = "MBX_SESSION_RESTORE";
 const LEASE: &str = "MBX_SESSION_LEASE";
+const BUILD_PATH: &str = "MBX_SESSION_PATH";
 
 type Environment = BTreeMap<OsString, OsString>;
 
@@ -51,11 +52,8 @@ pub fn recover_cli() -> Result<Option<ExitCode>> {
     if std::env::var_os(RESTORE).is_none() {
         return Ok(None);
     }
-    let arguments: Vec<_> = std::env::args().skip(1).collect();
-    let launching = arguments
-        .iter()
-        .find(|arg| !arg.starts_with('-') && !arg.starts_with('+'))
-        .is_some_and(|arg| matches!(arg.as_str(), "run" | "r"));
+    let arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let launching = matches!(cargo_subcommand(&arguments), Some("run" | "r"));
     let live = std::env::var_os(LEASE)
         .and_then(|path| std::fs::File::open(path).ok())
         .is_some_and(|file| matches!(file.try_lock(), Err(std::fs::TryLockError::WouldBlock)));
@@ -82,13 +80,31 @@ pub(super) fn needs_plain_launch(arguments: &[String]) -> bool {
         .iter()
         .take_while(|arg| arg.as_str() != "--")
         .collect();
-    args.iter().any(|arg| matches!(arg.as_str(), "run" | "r"))
+    matches!(cargo_subcommand(arguments), Some("run" | "r"))
         && args.iter().any(|arg| {
             arg.starts_with('+')
                 || arg.as_str() == "--config"
                 || arg.starts_with("--config=")
                 || arg.as_str() == "-C"
         })
+}
+
+/// Locate the command without interpreting option values or program arguments
+/// as subcommands. Cargo globals may precede a command through the Cargo shim.
+pub(super) fn cargo_subcommand<T: AsRef<OsStr>>(arguments: &[T]) -> Option<&str> {
+    let mut arguments = arguments.iter();
+    while let Some(argument) = arguments.next() {
+        let argument = argument.as_ref().to_str()?;
+        match argument {
+            "--" => return None,
+            "--color" | "--config" | "-Z" | "-C" | "--directory" => {
+                arguments.next()?;
+            }
+            value if !value.starts_with('-') && !value.starts_with('+') => return Some(value),
+            _ => {}
+        }
+    }
+    None
 }
 
 pub(super) fn lease(
@@ -110,6 +126,11 @@ struct Restore(Vec<(OsString, Option<OsString>)>);
 pub(super) fn record_overlay(environment: &mut BTreeMap<String, String>) -> Result<()> {
     let current = current_environment();
     let caller = CALLER.get().unwrap_or(&current);
+    let build_path = environment
+        .get("PATH")
+        .map(OsString::from)
+        .or_else(|| current.get(OsStr::new("PATH")).cloned());
+    environment.insert(BUILD_PATH.into(), serde_json::to_string(&build_path)?);
     let mut restore = BTreeMap::new();
     // A nested explicit mbx command may replace only part of its parent's
     // overlay. Carry the other keys too, so recovery cannot strand an outer
@@ -173,10 +194,7 @@ impl Launch {
         {
             return Ok(None);
         }
-        let command = args
-            .iter()
-            .find(|arg| !arg.starts_with('+') && !arg.starts_with('-'));
-        if !command.is_some_and(|arg| matches!(arg.as_str(), "run" | "r")) {
+        if !matches!(cargo_subcommand(arguments), Some("run" | "r")) {
             return Ok(None);
         }
         let config = cargo_config2::Config::load()?;
@@ -268,6 +286,43 @@ struct Captured {
     directory: PathBuf,
 }
 
+fn application_environment() -> Result<Environment> {
+    let mut restored = restored_environment()?;
+    // Cargo supplies its own executable path to the application, independently
+    // of the CARGO value mbx changed during compiler dispatch.
+    if let Some(cargo) = std::env::var_os("CARGO") {
+        restored.insert("CARGO".into(), cargo);
+    }
+    let build_path: Option<OsString> = std::env::var(BUILD_PATH)
+        .ok()
+        .map(|value| serde_json::from_str(&value))
+        .transpose()?
+        .flatten();
+    if let (Some(build), Some(launch)) = (build_path, std::env::var_os("PATH")) {
+        let original = restored
+            .get(OsStr::new("PATH"))
+            .cloned()
+            .unwrap_or_default();
+        restored.insert(
+            "PATH".into(),
+            restore_launch_path(&build, &launch, &original)?,
+        );
+    }
+    Ok(restored)
+}
+
+fn restore_launch_path(build: &OsStr, launch: &OsStr, original: &OsStr) -> Result<OsString> {
+    let build: Vec<_> = std::env::split_paths(build).collect();
+    let mut launch: Vec<_> = std::env::split_paths(launch).collect();
+    // On Windows Cargo adds native DLL search paths ahead of the build PATH.
+    // Replace only the inherited suffix, retaining those runtime additions.
+    if launch.ends_with(&build) {
+        launch.truncate(launch.len() - build.len());
+        launch.extend(std::env::split_paths(original));
+    }
+    Ok(std::env::join_paths(launch)?)
+}
+
 /// Capture Cargo's selected executable before normal mbx CLI dispatch.
 pub fn dispatch() -> Option<ExitCode> {
     if !std::env::args_os()
@@ -281,7 +336,7 @@ pub fn dispatch() -> Option<ExitCode> {
             .ok_or_else(|| eyre::eyre!("missing Cargo launch destination"))?;
         let captured = Captured {
             arguments: std::env::args_os().skip(1).collect(),
-            environment: restored_environment()?.into_iter().collect(),
+            environment: application_environment()?.into_iter().collect(),
             directory: std::env::current_dir()?,
         };
         let mut options = std::fs::OpenOptions::new();
@@ -301,4 +356,56 @@ pub fn dispatch() -> Option<ExitCode> {
             ExitCode::FAILURE
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_values_do_not_disable_caching_for_other_commands() {
+        for args in [
+            vec!["+nightly", "test", "run"],
+            vec!["+stable", "build", "--bin", "run"],
+            vec!["+nightly", "build", "--features", "run"],
+            vec!["--config", "run", "check"],
+        ] {
+            assert!(!needs_plain_launch(
+                &args.iter().map(|s| s.to_string()).collect::<Vec<_>>()
+            ));
+        }
+        assert_eq!(cargo_subcommand(&["--color", "always", "run"]), Some("run"));
+        assert_eq!(
+            cargo_subcommand(&["-Z", "unstable-options", "--directory", "run", "check"]),
+            Some("check")
+        );
+        assert!(needs_plain_launch(&[
+            "--config".into(),
+            "a.toml".into(),
+            "run".into()
+        ]));
+    }
+
+    #[test]
+    fn runtime_search_paths_survive_restoring_the_caller_path() {
+        let path = |parts: &[&str]| std::env::join_paths(parts).unwrap();
+        assert_eq!(
+            restore_launch_path(
+                &path(&["shim", "tools"]),
+                &path(&["deps", "sysroot", "shim", "tools"]),
+                &path(&["cargo-proxy", "tools"])
+            )
+            .unwrap(),
+            path(&["deps", "sysroot", "cargo-proxy", "tools"])
+        );
+        assert_eq!(
+            restore_launch_path(
+                &path(&["shim", "tools"]),
+                &path(&["custom"]),
+                &path(&["tools"])
+            )
+            .unwrap(),
+            path(&["custom"])
+        );
+    }
 }

--- a/crates/mbx/src/cli/launch.rs
+++ b/crates/mbx/src/cli/launch.rs
@@ -13,14 +13,22 @@ const LEASE: &str = "MBX_SESSION_LEASE";
 
 type Environment = BTreeMap<OsString, OsString>;
 
+fn current_environment() -> Environment {
+    let variables = std::env::vars_os();
+    // Windows names are case-insensitive: an inherited `Path` must match the
+    // `PATH` override instead of being mistaken for absent.
+    #[cfg(windows)]
+    let variables = variables.map(|(name, value)| (name.to_ascii_uppercase(), value));
+    variables.collect()
+}
+
 /// Snapshot before CLI dispatch changes PATH or CARGO.
 static CALLER: std::sync::OnceLock<Environment> = std::sync::OnceLock::new();
 
 /// Remember the environment to restore when a build later launches an application.
 pub fn remember_caller() {
     CALLER.get_or_init(|| {
-        let mut environment =
-            restored_environment().unwrap_or_else(|_| std::env::vars_os().collect());
+        let mut environment = restored_environment().unwrap_or_else(|_| current_environment());
         environment.remove(OsStr::new("MBX_CARGO_SHIM_MODE"));
         environment.remove(OsStr::new("MBX_CARGO_SHIM_PATH"));
         environment
@@ -100,7 +108,7 @@ pub(super) fn lease(
 struct Restore(Vec<(OsString, Option<OsString>)>);
 
 pub(super) fn record_overlay(environment: &mut BTreeMap<String, String>) -> Result<()> {
-    let current: Environment = std::env::vars_os().collect();
+    let current = current_environment();
     let caller = CALLER.get().unwrap_or(&current);
     let mut restore = BTreeMap::new();
     // A nested explicit mbx command may replace only part of its parent's
@@ -128,7 +136,7 @@ pub(super) fn record_overlay(environment: &mut BTreeMap<String, String>) -> Resu
 }
 
 fn restored_environment() -> Result<Environment> {
-    let mut environment: Environment = std::env::vars_os().collect();
+    let mut environment = current_environment();
     if let Some(encoded) = environment.remove(OsStr::new(RESTORE)) {
         let restore: Restore = serde_json::from_str(&encoded.to_string_lossy())?;
         for (name, value) in restore.0 {

--- a/crates/mbx/src/cli/launch.rs
+++ b/crates/mbx/src/cli/launch.rs
@@ -1,0 +1,296 @@
+//! Cargo owns executable selection; mbx owns the lifetime of its build context.
+use eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+const SHIM: &str = "mbx-launch";
+const CAPTURE: &str = "MBX_LAUNCH_CAPTURE";
+const RESTORE: &str = "MBX_SESSION_RESTORE";
+const LEASE: &str = "MBX_SESSION_LEASE";
+
+type Environment = BTreeMap<OsString, OsString>;
+
+/// Snapshot before CLI dispatch changes PATH or CARGO.
+static CALLER: std::sync::OnceLock<Environment> = std::sync::OnceLock::new();
+
+/// Remember the environment to restore when a build later launches an application.
+pub fn remember_caller() {
+    CALLER.get_or_init(|| {
+        let mut environment =
+            restored_environment().unwrap_or_else(|_| std::env::vars_os().collect());
+        environment.remove(OsStr::new("MBX_CARGO_SHIM_MODE"));
+        environment.remove(OsStr::new("MBX_CARGO_SHIM_PATH"));
+        environment
+    });
+}
+
+pub(super) fn plain_launch(cargo: &OsStr, arguments: &[String]) -> Result<ExitCode> {
+    let mut command = Command::new(cargo);
+    command.args(arguments);
+    if let Some(caller) = CALLER.get() {
+        command.env_clear().envs(caller);
+    }
+    Ok(super::cargo::exit_code(command.status()?))
+}
+
+/// Re-enter from the original environment when an application launch starts a
+/// new build, or when a previous session has ended. Compiler shims never call
+/// this: their diagnostic streams still belong to the compiler.
+pub fn recover_cli() -> Result<Option<ExitCode>> {
+    if std::env::var_os(RESTORE).is_none() {
+        return Ok(None);
+    }
+    let arguments: Vec<_> = std::env::args().skip(1).collect();
+    let launching = arguments
+        .iter()
+        .find(|arg| !arg.starts_with('-') && !arg.starts_with('+'))
+        .is_some_and(|arg| matches!(arg.as_str(), "run" | "r"));
+    let live = std::env::var_os(LEASE)
+        .and_then(|path| std::fs::File::open(path).ok())
+        .is_some_and(|file| matches!(file.try_lock(), Err(std::fs::TryLockError::WouldBlock)));
+    if live && !launching {
+        return Ok(None);
+    }
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .args(std::env::args_os().skip(1))
+        .env_clear()
+        .envs(restored_environment()?);
+    if super::is_cargo_shim() {
+        command.env("MBX_CARGO_SHIM_MODE", "1");
+    }
+    let status = command.status()?;
+    Ok(Some(super::cargo::exit_code(status)))
+}
+
+/// Config overrides cannot be resolved by cargo-config2. Let Cargo handle
+/// these launches with the caller's environment until it offers a stable
+/// resolved-config API. In particular, never replace an unknown runner.
+pub(super) fn needs_plain_launch(arguments: &[String]) -> bool {
+    let args: Vec<_> = arguments
+        .iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .collect();
+    args.iter().any(|arg| matches!(arg.as_str(), "run" | "r"))
+        && args.iter().any(|arg| {
+            arg.starts_with('+')
+                || arg.as_str() == "--config"
+                || arg.starts_with("--config=")
+                || arg.as_str() == "-C"
+        })
+}
+
+pub(super) fn lease(
+    directory: &Path,
+    environment: &mut BTreeMap<String, String>,
+) -> Result<std::fs::File> {
+    let path = directory.join("owner.lock");
+    let file = std::fs::File::create(&path)?;
+    file.lock()?;
+    environment.insert(LEASE.into(), path.to_string_lossy().into_owned());
+    Ok(file)
+}
+
+/// Only values overwritten by mbx are restored. Cargo's own launch environment
+/// (notably dynamic-library paths and CARGO_MANIFEST_DIR) must survive.
+#[derive(Serialize, Deserialize)]
+struct Restore(Vec<(OsString, Option<OsString>)>);
+
+pub(super) fn record_overlay(environment: &mut BTreeMap<String, String>) -> Result<()> {
+    let current: Environment = std::env::vars_os().collect();
+    let caller = CALLER.get().unwrap_or(&current);
+    let mut restore = BTreeMap::new();
+    // A nested explicit mbx command may replace only part of its parent's
+    // overlay. Carry the other keys too, so recovery cannot strand an outer
+    // runner or compiler adapter in a later application.
+    if let Some(encoded) = current.get(OsStr::new(RESTORE)) {
+        let previous: Restore = serde_json::from_str(&encoded.to_string_lossy())?;
+        for (name, _) in previous.0 {
+            restore.insert(name.clone(), caller.get(&name).cloned());
+        }
+    }
+    for name in environment
+        .keys()
+        .map(OsString::from)
+        .chain(["PATH", "CARGO"].into_iter().map(OsString::from))
+    {
+        restore.insert(name.clone(), caller.get(&name).cloned());
+    }
+    restore.insert(RESTORE.into(), None);
+    environment.insert(
+        RESTORE.into(),
+        serde_json::to_string(&Restore(restore.into_iter().collect()))?,
+    );
+    Ok(())
+}
+
+fn restored_environment() -> Result<Environment> {
+    let mut environment: Environment = std::env::vars_os().collect();
+    if let Some(encoded) = environment.remove(OsStr::new(RESTORE)) {
+        let restore: Restore = serde_json::from_str(&encoded.to_string_lossy())?;
+        for (name, value) in restore.0 {
+            match value {
+                Some(value) => {
+                    environment.insert(name, value);
+                }
+                None => {
+                    environment.remove(&name);
+                }
+            }
+        }
+    }
+    environment.remove(OsStr::new(CAPTURE));
+    Ok(environment)
+}
+
+pub(super) struct Launch {
+    capture: PathBuf,
+    runner: Option<cargo_config2::PathAndArgs>,
+    runner_key: String,
+    shim: PathBuf,
+}
+
+impl Launch {
+    pub(super) fn prepare(arguments: &[String], directory: &Path) -> Result<Option<Self>> {
+        let args: Vec<_> = arguments
+            .iter()
+            .take_while(|arg| arg.as_str() != "--")
+            .collect();
+        if args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+        {
+            return Ok(None);
+        }
+        let command = args
+            .iter()
+            .find(|arg| !arg.starts_with('+') && !arg.starts_with('-'));
+        if !command.is_some_and(|arg| matches!(arg.as_str(), "run" | "r")) {
+            return Ok(None);
+        }
+        let config = cargo_config2::Config::load()?;
+        let mut targets = Vec::new();
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            if arg == "--target" {
+                if let Some(target) = args.next() {
+                    targets.push(target.clone());
+                }
+            } else if let Some(target) = arg.strip_prefix("--target=") {
+                targets.push(target.to_owned());
+            }
+        }
+        let targets = config.build_target_for_config(&targets)?;
+        eyre::ensure!(targets.len() == 1, "cargo run requires exactly one target");
+        let target = &targets[0];
+        let runner = config.runner(target)?;
+        let runner_key = format!(
+            "CARGO_TARGET_{}_RUNNER",
+            target.triple().replace('-', "_").to_uppercase()
+        );
+        let shim = crate::session::install_shim_named(
+            &std::env::current_exe()?,
+            directory,
+            SHIM,
+            crate::session::ShimLink::Tracking,
+        )?;
+        Ok(Some(Self {
+            capture: directory.join("launch.json"),
+            runner,
+            runner_key,
+            shim,
+        }))
+    }
+
+    pub(super) fn environment(&self, environment: &mut BTreeMap<String, String>) -> Result<()> {
+        // Cargo splits environment runner strings on whitespace. Resolve the
+        // shim through PATH so a temporary directory containing spaces works.
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let path = std::env::join_paths(
+            std::iter::once(self.shim.parent().unwrap().to_path_buf())
+                .chain(std::env::split_paths(&path)),
+        )?;
+        environment.insert("PATH".into(), path.to_string_lossy().into_owned());
+        environment.insert(self.runner_key.clone(), SHIM.into());
+        environment.insert(CAPTURE.into(), self.capture.to_string_lossy().into_owned());
+        Ok(())
+    }
+
+    pub(super) fn was_captured(&self) -> bool {
+        self.capture.is_file()
+    }
+
+    pub(super) fn run(&self) -> Result<ExitCode> {
+        let captured: Captured = serde_json::from_slice(
+            &std::fs::read(&self.capture)
+                .wrap_err("Cargo did not hand off the application launch")?,
+        )?;
+        std::fs::remove_file(&self.capture)?;
+        let mut args = captured.arguments.into_iter();
+        let executable = args
+            .next()
+            .ok_or_else(|| eyre::eyre!("Cargo supplied no executable"))?;
+        let mut command = if let Some(runner) = &self.runner {
+            let mut command = Command::new(&runner.path);
+            command.args(&runner.args).arg(executable);
+            command
+        } else {
+            Command::new(executable)
+        };
+        command
+            .args(args)
+            .current_dir(captured.directory)
+            .env_clear()
+            .envs(captured.environment);
+        Ok(super::cargo::exit_code(
+            command
+                .status()
+                .wrap_err("failed to launch Cargo application")?,
+        ))
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Captured {
+    arguments: Vec<OsString>,
+    environment: Vec<(OsString, OsString)>,
+    directory: PathBuf,
+}
+
+/// Capture Cargo's selected executable before normal mbx CLI dispatch.
+pub fn dispatch() -> Option<ExitCode> {
+    if !std::env::args_os()
+        .next()
+        .is_some_and(|arg| Path::new(&arg).file_stem() == Some(OsStr::new(SHIM)))
+    {
+        return None;
+    }
+    let result = (|| -> Result<()> {
+        let path = std::env::var_os(CAPTURE)
+            .ok_or_else(|| eyre::eyre!("missing Cargo launch destination"))?;
+        let captured = Captured {
+            arguments: std::env::args_os().skip(1).collect(),
+            environment: restored_environment()?.into_iter().collect(),
+            directory: std::env::current_dir()?,
+        };
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        serde_json::to_writer(options.open(path)?, &captured)?;
+        Ok(())
+    })();
+    Some(match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("mbx[error]: failed to capture Cargo launch: {error:#}");
+            ExitCode::FAILURE
+        }
+    })
+}

--- a/crates/mbx/src/cli/mod.rs
+++ b/crates/mbx/src/cli/mod.rs
@@ -19,6 +19,7 @@ mod doctor;
 mod exec;
 mod explain;
 mod gc;
+pub mod launch;
 mod prefetch;
 mod setup;
 mod shim;

--- a/crates/mbx/src/cli/shim.rs
+++ b/crates/mbx/src/cli/shim.rs
@@ -172,19 +172,7 @@ fn cargo_proxy_passthrough(arguments: &[OsString]) -> bool {
     }) {
         return true;
     }
-    let mut skip_value = false;
-    let command = cargo_arguments.into_iter().find_map(|argument| {
-        if skip_value {
-            skip_value = false;
-            return None;
-        }
-        let argument = argument.to_str()?;
-        if matches!(argument, "--color" | "--config" | "-Z" | "-C") {
-            skip_value = true;
-            return None;
-        }
-        (!argument.starts_with('-') && !argument.starts_with('+')).then_some(argument)
-    });
+    let command = super::launch::cargo_subcommand(arguments);
     command.is_none()
         || matches!(
             command,

--- a/crates/mbx/src/main.rs
+++ b/crates/mbx/src/main.rs
@@ -1,6 +1,9 @@
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    if let Some(code) = mbx::cli::launch::dispatch() {
+        return code;
+    }
     mbx::phase_timing::initialize();
     if mbx::session::is_build_script_shim() {
         return mbx::session::run_build_script_shim();
@@ -20,6 +23,15 @@ fn main() -> ExitCode {
         return mbx::session::run_cc_shim(language);
     }
 
+    match mbx::cli::launch::recover_cli() {
+        Ok(Some(code)) => return code,
+        Ok(None) => {}
+        Err(error) => {
+            eprintln!("mbx[error]: failed to recover build environment: {error:#}");
+            return ExitCode::FAILURE;
+        }
+    }
+    mbx::cli::launch::remember_caller();
     let cargo_shim = mbx::cli::is_cargo_shim();
 
     // Top-level help and version terminate during argument parsing. Avoid

--- a/crates/mbx/tests/session_scope.rs
+++ b/crates/mbx/tests/session_scope.rs
@@ -14,6 +14,25 @@ fn project(path: &Path, source: &str) {
 fn mbx(root: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
     command.env_clear();
+    // rustc's MSVC discovery needs the Visual Studio/SDK environment as well
+    // as PATH. Without it Git's unrelated link.exe can win resolution.
+    #[cfg(windows)]
+    for (name, value) in std::env::vars_os() {
+        let key = name.to_string_lossy().to_ascii_uppercase();
+        if !key.starts_with("MBX_")
+            && !matches!(
+                key.as_str(),
+                "RUSTC_WRAPPER"
+                    | "RUSTC_WORKSPACE_WRAPPER"
+                    | "RUSTDOC"
+                    | "CARGO_TARGET_DIR"
+                    | "CARGO_INCREMENTAL"
+                    | "CARGO"
+            )
+        {
+            command.env(name, value);
+        }
+    }
     for name in [
         "PATH",
         "HOME",
@@ -26,7 +45,12 @@ fn mbx(root: &Path) -> Command {
         "TMPDIR",
     ] {
         if let Some(value) = std::env::var_os(name) {
-            command.env(name, value);
+            let key = if cfg!(windows) && name == "PATH" {
+                "Path"
+            } else {
+                name
+            };
+            command.env(key, value);
         }
     }
     command

--- a/crates/mbx/tests/session_scope.rs
+++ b/crates/mbx/tests/session_scope.rs
@@ -74,7 +74,10 @@ fn main() {
     }
     assert_eq!(std::env::var("CARGO_INCREMENTAL").unwrap(), "1");
     assert_eq!(std::env::var("MBX_VERIFY").unwrap(), "0");
-    assert_eq!(std::env::var_os("PATH"), std::env::var_os("EXPECTED_PATH"));
+    let path: Vec<_> = std::env::split_paths(&std::env::var_os("PATH").unwrap()).collect();
+    let expected: Vec<_> = std::env::split_paths(&std::env::var_os("EXPECTED_PATH").unwrap()).collect();
+    assert!(path.ends_with(&expected));
+    assert!(!std::env::var("CARGO").unwrap().is_empty());
     assert_eq!(std::env::args().nth(1).unwrap(), "argument with spaces");
     println!("application started");
     std::process::exit(23);
@@ -85,7 +88,16 @@ fn main() {
         .env("CARGO_INCREMENTAL", "1")
         .env("MBX_VERIFY", "0")
         .env("EXPECTED_PATH", std::env::var_os("PATH").unwrap())
-        .args(["run", "--offline", "--", "argument with spaces"])
+        .env("MBX_CARGO_SHIM_MODE", "1")
+        .env("RUSTFLAGS", "-C prefer-dynamic")
+        .args([
+            "--color",
+            "never",
+            "run",
+            "--offline",
+            "--",
+            "argument with spaces",
+        ])
         .output()
         .unwrap();
     assert_eq!(
@@ -190,16 +202,15 @@ fn main() {
         String::from_utf8_lossy(&output.stderr)
     );
     std::fs::write(&gate, "go").unwrap();
+    let mut contents = String::new();
     for _ in 0..200 {
-        if result.exists() {
+        contents = std::fs::read_to_string(&result).unwrap_or_default();
+        if contents == "independent build captured" {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
-    assert_eq!(
-        std::fs::read_to_string(result).unwrap(),
-        "independent build captured"
-    );
+    assert_eq!(contents, "independent build captured");
     assert!(!String::from_utf8_lossy(&output.stderr).contains("Checking scope-fixture"));
 }
 

--- a/crates/mbx/tests/session_scope.rs
+++ b/crates/mbx/tests/session_scope.rs
@@ -1,0 +1,317 @@
+use std::path::Path;
+use std::process::Command;
+
+fn project(path: &Path, source: &str) {
+    std::fs::create_dir_all(path.join("src")).unwrap();
+    std::fs::write(
+        path.join("Cargo.toml"),
+        "[package]\nname='scope-fixture'\nversion='0.0.0'\nedition='2021'\n",
+    )
+    .unwrap();
+    std::fs::write(path.join("src/main.rs"), source).unwrap();
+}
+
+fn mbx(root: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_mbx"));
+    command.env_clear();
+    for name in [
+        "PATH",
+        "HOME",
+        "RUSTUP_HOME",
+        "CARGO_HOME",
+        "RUSTUP_TOOLCHAIN",
+        "SystemRoot",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+    ] {
+        if let Some(value) = std::env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    command
+        .current_dir(root)
+        .env("MBX_CACHE_DIR", root.join("cache"))
+        .env("MBX_LINKER", "system")
+        .env("CI", "1")
+        .env("MBX_SUMMARY", "off");
+    command
+}
+
+#[test]
+fn cargo_run_restores_settings_before_starting_application() {
+    let root = tempfile::tempdir().unwrap();
+    project(
+        root.path(),
+        r#"
+fn main() {
+    for key in ["MBX_SOCKET", "MBX_BUILD", "MBX_SESSION_RESTORE", "MBX_SESSION_LEASE", "MBX_LAUNCH_CAPTURE", "MBX_WORKSPACE_ROOT", "MBX_TARGET_DIR", "RUSTDOC", "RUSTC_WRAPPER", "CARGO_TARGET_DIR"] {
+        assert!(std::env::var_os(key).is_none(), "{key} leaked");
+    }
+    assert_eq!(std::env::var("CARGO_INCREMENTAL").unwrap(), "1");
+    assert_eq!(std::env::var("MBX_VERIFY").unwrap(), "0");
+    assert_eq!(std::env::var_os("PATH"), std::env::var_os("EXPECTED_PATH"));
+    assert_eq!(std::env::args().nth(1).unwrap(), "argument with spaces");
+    println!("application started");
+    std::process::exit(23);
+}
+"#,
+    );
+    let output = mbx(root.path())
+        .env("CARGO_INCREMENTAL", "1")
+        .env("MBX_VERIFY", "0")
+        .env("EXPECTED_PATH", std::env::var_os("PATH").unwrap())
+        .args(["run", "--offline", "--", "argument with spaces"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(23),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("application started"));
+}
+
+#[cfg(unix)]
+#[test]
+fn cargo_run_preserves_configured_runner_and_wrapper() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = tempfile::tempdir().unwrap();
+    project(
+        root.path(),
+        r#"
+fn main() {
+    assert!(std::env::var_os("MBX_SOCKET").is_none());
+    assert!(std::env::var("RUSTC_WRAPPER").unwrap().ends_with("caller-wrapper"));
+    assert_eq!(std::env::var("RUNNER_ARGUMENT").unwrap(), "runner arg");
+}
+"#,
+    );
+    let wrapper = root.path().join("caller-wrapper");
+    std::fs::write(&wrapper, "#!/bin/sh\nexec \"$@\"\n").unwrap();
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let runner = root.path().join("caller-runner");
+    std::fs::write(
+        &runner,
+        "#!/bin/sh\nexport RUNNER_ARGUMENT=\"$1\"\nshift\nexec \"$@\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&runner, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::create_dir(root.path().join(".cargo")).unwrap();
+    std::fs::write(
+        root.path().join(".cargo/config.toml"),
+        "[target.'cfg(unix)']\nrunner = ['./caller-runner', 'runner arg']\n",
+    )
+    .unwrap();
+    let output = mbx(root.path())
+        .env("RUSTC_WRAPPER", wrapper)
+        .args(["run", "--offline"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn application_daemon_outlives_session_and_captures_an_independent_build() {
+    let root = tempfile::tempdir().unwrap();
+    let other = root.path().join("other");
+    project(&other, "fn main() {}\n");
+    project(
+        root.path(),
+        r#"
+use std::process::{Command, Stdio};
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    if args.get(1).map(String::as_str) != Some("daemon") {
+        assert!(std::os::unix::net::UnixStream::connect(env!("OUTER_SOCKET")).is_err(), "session still alive at application launch");
+        Command::new(std::env::current_exe().unwrap()).arg("daemon").args(&args[1..])
+            .stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null()).spawn().unwrap();
+        return;
+    }
+    for _ in 0..200 {
+        if std::path::Path::new(&args[4]).exists() { break; }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(std::path::Path::new(&args[4]).exists());
+    assert!(std::env::var_os("MBX_SOCKET").is_none());
+    assert!(std::env::var_os("RUSTC_WRAPPER").is_none());
+    let output = Command::new(&args[2]).args(["check", "--offline"])
+        .current_dir(&args[3]).env("MBX_LOG", "debug").output().unwrap();
+    assert!(output.status.success(), "{:?}", output);
+    assert!(!output.stderr.is_empty());
+    std::fs::write(&args[5], "independent build captured").unwrap();
+}
+"#,
+    );
+    std::fs::write(root.path().join("build.rs"),
+        "fn main() { println!(\"cargo:rustc-env=OUTER_SOCKET={}\", std::env::var(\"MBX_SOCKET\").unwrap()); }\n").unwrap();
+    let gate = root.path().join("launcher-exited");
+    let result = root.path().join("daemon-result");
+    let output = mbx(root.path())
+        .args(["run", "--offline", "--", env!("CARGO_BIN_EXE_mbx")])
+        .arg(&other)
+        .arg(&gate)
+        .arg(&result)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::write(&gate, "go").unwrap();
+    for _ in 0..200 {
+        if result.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert_eq!(
+        std::fs::read_to_string(result).unwrap(),
+        "independent build captured"
+    );
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("Checking scope-fixture"));
+}
+
+#[test]
+fn stale_session_recovers_original_environment_before_building() {
+    use std::ffi::OsString;
+    let root = tempfile::tempdir().unwrap();
+    project(root.path(), "fn main() {}\n");
+    std::fs::write(
+        root.path().join("build.rs"),
+        r#"
+fn main() {
+    assert!(!std::env::var("MBX_SOCKET").unwrap().contains("missing-session"));
+    assert!(std::env::var("MBX_WORKSPACE_ROOT").unwrap().contains(".tmp"));
+}
+"#,
+    )
+    .unwrap();
+    let restore: Vec<(OsString, Option<OsString>)> = [
+        "MBX_SOCKET",
+        "MBX_SESSION_LEASE",
+        "MBX_SESSION_RESTORE",
+        "RUSTC_WRAPPER",
+        "MBX_WORKSPACE_ROOT",
+    ]
+    .into_iter()
+    .map(|key| (key.into(), None))
+    .collect();
+    let output = mbx(root.path())
+        .env("MBX_SOCKET", "missing-session")
+        .env("MBX_SESSION_LEASE", root.path().join("missing-owner"))
+        .env(
+            "MBX_SESSION_RESTORE",
+            serde_json::to_string(&restore).unwrap(),
+        )
+        .env("RUSTC_WRAPPER", "missing-wrapper")
+        .env("MBX_WORKSPACE_ROOT", "wrong-workspace")
+        .args(["check", "--offline"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn command_line_runner_override_uses_original_environment() {
+    let root = tempfile::tempdir().unwrap();
+    project(
+        root.path(),
+        "fn main() { assert!(std::env::var_os(\"MBX_SOCKET\").is_none()); }\n",
+    );
+    let output = mbx(root.path())
+        .args([
+            "run",
+            "--offline",
+            "--config",
+            "target.'cfg(unix)'.runner = ['env', 'CALLER_RUNNER=1']",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn nested_build_orchestrators_keep_the_live_session() {
+    use std::os::unix::fs::PermissionsExt;
+    for orchestrator in ["watch", "nextest"] {
+        let root = tempfile::tempdir().unwrap();
+        project(root.path(), "fn main() {}\n");
+        std::fs::write(
+            root.path().join("build.rs"),
+            r#"
+fn main() {
+    assert_eq!(std::env::var("MBX_SOCKET").unwrap(), std::env::var("EXPECTED_SOCKET").unwrap());
+    assert_eq!(std::env::var("MBX_BUILD").unwrap(), std::env::var("EXPECTED_BUILD").unwrap());
+}
+"#,
+        )
+        .unwrap();
+        let program = root.path().join(format!("cargo-{orchestrator}"));
+        std::fs::write(&program, "#!/bin/sh\nexport EXPECTED_SOCKET=\"$MBX_SOCKET\" EXPECTED_BUILD=\"$MBX_BUILD\"\nMBX_CARGO_SHIM_MODE=1 exec \"$TEST_MBX\" check --offline\n").unwrap();
+        std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = std::env::join_paths(
+            std::iter::once(root.path().to_path_buf())
+                .chain(std::env::split_paths(&std::env::var_os("PATH").unwrap())),
+        )
+        .unwrap();
+        let output = mbx(root.path())
+            .env("PATH", path)
+            .env("TEST_MBX", env!("CARGO_BIN_EXE_mbx"))
+            .arg(orchestrator)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{orchestrator}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn launch_preserves_non_unicode_environment_and_temporary_paths_with_spaces() {
+    use std::os::unix::ffi::OsStringExt;
+    let root = tempfile::tempdir().unwrap();
+    project(
+        root.path(),
+        r#"
+use std::os::unix::ffi::OsStrExt;
+fn main() { assert_eq!(std::env::var_os("OPAQUE").unwrap().as_bytes(), b"\xff"); }
+"#,
+    );
+    let temporary = tempfile::Builder::new()
+        .prefix("mbx space ")
+        .tempdir_in("/tmp")
+        .unwrap();
+    let output = mbx(root.path())
+        .env("TMPDIR", temporary.path())
+        .env("MBX_CC", "0")
+        .env("OPAQUE", std::ffi::OsString::from_vec(vec![255]))
+        .args(["run", "--offline"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
`mbx run` currently keeps the cache session alive for the application's lifetime. Builds started by that application inherit its socket, compiler adapters, roots, and policy; their mbx diagnostics can appear on the launcher's terminal even when the application captures subprocess output.

This change uses an internal Cargo runner to capture Cargo's selected executable, arguments, working directory, and launch environment. After Cargo returns, mbx commits and closes the build session, prints its cache summary, and starts the application through the caller's configured runner. Only mbx's environment overrides are restored, including the original PATH and compiler wrappers; Cargo's dynamic-library paths remain intact. The application's exit status is returned to the caller. Automatic garbage collection and lifetime-savings reporting remain after application exit, so a target sweep cannot remove the executable before launch.

Sessions carry an environment restoration record and an owner lock. A subsequent mbx/Cargo-shim invocation can restore the original settings and establish a new session after that owner exits. Live nested build orchestration continues to reuse its session. The artifact store and machine-wide scheduler remain shared.

Scope and compatibility:
- Covers direct `run` and `r` invocations. Arbitrary shell aliases and application launches inside external orchestration tools still require a separate boundary design.
- Existing config-file and environment runners are resolved with `cargo-config2`, including target-specific runners and runner arguments. Launches using `+toolchain`, `--config`, or `-C` use ordinary Cargo with the caller's environment because the resolver cannot faithfully resolve those overrides. Those invocations retain Cargo behavior but do not receive an mbx build session.
- Stale-session recovery uses restoration data emitted by this version; it cannot reconstruct overwritten caller values from older mbx sessions.

Validation: `mise run ci` passes, including debug/release Clippy, workspace tests, all 59 Bats cases, release diagnostics, generated documentation, and documentation links. New integration cases cover environment and exit-status restoration, configured runners/wrappers, a detached daemon capturing a build in another workspace after the launcher exits, stale-session recovery, live watch/nextest-style nesting, command-line runner overrides, and non-Unicode environment values with temporary paths containing spaces.

Addresses https://github.com/jdx/mr-boxington/discussions/434.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and environment restoration for `cargo run`, with complex PATH/runner handling; mistakes could leak session state or break launches, but behavior is heavily covered by new integration tests.
> 
> **Overview**
> **`cargo run` / `r` no longer keeps the mbx cache session alive while the built binary runs.** A new launch path installs a temporary `mbx-launch` Cargo runner shim that records the executable, args, cwd, and launch environment; after Cargo succeeds, mbx shuts down the session (including cache summary) and starts the app with the caller’s restored env and configured target runner, returning the application’s exit code.
> 
> **Session boundaries and recovery:** Build sessions record env overlays (`MBX_SESSION_RESTORE`) and hold an owner lock (`MBX_SESSION_LEASE`) so later invocations can restore the original PATH/wrappers when the launcher exits, while live nested orchestrators (e.g. watch/nextest) still reuse an active session. **`+toolchain`, `--config`, and `-C` on `run`** bypass this path and invoke plain Cargo with the remembered caller environment (no mbx session) because `cargo-config2` cannot resolve those overrides safely.
> 
> Shared **`cargo_subcommand`** parsing replaces duplicated logic in the cargo shim. Adds **`cargo-config2`** and integration tests in `session_scope.rs` for env restoration, runners, detached builds, stale recovery, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a2be1fb54ebb9a13e1c50e992bfc751030ba96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->