### PR TITLE
chore: refresh real-world benchmarks for mbx v1.11.0

### DIFF
--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -4,11 +4,11 @@
   "revision": "fc29ead1456ba7c1f62826c284126410a4014b00",
   "toolchain": "1.97.1",
   "platform": "Linux-7.1.4-x86_64-with-glibc2.39",
-  "runner": "nsc-runner-1gfc9921cembq",
-  "workflow_run": "34530022340",
-  "commit": "36b9f33904145fd6c930383463f258f861fa4e91",
+  "runner": "nsc-runner-4eu9mf1icdk5o",
+  "workflow_run": "34643194197",
+  "commit": "4ebd2af1eb7e70fee37ec8678c30c0619f5ed5af",
   "versions": {
-    "mbx": "1.10.1",
+    "mbx": "1.11.0",
     "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
     "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
     "kache": "kache 0.19.0"
@@ -23,31 +23,31 @@
       "results": [
         {
           "tool": "mbx",
-          "wall_duration_ns": 11712570387,
+          "wall_duration_ns": 7814762182,
           "trials": 3,
           "wall_durations_ns": [
-            11712570387,
-            11716786826,
-            9691630614
+            8271110511,
+            7814762182,
+            7533359916
           ],
           "stats": {
-            "lookups": 722,
-            "hits": 721,
+            "lookups": 723,
+            "hits": 722,
             "misses": 1,
-            "unconsulted": 6,
-            "predictions_loaded": 927,
-            "restored_output_files": 1559,
-            "restored_output_bytes": 1392782427
+            "unconsulted": 5,
+            "predictions_loaded": 928,
+            "restored_output_files": 1560,
+            "restored_output_bytes": 1396623403
           }
         },
         {
           "tool": "kache",
-          "wall_duration_ns": 8973155550,
+          "wall_duration_ns": 8734590611,
           "trials": 3,
           "wall_durations_ns": [
-            9096132463,
-            8973155550,
-            8277847001
+            8970193889,
+            8499666312,
+            8734590611
           ]
         }
       ],
@@ -60,41 +60,41 @@
       "results": [
         {
           "tool": "cargo",
-          "wall_duration_ns": 30967949882,
+          "wall_duration_ns": 23206376042,
           "trials": 3,
           "wall_durations_ns": [
-            30967949882,
-            30688030845,
-            32999925738
+            24438353704,
+            23038000981,
+            23206376042
           ]
         },
         {
           "tool": "mbx",
-          "wall_duration_ns": 22793426755,
+          "wall_duration_ns": 16679813532,
           "trials": 3,
           "wall_durations_ns": [
-            22793426755,
-            23532843296,
-            21383876887
+            16213382280,
+            16679813532,
+            18550619824
           ],
           "stats": {
-            "lookups": 723,
-            "hits": 720,
+            "lookups": 724,
+            "hits": 721,
             "misses": 3,
-            "unconsulted": 6,
-            "predictions_loaded": 927,
-            "restored_output_files": 1557,
-            "restored_output_bytes": 1206269339
+            "unconsulted": 5,
+            "predictions_loaded": 928,
+            "restored_output_files": 1558,
+            "restored_output_bytes": 1210110315
           }
         },
         {
           "tool": "kache",
-          "wall_duration_ns": 20585123474,
+          "wall_duration_ns": 18327838234,
           "trials": 3,
           "wall_durations_ns": [
-            19515839822,
-            22332864429,
-            20585123474
+            18920667367,
+            17417087496,
+            18327838234
           ]
         }
       ],
@@ -108,45 +108,45 @@
       "results": [
         {
           "tool": "cargo",
-          "wall_duration_ns": 4008212475,
+          "wall_duration_ns": 3729264110,
           "trials": 3,
           "wall_durations_ns": [
-            3869377552,
-            4008212475,
-            4361935616
+            3629279774,
+            3729264110,
+            3773813623
           ],
-          "warmup_wall_duration_ns": 4325889449
+          "warmup_wall_duration_ns": 3770130123
         },
         {
           "tool": "mbx",
-          "wall_duration_ns": 4744051017,
+          "wall_duration_ns": 4419922199,
           "trials": 3,
           "wall_durations_ns": [
-            4458572903,
-            4776279194,
-            4744051017
+            4419922199,
+            4400969574,
+            5638622513
           ],
-          "warmup_wall_duration_ns": 17029362833,
+          "warmup_wall_duration_ns": 15555720498,
           "stats": {
             "lookups": 1,
             "hits": 1,
             "misses": 0,
             "unconsulted": 0,
-            "predictions_loaded": 927,
+            "predictions_loaded": 928,
             "restored_output_files": 2,
             "restored_output_bytes": 10242953
           }
         },
         {
           "tool": "kache",
-          "wall_duration_ns": 4201419688,
+          "wall_duration_ns": 4814450757,
           "trials": 3,
           "wall_durations_ns": [
-            4473460225,
-            4201419688,
-            3888023283
+            5055992689,
+            4814450757,
+            4755908212
           ],
-          "warmup_wall_duration_ns": 17572785669
+          "warmup_wall_duration_ns": 19089780951
         }
       ],
       "skipped": [],
@@ -159,15 +159,15 @@
       "results": [
         {
           "tool": "mbx-sequential",
-          "wall_duration_ns": 79534363104,
+          "wall_duration_ns": 73082018581,
           "peak_compilers": 31,
-          "min_available_bytes": 62964453376,
+          "min_available_bytes": 63010795520,
           "permits": null,
           "trials": 3,
           "wall_durations_ns": [
-            79145918939,
-            79534363104,
-            85858044100
+            79914094746,
+            69978695913,
+            73082018581
           ],
           "stats": {
             "hits": 8
@@ -175,15 +175,15 @@
         },
         {
           "tool": "mbx-unscheduled",
-          "wall_duration_ns": 76119871047,
-          "peak_compilers": 168,
-          "min_available_bytes": 54341431296,
+          "wall_duration_ns": 63238467156,
+          "peak_compilers": 187,
+          "min_available_bytes": 54072492032,
           "permits": null,
           "trials": 3,
           "wall_durations_ns": [
-            78813437347,
-            76119871047,
-            73511342423
+            64407287744,
+            63238467156,
+            60314911716
           ],
           "stats": {
             "hits": 12
@@ -191,15 +191,15 @@
         },
         {
           "tool": "mbx",
-          "wall_duration_ns": 53139590926,
+          "wall_duration_ns": 41169642483,
           "peak_compilers": 32,
-          "min_available_bytes": 61882585088,
+          "min_available_bytes": 61629624320,
           "permits": 32,
           "trials": 3,
           "wall_durations_ns": [
-            53139590926,
-            51864566201,
-            56721626095
+            41169642483,
+            42365968588,
+            38811576742
           ],
           "stats": {
             "hits": 3390


### PR DESCRIPTION
## Refreshed real-world benchmarks

`benchmarks/results.json` was measured with `1.10.1`; the latest release is now `mbx 1.11.0`. Re-ran the benchmark with that release on the fixed Namespace Linux xlarge profile: a pinned checkout of jdx/hk built under raw cargo, mbx, and kache across the warm, next-commit, edit-loop, and six-job contention scenarios, three trials of each.

**Read the numbers before merging.** They publish to https://mr-boxington.jdx.dev/benchmarks on merge. Look into a scenario that swapped places, or a trial range wide enough to explain the gap beside it, before it goes on the site.

## Real-world benchmark: hk

jdx/hk, a mid-size Rust CLI with C dependencies, `cargo build --locked` on Rust 1.97.1.

### warm

warm store, fresh target -- CI restoring the same commit; plain Cargo has no cache to restore

| Tool | Median wall time | Trials | Hits | Restored files |
| :--- | ---: | ---: | ---: | ---: |
| mbx | 7.8 s | 3 (7.5-8.3 s) | 722 | 1560 |
| kache | 8.7 s | 3 (8.5-9.0 s) | - | - |

### commit

cache tools warmed at the parent commit, build the child -- Cargo is the uncached push-to-push baseline

| Tool | Median wall time | Trials | Hits | Restored files |
| :--- | ---: | ---: | ---: | ---: |
| cargo | 23.2 s | 3 (23.0-24.4 s) | - | - |
| mbx | 16.7 s | 3 (16.2-18.6 s) | 721 | 1558 |
| kache | 18.3 s | 3 (17.4-18.9 s) | - | - |

### edit

one line changed and rebuilt in place, incremental on -- the local edit loop in its steady state, where Cargo is the thing to beat

| Tool | Median wall time | Trials | Hits | Restored files |
| :--- | ---: | ---: | ---: | ---: |
| cargo | 3.7 s | 3 (3.6-3.8 s) | - | - |
| mbx | 4.4 s | 3 (4.4-5.6 s) | 1 | 2 |
| kache | 4.8 s | 3 (4.8-5.1 s) | - | - |

### contention

six overlapping check, Clippy, and test jobs -- sequential for context, then parallel with and without mbx's machine-wide compiler limit

| Tool | Batch wall time | Peak compilers | Lowest free memory | Hits |
| :--- | ---: | ---: | ---: | ---: |
| mbx-sequential | 73.1 s | 31 | 63.0 GB | 8 |
| mbx-unscheduled | 63.2 s | 187 | 54.1 GB | 12 |
| mbx | 41.2 s | 32 / 32 permits | 61.6 GB | 3390 |

---
The [run](https://github.com/jdx/mr-boxington/actions/runs/34643194197) has the per-build logs. Generated by the `bench-refresh` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only update to published benchmark JSON; no application or build logic changes.
> 
> **Overview**
> Updates **`benchmarks/results.json`** with a new real-world benchmark run on **mbx 1.11.0** (was 1.10.1), including fresh CI metadata (`runner`, `workflow_run`, `commit`).
> 
> All scenario timings and mbx cache stats are replaced: **warm** and **commit** builds are faster for mbx vs the prior snapshot; **contention** shows a large drop for scheduled **mbx** (~53s → ~41s median) with higher peak compilers for the unscheduled variant; **edit** loop numbers shift slightly (mbx/kache still slower than raw Cargo on median). **`passed`** remains true with no failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f800e69dc11bb5ad3110613b2e4db0db5c0202a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed benchmark results with data from a new run.
  * Updated recorded run metadata and performance statistics across multiple benchmark scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->