### PR TITLE
docs: clarify breaking change scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,15 @@ subjects should use the same format. Start descriptions with a lowercase
 character and keep them concise and imperative. Use `!` for a breaking change and explain it with a
 `BREAKING CHANGE:` footer.
 
+Breaking markers are commit-wide; a Conventional Commit scope does not limit
+them to one crate. Because pull requests are squash-merged, do not use `!` or a
+`BREAKING CHANGE:` footer on a pull request that touches `mbx` unless the CLI
+itself requires a major release. A breaking CLI change requires exceptional
+justification and explicit maintainer agreement before using either marker. A
+breaking API change confined to a pre-1.0 subcrate should be isolated from
+`mbx` changes so release-plz can give that subcrate its permitted 0.x minor
+bump without triggering an `mbx` major bump.
+
 Allowed types are `bench`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
 `refactor`, `revert`, `security`, `style`, and `test`.
 


### PR DESCRIPTION
Clarify that Conventional Commit breaking markers apply across the squash commit rather than being contained by a crate scope.

Require exceptional justification and explicit maintainer agreement for an `mbx` CLI major-version break, while documenting how to isolate permitted breaking changes in the pre-1.0 subcrates.

Validation:
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to contributor guidelines; no runtime or release automation changes.
> 
> **Overview**
> **Expands the Conventional Commits section in `AGENTS.md`** with maintainer guidance on how breaking markers interact with squash merges and multi-crate releases.
> 
> The new text states that `!` and `BREAKING CHANGE:` apply to the whole squash commit, not a single scope. It tells contributors not to mark PRs that touch `mbx` as breaking unless the CLI truly needs a major release, and that such CLI breaks need explicit maintainer approval. It also explains isolating pre-1.0 subcrate API breaks from `mbx` changes so release-plz can bump those crates on 0.x without forcing an `mbx` major.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5edf0f6ed530206c0e5ea82d4936618c80891553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->