### PR TITLE
feat(cli): add append-only progress for agent builds

### DIFF
--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -271,7 +271,7 @@ fn cargo_with_settings_bypass_log_and_roots(
                 Ok(None) => run_cargo(&cargo, arguments, environment),
                 Err(error) => Err(error),
             }
-        } else if super::pretty::eligible(arguments)
+        } else if super::plain_progress::eligible(arguments, std::env::var("CARGO_TERM_PROGRESS_WHEN").ok().as_deref())
             && !matches!(settings.summary, SummaryStyle::Off)
             && log::max_level() < log::LevelFilter::Debug
             && (settings.plain_output || !std::io::stderr().is_terminal())

--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -261,13 +261,22 @@ fn cargo_with_settings_bypass_log_and_roots(
         if let Some(launch) = &launch {
             launch.environment(&mut environment)?;
         }
+        if settings.plain_output {
+            environment.insert("CARGO_TERM_PROGRESS_WHEN".into(), "never".into());
+        }
         super::launch::record_overlay(&mut environment)?;
-        let status = if super::pretty::enabled(arguments) {
+        let status = if !settings.plain_output && super::pretty::enabled(arguments) {
             match super::pretty::run(&cargo, arguments, &environment, settings.pretty_inspect, || session.progress_stats()) {
                 Ok(Some(status)) => Ok(status),
                 Ok(None) => run_cargo(&cargo, arguments, environment),
                 Err(error) => Err(error),
             }
+        } else if super::pretty::eligible(arguments)
+            && !matches!(settings.summary, SummaryStyle::Off)
+            && log::max_level() < log::LevelFilter::Debug
+            && (settings.plain_output || !std::io::stderr().is_terminal())
+        {
+            super::plain_progress::run(&cargo, arguments, environment, || session.progress_stats())
         } else {
             run_cargo(&cargo, arguments, environment)
         };

--- a/crates/mbx/src/cli/cargo.rs
+++ b/crates/mbx/src/cli/cargo.rs
@@ -188,10 +188,13 @@ fn cargo_with_settings_bypass_log_and_roots(
                 // compiler wrappers cannot inherit an enclosing session that
                 // this build did not start. An empty socket is deliberately
                 // equivalent to an absent one to every mbx shim.
-                let environment = BTreeMap::from([
+                let mut environment = BTreeMap::from([
                     ("MBX_DISABLE".into(), "1".into()),
                     (session::SOCKET_ENV.into(), String::new()),
                 ]);
+                if settings.plain_output {
+                    environment.insert("CARGO_TERM_PROGRESS_WHEN".into(), "never".into());
+                }
                 return Ok((run_cargo(&cargo, arguments, environment), None));
             }
             Err(error) => return Err(error),

--- a/crates/mbx/src/cli/mod.rs
+++ b/crates/mbx/src/cli/mod.rs
@@ -20,6 +20,7 @@ mod exec;
 mod explain;
 mod gc;
 pub mod launch;
+mod plain_progress;
 mod prefetch;
 mod pretty;
 mod setup;

--- a/crates/mbx/src/cli/plain_progress.rs
+++ b/crates/mbx/src/cli/plain_progress.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 pub(super) fn eligible(arguments: &[String], progress: Option<&str>) -> bool {
     progress != Some("never")
         && matches!(
-            super::pretty::cargo_verb(arguments),
+            super::launch::cargo_subcommand(arguments),
             Some("build" | "b" | "check" | "c" | "clippy" | "run" | "r" | "test" | "t")
         )
         && !arguments
@@ -22,10 +22,20 @@ pub(super) fn eligible(arguments: &[String], progress: Option<&str>) -> bool {
                     arg.as_str(),
                     "--quiet" | "--verbose" | "--help" | "--version" | "--message-format"
                 ) || arg.starts_with("--message-format=")
-                    || (arg.starts_with('-')
-                        && !arg.starts_with("--")
-                        && arg[1..].contains(['q', 'v', 'h', 'V']))
+                    || (arg.starts_with('-') && !arg.starts_with("--") && short_opt_out(&arg[1..]))
             })
+}
+
+fn short_opt_out(flags: &str) -> bool {
+    for flag in flags.chars() {
+        match flag {
+            'q' | 'v' | 'h' | 'V' => return true,
+            // Everything after a value-taking flag is its attached value.
+            'j' | 'p' | 'F' | 'Z' | 'C' => return false,
+            _ => {}
+        }
+    }
+    false
 }
 
 pub(super) fn run(
@@ -139,5 +149,27 @@ mod policy_tests {
             &["run".into(), "--".into(), "--quiet".into()],
             None
         ));
+    }
+}
+
+#[cfg(test)]
+mod argument_tests {
+    use super::*;
+    #[test]
+    fn global_options_and_attached_values_keep_progress() {
+        for arguments in [
+            vec!["--color", "always", "build"],
+            vec!["+nightly", "--config", "build.jobs=2", "check"],
+            vec!["--config=build.jobs=2", "build", "-Zunstable-options"],
+            vec!["build", "-Fchrono", "-pwhatever"],
+        ] {
+            assert!(eligible(
+                &arguments.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                None
+            ));
+        }
+        for flag in ["-q", "-vv", "-vq", "-vFchrono", "--verbose"] {
+            assert!(!eligible(&["build".into(), flag.into()], None));
+        }
     }
 }

--- a/crates/mbx/src/cli/plain_progress.rs
+++ b/crates/mbx/src/cli/plain_progress.rs
@@ -1,0 +1,103 @@
+//! Append-only cache progress for pipes and agents using a terminal.
+use crate::session;
+use eyre::Result;
+use mbx_cache_core::AgentStats;
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::process::ExitCode;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+pub(super) fn run(
+    cargo: &OsStr,
+    arguments: &[String],
+    environment: BTreeMap<String, String>,
+    stats: impl Fn() -> AgentStats + Sync,
+) -> Result<ExitCode> {
+    with_progress(
+        Duration::from_secs(15),
+        stats,
+        |line| crate::logging::note(&line),
+        || super::cargo::run_cargo(cargo, arguments, environment),
+    )
+}
+
+fn with_progress<T>(
+    interval: Duration,
+    stats: impl Fn() -> AgentStats + Sync,
+    report: impl Fn(String) + Sync,
+    operation: impl FnOnce() -> T,
+) -> T {
+    std::thread::scope(|scope| {
+        let (stop, stopped) = mpsc::channel::<()>();
+        let stats = &stats;
+        let report = &report;
+        scope.spawn(move || {
+            let started = Instant::now();
+            while matches!(
+                stopped.recv_timeout(interval),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ) {
+                report(line(started.elapsed(), &stats()));
+            }
+        });
+        // Cargo retains its inherited streams, signals, arguments and runners.
+        // Dropping the sender also interrupts the wait when operation unwinds.
+        let result = operation();
+        drop(stop);
+        result
+    })
+}
+
+fn line(elapsed: Duration, stats: &AgentStats) -> String {
+    format!(
+        "mbx[progress]: {}s elapsed; {} hits, {} misses, {} bypassed, {} not looked up; ~{:.1}s compiler work saved",
+        elapsed.as_secs(),
+        stats.hits,
+        session::cache_misses(stats),
+        session::unexpected_bypasses(stats),
+        stats.unconsulted,
+        stats.avoided_compiler_duration_ns as f64 / 1e9,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn long_commands_report_without_changing_the_result_or_using_terminal_controls() {
+        let (send, receive) = mpsc::channel();
+        let result = with_progress(
+            Duration::from_millis(5),
+            || {
+                let mut stats = AgentStats::default();
+                stats.hits = 1;
+                stats.lookups = 3;
+                stats.avoided_compiler_duration_ns = 1_500_000_000;
+                stats
+            },
+            |line| send.send(line).unwrap(),
+            || {
+                let line = receive.recv_timeout(Duration::from_secs(2)).unwrap();
+                assert!(line.contains("1 hits, 2 misses"));
+                assert!(line.contains("~1.5s compiler work saved"));
+                assert!(!line.contains(['\r', '\x1b']));
+                101
+            },
+        );
+        assert_eq!(result, 101);
+    }
+
+    #[test]
+    fn short_commands_stop_reporting_immediately() {
+        let started = Instant::now();
+        with_progress(
+            Duration::from_secs(60),
+            AgentStats::default,
+            |_| panic!("short command reported"),
+            || (),
+        );
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+}

--- a/crates/mbx/src/cli/plain_progress.rs
+++ b/crates/mbx/src/cli/plain_progress.rs
@@ -8,6 +8,26 @@ use std::process::ExitCode;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+pub(super) fn eligible(arguments: &[String], progress: Option<&str>) -> bool {
+    progress != Some("never")
+        && matches!(
+            super::pretty::cargo_verb(arguments),
+            Some("build" | "b" | "check" | "c" | "clippy" | "run" | "r" | "test" | "t")
+        )
+        && !arguments
+            .iter()
+            .take_while(|arg| arg.as_str() != "--")
+            .any(|arg| {
+                matches!(
+                    arg.as_str(),
+                    "--quiet" | "--verbose" | "--help" | "--version" | "--message-format"
+                ) || arg.starts_with("--message-format=")
+                    || (arg.starts_with('-')
+                        && !arg.starts_with("--")
+                        && arg[1..].contains(['q', 'v', 'h', 'V']))
+            })
+}
+
 pub(super) fn run(
     cargo: &OsStr,
     arguments: &[String],
@@ -99,5 +119,25 @@ mod tests {
             || (),
         );
         assert!(started.elapsed() < Duration::from_secs(2));
+    }
+}
+
+#[cfg(test)]
+mod policy_tests {
+    use super::*;
+    #[test]
+    fn plain_progress_honors_opt_out_and_allows_cargo_presentation_flags() {
+        let args = ["build", "--color=always", "--config", "build.jobs=2"].map(str::to_string);
+        assert!(eligible(&args, None));
+        assert!(!eligible(&args, Some("never")));
+        assert!(!eligible(
+            &["build".into(), "--message-format=json".into()],
+            None
+        ));
+        assert!(!eligible(&["build".into(), "-q".into()], None));
+        assert!(eligible(
+            &["run".into(), "--".into(), "--quiet".into()],
+            None
+        ));
     }
 }

--- a/crates/mbx/src/cli/pretty.rs
+++ b/crates/mbx/src/cli/pretty.rs
@@ -41,7 +41,7 @@ pub(super) fn enabled(arguments: &[String]) -> bool {
         && terminal::size().is_ok_and(|(cols, rows)| cols >= 50 && rows >= 16)
 }
 
-fn cargo_verb(arguments: &[String]) -> Option<&str> {
+pub(super) fn cargo_verb(arguments: &[String]) -> Option<&str> {
     arguments
         .get(usize::from(
             arguments.first().is_some_and(|arg| arg.starts_with('+')),
@@ -49,7 +49,7 @@ fn cargo_verb(arguments: &[String]) -> Option<&str> {
         .map(String::as_str)
 }
 
-pub(super) fn eligible(arguments: &[String]) -> bool {
+fn eligible(arguments: &[String]) -> bool {
     matches!(
         cargo_verb(arguments),
         Some("build" | "b" | "check" | "c" | "clippy" | "run" | "r" | "test" | "t")

--- a/crates/mbx/src/cli/pretty.rs
+++ b/crates/mbx/src/cli/pretty.rs
@@ -41,7 +41,7 @@ pub(super) fn enabled(arguments: &[String]) -> bool {
         && terminal::size().is_ok_and(|(cols, rows)| cols >= 50 && rows >= 16)
 }
 
-pub(super) fn cargo_verb(arguments: &[String]) -> Option<&str> {
+fn cargo_verb(arguments: &[String]) -> Option<&str> {
     arguments
         .get(usize::from(
             arguments.first().is_some_and(|arg| arg.starts_with('+')),

--- a/crates/mbx/src/cli/pretty.rs
+++ b/crates/mbx/src/cli/pretty.rs
@@ -49,7 +49,7 @@ fn cargo_verb(arguments: &[String]) -> Option<&str> {
         .map(String::as_str)
 }
 
-fn eligible(arguments: &[String]) -> bool {
+pub(super) fn eligible(arguments: &[String]) -> bool {
     matches!(
         cargo_verb(arguments),
         Some("build" | "b" | "check" | "c" | "clippy" | "run" | "r" | "test" | "t")

--- a/crates/mbx/src/config.rs
+++ b/crates/mbx/src/config.rs
@@ -118,6 +118,9 @@ pub(crate) struct RawConfig {
     /// Open the terminal warning browser after a successful Cargo build.
     #[usage(env = "MBX_PRETTY_INSPECT", default = false)]
     pretty_inspect: bool,
+    /// Cargo display mode. Plain disables animated output even in a terminal.
+    #[usage(env = "MBX_DISPLAY", default = "auto", choices("auto", "plain"))]
+    display: String,
     /// Compile and consult the cache, then compare outputs.
     #[usage(env = "MBX_VERIFY", default = false, scope = "env")]
     verify: bool,
@@ -572,6 +575,7 @@ pub(crate) struct CliSettings {
     pub savings: SavingsStyle,
     pub summary: SummaryStyle,
     pub pretty_inspect: bool,
+    pub plain_output: bool,
     /// Whether a churning crate may compile with its own incremental state.
     pub learned_incremental: bool,
     /// How much of that state one crate may keep, in bytes; `None` is no limit.
@@ -589,6 +593,7 @@ impl Default for CliSettings {
             savings: SavingsStyle::default(),
             summary: SummaryStyle::default(),
             pretty_inspect: false,
+            plain_output: false,
             learned_incremental: true,
             learned_incremental_max_size: Some(DEFAULT_LEARNED_INCREMENTAL_MAX_SIZE),
             cache_links: true,
@@ -910,6 +915,7 @@ impl Config {
                 savings: raw.savings.parse().wrap_err("invalid savings")?,
                 summary: raw.summary.parse().wrap_err("invalid summary")?,
                 pretty_inspect: raw.pretty_inspect,
+                plain_output: raw.display == "plain",
                 learned_incremental: raw._learned_incremental,
                 learned_incremental_max_size: parse_optional_byte_size(
                     &raw.learned_incremental_max_size,

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -57,6 +57,19 @@ Cache C and C++ compilations run by build scripts.
 
 Store C objects that embed absolute paths under checkout-specific keys. Disable for disposable worktrees to avoid storing objects that cannot be reused at another path. Existing entries may still be restored.
 
+### `display`
+
+- **Type:** `string`
+- **Default:** `auto`
+- **Set with:** `MBX_DISPLAY`
+
+Cargo display mode. Plain disables animated output even in a terminal.
+
+**Choices:**
+- `auto`
+- `plain`
+
+
 ### `events`
 
 - **Type:** `bool`

--- a/scripts/test-cargo-pretty.py
+++ b/scripts/test-cargo-pretty.py
@@ -174,10 +174,27 @@ pub fn answer() -> u32 { dep::value() }
         for level in ['debug', 'mbx_cache_core=trace']:
             code, output = terminal_run(root, dict(env, MBX_LOG=level), ['check'])
             assert code == 0 and b'\x1b[?2026h' not in output and b'Build / cache' not in output
+        code, output = terminal_run(root, dict(env, MBX_DISPLAY='plain'), ['run', '--', 'plain mode'], respond=(b'INPUT_READY', b'hello\n'))
+        assert code == 0 and b'ARG:plain mode' in output
+        code, output = terminal_run(root, dict(env, MBX_DISPLAY='plain'), ['check'])
+        assert code == 0 and b'\x1b[?2026h' not in output and b'Build / cache' not in output
         (root/'src/lib.rs').write_text('this does not compile\n')
         code, output = terminal_run(root, env, ['run'])
         assert code == 101 and b'error' in output, output[-3000:]
         assert not re.search(rb'(?<!\r)\n', output), 'error diagnostics need CRLF in raw mode'
+        agent = root/'agent'
+        (agent/'src').mkdir(parents=True)
+        (agent/'Cargo.toml').write_text('[package]\nname="agent-output"\nversion="0.1.0"\nedition="2024"\n')
+        (agent/'src/lib.rs').write_text('pub fn value() {}\n')
+        (agent/'build.rs').write_text('fn main() { std::thread::sleep(std::time::Duration::from_secs(16)); }\n')
+        agent_env = dict(environment(agent), MBX_SUMMARY='short')
+        result = subprocess.run([str(BINARY), 'check'], cwd=agent, env=agent_env, capture_output=True, timeout=60)
+        assert result.returncode == 0 and b'mbx[progress]:' in result.stderr, result.stderr
+        assert b'\x1b' not in result.stderr and b'\r' not in result.stderr
+        assert not result.stdout
+        result = subprocess.run([str(BINARY), 'check', '--message-format=json'], cwd=agent, env=agent_env, capture_output=True, timeout=60)
+        assert result.returncode == 0 and b'mbx[progress]:' not in result.stderr
+        assert all(isinstance(json.loads(line), dict) for line in result.stdout.splitlines())
         print('Passed: build/check/clippy, fresh/warm cache counts, interactive run, tests/doctests, custom harness, runner, failure diagnostics, cancellation, JSON passthrough, warning browser, terminal restoration.')
 
 

--- a/scripts/test-cargo-pretty.py
+++ b/scripts/test-cargo-pretty.py
@@ -76,7 +76,7 @@ def terminal_run(root, env, args, *, respond=None, limit=90):
 
 def environment(root):
     env = dict(os.environ, TERM='xterm-256color', MBX_CACHE_DIR=str(root/'cache'), MBX_TARGET_VIEWS='false', MBX_GC_AUTO='false', MBX_SUMMARY='off', MBX_SAVINGS='off', MBX_STATS_REPORT=str(root/'stats.json'))
-    for key in ['CI', 'GITHUB_ACTIONS', 'NO_COLOR', 'CARGO_TERM_COLOR', 'CARGO_TERM_PROGRESS_WHEN', 'CARGO_TERM_PROGRESS_WIDTH', 'MBX_DISABLE', 'RUSTC_WRAPPER', 'RUSTC_WORKSPACE_WRAPPER']:
+    for key in ['CI', 'GITHUB_ACTIONS', 'MBX_DISPLAY', 'NO_COLOR', 'CARGO_TERM_COLOR', 'CARGO_TERM_PROGRESS_WHEN', 'CARGO_TERM_PROGRESS_WIDTH', 'MBX_DISABLE', 'RUSTC_WRAPPER', 'RUSTC_WORKSPACE_WRAPPER']:
         env.pop(key, None)
     stamp = root/'cache/actions/notice/v1/explained'
     stamp.parent.mkdir(parents=True)


### PR DESCRIPTION
Long builds invoked through pipes currently go quiet between Cargo messages, while agents using a PTY can receive cursor-based animation. Add an append-only cache progress line on stderr every 15 seconds for long non-TTY commands, and `MBX_DISPLAY=plain` to disable animation explicitly in a terminal.

The progress line reports elapsed time, cache hits/misses/bypasses, work not looked up, and estimated compiler work saved. Short commands add no progress lines. Cargo keeps its inherited streams, arguments, runners, signal handling, and exit status; the reporting thread stops before the final session summary. Quiet mode, explicit JSON output, disabled summaries, debug/trace logging, and `CARGO_TERM_PROGRESS_WHEN=never` retain their existing output paths. Color flags and ordinary Cargo configuration overrides do not disable append-only progress. Cargo JSON stdout and mbx's JSON stats report are unchanged.

This PR is stacked on #435 so the agent-output change can be reviewed separately. Both should remain unmerged pending review.

### Before / after

For a long build captured through pipes, Cargo can finish printing its crate-start messages and then remain silent while compilation continues. The excerpts below use illustrative counts and omit the unchanged final Cargo/cache summaries.

**Before:** no indication of elapsed time or cache activity during that gap.

```text
   Compiling example v0.1.0
```

**After:** append-only progress on stderr every 15 seconds until Cargo exits.

```text
   Compiling example v0.1.0
mbx[progress]: 15s elapsed; 12 hits, 3 misses, 0 bypassed, 0 not looked up; ~8.4s compiler work saved
mbx[progress]: 30s elapsed; 18 hits, 5 misses, 1 bypassed, 0 not looked up; ~13.7s compiler work saved
```

For an agent that allocates a PTY:

| Before | After |
| --- | --- |
| TTY detection can select the animated display, including cursor movement. | `MBX_DISPLAY=plain mbx build` selects ordinary Cargo output plus append-only progress for long commands. |

Short commands emit no extra progress lines. `mbx build --message-format=json` retains Cargo's JSON stdout and does not add these progress lines; `MBX_STATS_REPORT` remains available for structured cache statistics.

Validation:
- `mise run ci` using the repository-pinned usage executable through the local shell adapter.
- A real 16-second non-TTY build verifies append-only stderr progress and empty stdout.
- PTY checks verify `MBX_DISPLAY=plain` and native application environment restoration.
- JSON output remains parseable, and unit tests cover reporting, exit-result preservation, and immediate shutdown for short commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Cargo is launched and what appears on stderr/stdout for many builds; behavior is gated but agents and CI that parse logs may see new progress lines.
> 
> **Overview**
> Adds **`MBX_DISPLAY=plain`** (`display` / `CliSettings.plain_output`) so builds skip the animated pretty adapter, force **`CARGO_TERM_PROGRESS_WHEN=never`**, and use normal Cargo output even on a TTY.
> 
> When pretty mode is off, eligible long **`build`/`check`/…** invocations on a **non-TTY stderr** (or in plain display) can use a new **`plain_progress`** path that prints **`mbx[progress]:`** lines to stderr every **15s** with cache hits/misses and estimated compiler time saved—no escape sequences. JSON **`--message-format`**, quiet/verbose, **`MBX_SUMMARY=off`**, debug logging, and **`CARGO_TERM_PROGRESS_WHEN=never`** stay on the existing direct **`run_cargo`** path.
> 
> Configuration and CLI docs document **`display`**. Integration tests cover plain PTY behavior and piped agent builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef2460aa5f6978cc2a424d815f4230315be4461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a plain display mode that disables animated Cargo output, including when running in a terminal.
  - Added periodic plain-text progress updates with cache statistics and estimated compiler time savings for eligible commands.
  - Added the `MBX_DISPLAY` configuration option with `auto` and `plain` choices.

- **Documentation**
  - Documented the new display configuration and its available modes.

- **Bug Fixes**
  - Preserved structured JSON output by suppressing progress messages for JSON-formatted commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->